### PR TITLE
fix: surface silent install failures + backup/nginx/npm-wal/release-smoke hardening

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,9 +22,18 @@ on:
       - 'tsconfig.json'
       - '.github/workflows/build-images.yml'
   pull_request:
+    # Must cover the SAME effective input set as the push filter above: the
+    # worker Containerfiles `npm ci` the whole workspace and COPY api-client's
+    # source + the shared tsconfig, so an api-client / lockfile / manifest /
+    # tsconfig break would otherwise skip the PR build and only fail after
+    # merge (#2162).
     paths:
       - 'packages/disk-import-worker/**'
       - 'packages/backup-worker/**'
+      - 'packages/api-client/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
       - '.github/workflows/build-images.yml'
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,43 @@ jobs:
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(main): release') }}
             type=raw,value=test,enable=${{ github.ref == 'refs/heads/test' }}
 
-      - name: Build and push Docker image
+      # Build the image into the LOCAL docker daemon (load, do NOT push yet) so
+      # we can boot it and smoke-test /health before it ever becomes :latest.
+      # Layers land in the GHA cache (mode=max), so the gated push step below
+      # is a cache-only re-export — no second real build (#2155).
+      - name: Build Docker image (load, no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          push: false
+          # A single local tag for the smoke test. The real registry tags are
+          # applied by the push step after the smoke test passes.
+          tags: servicebay-release-candidate:smoke
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Boot the freshly built image and exercise it end-to-end BEFORE pushing.
+      # scripts/test-container-e2e.sh (the proven local harness) starts the
+      # container, waits for HTTP readiness, probes GET /api/system/version, and
+      # scans logs for "Cannot find module"/MODULE_NOT_FOUND crash signatures —
+      # which is exactly how a boot failure, an un-loadable dist-server/server.cjs
+      # bundle, or a runtime dep dropped by `npm ci --omit=dev` surfaces. A
+      # non-2xx probe or a crash signature exits non-zero and fails this step,
+      # so a broken image never reaches the push below (#2155).
+      # The harness uses podman (preinstalled on ubuntu-latest); load the
+      # docker-built image into podman's store so it can run it.
+      - name: Smoke-test the built image (boot + /health before push)
+        run: |
+          set -euo pipefail
+          docker save servicebay-release-candidate:smoke | podman load
+          scripts/test-container-e2e.sh servicebay-release-candidate:smoke
+
+      # Only reached when the smoke test passed. Re-runs build-push-action with
+      # push: true; every layer is already in the GHA cache from the load build
+      # above, so this is a cache-hit export + push, not a second compilation.
+      - name: Push Docker image (smoke test passed)
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "sb-config-upload": "tsx scripts/sb-config-upload.ts",
     "disk-import": "tsx scripts/disk-import.ts",
     "check:invariants": "tsx scripts/check-invariants.ts",
+    "check:backup-coverage": "tsx scripts/check-backup-coverage.ts",
     "check:deps": "depcruise --config .dependency-cruiser.cjs packages/frontend/src packages/backend/src",
-    "check:arch": "npm run check:invariants && npm run check:deps",
+    "check:arch": "npm run check:invariants && npm run check:backup-coverage && npm run check:deps",
     "prepare": "husky || true"
   },
   "lint-staged": {

--- a/packages/backend/src/lib/adguard/rewrites.test.ts
+++ b/packages/backend/src/lib/adguard/rewrites.test.ts
@@ -161,3 +161,39 @@ describe('removeWildcardRewrite', () => {
     ).toBe('absent');
   });
 });
+
+// #2158 — every AdGuard admin fetch must carry an AbortSignal timeout so an
+// unreachable/wedged AdGuard fails fast instead of hanging the op, and callers
+// degrade gracefully on the resulting rejection.
+describe('AdGuard fetch timeout (#2158)', () => {
+  it('passes an AbortSignal on every admin call', async () => {
+    const signals: (AbortSignal | null | undefined)[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      signals.push(init.signal);
+      return { ok: true, json: async () => [] } as Response;
+    });
+    await listRewrites(opts(fetchImpl as unknown as typeof fetch));
+    await ensureWildcardRewrite(opts(fetchImpl as unknown as typeof fetch), '*.home.arpa', '10.0.0.5');
+    expect(signals.length).toBeGreaterThan(0);
+    for (const s of signals) expect(s).toBeInstanceOf(AbortSignal);
+  });
+
+  it('listRewrites degrades to [] when the fetch aborts (timeout)', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    });
+    expect(await listRewrites(opts(fetchImpl as unknown as typeof fetch))).toEqual([]);
+  });
+
+  it("ensureWildcardRewrite returns 'failed' when the add fetch aborts", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (new URL(url).pathname.endsWith('/list')) {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+    });
+    expect(
+      await ensureWildcardRewrite(opts(fetchImpl as unknown as typeof fetch), '*.home.arpa', '10.0.0.5'),
+    ).toBe('failed');
+  });
+});

--- a/packages/backend/src/lib/adguard/rewrites.ts
+++ b/packages/backend/src/lib/adguard/rewrites.ts
@@ -14,6 +14,15 @@
  * boot (#266 self-IP auto-update) and on every public-domain switch.
  */
 
+/** Abort any AdGuard admin API call that doesn't answer within ~8s so an
+ *  unreachable/wedged AdGuard fails fast instead of hanging the whole
+ *  wildcard-rewrite op (#2158). Matches the diagnose house pattern
+ *  (`ssoVerify.ts`, `certExpiry.ts` all use `AbortSignal.timeout(...)`).
+ *  Callers already degrade on rejection (`listRewrites` → `[]`,
+ *  ensure/remove → `'failed'`), so the timeout surfaces as a clear
+ *  degrade rather than an indefinite stall. */
+const HTTP_TIMEOUT_MS = 8000;
+
 const REWRITES_LIST = '/control/rewrite/list';
 const REWRITES_ADD = '/control/rewrite/add';
 const REWRITES_UPDATE = '/control/rewrite/update';
@@ -48,6 +57,7 @@ async function request(opts: ClientOpts, path: string, body?: unknown, method: '
     method,
     headers,
     body: method === 'POST' ? JSON.stringify(body ?? {}) : undefined,
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
   });
 }
 

--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -414,6 +414,21 @@ export interface AppConfig {
    */
   servicePostDeploy?: Record<string, ServicePostDeployRecord>;
   /**
+   * Unresolved install-time failures that the deploy could NOT recover
+   * from and that leave a service in a silent half-state — a capability
+   * handler that never registered its OIDC client / proxy host after
+   * bounded retries (#2160), or a NAS auto-restore that failed so the
+   * service came up on default config (#2161). Persisted so the
+   * `install_handler_failed` diagnose probe surfaces them with a
+   * retry/reconcile action long after the install log scrolled away,
+   * symmetric with `servicePostDeploy` + `post_deploy_failed`.
+   *
+   * Key is `${kind}:${service}` (e.g. `capability:immich`,
+   * `restore:radicale`) so a later successful reconcile of the same
+   * service clears exactly its record.
+   */
+  installHandlerFailures?: Record<string, InstallHandlerFailureRecord>;
+  /**
    * Per-service record of the template-schema-version that was
    * deployed. Updated by `ServiceManager.deployKubeService` whenever a
    * deploy succeeds, so the next deploy can detect a breaking-change
@@ -535,6 +550,23 @@ export interface ServicePostDeployRecord {
   exitCode: number;
   /** Tail of stdout (last ~1KB). Aids "what failed" diagnosis without bloating config. */
   stdoutTail?: string;
+}
+
+/**
+ * One unresolved install-time failure surfaced by the
+ * `install_handler_failed` diagnose probe (#2160 / #2161). See
+ * `installHandlerFailures` on `AppConfig` for the keying convention.
+ */
+export interface InstallHandlerFailureRecord {
+  /** What failed: a capability handler emit, or a NAS auto-restore. Drives
+   *  which retry action the diagnose probe offers. */
+  kind: 'capability' | 'restore';
+  /** The service/template the failure affects (e.g. `immich`). */
+  service: string;
+  /** Human-readable cause (handler name + message, or the restore error). */
+  message: string;
+  /** ISO timestamp of the last (exhausted) attempt. */
+  lastFailedAt: string;
 }
 
 /**

--- a/packages/backend/src/lib/diagnose/probes/installHandlerFailed.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/installHandlerFailed.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockConfig: any = {};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(mockConfig)),
+  saveConfig: vi.fn((cfg: any) => {
+    mockConfig = cfg;
+    return Promise.resolve();
+  }),
+}));
+
+// Keep the capability/internalFetch deps out of the probe's load graph for
+// these finding/dismiss tests (retry_capability isn't exercised here).
+vi.mock('@/lib/api/internalFetch', () => ({ internalFetch: vi.fn() }));
+vi.mock('@/lib/capabilities/authelia', () => ({ buildOidcReconcilePayload: vi.fn() }));
+
+import { checkInstallHandlerFailed } from './installHandlerFailed';
+import { dispatchProbeAction } from '../actions';
+import './installHandlerFailed';
+import { recordHandlerFailure } from '@/lib/install/handlerFailures';
+
+beforeEach(() => {
+  mockConfig = {};
+});
+
+describe('install_handler_failed probe (#2160/#2161)', () => {
+  it('is ok with no standing failures', async () => {
+    const res = await checkInstallHandlerFailed();
+    expect(res.status).toBe('ok');
+    expect(res.items).toBeUndefined();
+  });
+
+  it('emits a warn finding with a retry action per standing failure', async () => {
+    await recordHandlerFailure({ kind: 'capability', service: 'immich', message: 'authelia.oidc: HTTP 500' });
+    await recordHandlerFailure({ kind: 'restore', service: 'radicale', message: 'NAS config restore failed: refused' });
+
+    const res = await checkInstallHandlerFailed();
+    expect(res.status).toBe('warn');
+    expect(res.items).toHaveLength(2);
+    const cap = res.items!.find(i => i.id === 'capability:immich')!;
+    expect(cap.status).toBe('warn');
+    expect(cap.actionIds).toContain('retry_install_handler');
+    expect(cap.detail).toContain('authelia.oidc');
+    const restore = res.items!.find(i => i.id === 'restore:radicale')!;
+    expect(restore.detail).toContain('NAS restore');
+  });
+
+  it('dismiss action clears the standing record', async () => {
+    await recordHandlerFailure({ kind: 'capability', service: 'immich', message: 'x' });
+    const result = await dispatchProbeAction({
+      probeId: 'install_handler_failed',
+      actionId: 'dismiss_install_handler',
+      node: 'Local',
+      itemId: 'capability:immich',
+    });
+    expect(result.ok).toBe(true);
+    expect((await checkInstallHandlerFailed()).status).toBe('ok');
+  });
+
+  it('rejects an unrecognized item id', async () => {
+    const result = await dispatchProbeAction({
+      probeId: 'install_handler_failed',
+      actionId: 'retry_install_handler',
+      node: 'Local',
+      itemId: 'bogus',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Unrecognized/);
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/installHandlerFailed.ts
+++ b/packages/backend/src/lib/diagnose/probes/installHandlerFailed.ts
@@ -1,0 +1,195 @@
+/**
+ * `install_handler_failed` probe (#2160 / #2161) — surfaces install-time
+ * failures that left a service in a silent half-state and that the install
+ * itself could NOT recover from:
+ *
+ *   - `capability`: a `feature.installed` capability handler (Authelia OIDC
+ *     client, NPM proxy host, AdGuard rewrite) that stayed failed after the
+ *     runner's bounded retries. The service is "installed" but its SSO /
+ *     proxy registration never landed → invalid_client or no route.
+ *   - `restore`: a NAS auto-restore that failed, so the service came up on
+ *     default config while the operator believes their state was restored.
+ *
+ * Symmetric with `post_deploy_failed`: each standing failure is one item
+ * with a retry/reconcile action so the operator can recover it long after
+ * the install log scrolled away — while the backup still exists, in the
+ * restore case. Reads the persistent store `config.installHandlerFailures`
+ * (`lib/install/handlerFailures.ts`); a successful retry clears the record.
+ */
+
+import { logger } from '@/lib/logger';
+import { internalFetch } from '@/lib/api/internalFetch';
+import { getConfig } from '@/lib/config';
+import { buildOidcReconcilePayload } from '@/lib/capabilities/authelia';
+import {
+  listHandlerFailures,
+  clearHandlerFailure,
+  handlerFailureKey,
+} from '@/lib/install/handlerFailures';
+import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+
+export const PROBE_ID = 'install_handler_failed';
+
+export interface InstallHandlerFailedResult {
+  status: 'ok' | 'warn' | 'info';
+  detail: string;
+  hint?: string;
+  items?: ProbeItem[];
+}
+
+export async function checkInstallHandlerFailed(): Promise<InstallHandlerFailedResult> {
+  const failures = await listHandlerFailures();
+  if (failures.length === 0) {
+    return {
+      status: 'ok',
+      detail: 'No unresolved install-time capability or restore failures.',
+    };
+  }
+  const items: ProbeItem[] = failures.map(f => ({
+    id: handlerFailureKey(f.kind, f.service),
+    label: f.service,
+    detail:
+      `${f.kind === 'restore' ? 'NAS restore' : 'capability registration'} failed at ` +
+      `${new Date(f.lastFailedAt).toLocaleString()} — ${f.message}`,
+    status: 'warn',
+    actionIds: ['retry_install_handler', 'dismiss_install_handler'],
+  }));
+  return {
+    status: 'warn',
+    detail:
+      `${failures.length} service${failures.length === 1 ? '' : 's'} finished installing in a degraded state — ` +
+      `a capability handler (SSO/proxy) or a NAS restore didn't complete. The service is up but on incomplete/default config.`,
+    hint: 'Click "Retry" on a row to re-run the failed step (re-register the OIDC client / re-restore from the NAS). Idempotent — already-done work is skipped.',
+    items,
+  };
+}
+
+/** Parse `${kind}:${service}` back into its parts. */
+function parseItemId(itemId: string): { kind: 'capability' | 'restore'; service: string } | null {
+  const idx = itemId.indexOf(':');
+  if (idx < 0) return null;
+  const kind = itemId.slice(0, idx);
+  const service = itemId.slice(idx + 1);
+  if ((kind !== 'capability' && kind !== 'restore') || !service) return null;
+  return { kind, service };
+}
+
+/** Re-run the capability registration for a service by reconciling its OIDC
+ *  client(s) — the concrete recoverable case (Authelia registration races,
+ *  authelia.ts:142). The POST endpoint is reconcile-first (skips already-
+ *  registered client_ids, never rotates a secret), so this is idempotent. */
+async function retryCapability(service: string): Promise<ProbeActionResult> {
+  const cfg = await getConfig();
+  const payload = await buildOidcReconcilePayload({
+    installedTemplates: Object.keys(cfg.installedTemplates ?? {}),
+    publicDomain: cfg.reverseProxy?.publicDomain,
+  });
+  if (!payload) {
+    // Nothing to reconcile (no public domain / no OIDC-declaring template).
+    // The failure was likely a non-OIDC handler (proxy/DNS) — clear the
+    // stale record so the operator isn't nagged; a redeploy re-emits it.
+    await clearHandlerFailure('capability', service);
+    return {
+      ok: true,
+      message: `Cleared the ${service} record — no OIDC client to reconcile (no public domain configured). Redeploy the service to re-run proxy/DNS registration.`,
+      refresh: true,
+    };
+  }
+  let res: Response;
+  try {
+    res = await internalFetch('/api/system/authelia/oidc-clients', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (e) {
+    return { ok: false, message: `Reconcile failed: ${e instanceof Error ? e.message : String(e)}`, refresh: false };
+  }
+  if (res.status === 404) {
+    return { ok: false, message: 'Authelia is not deployed — install the auth stack, then retry.', refresh: false };
+  }
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: unknown };
+    const message = typeof body.error === 'string' ? body.error : `HTTP ${res.status}`;
+    return { ok: false, message: `Reconcile failed: ${message}`, refresh: false };
+  }
+  await clearHandlerFailure('capability', service);
+  return { ok: true, message: `Re-registered OIDC client(s) for ${service}. SSO should work now.`, refresh: true };
+}
+
+/** Re-run the NAS auto-restore for a service (force overwrite of config).
+ *  Only recoverable while the backup still exists on the NAS. */
+async function retryRestore(service: string): Promise<ProbeActionResult> {
+  // Lazy import to keep the restore module (and its executor deps) out of
+  // the probe's module-load graph.
+  const { autoRestoreServiceOnReinstall } = await import('@/lib/externalBackup/restore');
+  const lines: string[] = [];
+  try {
+    await autoRestoreServiceOnReinstall(
+      service,
+      { wipeMode: 'wipe-config', node: 'Local', local: true },
+      async (line: string) => {
+        lines.push(line);
+      },
+    );
+  } catch (e) {
+    return { ok: false, message: `Restore retry failed: ${e instanceof Error ? e.message : String(e)}`, refresh: false };
+  }
+  // autoRestoreServiceOnReinstall records a fresh failure if it fails again;
+  // check the store to decide success vs. still-failed.
+  const stillFailing = (await listHandlerFailures()).some(
+    f => f.kind === 'restore' && f.service === service,
+  );
+  if (stillFailing) {
+    const last = lines[lines.length - 1] ?? 'see install log';
+    return { ok: false, message: `Restore still failing for ${service}: ${last}`, refresh: true };
+  }
+  await clearHandlerFailure('restore', service);
+  return { ok: true, message: `Restored ${service} config from the NAS.`, refresh: true };
+}
+
+async function retryInstallHandler({ itemId }: { itemId?: string }): Promise<ProbeActionResult> {
+  if (!itemId) return { ok: false, message: 'No service supplied.', refresh: false };
+  const parsed = parseItemId(itemId);
+  if (!parsed) return { ok: false, message: `Unrecognized item id: ${itemId}`, refresh: false };
+  try {
+    return parsed.kind === 'restore'
+      ? await retryRestore(parsed.service)
+      : await retryCapability(parsed.service);
+  } catch (e) {
+    logger.warn('diagnose:install_handler_failed', `retry ${itemId} threw:`, e);
+    return { ok: false, message: `Retry failed: ${e instanceof Error ? e.message : String(e)}`, refresh: false };
+  }
+}
+
+async function dismissInstallHandler({ itemId }: { itemId?: string }): Promise<ProbeActionResult> {
+  if (!itemId) return { ok: false, message: 'No service supplied.', refresh: false };
+  const parsed = parseItemId(itemId);
+  if (!parsed) return { ok: false, message: `Unrecognized item id: ${itemId}`, refresh: false };
+  const existed = await clearHandlerFailure(parsed.kind, parsed.service);
+  return existed
+    ? { ok: true, message: `Cleared the ${parsed.service} record.`, refresh: true }
+    : { ok: false, message: `No standing record for ${parsed.service}.`, refresh: false };
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'retry_install_handler',
+    label: 'Retry',
+    description:
+      'Re-runs the failed install step for this service — re-registers its Authelia OIDC client (fixes SSO invalid_client) or re-restores its config from the NAS. Idempotent: already-completed work is skipped. Clears the warning on success.',
+  },
+  retryInstallHandler,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'dismiss_install_handler',
+    label: 'Clear record',
+    description:
+      'Removes the persisted failure record so the probe stops surfacing it. Use when you fixed the service manually and no longer want the warning.',
+  },
+  dismissInstallHandler,
+);

--- a/packages/backend/src/lib/diagnose/probes/nginxOnlineFailed.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/nginxOnlineFailed.test.ts
@@ -1,0 +1,129 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = {
+  config: {} as any,
+  services: [] as any[],
+};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(state.config)),
+}));
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { listServices: vi.fn(() => Promise.resolve(state.services)) },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { checkNginxOnlineFailed } from './nginxOnlineFailed';
+import { dispatchProbeAction } from '../actions';
+import './nginxOnlineFailed';
+
+const ACTIVE_NGINX = [{ name: 'nginx', active: true, ports: [{ host: '8081', container: '81' }] }];
+
+const tokenOk = () => ({ ok: true, json: () => Promise.resolve({ token: 'tok' }) });
+const hostList = (hosts: any[]) => ({ ok: true, json: () => Promise.resolve(hosts) });
+
+beforeEach(() => {
+  state.config = { reverseProxy: { npm: { email: 'a@b.c', password: 'pw' } } };
+  state.services = ACTIVE_NGINX;
+  mockFetch.mockReset();
+});
+
+describe('nginx_online_failed check', () => {
+  it('is info when nginx is not deployed', async () => {
+    state.services = [];
+    const r = await checkNginxOnlineFailed('Local');
+    expect(r.status).toBe('info');
+  });
+
+  it('is ok when every host has nginx_online=true', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(hostList([
+        { id: 1, domain_names: ['a.example.com'], meta: { nginx_online: true } },
+        { id: 2, domain_names: ['b.example.com'], meta: { nginx_online: true } },
+      ]));
+    const r = await checkNginxOnlineFailed('Local');
+    expect(r.status).toBe('ok');
+    expect(r.items).toBeUndefined();
+  });
+
+  it('fails and surfaces nginx_err for a host with nginx_online=false', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(hostList([
+        { id: 1, domain_names: ['ok.example.com'], meta: { nginx_online: true } },
+        {
+          id: 9,
+          domain_names: ['tor.dopp.cloud'],
+          meta: { nginx_online: false, nginx_err: 'nginx: [emerg] duplicate location "/.well-known/acme-challenge/"' },
+        },
+      ]));
+    const r = await checkNginxOnlineFailed('Local');
+    expect(r.status).toBe('fail');
+    expect(r.items).toHaveLength(1);
+    expect(r.items?.[0].id).toBe('tor.dopp.cloud');
+    expect(r.items?.[0].detail).toMatch(/duplicate location/);
+    expect(r.items?.[0].actionIds).toContain('rerender_host');
+    expect(r.detail).toMatch(/nginx_online=false/);
+  });
+
+  it('degrades to info (not false-ok) when the host list can not be read', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce({ ok: false, status: 502, json: () => Promise.resolve({}) });
+    const r = await checkNginxOnlineFailed('Local');
+    expect(r.status).toBe('info');
+  });
+});
+
+describe('nginx_online_failed.rerender_host action', () => {
+  it('rejects empty itemId', async () => {
+    const r = await dispatchProbeAction({ probeId: 'nginx_online_failed', actionId: 'rerender_host', node: 'Local' });
+    expect(r.ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('disable→enables the matching id and reports online after a good re-render', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenOk()) // /api/tokens
+      .mockResolvedValueOnce(hostList([{ id: 9, domain_names: ['tor.dopp.cloud'], meta: { nginx_online: false } }])) // resolve id
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') }) // disable
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') }) // enable
+      .mockResolvedValueOnce(hostList([{ id: 9, domain_names: ['tor.dopp.cloud'], meta: { nginx_online: true } }])); // read-back
+    const r = await dispatchProbeAction({
+      probeId: 'nginx_online_failed',
+      actionId: 'rerender_host',
+      itemId: 'tor.dopp.cloud',
+      node: 'Local',
+    });
+    expect(r.ok).toBe(true);
+    expect(r.message).toMatch(/nginx_online=true/);
+    // disable hit /9/disable, enable hit /9/enable
+    expect(mockFetch.mock.calls[2][0]).toMatch(/\/proxy-hosts\/9\/disable$/);
+    expect(mockFetch.mock.calls[3][0]).toMatch(/\/proxy-hosts\/9\/enable$/);
+  });
+
+  it('reports still-offline when the conf is still broken after re-render', async () => {
+    mockFetch
+      .mockResolvedValueOnce(tokenOk())
+      .mockResolvedValueOnce(hostList([{ id: 9, domain_names: ['tor.dopp.cloud'], meta: { nginx_online: false } }]))
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') }) // disable
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') }) // enable
+      .mockResolvedValueOnce(hostList([
+        { id: 9, domain_names: ['tor.dopp.cloud'], meta: { nginx_online: false, nginx_err: 'still bad' } },
+      ]));
+    const r = await dispatchProbeAction({
+      probeId: 'nginx_online_failed',
+      actionId: 'rerender_host',
+      itemId: 'tor.dopp.cloud',
+      node: 'Local',
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toMatch(/still offline/i);
+    expect(r.details).toMatch(/still bad/);
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/nginxOnlineFailed.ts
+++ b/packages/backend/src/lib/diagnose/probes/nginxOnlineFailed.ts
@@ -1,0 +1,259 @@
+/**
+ * `nginx_online_failed` probe (#2156) — surfaces NPM proxy hosts that NPM
+ * accepted (HTTP 200 on create) but nginx then REFUSED to load: NPM sets
+ * the host's `meta.nginx_online` to false and stashes the `[emerg]` reason
+ * in `meta.nginx_err`. This is the exact buerolicht/tor.dopp.cloud failure
+ * mode — a bad advanced_config (duplicate acme-challenge location) reverted
+ * the conf, so the domain 000s/502s while every other signal stays green.
+ *
+ * The ground truth already exists in NPM (it records nginx_err in
+ * proxy_host.meta in its database.sqlite, and mirrors it into the
+ * GET /api/nginx/proxy-hosts response), but nothing surfaced it — this
+ * probe reads NPM's host list and lights up every host whose nginx_online
+ * is false, with the nginx_err text and a per-row "Re-render route" action
+ * that disable→enables the host to force NPM to regenerate + reload the
+ * conf once the operator has fixed the underlying advanced_config.
+ *
+ * Sibling of `dangling_proxy` (stale routes) and `proxy_route_missing`
+ * (creation failed): this one is "created, but nginx won't serve it".
+ */
+
+import { getConfig } from '@/lib/config';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { logger } from '@/lib/logger';
+import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+
+const PROBE_ID = 'nginx_online_failed';
+
+export interface NginxOnlineFailedResult {
+  status: 'ok' | 'warn' | 'fail' | 'info';
+  detail: string;
+  hint?: string;
+  items?: ProbeItem[];
+}
+
+interface NpmHost {
+  id?: number;
+  domain_names?: string[];
+  meta?: { nginx_online?: boolean; nginx_err?: string | null };
+}
+
+/** Locate NPM's admin URL on the given node. Returns null when nginx
+ *  isn't deployed or its admin port can't be derived. Mirrors the
+ *  helper in danglingProxy.ts / npmDataStale.ts — kept local to avoid
+ *  coupling probes to each other. */
+async function findNpmAdminUrl(node: string): Promise<string | null> {
+  try {
+    const services = await ServiceManager.listServices(node);
+    const nginx = services.find(
+      s => s.name === 'nginx' || s.name === 'nginx-web' || (s.name.includes('nginx') && !s.name.startsWith('install-')),
+    );
+    if (!nginx?.active) return null;
+    const ports = (nginx.ports ?? [])
+      .map(p => parseInt(String(p.host ?? ''), 10))
+      .filter(p => Number.isFinite(p) && p !== 80 && p !== 443);
+    const adminPort = ports[0] ?? 81;
+    return `http://localhost:${adminPort}`;
+  } catch {
+    return null;
+  }
+}
+
+/** Try stored credentials first, then NPM defaults. Returns the bearer
+ *  token, or null when nothing works. Mirrors danglingProxy.ts. */
+async function getNpmToken(adminUrl: string): Promise<string | null> {
+  const config = await getConfig();
+  const candidates: { identity: string; secret: string }[] = [];
+  const stored = config.reverseProxy?.npm;
+  if (stored?.email && stored?.password) {
+    candidates.push({ identity: stored.email, secret: stored.password });
+  }
+  candidates.push({ identity: 'admin@example.com', secret: 'changeme' });
+
+  for (const cred of candidates) {
+    try {
+      const res = await fetch(`${adminUrl}/api/tokens`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cred),
+        signal: AbortSignal.timeout(4000),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (typeof data.token === 'string') return data.token;
+      }
+    } catch {
+      // try next
+    }
+  }
+  return null;
+}
+
+/** Fetch NPM's proxy host list. Returns null on any failure so the probe
+ *  degrades to `info` instead of a false `ok`. */
+async function fetchNpmHosts(adminUrl: string, token: string): Promise<NpmHost[] | null> {
+  try {
+    const res = await fetch(`${adminUrl}/api/nginx/proxy-hosts`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) return null;
+    const hosts = await res.json();
+    return Array.isArray(hosts) ? (hosts as NpmHost[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function checkNginxOnlineFailed(node: string): Promise<NginxOnlineFailedResult> {
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) {
+    return { status: 'info', detail: 'Nginx Proxy Manager is not deployed or not active on this node.' };
+  }
+  const token = await getNpmToken(adminUrl);
+  if (!token) {
+    return {
+      status: 'info',
+      detail: 'Could not authenticate against NPM to read per-host nginx status. If npm_data_stale is also warning, fix that first.',
+    };
+  }
+  const hosts = await fetchNpmHosts(adminUrl, token);
+  if (hosts === null) {
+    return { status: 'info', detail: 'Could not read the NPM proxy host list.' };
+  }
+  const offline = hosts.filter(h => h.meta?.nginx_online === false);
+  if (offline.length === 0) {
+    return {
+      status: 'ok',
+      detail: `${hosts.length} proxy host${hosts.length === 1 ? '' : 's'} recorded; nginx loaded every conf (nginx_online=true).`,
+    };
+  }
+  const items: ProbeItem[] = offline.map(h => {
+    const domain = h.domain_names?.[0] ?? `host ${h.id ?? '?'}`;
+    const err = (h.meta?.nginx_err ?? '').trim() || 'nginx reverted the conf (no error text recorded).';
+    return {
+      id: domain,
+      label: domain,
+      // The [emerg] reason is the actionable content — put it on the row.
+      detail: err.slice(0, 400),
+      status: 'fail',
+      actionIds: ['rerender_host'],
+    };
+  });
+  return {
+    status: 'fail',
+    detail: `${offline.length} proxy host${offline.length === 1 ? '' : 's'} exist in NPM but nginx refused the conf (nginx_online=false) — those domains return 000/502 while everything else looks green.`,
+    hint: 'Fix the host\'s advanced_config (the row shows the [emerg] reason), then click "Re-render route" to make NPM regenerate + reload the conf.',
+    items,
+  };
+}
+
+/**
+ * Map a domain (server_name) to NPM's numeric proxy_host id. Returns null
+ * when no host matches or the request fails.
+ */
+async function resolveProxyHostId(adminUrl: string, token: string, domain: string): Promise<number | null> {
+  const hosts = await fetchNpmHosts(adminUrl, token);
+  if (!hosts) return null;
+  for (const h of hosts) {
+    if ((h.domain_names ?? []).includes(domain) && typeof h.id === 'number') return h.id;
+  }
+  return null;
+}
+
+/**
+ * Force NPM to regenerate + reload a host's conf by disabling then
+ * re-enabling it. NPM rewrites the .conf and runs nginx -t/reload on both
+ * transitions, so once the operator fixed the offending advanced_config
+ * this clears nginx_online back to true (or re-surfaces a still-broken
+ * conf with the fresh error).
+ */
+async function rerenderHost({
+  node,
+  itemId,
+}: {
+  node: string;
+  itemId?: string;
+}): Promise<ProbeActionResult> {
+  if (!itemId) {
+    return { ok: false, message: 'No domain supplied — cannot re-render.', refresh: false };
+  }
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) {
+    return { ok: false, message: 'Nginx Proxy Manager is not deployed or active on this node.', refresh: false };
+  }
+  const token = await getNpmToken(adminUrl);
+  if (!token) {
+    return {
+      ok: false,
+      message: 'Could not authenticate against NPM. If npm_data_stale is also showing, fix that first.',
+      refresh: false,
+    };
+  }
+  const id = await resolveProxyHostId(adminUrl, token, itemId);
+  if (id === null) {
+    return {
+      ok: false,
+      message: `Couldn't find an NPM proxy host for ${itemId} — it may have been deleted since the probe ran.`,
+      refresh: true,
+    };
+  }
+  return performRerender(adminUrl, token, id, itemId);
+}
+
+/** Issue disable→enable against NPM and read back nginx_online. Split out
+ *  of rerenderHost to stay under the function-length budget. */
+async function performRerender(
+  adminUrl: string,
+  token: string,
+  id: number,
+  itemId: string,
+): Promise<ProbeActionResult> {
+  const call = (path: string) =>
+    fetch(`${adminUrl}/api/nginx/proxy-hosts/${id}/${path}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(8000),
+    });
+  try {
+    await call('disable');
+    const enableRes = await call('enable');
+    if (!enableRes.ok) {
+      const body = await enableRes.text().catch(() => '');
+      logger.warn('diagnose:nginx_online_failed', `re-enable id=${id} (${itemId}) returned HTTP ${enableRes.status}: ${body.slice(0, 200)}`);
+      return { ok: false, message: `NPM returned HTTP ${enableRes.status} re-enabling ${itemId}.`, refresh: true };
+    }
+    // Read back the live status so the toast tells the operator whether the
+    // conf actually loaded this time — a re-render on a still-broken config
+    // just re-populates nginx_err.
+    const hosts = await fetchNpmHosts(adminUrl, token);
+    const host = hosts?.find(h => h.id === id);
+    if (host?.meta?.nginx_online === false) {
+      const err = (host.meta.nginx_err ?? '').trim();
+      return {
+        ok: false,
+        message: `${itemId} still offline after re-render — nginx rejected the conf again. Fix the advanced_config, then retry.`,
+        details: err || undefined,
+        refresh: true,
+      };
+    }
+    return { ok: true, message: `${itemId} re-rendered — nginx loaded the conf (nginx_online=true).`, refresh: true };
+  } catch (e) {
+    return {
+      ok: false,
+      message: `Failed to reach NPM while re-rendering ${itemId}: ${e instanceof Error ? e.message : String(e)}`,
+      refresh: false,
+    };
+  }
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'rerender_host',
+    label: 'Re-render route',
+    description:
+      'Disables then re-enables this proxy host so Nginx Proxy Manager regenerates its config and runs nginx -t / reload. Use after fixing the advanced_config the [emerg] error points at — if the config is still bad, nginx just rejects it again and the error re-appears.',
+  },
+  rerenderHost,
+);

--- a/packages/backend/src/lib/diagnose/probes/register.ts
+++ b/packages/backend/src/lib/diagnose/probes/register.ts
@@ -16,6 +16,7 @@ import './npmDataStale';
 import './routerDnsNotPointing';
 import './danglingProxy';
 import './postDeployFailed';
+import './installHandlerFailed';
 import './crashLoop';
 import './proxyRouteMissing';
 import './nginxOnlineFailed';

--- a/packages/backend/src/lib/diagnose/probes/register.ts
+++ b/packages/backend/src/lib/diagnose/probes/register.ts
@@ -18,6 +18,7 @@ import './danglingProxy';
 import './postDeployFailed';
 import './crashLoop';
 import './proxyRouteMissing';
+import './nginxOnlineFailed';
 import './failedUnits';
 import './healthChecks';
 import './disk';

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -22,6 +22,7 @@ import { checkRouterDnsNotPointing } from '@/lib/diagnose/probes/routerDnsNotPoi
 import { checkPostDeployFailed } from '@/lib/diagnose/probes/postDeployFailed';
 import { checkMediaLibraryAccess } from '@/lib/diagnose/probes/mediaLibraryAccess';
 import { checkProxyRouteMissing } from '@/lib/diagnose/probes/proxyRouteMissing';
+import { checkNginxOnlineFailed } from '@/lib/diagnose/probes/nginxOnlineFailed';
 import { checkCertExpiry } from '@/lib/diagnose/probes/certExpiry';
 import { checkCertRequestFailure } from '@/lib/diagnose/probes/certRequestFailure';
 import { checkAdguardRewritesMissing } from '@/lib/diagnose/probes/adguardRewritesMissing';
@@ -831,6 +832,24 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });
+  }
+
+  // 11b) #2156 — routes NPM created (HTTP 200) but nginx REFUSED to load
+  //      (meta.nginx_online=false): a bad advanced_config reverted the conf,
+  //      so the domain 000s/502s while everything else is green. Row carries
+  //      the [emerg] reason + a "Re-render route" retry action.
+  try {
+    const nof = await checkNginxOnlineFailed(nodeName);
+    probes.push({
+      id: 'nginx_online_failed',
+      label: 'Reverse-proxy nginx load',
+      status: nof.status,
+      detail: nof.detail,
+      hint: nof.hint,
+      _items: nof.items && nof.items.length > 0 ? nof.items : undefined,
+    });
+  } catch (e) {
+    probes.push({ id: 'nginx_online_failed', label: 'Reverse-proxy nginx load', status: 'info', detail: `Skipped: ${e instanceof Error ? e.message : String(e)}` });
   }
 
   // 12) NPM admin credentials staleness — probe-action handlers

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -20,6 +20,7 @@ import { checkNpmDataStale } from '@/lib/diagnose/probes/npmDataStale';
 import { checkLanIpChanged } from '@/lib/diagnose/probes/lanIpChanged';
 import { checkRouterDnsNotPointing } from '@/lib/diagnose/probes/routerDnsNotPointing';
 import { checkPostDeployFailed } from '@/lib/diagnose/probes/postDeployFailed';
+import { checkInstallHandlerFailed } from '@/lib/diagnose/probes/installHandlerFailed';
 import { checkMediaLibraryAccess } from '@/lib/diagnose/probes/mediaLibraryAccess';
 import { checkProxyRouteMissing } from '@/lib/diagnose/probes/proxyRouteMissing';
 import { checkNginxOnlineFailed } from '@/lib/diagnose/probes/nginxOnlineFailed';
@@ -79,6 +80,7 @@ const PROBE_GROUP: Record<string, ProbeGroup> = {
   failed_units: 'services',
   crash_loop: 'services',
   post_deploy_failed: 'services',
+  install_handler_failed: 'services',
   // Reverse-proxy routes
   dangling_proxy: 'reverse-proxy',
   // Proxy admin reachable
@@ -977,6 +979,31 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     probes.push({
       id: 'post_deploy_failed',
       label: 'Service seed steps',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 15a) Unresolved install-time capability/restore failures (#2160/#2161).
+  //     A `feature.installed` handler (OIDC/proxy/DNS) that stayed failed
+  //     after the runner's bounded retries, or a NAS auto-restore that
+  //     failed — the service is up but on incomplete/default config.
+  //     Symmetric with post_deploy_failed: one row per service, each with
+  //     a "Retry" (re-register / re-restore) + "Clear record" action.
+  try {
+    const ihf = await checkInstallHandlerFailed();
+    probes.push({
+      id: 'install_handler_failed',
+      label: 'Install capability/restore',
+      status: ihf.status,
+      detail: ihf.detail,
+      hint: ihf.hint,
+      _items: ihf.items,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'install_handler_failed',
+      label: 'Install capability/restore',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/packages/backend/src/lib/externalBackup/backupAtomRegression.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupAtomRegression.test.ts
@@ -111,22 +111,19 @@ describe('GOLDEN: stageServiceBackup selection per real manifest', () => {
     expect(staged).toEqual(['conf/AdGuardHome.yaml']);
   });
 
-  it('authelia — keeps users_database.yml with password hashes STRIPPED, identity kept', async () => {
+  it('authelia — backs up the db.sqlite3 secret store, not the dead legacy YAML (#2153)', async () => {
     const src = await mkTmp();
-    await write(
-      src,
-      'users_database.yml',
-      'users:\n  alice:\n    password: $argon2id$SECRET\n    displayname: Alice\n    email: a@x\n    groups:\n      - admins\n',
-    );
+    // The real per-service secret store (TOTP/WebAuthn/OIDC consent) — kept
+    // verbatim (encrypted at rest, trusted-NAS class).
+    await write(src, 'db.sqlite3', 'AUTHELIA-SQLITE-SECRETS');
+    // The legacy file-backend YAML is no longer in the include-set — even if a
+    // stray file is present, it must NOT enter the tarball.
+    await write(src, 'users_database.yml', 'users:\n  alice:\n    password: $argon2id$SECRET\n');
     const staging = await mkTmp();
     const staged = await stageServiceBackup(src, getServiceManifest('authelia')!, staging);
-    expect(staged).toEqual(['users_database.yml']);
-    const out = await fs.readFile(path.join(staging, 'users_database.yml'), 'utf8');
-    expect(out).not.toContain('SECRET');
-    expect(out).not.toMatch(/password:/);
-    expect(out).toContain('a@x');
-    expect(out).toContain('Alice');
-    expect(out).toContain('admins');
+    expect(staged).toEqual(['db.sqlite3']);
+    expect(await fs.readFile(path.join(staging, 'db.sqlite3'), 'utf8')).toBe('AUTHELIA-SQLITE-SECRETS');
+    await expect(fs.access(path.join(staging, 'users_database.yml'))).rejects.toThrow();
   });
 
   it('home-assistant — globs (lovelace*/hacs*) + custom_components dir + config-entries transform; DB/logs excluded', async () => {
@@ -248,13 +245,9 @@ describe('GOLDEN: runConfigUpload writes the canonical on-NAS atom (real produce
     return { log: () => {}, confirm: async () => true };
   }
 
-  it('produces sb-backup/authelia.tar (whitelist + strip) + .meta.json sidecar', async () => {
+  it('produces sb-backup/authelia.tar (db.sqlite3 whitelist) + .meta.json sidecar', async () => {
     const from = await mkTmp();
-    await write(
-      from,
-      'users_database.yml',
-      'users:\n  bob:\n    password: $argon2$NOPE\n    email: b@x\n',
-    );
+    await write(from, 'db.sqlite3', 'AUTHELIA-SECRETS-BLOB');
     await write(from, 'ignored.txt', 'not in the manifest');
 
     const result = await runConfigUpload(
@@ -273,13 +266,13 @@ describe('GOLDEN: runConfigUpload writes the canonical on-NAS atom (real produce
     expect(uploadPaths).toContain(`sb-backup/${result.tarName}`);
     expect(uploadPaths).toContain(`sb-backup/${result.metaName}`);
 
-    // The tar carries the stripped whitelist file only — same as a box backup.
+    // The tar carries the db.sqlite3 whitelist only (the -wal/-shm sidecars
+    // aren't present in this fixture); ignored.txt is not in the manifest.
     const tarBuf = mockNas.nasUpload.mock.calls.find(c => datedTarRe('authelia').test(String(c[0])))![1] as Buffer;
     const extracted = await extractTar(tarBuf);
-    expect(await listFilesRel(extracted)).toEqual(['users_database.yml']);
-    const body = await fs.readFile(path.join(extracted, 'users_database.yml'), 'utf8');
-    expect(body).not.toContain('NOPE');
-    expect(body).toContain('b@x');
+    expect(await listFilesRel(extracted)).toEqual(['db.sqlite3']);
+    const body = await fs.readFile(path.join(extracted, 'db.sqlite3'), 'utf8');
+    expect(body).toBe('AUTHELIA-SECRETS-BLOB');
 
     // Sidecar JSON shape.
     const metaBuf = mockNas.nasUpload.mock.calls.find(c => String(c[0]).endsWith('.meta.json'))![1] as Buffer;

--- a/packages/backend/src/lib/externalBackup/backupRestoreRoundtrip.test.ts
+++ b/packages/backend/src/lib/externalBackup/backupRestoreRoundtrip.test.ts
@@ -90,26 +90,23 @@ describe('backup → restore round-trip (#1218 / #1190)', () => {
     expect(await exists(path.join(dataDir, 'www'))).toBe(false);
   });
 
-  it('authelia: round-trips usernames + email but strips password hashes', async () => {
+  it('authelia: round-trips the db.sqlite3 secret store, not the dead legacy YAML (#2153)', async () => {
     const src = path.join(tmpRoot, 'src-authelia');
     await writeFiles(src, {
-      'users_database.yml': [
-        'users:',
-        '  alice:',
-        '    displayname: Alice',
-        '    email: alice@dopp.cloud',
-        '    password: $argon2id$SECRET-HASH',
-        '',
-      ].join('\n'),
+      // The real per-service secrets (TOTP/WebAuthn/OIDC consent) live here now;
+      // kept verbatim (encrypted at rest, trusted-NAS class).
+      'db.sqlite3': 'AUTHELIA-TOTP-WEBAUTHN-SECRETS',
+      // Legacy file-backend YAML — no longer in the include-set, must not survive.
+      'users_database.yml': 'users:\n  alice:\n    password: $argon2id$SECRET-HASH\n',
     });
 
     await backupServiceToNas('authelia', { serviceDataDir: src });
     const { dataDir } = await restoreServiceBackup('authelia', { local: true });
-    const restored = await fs.readFile(path.join(dataDir, 'users_database.yml'), 'utf8');
 
-    expect(restored).toContain('alice');
-    expect(restored).toContain('alice@dopp.cloud');
-    expect(restored).not.toContain('SECRET-HASH'); // password stripped before it ever reaches the NAS
+    const restored = await fs.readFile(path.join(dataDir, 'db.sqlite3'), 'utf8');
+    expect(restored).toBe('AUTHELIA-TOTP-WEBAUTHN-SECRETS');
+    // The dead YAML never reached the NAS, so it isn't restored.
+    await expect(fs.access(path.join(dataDir, 'users_database.yml'))).rejects.toThrow();
   });
 
   it('survives a wipe-then-reinstall: a populated source restores cleanly into the emptied data dir', async () => {

--- a/packages/backend/src/lib/externalBackup/configUpload.test.ts
+++ b/packages/backend/src/lib/externalBackup/configUpload.test.ts
@@ -140,7 +140,7 @@ describe('runConfigUpload', () => {
   it('rejects an unknown service before touching the filesystem', async () => {
     const io = fakeIO();
     await expect(
-      runConfigUpload({ service: 'vaultwarden', from: '/x', target: 'fritzbox', assumeYes: true }, io),
+      runConfigUpload({ service: 'not-a-real-service', from: '/x', target: 'fritzbox', assumeYes: true }, io),
     ).rejects.toThrow(ConfigUploadError);
     expect(mockBackup).not.toHaveBeenCalled();
   });

--- a/packages/backend/src/lib/externalBackup/producer.test.ts
+++ b/packages/backend/src/lib/externalBackup/producer.test.ts
@@ -393,7 +393,9 @@ describe('backupServiceToNas', () => {
   });
 
   it('rejects a service with no manifest without touching the NAS', async () => {
-    await expect(backupServiceToNas('vaultwarden')).rejects.toThrow(/No backup manifest/);
+    // immich has persistent volumes but no config-backup manifest (all bulk —
+    // photo library + Postgres, EXCLUDED_BULK_VOLUMES), so it has no tarball.
+    await expect(backupServiceToNas('immich')).rejects.toThrow(/No backup manifest/);
     expect(mockNas.nasUpload).not.toHaveBeenCalled();
   });
 

--- a/packages/backend/src/lib/externalBackup/restore.test.ts
+++ b/packages/backend/src/lib/externalBackup/restore.test.ts
@@ -9,7 +9,7 @@ const execFileAsync = promisify(execFile);
 
 const { mockNas, mockCfg, mockNpmCredStatus, mockRekeyNpm, mockGetExecutor } = vi.hoisted(() => ({
   mockNas: { nasUpload: vi.fn(), nasDownload: vi.fn(), nasList: vi.fn() },
-  mockCfg: { getConfig: vi.fn() },
+  mockCfg: { getConfig: vi.fn(), saveConfig: vi.fn() },
   mockNpmCredStatus: vi.fn(),
   mockRekeyNpm: vi.fn(),
   mockGetExecutor: vi.fn(),
@@ -55,6 +55,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'restore-test-'));
   mockCfg.getConfig.mockResolvedValue({ templateSettings: { DATA_DIR: tmpRoot } });
+  mockCfg.saveConfig.mockResolvedValue(undefined);
   // #1865 — restore now resolves the latest snapshot from the listing. Default
   // to advertising the bare legacy slot (a valid undated snapshot) so the
   // existing backward-compat restore tests resolve it; tests asserting dated
@@ -248,6 +249,26 @@ describe('autoRestoreServiceOnReinstall (#1218 entry point 1)', () => {
     await autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local', local: true }, async l => { logs.push(l); });
     expect(await fs.readFile(path.join(dataDir, 'configuration.yaml'), 'utf8')).toBe('restored:');
     expect(logs.some(l => l.includes('restored') && l.includes('home-assistant'))).toBe(true);
+  });
+
+  it('a failed restore is a LOUD warning + persists a diagnose finding, never a quiet note (#2161)', async () => {
+    // A backup exists (so we attempt), but the download blows up mid-restore.
+    mockNas.nasList.mockResolvedValue([{ name: 'home-assistant.tar', size: 1024 }]);
+    mockNas.nasDownload.mockRejectedValue(new Error('NAS connection refused'));
+    const logs: string[] = [];
+    await expect(
+      autoRestoreServiceOnReinstall('home-assistant', { wipeMode: 'wipe-all', node: 'Local', local: true }, async l => { logs.push(l); }),
+    ).resolves.toBeUndefined(); // never blocks the deploy
+    // Loud warning naming the service + the default-config consequence.
+    expect(logs.some(l => l.includes('⚠️') && l.includes('home-assistant') && /FAILED/i.test(l) && /DEFAULT config/i.test(l))).toBe(true);
+    // NOT demoted to a quiet (note).
+    expect(logs.some(l => l.startsWith('(note) home-assistant: NAS config restore skipped'))).toBe(false);
+    // Persistent diagnose finding recorded (saveConfig carries the restore failure).
+    type SavedCfg = { installHandlerFailures?: Record<string, { message: string }> };
+    const saved = mockCfg.saveConfig.mock.calls.map(c => c[0] as SavedCfg);
+    const withFailure = saved.find(c => c?.installHandlerFailures?.['restore:home-assistant']);
+    expect(withFailure).toBeTruthy();
+    expect(withFailure!.installHandlerFailures!['restore:home-assistant'].message).toMatch(/NAS config restore failed/);
   });
 });
 

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -29,6 +29,9 @@ import { getServiceManifest, getConfigPaths } from './serviceManifest';
 import { safeTarExtract, extractServiceConfigToNode } from '../systemBackup';
 import { getExecutor, type Executor } from '../executor';
 import { logger } from '../logger';
+// handlerFailures only imports config + logger (no runner) — no cycle with the
+// install module despite living under install/. See #2160/#2161 plumbing.
+import { recordHandlerFailure } from '../install/handlerFailures';
 
 /**
  * Per-service wipe mode (#1585). Structurally identical to
@@ -401,7 +404,21 @@ export async function autoRestoreServiceOnReinstall(
       await log(`${r.credentialReconcile.ok ? '🔑 ' : '⚠️ '}${service}: ${r.credentialReconcile.message}`);
     }
   } catch (e) {
-    // A restore failure must never block the deploy — log a breadcrumb and continue.
-    await log(`(note) ${service}: NAS config restore skipped — ${e instanceof Error ? e.message : String(e)}.`);
+    // A restore failure must never block the deploy (best-effort by design),
+    // but it must NOT be a quiet `(note)` either (#2161): the service comes up
+    // on fresh/default config while the operator believes their backed-up
+    // state was restored, and discovers the loss much later. Make it a
+    // PROMINENT warning naming the service, AND persist a standing diagnose
+    // finding with a retry action so the state stays recoverable while the
+    // backup still exists on the NAS.
+    const message = e instanceof Error ? e.message : String(e);
+    await log(
+      `⚠️ ${service}: NAS config restore FAILED — ${message}. The service will start on DEFAULT config; your backed-up state was NOT restored. Retry it from Diagnose while the backup is still on the NAS.`,
+    );
+    await recordHandlerFailure({
+      kind: 'restore',
+      service,
+      message: `NAS config restore failed: ${message}`,
+    });
   }
 }

--- a/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
@@ -14,12 +14,55 @@ import {
 } from './serviceManifest';
 
 describe('service backup manifests', () => {
-  it('covers the #1190 services and excludes vaultwarden', () => {
+  it('covers the #1190 services plus the #2153 coverage-gap services', () => {
     const names = SERVICE_BACKUP_MANIFESTS.map(m => m.service);
     expect(names).toEqual(
-      expect.arrayContaining(['home-assistant', 'authelia', 'adguard', 'syncthing', 'hermes']),
+      expect.arrayContaining([
+        'home-assistant', 'authelia', 'adguard', 'syncthing', 'hermes',
+        // #2153 — previously unprotected services now covered.
+        'lldap', 'vaultwarden', 'radicale', 'jellyfin', 'honcho', 'file-share',
+      ]),
     );
-    expect(getServiceManifest('vaultwarden')).toBeUndefined();
+  });
+
+  it('backs up LLDAP users.db — the family identity store (#2153)', () => {
+    const lldap = getServiceManifest('lldap')!;
+    expect(lldap.dataSubdir).toBe('auth/lldap');
+    expect(lldap.include).toContain('users.db');
+    // Identities can't be regenerated — kept verbatim.
+    expect(lldap.strip).toBeUndefined();
+  });
+
+  it('backs up vaultwarden vault + JWT signing keys, excludes bulk attachments (#2153)', () => {
+    const vw = getServiceManifest('vaultwarden')!;
+    expect(vw.include).toEqual(
+      expect.arrayContaining(['db.sqlite3', 'rsa_key.pem', 'rsa_key.pub.pem', 'config.json']),
+    );
+    // rsa keys MUST persist or every session/token breaks — never stripped.
+    expect(vw.strip).toBeUndefined();
+    // Attachments/sends are bulk user DATA, kept off the tarball.
+    expect(vw.exclude).toContain('attachments');
+    expect(vw.data).toContain('attachments');
+  });
+
+  it('backs up radicale collections (calendars/contacts) (#2153)', () => {
+    const rad = getServiceManifest('radicale')!;
+    expect(rad.dataSubdir).toBe('radicale/data');
+    expect(rad.include).toContain('collections');
+  });
+
+  it('backs up jellyfin server config + users db, excludes regenerable caches (#2153)', () => {
+    const jf = getServiceManifest('jellyfin')!;
+    expect(jf.dataSubdir).toBe('media/jellyfin-config');
+    expect(jf.include).toEqual(expect.arrayContaining(['config', 'data/jellyfin.db', 'plugins']));
+    // The media library + caches are never in the tarball.
+    expect(jf.exclude).toEqual(expect.arrayContaining(['cache', 'metadata', 'transcodes']));
+  });
+
+  it('backs up file-share samba passdb + filebrowser config (#2153)', () => {
+    const fs = getServiceManifest('file-share')!;
+    expect(fs.include).toContain('samba-private');
+    expect(fs.include).toContain('filebrowser-config');
   });
 
   it('keeps the zwave_js network keys in home-assistant (needed to recover the mesh)', () => {
@@ -142,17 +185,28 @@ describe('config/data classification (#1585)', () => {
   it('a service may declare no DATA class (authelia is config-only)', () => {
     expect(getServiceManifest('authelia')!.data).toBeUndefined();
     expect(getDataPaths('authelia')).toEqual([]);
-    expect(getConfigPaths('authelia')).toContain('users_database.yml');
+  });
+
+  it('authelia backs up the SQLite secret store, not the dead legacy YAML (#2153)', () => {
+    const authelia = getServiceManifest('authelia')!;
+    // The real per-service secrets (TOTP/WebAuthn/OIDC consent) live in db.sqlite3.
+    expect(authelia.dataSubdir).toBe('auth/authelia-data');
+    expect(getConfigPaths('authelia')).toContain('db.sqlite3');
+    // The legacy file-backend YAML is dead (LLDAP is the auth source) — not backed up.
+    expect(getConfigPaths('authelia')).not.toContain('users_database.yml');
+    // Encrypted at rest, kept verbatim — no strip.
+    expect(authelia.strip).toBeUndefined();
   });
 });
 
 describe('applyStripRules', () => {
   it('strips a targeted file and passes other files through untouched', () => {
-    const authelia = getServiceManifest('authelia')!;
-    const stripped = applyStripRules(authelia, 'users_database.yml', 'users:\n  a:\n    password: x\n');
-    expect(stripped).not.toContain('password');
-    const passthrough = applyStripRules(authelia, 'some-other-file.yml', 'password: keep\n');
-    expect(passthrough).toBe('password: keep\n');
+    // hermes strips LLM api keys from config.yaml; other files pass through.
+    const hermes = getServiceManifest('hermes')!;
+    const stripped = applyStripRules(hermes, 'config.yaml', 'api_key: SEKRIT\nmodel: gemma\n');
+    expect(stripped).not.toContain('SEKRIT');
+    const passthrough = applyStripRules(hermes, 'some-other-file.yml', 'api_key: keep\n');
+    expect(passthrough).toBe('api_key: keep\n');
   });
 });
 

--- a/packages/backend/src/lib/externalBackup/serviceManifest.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.ts
@@ -146,9 +146,12 @@ export interface ServiceBackupManifest {
 }
 
 /**
- * Per-service config scope, transcribed from the table in #1190.
- * vaultwarden is intentionally absent — its vault DB has no reset path and
- * needs its own user-exported backup story, out of scope for this feature.
+ * Per-service config scope, transcribed from the table in #1190 and extended in
+ * #2153 to close the coverage gap (lldap / vaultwarden / radicale / jellyfin /
+ * honcho / file-share / authelia db.sqlite3). Every template that declares a
+ * persistent `{{DATA_DIR}}/…` volume must either appear here (a manifest entry)
+ * or be listed in `EXCLUDED_BULK_VOLUMES` below — enforced by
+ * `scripts/check-backup-coverage.ts` so a new template can't silently opt out.
  */
 export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
   {
@@ -234,12 +237,22 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     data: ['store.jsonl'],
   },
   {
+    // Authelia (#2153). Its real per-service secret store is the SQLite DB at
+    // `auth/authelia-data/db.sqlite3` — TOTP secrets, WebAuthn credentials, and
+    // OIDC consent grants. The legacy `users_database.yml` file-backend is dead
+    // on a live box (LLDAP is the auth source since #1737), so backing that up
+    // preserved nothing useful while the actual secrets were lost on reinstall.
+    // `configuration.yml` is NOT backed up: ServiceBay re-renders it from
+    // `configuration.yml.mustache` on every deploy (it's regenerable, not state).
     service: 'authelia',
-    include: ['users_database.yml'],
+    dataSubdir: 'auth/authelia-data',
+    // db.sqlite3 is WAL-mode (post-deploy.py flips journal_mode=WAL, #1679). We
+    // stage the main DB plus its `-wal`/`-shm` sidecars byte-for-byte so a live
+    // copy stays whole on restore (the same reason NPM ships a snapshot). The DB
+    // is encrypted with AUTHELIA_STORAGE_ENCRYPTION_KEY and kept verbatim — no
+    // strip; the trusted-NAS decision (see NPM below) covers it.
+    include: ['db.sqlite3', 'db.sqlite3-wal', 'db.sqlite3-shm'],
     exclude: [],
-    // Usernames, groups, email, display name only — password hashes are
-    // stripped; operators reset via email-forgotten after a restore.
-    strip: [{ file: 'users_database.yml', dropYamlKeys: ['password'] }],
   },
   {
     service: 'adguard',
@@ -301,7 +314,122 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     // are never staged (they're not in `include`), so the restored DB is whole.
     collector: { kind: 'npm-sqlite' },
   },
+  {
+    // LLDAP (#2153). `users.db` is the family identity store — every user,
+    // group, and membership (the documented reinstall foot-gun in
+    // docs/CREDENTIAL_SELF_HEAL.md). LLDAP 0.6.x stores it as SQLite under the
+    // container's /data → `auth/lldap/`. Kept verbatim (identities can't be
+    // regenerated; trusted-NAS class). The `-wal`/`-shm` sidecars ride along so
+    // a live copy restores whole.
+    service: 'lldap',
+    dataSubdir: 'auth/lldap',
+    include: ['users.db', 'users.db-wal', 'users.db-shm'],
+    exclude: [],
+  },
+  {
+    // Vaultwarden (#2153) — the household password vault. Small config-grade
+    // state, maximal value. `db.sqlite3` is the vault ciphertext (encrypted with
+    // each user's master password — useless to an attacker with the NAS, so kept
+    // verbatim); `rsa_key.*` are the JWT signing keys that MUST persist or every
+    // session/invite token breaks after a reinstall; `config.json` holds the
+    // admin/runtime config. Attachments/sends/icon_cache are bulk user data.
+    service: 'vaultwarden',
+    include: [
+      'db.sqlite3', 'db.sqlite3-wal', 'db.sqlite3-shm',
+      'rsa_key.pem', 'rsa_key.pub.pem', 'config.json',
+    ],
+    exclude: ['icon_cache', 'tmp', 'attachments', 'sends'],
+    // The vault DB is encrypted at rest; attachments are the heavy on-RAID data.
+    data: ['attachments', 'sends'],
+  },
+  {
+    // Radicale (#2153) — CalDAV/CardDAV. The `collections` tree under /data holds
+    // every calendar event and contact card; without it a reinstall loses all
+    // family calendars/contacts. Kept verbatim (plain files, no secrets).
+    service: 'radicale',
+    dataSubdir: 'radicale/data',
+    include: ['collections'],
+    exclude: [],
+  },
+  {
+    // Jellyfin (#2153) — the media SERVER's config, NOT the media library. Data
+    // lives under `media/jellyfin-config/` (the container's /config). We back up
+    // the small config-grade bits — server settings (`config/`: system.xml,
+    // network.xml, encoding.xml, the LDAP-plugin config), the users/libraries DB
+    // (`data/jellyfin.db`), and installed plugins + their config — and EXCLUDE
+    // the regenerable bulk: transcode/artwork caches, logs, and re-scannable
+    // metadata. The media files themselves live on a separate volume
+    // (`JELLYFIN_MEDIA_PATH`) that is never backed up (EXCLUDED_BULK_VOLUMES).
+    service: 'jellyfin',
+    dataSubdir: 'media/jellyfin-config',
+    include: [
+      'config',
+      'data/jellyfin.db', 'data/jellyfin.db-wal', 'data/jellyfin.db-shm',
+      'plugins',
+    ],
+    exclude: [
+      'cache', 'log', 'transcodes', 'metadata',
+      'data/subtitles', 'data/transcodes',
+    ],
+    // Artwork/metadata caches are large and re-scannable — kept on the RAID
+    // through a wipe-config rather than re-downloaded.
+    data: ['metadata', 'cache'],
+  },
+  {
+    // Honcho (#2153) — AI memory service. The app's config-grade state lives on
+    // its /data volume (`honcho/data/`). Its Postgres store is a SEPARATE volume
+    // (`honcho/pgdata/`) that is bulk + credential-coupled: it's excluded here
+    // (EXCLUDED_BULK_VOLUMES) and reconciled by the reinstall-over-pgdata rekey
+    // work (#2165), not restored from a NAS tarball. The pg password is an
+    // env-injected secret, not a file, so there is nothing to strip here.
+    service: 'honcho',
+    dataSubdir: 'honcho/data',
+    include: ['config.json'],
+    exclude: [],
+  },
+  {
+    // File-share (#2153) — the config that defines the shares, NOT the shared
+    // files. Data lives under `file-share/`: `samba-private/` holds the Samba
+    // passdb (user accounts + password hashes — kept verbatim, they can't be
+    // regenerated), `filebrowser-db/` is FileBrowser's user/settings SQLite, and
+    // `filebrowser-config/` its settings. The `data/` volume is the shared
+    // household files — bulk, never backed up (EXCLUDED_BULK_VOLUMES).
+    service: 'file-share',
+    include: [
+      'samba-private',
+      'filebrowser-db/filebrowser.db',
+      'filebrowser-config',
+    ],
+    exclude: [],
+  },
 ];
+
+/**
+ * Templates that declare a persistent `{{DATA_DIR}}/…` volume which is
+ * DELIBERATELY not in a backup manifest — bulk/regenerable/credential-coupled
+ * data that must never enter a NAS tarball (multi-GB media, photo blobs, the
+ * recorder DB, Postgres data dirs reconciled by rekey, caches). Each key is the
+ * `{{DATA_DIR}}`-relative volume path exactly as the template declares it; the
+ * value is the reason. `scripts/check-backup-coverage.ts` treats a volume as
+ * covered if it maps to a manifest entry OR appears here — so a new template
+ * volume can't silently opt out of the backup contract (#2153).
+ */
+export const EXCLUDED_BULK_VOLUMES: Readonly<Record<string, string>> = {
+  // Regenerable / re-syncable / re-scannable bulk.
+  'auth/authelia-config': 'configuration.yml is re-rendered from configuration.yml.mustache on every deploy — regenerable, not state.',
+  'home-assistant/matter-server': 'Matter fabric is re-commissioned per reinstall, not restored (project_matter_fabric_not_portable).',
+  'media/jellyfin-cache': 'Jellyfin transcode/artwork cache — regenerable.',
+  'immich/model-cache': 'ML model cache — re-downloaded on demand.',
+  'claude-dev/workspace': 'Ephemeral dev scratch workspace — not household config.',
+  // Heavy household DATA (photos, media, shared files) — never in a tarball.
+  JELLYFIN_MEDIA_PATH: 'The media library itself — multi-TB, lives on the RAID.',
+  'immich/upload': 'Immich photo/video library — multi-GB blobs, RAID-resident.',
+  'file-share/data': 'The shared household files — bulk user data on the RAID.',
+  // Postgres data dirs: credential-coupled, reconciled by rekey (#2165), not
+  // restored from a NAS tarball.
+  'honcho/pgdata': 'Postgres data dir — reconciled by reinstall-over-data rekey (#2165), not NAS-restored.',
+  'immich/pgdata': 'Immich Postgres data dir — RAID-resident, rekey-reconciled, not NAS-restored.',
+};
 
 export function getServiceManifest(service: string): ServiceBackupManifest | undefined {
   return SERVICE_BACKUP_MANIFESTS.find(m => m.service === service);

--- a/packages/backend/src/lib/install/handlerFailures.test.ts
+++ b/packages/backend/src/lib/install/handlerFailures.test.ts
@@ -19,7 +19,7 @@ import {
   emitFeatureInstalledWithRetry,
   MAX_EMIT_ATTEMPTS,
 } from './handlerFailures';
-import type { EmitResult } from '@/lib/capabilities/bus';
+import type { EmitResult } from '@/lib/capabilities/types';
 
 beforeEach(() => {
   mockConfig = {};

--- a/packages/backend/src/lib/install/handlerFailures.test.ts
+++ b/packages/backend/src/lib/install/handlerFailures.test.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockConfig: any = {};
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn(() => Promise.resolve(mockConfig)),
+  saveConfig: vi.fn((cfg: any) => {
+    mockConfig = cfg;
+    return Promise.resolve();
+  }),
+}));
+
+import {
+  recordHandlerFailure,
+  clearHandlerFailure,
+  listHandlerFailures,
+  handlerFailureKey,
+  emitFeatureInstalledWithRetry,
+  MAX_EMIT_ATTEMPTS,
+} from './handlerFailures';
+import type { EmitResult } from '@/lib/capabilities/bus';
+
+beforeEach(() => {
+  mockConfig = {};
+});
+
+const ok: EmitResult = { ok: true, results: [], failures: [] };
+const retryableFail = (msg = 'boom'): EmitResult => ({
+  ok: false,
+  results: [{ handler: 'authelia.oidc', result: { ok: false, retryable: true, message: msg } }],
+  failures: [{ handler: 'authelia.oidc', result: { ok: false, retryable: true, message: msg } }],
+});
+const nonRetryableFail = (): EmitResult => ({
+  ok: false,
+  results: [{ handler: 'nginx.proxy', result: { ok: false, retryable: false, message: 'nope' } }],
+  failures: [{ handler: 'nginx.proxy', result: { ok: false, retryable: false, message: 'nope' } }],
+});
+
+describe('emitFeatureInstalledWithRetry (#2160)', () => {
+  it('a handler that fails-then-succeeds is retried and ends green', async () => {
+    const emit = vi
+      .fn<[], Promise<EmitResult>>()
+      .mockResolvedValueOnce(retryableFail())
+      .mockResolvedValueOnce(ok);
+    const result = await emitFeatureInstalledWithRetry({ emit, sleep: async () => {} });
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('a handler that always fails exhausts the retry budget and stays failed', async () => {
+    const emit = vi.fn<[], Promise<EmitResult>>().mockResolvedValue(retryableFail());
+    const onRetry = vi.fn();
+    const result = await emitFeatureInstalledWithRetry({ emit, onRetry, sleep: async () => {} });
+    expect(emit).toHaveBeenCalledTimes(MAX_EMIT_ATTEMPTS);
+    expect(onRetry).toHaveBeenCalledTimes(MAX_EMIT_ATTEMPTS - 1);
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(1);
+  });
+
+  it('does not retry a non-retryable failure', async () => {
+    const emit = vi.fn<[], Promise<EmitResult>>().mockResolvedValue(nonRetryableFail());
+    const result = await emitFeatureInstalledWithRetry({ emit, sleep: async () => {} });
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('handler failure store (#2160/#2161)', () => {
+  it('records, lists, and clears a failure keyed by kind+service', async () => {
+    await recordHandlerFailure({ kind: 'capability', service: 'immich', message: 'authelia.oidc: HTTP 500' });
+    await recordHandlerFailure({ kind: 'restore', service: 'radicale', message: 'NAS unreachable' });
+
+    let all = await listHandlerFailures();
+    expect(all).toHaveLength(2);
+    expect(mockConfig.installHandlerFailures[handlerFailureKey('capability', 'immich')].message).toContain('authelia.oidc');
+
+    const cleared = await clearHandlerFailure('capability', 'immich');
+    expect(cleared).toBe(true);
+    all = await listHandlerFailures();
+    expect(all).toHaveLength(1);
+    expect(all[0].service).toBe('radicale');
+  });
+
+  it('clearing a non-existent record returns false', async () => {
+    expect(await clearHandlerFailure('restore', 'nope')).toBe(false);
+  });
+
+  it('re-recording the same service overwrites (idempotent key)', async () => {
+    await recordHandlerFailure({ kind: 'restore', service: 'radicale', message: 'first' });
+    await recordHandlerFailure({ kind: 'restore', service: 'radicale', message: 'second' });
+    const all = await listHandlerFailures();
+    expect(all).toHaveLength(1);
+    expect(all[0].message).toBe('second');
+  });
+});

--- a/packages/backend/src/lib/install/handlerFailures.test.ts
+++ b/packages/backend/src/lib/install/handlerFailures.test.ts
@@ -40,7 +40,7 @@ const nonRetryableFail = (): EmitResult => ({
 describe('emitFeatureInstalledWithRetry (#2160)', () => {
   it('a handler that fails-then-succeeds is retried and ends green', async () => {
     const emit = vi
-      .fn<[], Promise<EmitResult>>()
+      .fn<() => Promise<EmitResult>>()
       .mockResolvedValueOnce(retryableFail())
       .mockResolvedValueOnce(ok);
     const result = await emitFeatureInstalledWithRetry({ emit, sleep: async () => {} });
@@ -50,7 +50,7 @@ describe('emitFeatureInstalledWithRetry (#2160)', () => {
   });
 
   it('a handler that always fails exhausts the retry budget and stays failed', async () => {
-    const emit = vi.fn<[], Promise<EmitResult>>().mockResolvedValue(retryableFail());
+    const emit = vi.fn<() => Promise<EmitResult>>().mockResolvedValue(retryableFail());
     const onRetry = vi.fn();
     const result = await emitFeatureInstalledWithRetry({ emit, onRetry, sleep: async () => {} });
     expect(emit).toHaveBeenCalledTimes(MAX_EMIT_ATTEMPTS);
@@ -60,7 +60,7 @@ describe('emitFeatureInstalledWithRetry (#2160)', () => {
   });
 
   it('does not retry a non-retryable failure', async () => {
-    const emit = vi.fn<[], Promise<EmitResult>>().mockResolvedValue(nonRetryableFail());
+    const emit = vi.fn<() => Promise<EmitResult>>().mockResolvedValue(nonRetryableFail());
     const result = await emitFeatureInstalledWithRetry({ emit, sleep: async () => {} });
     expect(emit).toHaveBeenCalledTimes(1);
     expect(result.ok).toBe(false);

--- a/packages/backend/src/lib/install/handlerFailures.ts
+++ b/packages/backend/src/lib/install/handlerFailures.ts
@@ -1,0 +1,126 @@
+/**
+ * Persistent store for unresolved install-time failures (#2160 / #2161).
+ *
+ * Two failure classes leave a service in a silent half-state that the
+ * install log alone can't recover from once it scrolls away:
+ *   - a `feature.installed` capability handler (OIDC client / NPM proxy
+ *     host / AdGuard rewrite) that stayed failed after bounded retries;
+ *   - a NAS auto-restore that failed, so the service came up on default
+ *     config while the operator believes their state was restored.
+ *
+ * Both are recorded here (keyed `${kind}:${service}`) so the
+ * `install_handler_failed` diagnose probe can surface them with a
+ * retry/reconcile action — symmetric with `servicePostDeploy` +
+ * `post_deploy_failed`. A successful reconcile clears exactly the one
+ * service's record.
+ *
+ * All writes are best-effort: a persistence failure here must never
+ * abort or fail an install (it only means the operator loses the
+ * standing diagnose row), so callers get a swallow-on-error contract.
+ */
+import { getConfig, saveConfig } from '@/lib/config';
+import { logger } from '@/lib/logger';
+import type { InstallHandlerFailureRecord } from '@/lib/config';
+import type { EmitResult } from '@/lib/capabilities/bus';
+
+export type { InstallHandlerFailureRecord };
+
+/** How many times the install runner emits `feature.installed` before it
+ *  gives up on a still-retryable handler failure (#2160). */
+export const MAX_EMIT_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 2_000;
+
+/**
+ * Emit `feature.installed` with bounded retry of RETRYABLE handler
+ * failures (#2160). Handlers are idempotent, so re-emitting the whole
+ * event is safe — already-done work no-ops and only the still-failing
+ * handler gets another attempt. Stops early once no failure is still
+ * retryable, or after `MAX_EMIT_ATTEMPTS`. Non-retryable failures are
+ * never retried. Extracted from the runner so the retry policy is unit-
+ * testable (a fail-then-succeed handler retries; an always-fail one
+ * exhausts). Injects `emit`, `onRetry`, and `sleep` for the tests.
+ */
+export async function emitFeatureInstalledWithRetry(deps: {
+  emit: () => Promise<EmitResult>;
+  onRetry?: (attempt: number, retryableCount: number) => void | Promise<void>;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<EmitResult> {
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)));
+  let result = await deps.emit();
+  for (
+    let attempt = 1;
+    attempt < MAX_EMIT_ATTEMPTS && result.failures.some(f => !f.result.ok && f.result.retryable);
+    attempt++
+  ) {
+    const retryableCount = result.failures.filter(f => !f.result.ok && f.result.retryable).length;
+    await deps.onRetry?.(attempt, retryableCount);
+    await sleep(RETRY_DELAY_MS);
+    result = await deps.emit();
+  }
+  return result;
+}
+
+const LOG_SCOPE = 'install:handlerFailures';
+
+/** Compose the record key. Exported so the probe + callers agree. */
+export function handlerFailureKey(kind: InstallHandlerFailureRecord['kind'], service: string): string {
+  return `${kind}:${service}`;
+}
+
+/**
+ * Persist (or overwrite) one unresolved failure. Best-effort — a write
+ * error is logged and swallowed so it can never break the install.
+ */
+export async function recordHandlerFailure(
+  entry: Omit<InstallHandlerFailureRecord, 'lastFailedAt'> & { lastFailedAt?: string },
+): Promise<void> {
+  const record: InstallHandlerFailureRecord = {
+    kind: entry.kind,
+    service: entry.service,
+    message: entry.message,
+    lastFailedAt: entry.lastFailedAt ?? new Date().toISOString(),
+  };
+  try {
+    const config = await getConfig();
+    const failures = { ...(config.installHandlerFailures ?? {}) };
+    failures[handlerFailureKey(record.kind, record.service)] = record;
+    // saveConfig (not updateConfig): updateConfig deep-merges, which can't
+    // remove keys — but here we always write the whole map so add/overwrite
+    // and the delete path in `clearHandlerFailure` stay consistent.
+    await saveConfig({ ...config, installHandlerFailures: failures });
+  } catch (e) {
+    logger.warn(LOG_SCOPE, `Could not persist ${record.kind} failure for ${record.service}:`, e);
+  }
+}
+
+/**
+ * Clear the record for one service+kind (e.g. after a successful
+ * reconcile/retry). Best-effort. Returns true if a record existed.
+ */
+export async function clearHandlerFailure(
+  kind: InstallHandlerFailureRecord['kind'],
+  service: string,
+): Promise<boolean> {
+  try {
+    const config = await getConfig();
+    const failures = { ...(config.installHandlerFailures ?? {}) };
+    const key = handlerFailureKey(kind, service);
+    if (!(key in failures)) return false;
+    delete failures[key];
+    await saveConfig({ ...config, installHandlerFailures: failures });
+    return true;
+  } catch (e) {
+    logger.warn(LOG_SCOPE, `Could not clear ${kind} failure for ${service}:`, e);
+    return false;
+  }
+}
+
+/** Read all standing failures (probe-facing). Never throws. */
+export async function listHandlerFailures(): Promise<InstallHandlerFailureRecord[]> {
+  try {
+    const config = await getConfig();
+    return Object.values(config.installHandlerFailures ?? {});
+  } catch {
+    return [];
+  }
+}

--- a/packages/backend/src/lib/install/handlerFailures.ts
+++ b/packages/backend/src/lib/install/handlerFailures.ts
@@ -21,7 +21,7 @@
 import { getConfig, saveConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
 import type { InstallHandlerFailureRecord } from '@/lib/config';
-import type { EmitResult } from '@/lib/capabilities/bus';
+import type { EmitResult } from '@/lib/capabilities/types';
 
 export type { InstallHandlerFailureRecord };
 

--- a/packages/backend/src/lib/install/jobStore.ts
+++ b/packages/backend/src/lib/install/jobStore.ts
@@ -117,6 +117,14 @@ export interface JobState {
     totalCount: number;
   };
   error?: string;
+  /** Non-fatal problems that leave the install in a degraded-but-done
+   *  state — e.g. a capability handler that stayed failed after bounded
+   *  retries, or a NAS restore that failed (#2160/#2161). The install
+   *  still reaches `phase: 'done'` (one-shot, no rollback), but a
+   *  non-empty `warnings` marks the run non-green: the Done UI shows it
+   *  as "completed with warnings" and diagnose carries the standing
+   *  finding + retry action. */
+  warnings?: string[];
   credentialsManifest?: Credential[];
   /** Set when the runner pauses on the NPM credentials prompt. The
    *  client reads `fallback` to pre-fill the prompt UI. */

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -47,6 +47,7 @@ import { buildCredentialsManifest, mergeCredentials, type Credential } from '@/l
 import { provisionPortalWithRetries } from '@/lib/stackInstall/portalProvision';
 import { npmAdminCredStatus, rekeyNpmAdmin } from '@/lib/reverseProxy/npmAdminRekey';
 import { getCapabilityBus } from '@/lib/capabilities/bus';
+import { recordHandlerFailure, emitFeatureInstalledWithRetry, MAX_EMIT_ATTEMPTS } from './handlerFailures';
 import { getStoreSnapshot } from '@/lib/store/repository';
 import { getInternalApiToken } from '@/lib/auth/internalToken';
 import { getConfig, saveConfig, type InstalledCredential } from '@/lib/config';
@@ -149,6 +150,17 @@ async function patchJob(
   const next = await updateJob(jobId, partial);
   if (next) emitJobUpdate(next);
   return next;
+}
+
+/** Mark the install run non-green with a standing warning (#2160/#2161).
+ *  Appends to `JobState.warnings` (deep-merge can't append arrays, so we
+ *  read → concat → write the whole array). The install still reaches
+ *  `phase: 'done'`, but a non-empty `warnings` flags it as "completed with
+ *  warnings" in the Done UI. Best-effort; never throws. */
+async function appendJobWarning(jobId: string, warning: string): Promise<void> {
+  const job = await getJob(jobId).catch(() => null);
+  const warnings = [...(job?.warnings ?? []), warning];
+  await patchJob(jobId, { warnings }).catch(() => undefined);
 }
 
 /** Public abort entry-point. Sets the in-memory flag and unblocks any
@@ -1403,19 +1415,34 @@ async function runJob(jobId: string): Promise<void> {
         await log(jobId, `(note) skipped capability emit for ${name}: ${parsed.errors.join('; ')}`);
         continue;
       }
-      const result = await bus.emit({
-        kind: 'feature.installed',
-        template: name,
-        manifest: parsed.manifest,
-        variables,
+      // Bounded retry of RETRYABLE handler failures (#2160). Covers the
+      // Authelia `retryable: true` OIDC-registration races (auth pod
+      // restarting mid-install, capabilities/authelia.ts:142) that were
+      // previously dropped. Retry policy lives in `emitFeatureInstalledWithRetry`.
+      const result = await emitFeatureInstalledWithRetry({
+        emit: () =>
+          bus.emit({
+            kind: 'feature.installed',
+            template: name,
+            manifest: parsed.manifest,
+            variables,
+          }),
+        onRetry: (attempt, count) =>
+          log(jobId, `↻ Retrying ${count} recoverable handler failure(s) for ${name} (attempt ${attempt + 1}/${MAX_EMIT_ATTEMPTS})…`),
       });
       for (const f of result.failures) {
-        // Surface as diagnose-style log lines but don't abort — handler
-        // failures are recoverable and the operator can retry the
-        // specific service via diagnose actions.
-        if (!f.result.ok) {
-          await log(jobId, `⚠️ ${f.handler} (${name}): ${f.result.message}`);
-        }
+        if (f.result.ok) continue;
+        // A failure that survived bounded retries (or was never retryable)
+        // leaves this service in a silent half-state. Mark the install
+        // non-green and persist a standing diagnose finding with a
+        // reconcile action — don't just log-and-forget (#2160).
+        await log(jobId, `⚠️ ${f.handler} (${name}): ${f.result.message} — capability registration did NOT complete; SSO/proxy for this service may be dead until reconciled.`);
+        await appendJobWarning(jobId, `${name}: ${f.handler} — ${f.result.message}`);
+        await recordHandlerFailure({
+          kind: 'capability',
+          service: name,
+          message: `${f.handler}: ${f.result.message}`,
+        });
       }
     } catch (e) {
       await log(jobId, `(note) capability emit failed for ${name}: ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/backend/src/lib/reverseProxy/npmAdminRekey.test.ts
+++ b/packages/backend/src/lib/reverseProxy/npmAdminRekey.test.ts
@@ -32,7 +32,7 @@ vi.stubGlobal('fetch', vi.fn(async () => {
   return { ok: state.fetchStatus < 400, status: state.fetchStatus, json: async () => state.fetchBody } as unknown as Response;
 }));
 
-import { npmAdminCredStatus, rekeyNpmAdmin } from './npmAdminRekey';
+import { npmAdminCredStatus, rekeyNpmAdmin, NPM_REKEY_JS } from './npmAdminRekey';
 
 const ACTIVE_NGINX = [{ name: 'nginx-web', active: true, ports: [{ host: '81', container: '81' }] }];
 
@@ -81,6 +81,26 @@ describe('npmAdminCredStatus', () => {
   it("returns 'unknown' when NPM is unreachable (skip, don't re-key blindly)", async () => {
     state.fetchThrows = true;
     expect(await npmAdminCredStatus('Local')).toBe('unknown');
+  });
+});
+
+describe('NPM_REKEY_JS — concurrency pragmas (avoid `database is locked` #1679)', () => {
+  it('sets busy_timeout and journal_mode=WAL immediately after opening the DB', () => {
+    expect(NPM_REKEY_JS).toContain("db.pragma('busy_timeout = 5000');");
+    expect(NPM_REKEY_JS).toContain("db.pragma('journal_mode = WAL');");
+  });
+
+  it('applies both pragmas AFTER the Database() open and BEFORE the first query', () => {
+    const open = NPM_REKEY_JS.indexOf("const db=Database('/data/database.sqlite');");
+    const busy = NPM_REKEY_JS.indexOf("db.pragma('busy_timeout = 5000');");
+    const wal = NPM_REKEY_JS.indexOf("db.pragma('journal_mode = WAL');");
+    const firstQuery = NPM_REKEY_JS.indexOf('db.prepare(');
+    expect(open).toBeGreaterThanOrEqual(0);
+    // busy_timeout first (per-connection, always safe), then WAL, both between
+    // the open and the first prepared statement.
+    expect(open).toBeLessThan(busy);
+    expect(busy).toBeLessThan(wal);
+    expect(wal).toBeLessThan(firstQuery);
   });
 });
 

--- a/packages/backend/src/lib/reverseProxy/npmAdminRekey.ts
+++ b/packages/backend/src/lib/reverseProxy/npmAdminRekey.ts
@@ -107,10 +107,21 @@ export async function npmAdminCredStatus(node: string): Promise<'ok' | 'rejected
 
 // Runs inside the NPM container. Reads NEWPW from env; re-keys the first
 // non-deleted admin user's password hash. Prints `email=<x>;updated=<n>`.
-const NPM_REKEY_JS = [
+//
+// Concurrency pragmas set immediately after open, BEFORE any query: NPM is
+// actively writing this same DB during host creates / cert renewals, so an
+// unguarded external opener races and fails with `database is locked` (the
+// #1679 class). `busy_timeout=5000` (per-connection, always safe) makes this
+// opener WAIT out a concurrent write instead of aborting; `journal_mode=WAL`
+// matches NPM's own journal mode (jc21 runs its SQLite in WAL), so readers
+// and writers don't block each other. Mirrors the in-repo pattern in
+// logger.ts / auth/rateLimit.ts (pragma right after the Database() open).
+export const NPM_REKEY_JS = [
   "const bcrypt=require('/app/node_modules/bcrypt');",
   "const Database=require('/app/node_modules/better-sqlite3');",
   "const db=Database('/data/database.sqlite');",
+  "db.pragma('busy_timeout = 5000');",
+  "db.pragma('journal_mode = WAL');",
   "const u=db.prepare(\"SELECT id,email FROM user WHERE is_deleted=0 ORDER BY id LIMIT 1\").get();",
   "if(!u){process.stdout.write('noadmin');process.exit(0);}",
   "const hash=bcrypt.hashSync(process.env.NEWPW,13);",

--- a/packages/backup-worker/src/engine/serviceManifest.ts
+++ b/packages/backup-worker/src/engine/serviceManifest.ts
@@ -73,7 +73,11 @@ export interface ServiceBackupManifest {
   renames?: Record<string, string>;
 }
 
-/** Per-service config scope, transcribed from the table in #1190. */
+/** Per-service config scope, transcribed from the table in #1190 and extended
+ *  in #2153 (lldap/vaultwarden/radicale/jellyfin/honcho/file-share + authelia
+ *  db.sqlite3). Kept in sync with the backend copy; the coverage contract that
+ *  gates new template volumes lives on the backend side
+ *  (scripts/check-backup-coverage.ts + EXCLUDED_BULK_VOLUMES). */
 export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
   {
     service: 'home-assistant',
@@ -108,10 +112,16 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     data: ['store.jsonl'],
   },
   {
+    // Authelia (#2153): back up the real secret store — the SQLite DB (TOTP,
+    // WebAuthn, OIDC consent) at auth/authelia-data/db.sqlite3 — not the dead
+    // legacy users_database.yml (LLDAP is the auth source since #1737).
+    // configuration.yml is re-rendered per deploy (regenerable), so it's excluded.
+    // WAL-mode → stage the -wal/-shm sidecars so a live copy restores whole.
+    // Encrypted at rest, kept verbatim (trusted-NAS class) — no strip.
     service: 'authelia',
-    include: ['users_database.yml'],
+    dataSubdir: 'auth/authelia-data',
+    include: ['db.sqlite3', 'db.sqlite3-wal', 'db.sqlite3-shm'],
     exclude: [],
-    strip: [{ file: 'users_database.yml', dropYamlKeys: ['password'] }],
   },
   {
     service: 'adguard',
@@ -138,7 +148,91 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     exclude: ['letsencrypt/logs', 'data/nginx', 'data/logs'],
     collector: { kind: 'npm-sqlite' },
   },
+  {
+    // LLDAP (#2153): users.db is the family identity store (LLDAP 0.6.x SQLite
+    // under /data → auth/lldap/). Kept verbatim; sidecars ride along.
+    service: 'lldap',
+    dataSubdir: 'auth/lldap',
+    include: ['users.db', 'users.db-wal', 'users.db-shm'],
+    exclude: [],
+  },
+  {
+    // Vaultwarden (#2153): vault ciphertext DB + JWT signing keys + config; the
+    // rsa keys MUST persist or every session/token breaks. Attachments/sends are
+    // bulk user data (DATA), caches excluded.
+    service: 'vaultwarden',
+    include: [
+      'db.sqlite3', 'db.sqlite3-wal', 'db.sqlite3-shm',
+      'rsa_key.pem', 'rsa_key.pub.pem', 'config.json',
+    ],
+    exclude: ['icon_cache', 'tmp', 'attachments', 'sends'],
+    data: ['attachments', 'sends'],
+  },
+  {
+    // Radicale (#2153): the collections tree holds every calendar/contact.
+    service: 'radicale',
+    dataSubdir: 'radicale/data',
+    include: ['collections'],
+    exclude: [],
+  },
+  {
+    // Jellyfin (#2153): server config + users/libraries DB + plugins; caches,
+    // logs, transcodes and re-scannable metadata excluded. The media library is
+    // a separate volume, never backed up.
+    service: 'jellyfin',
+    dataSubdir: 'media/jellyfin-config',
+    include: [
+      'config',
+      'data/jellyfin.db', 'data/jellyfin.db-wal', 'data/jellyfin.db-shm',
+      'plugins',
+    ],
+    exclude: [
+      'cache', 'log', 'transcodes', 'metadata',
+      'data/subtitles', 'data/transcodes',
+    ],
+    data: ['metadata', 'cache'],
+  },
+  {
+    // Honcho (#2153): app config on /data (honcho/data). Its Postgres store is a
+    // separate volume, excluded + rekey-reconciled (#2165), not NAS-restored.
+    service: 'honcho',
+    dataSubdir: 'honcho/data',
+    include: ['config.json'],
+    exclude: [],
+  },
+  {
+    // File-share (#2153): the Samba passdb + FileBrowser db/config that DEFINE
+    // the shares. The shared files themselves (file-share/data) are bulk, excluded.
+    service: 'file-share',
+    include: [
+      'samba-private',
+      'filebrowser-db/filebrowser.db',
+      'filebrowser-config',
+    ],
+    exclude: [],
+  },
 ];
+
+/**
+ * Bulk/regenerable/credential-coupled template volumes deliberately NOT backed
+ * up (mirrors the backend copy — the coverage contract in
+ * scripts/check-backup-coverage.ts reads the backend's authoritative export;
+ * this copy is kept in sync so the worker's manifest file stays a faithful
+ * mirror). Keys are `{{DATA_DIR}}`-relative volume paths as templates declare
+ * them (#2153).
+ */
+export const EXCLUDED_BULK_VOLUMES: Readonly<Record<string, string>> = {
+  'auth/authelia-config': 'configuration.yml is re-rendered from its .mustache on every deploy — regenerable.',
+  'home-assistant/matter-server': 'Matter fabric is re-commissioned per reinstall, not restored.',
+  'media/jellyfin-cache': 'Jellyfin transcode/artwork cache — regenerable.',
+  'immich/model-cache': 'ML model cache — re-downloaded on demand.',
+  'claude-dev/workspace': 'Ephemeral dev scratch workspace — not household config.',
+  JELLYFIN_MEDIA_PATH: 'The media library itself — multi-TB, lives on the RAID.',
+  'immich/upload': 'Immich photo/video library — multi-GB blobs, RAID-resident.',
+  'file-share/data': 'The shared household files — bulk user data on the RAID.',
+  'honcho/pgdata': 'Postgres data dir — reconciled by reinstall-over-data rekey (#2165), not NAS-restored.',
+  'immich/pgdata': 'Immich Postgres data dir — RAID-resident, rekey-reconciled, not NAS-restored.',
+};
 
 export function getServiceManifest(service: string): ServiceBackupManifest | undefined {
   return SERVICE_BACKUP_MANIFESTS.find(m => m.service === service);

--- a/packages/backup-worker/src/engine/staging.test.ts
+++ b/packages/backup-worker/src/engine/staging.test.ts
@@ -57,16 +57,17 @@ describe('stageServiceBackup', () => {
     expect(staged).toContain('configuration.yaml');
   });
 
-  it('applies strip rules (password hashes never enter the tar)', async () => {
+  it('applies strip rules (secrets never enter the tar)', async () => {
+    // hermes strips LLM api keys from config.yaml before it enters the tarball.
     const src = await mkTmp();
-    await write(src, 'users_database.yml', 'users:\n  a:\n    password: $argon2$SEKRIT\n    email: a@x\n');
+    await write(src, 'config.yaml', 'api_key: SEKRIT\nmodel: gemma-e4b\n');
     const staging = await mkTmp();
 
-    await stageServiceBackup(src, getServiceManifest('authelia')!, staging);
+    await stageServiceBackup(src, getServiceManifest('hermes')!, staging);
 
-    const out = await fs.readFile(path.join(staging, 'users_database.yml'), 'utf8');
+    const out = await fs.readFile(path.join(staging, 'config.yaml'), 'utf8');
     expect(out).not.toContain('SEKRIT');
-    expect(out).toContain('a@x');
+    expect(out).toContain('gemma-e4b');
   });
 
   it('stages a renamed source path under its canonical tar name', async () => {

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/decideNginxOnline.test.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/decideNginxOnline.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { decideNginxOnline } from './route';
+
+// #2156 — after NPM returns HTTP 200 for a created host, the caller reads
+// the live meta.nginx_online and flags the step when nginx refused the conf.
+// This exercises that decision (the flag-the-step path) without standing up
+// the whole POST handler.
+describe('decideNginxOnline', () => {
+    it('treats nginx_online=false as a failure and surfaces nginx_err', () => {
+        const r = decideNginxOnline({
+            nginx_online: false,
+            nginx_err: 'nginx: [emerg] duplicate location "/.well-known/acme-challenge/"',
+        });
+        expect(r.online).toBe(false);
+        expect(r.err).toMatch(/duplicate location/);
+    });
+
+    it('supplies a fallback message when nginx_online=false but nginx_err is empty', () => {
+        const r = decideNginxOnline({ nginx_online: false, nginx_err: null });
+        expect(r.online).toBe(false);
+        expect(r.err).toMatch(/reverted the conf/);
+    });
+
+    it('is fail-open: nginx_online=true is online', () => {
+        expect(decideNginxOnline({ nginx_online: true }).online).toBe(true);
+    });
+
+    it('is fail-open: undefined meta / undefined status is online', () => {
+        expect(decideNginxOnline(undefined).online).toBe(true);
+        expect(decideNginxOnline({}).online).toBe(true);
+    });
+});

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -627,13 +627,24 @@ async function patchProxyHostConfFile(
         if (testFailed) {
             // Roll the offending host back to its pre-patch conf so it can't
             // crash the proxy; the patch we just wrote never gets loaded.
-            await agent.sendCommand('write_file', { path: confPath, content, sudo: true }).catch(() => {});
+            // #2156 — a failing rollback write leaves the crashing patch on
+            // disk, so log the command error instead of swallowing it: the
+            // operator (and box-verify) needs to know the quarantine itself
+            // didn't take.
+            await agent.sendCommand('write_file', { path: confPath, content, sudo: true }).catch((e: unknown) => {
+                logger.error('ProxyHosts', `Rollback write of ${confPath} for ${domain} FAILED — the rejected patch may still be on disk: ${e instanceof Error ? e.message : String(e)}`);
+            });
             const reason = `nginx -t rejected the patched config for ${domain}; quarantined (kept previous conf). ${testOut.split('\n').find(l => /\[emerg\]/i.test(l))?.trim() ?? testRes?.error ?? ''}`.trim();
             logger.warn('ProxyHosts', reason);
             return { patched: false, reason };
         }
         // Reload nginx to pick up the change (config validated above).
-        await agent.sendCommand('exec', { command: 'podman exec nginx-nginx-proxy-manager nginx -s reload' }).catch(() => {});
+        // #2156 — a `nginx -s reload` failure here leaves stale routing with
+        // zero breadcrumb; log the command error so a silently-dead reload is
+        // visible in the install log / journal instead of vanishing.
+        await agent.sendCommand('exec', { command: 'podman exec nginx-nginx-proxy-manager nginx -s reload' }).catch((e: unknown) => {
+            logger.warn('ProxyHosts', `nginx -s reload after patching ${domain} FAILED — routing may be stale: ${e instanceof Error ? e.message : String(e)}`);
+        });
         logger.info('ProxyHosts', `Patched ${domain} location / with forward-auth headers${upstreamHostHeader ? ` + Host=${upstreamHostHeader}` : ''}`);
         return { patched: true };
     } catch (e) {
@@ -744,6 +755,53 @@ async function createProxyHost(baseUrl: string, token: string, host: ProxyHostRe
         throw new Error(err.message || `NPM API returned ${res.status}`);
     }
     return await res.json();
+}
+
+/**
+ * #2156 — NPM returns HTTP 200 the instant it writes a host's DB row, but
+ * the row's `meta.nginx_online` only flips true once nginx actually loaded
+ * the generated conf. A bad advanced_config (e.g. the duplicate
+ * acme-challenge location that reverted the buerolicht host) makes nginx
+ * reject the conf: NPM sets `nginx_online:false` and stashes the `[emerg]`
+ * text in `nginx_err` — but the create call already returned 200. This
+ * fetches the live host record so the caller can surface `nginx_err` and
+ * flag the step instead of reporting a green create for a dead route.
+ *
+ * Returns `{ online: true }` on success or when the status can't be read
+ * (fail-open: an unreadable status must not turn a working create red).
+ */
+/**
+ * Pure decision for a fetched host's meta: only `nginx_online === false`
+ * is a definite failure. `undefined`/`true` (older NPM, or the status not
+ * yet computed) stays online to be fail-open. Exported for unit testing
+ * the flag-the-step path without standing up the whole POST handler.
+ */
+export function decideNginxOnline(
+    meta: { nginx_online?: boolean; nginx_err?: string | null } | undefined,
+): { online: boolean; err?: string } {
+    if (meta?.nginx_online === false) {
+        return { online: false, err: (meta.nginx_err ?? '').trim() || 'nginx reverted the conf (no error text recorded)' };
+    }
+    return { online: true };
+}
+
+async function checkNginxOnline(
+    baseUrl: string,
+    token: string,
+    hostId: number,
+): Promise<{ online: boolean; err?: string }> {
+    try {
+        const res = await fetch(`${baseUrl}/api/nginx/proxy-hosts/${hostId}`, {
+            method: 'GET',
+            headers: { 'Authorization': `Bearer ${token}` },
+            signal: AbortSignal.timeout(10_000),
+        });
+        if (!res.ok) return { online: true };
+        const h = (await res.json()) as { meta?: { nginx_online?: boolean; nginx_err?: string | null } };
+        return decideNginxOnline(h.meta);
+    } catch {
+        return { online: true };
+    }
 }
 
 /**
@@ -1003,7 +1061,7 @@ export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request })
         const errorPageDomain = publicDomain ?? config.reverseProxy?.publicDomain;
         await deployProxyErrorPages(errorPageDomain, node);
 
-        const results: { domain: string; success: boolean; error?: string; certIssued?: boolean; certError?: string; lanRestricted?: boolean }[] = [];
+        const results: { domain: string; success: boolean; error?: string; certIssued?: boolean; certError?: string; lanRestricted?: boolean; nginxOffline?: boolean; nginxErr?: string }[] = [];
 
         // The `__authelia_forward_auth__` sentinel is normally expanded by the
         // STACK INSTALLER (postInstall) right before Mustache renders. A DIRECT
@@ -1148,6 +1206,27 @@ export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request })
                     }
                 }
             }
+
+            // #2156 — NPM's create/cert-bind/patch all returned "ok", but the
+            // route only actually routes if nginx loaded the conf. Read the
+            // live meta.nginx_online now (after cert-bind + any re-patch have
+            // settled): a bad advanced_config makes nginx revert the conf and
+            // NPM records the [emerg] reason in nginx_err while still having
+            // answered 200. Surface it in the install log and flag the step so
+            // a dead route isn't reported green.
+            if (typeof createdHost?.id === 'number') {
+                const onlineStatus = await checkNginxOnline(npm.apiUrl, token, createdHost.id);
+                if (!onlineStatus.online) {
+                    const last = results[results.length - 1];
+                    last.nginxOffline = true;
+                    last.nginxErr = onlineStatus.err;
+                    // Flag the step: a route nginx refused to load is not a
+                    // successful create, even though NPM's API said 200.
+                    last.success = false;
+                    last.error = last.error ?? `nginx refused the conf (nginx_online=false): ${onlineStatus.err}`;
+                    logger.error('ProxyHosts', `Route ${host.domain} created in NPM but nginx_online=false — traffic will 000/502. nginx_err: ${onlineStatus.err}`);
+                }
+            }
         }
 
         const created = results.filter(r => r.success);
@@ -1222,6 +1301,14 @@ export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request })
             // are still publicly reachable — the diagnose UI is the
             // recovery path).
             lanRestricted: results.filter(r => r.lanRestricted).map(r => r.domain),
+            // #2156 — hosts NPM created (HTTP 200) but nginx refused to load
+            // (meta.nginx_online=false). These also appear in `failed[]`; this
+            // array carries the [emerg] reason so the wizard can name the
+            // nginx error, and the nginx_online_failed diagnose probe is the
+            // recovery path.
+            nginxOffline: results
+                .filter(r => r.nginxOffline)
+                .map(r => ({ domain: r.domain, nginx_err: r.nginxErr })),
             adminUrl: npm.apiUrl,
             node: npm.nodeName,
         });

--- a/scripts/check-backup-coverage.ts
+++ b/scripts/check-backup-coverage.ts
@@ -1,0 +1,128 @@
+/**
+ * Backup-coverage contract (#2153).
+ *
+ * Every template that declares a PERSISTENT host volume must either:
+ *   (a) be covered by a `SERVICE_BACKUP_MANIFESTS` entry (its config lands in
+ *       the NAS tarball on reinstall), OR
+ *   (b) be listed in `EXCLUDED_BULK_VOLUMES` with a reason (deliberately not
+ *       backed up — bulk / regenerable / credential-coupled data).
+ *
+ * This closes the silent-opt-out gap: before #2153 a new template could ship a
+ * `{{DATA_DIR}}/…` hostPath and lose all its state on a disk-loss reinstall with
+ * nothing to catch it. This check fails CI when a persistent volume is neither
+ * covered nor explicitly excluded.
+ *
+ * A volume is COVERED by a manifest when its `{{DATA_DIR}}`-relative path equals
+ * or is nested under a manifest's data dir (`dataSubdir ?? service`) — e.g. the
+ * `adguard/work` + `adguard/conf` volumes are both under the `adguard` manifest,
+ * and `file-share/samba-private` is under the `file-share` manifest.
+ *
+ * Exits 0 (all covered) or 1 (one or more uncovered volumes).
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import {
+  SERVICE_BACKUP_MANIFESTS,
+  EXCLUDED_BULK_VOLUMES,
+} from '../packages/backend/src/lib/externalBackup/serviceManifest.js';
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TEMPLATES_DIR = path.join(REPO_ROOT, 'templates');
+
+/** A persistent volume declared by a template. */
+interface TemplateVolume {
+  template: string;
+  /** The raw `path:` value, e.g. `{{DATA_DIR}}/vaultwarden` or `{{JELLYFIN_MEDIA_PATH}}`. */
+  raw: string;
+  /** Coverage key: `{{DATA_DIR}}`-relative subpath, or the bare `{{VAR}}` token. */
+  key: string;
+}
+
+/**
+ * A hostPath volume is a candidate for the backup contract when it points at
+ * the box's persistent data root (`{{DATA_DIR}}/…`) or a whole-volume variable
+ * (`{{SOME_MEDIA_PATH}}`). Device passthroughs (`{{ZWAVE_DEVICE}}`) and in-pod /
+ * ephemeral mounts are NOT persistent household state — a volume rooted at a
+ * bare device/`/dev`/`/run` path is skipped. We include `{{DATA_DIR}}/…` and any
+ * single `{{VAR}}` whose name reads like a data path (ends in `_PATH`/`_DIR`).
+ */
+function toCoverageKey(raw: string): string | null {
+  const dataDir = raw.match(/^\{\{DATA_DIR\}\}\/(.+)$/);
+  if (dataDir) return dataDir[1].replace(/\/+$/, '');
+  const bareVar = raw.match(/^\{\{([A-Z0-9_]+)\}\}$/);
+  if (bareVar) {
+    const name = bareVar[1];
+    if (name === 'DATA_DIR') return null; // the root itself, not a leaf volume
+    if (/_(PATH|DIR)$/.test(name)) return raw.slice(2, -2); // e.g. JELLYFIN_MEDIA_PATH
+    return null; // device/port/other vars — not a persistent data volume
+  }
+  return null; // absolute host paths (devices, /run, in-pod) — not our contract
+}
+
+/** Extract every `path:` under a `hostPath:` block from a template's YAML text. */
+function extractHostPathVolumes(template: string, yamlText: string): TemplateVolume[] {
+  const lines = yamlText.split('\n');
+  const vols: TemplateVolume[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*hostPath:\s*$/.test(lines[i])) continue;
+    // The `path:` belongs to this hostPath block — scan the next few lines.
+    for (let j = i + 1; j < Math.min(i + 4, lines.length); j++) {
+      const m = lines[j].match(/^\s*path:\s*(\S+)\s*$/);
+      if (m) {
+        const raw = m[1];
+        const key = toCoverageKey(raw);
+        if (key) vols.push({ template, raw, key });
+        break;
+      }
+      if (/^\s*hostPath:\s*$/.test(lines[j])) break; // next block — malformed, bail
+    }
+  }
+  return vols;
+}
+
+/** The `{{DATA_DIR}}`-relative data dir a manifest owns (dataSubdir ?? service). */
+function manifestDataDirs(): string[] {
+  return SERVICE_BACKUP_MANIFESTS.map(m => (m.dataSubdir ?? m.service).replace(/\/+$/, ''));
+}
+
+/** Is `key` equal to, or nested under, any covered root in `roots`? */
+function isUnder(key: string, roots: string[]): boolean {
+  return roots.some(root => key === root || key.startsWith(root + '/'));
+}
+
+function main(): void {
+  const manifestRoots = manifestDataDirs();
+  const excludedRoots = Object.keys(EXCLUDED_BULK_VOLUMES).map(k => k.replace(/\/+$/, ''));
+
+  const templates = readdirSync(TEMPLATES_DIR, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name);
+
+  const uncovered: TemplateVolume[] = [];
+  let checked = 0;
+
+  for (const template of templates) {
+    const tmplPath = path.join(TEMPLATES_DIR, template, 'template.yml');
+    if (!existsSync(tmplPath)) continue;
+    const vols = extractHostPathVolumes(template, readFileSync(tmplPath, 'utf8'));
+    for (const vol of vols) {
+      checked++;
+      const covered = isUnder(vol.key, manifestRoots) || isUnder(vol.key, excludedRoots);
+      if (!covered) uncovered.push(vol);
+    }
+  }
+
+  if (uncovered.length > 0) {
+    console.error('✗ backup-coverage contract (#2153): persistent volume(s) with no manifest entry and no EXCLUDED_BULK_VOLUMES marker:\n');
+    for (const v of uncovered) {
+      console.error(`  ${v.template}: ${v.raw}`);
+    }
+    console.error('\nAdd a SERVICE_BACKUP_MANIFESTS entry for it, or list it in EXCLUDED_BULK_VOLUMES with a reason.');
+    console.error('Both live in packages/backend/src/lib/externalBackup/serviceManifest.ts (mirror the worker copy).');
+    process.exit(1);
+  }
+
+  console.log(`✓ backup-coverage: ${checked} persistent template volume(s) all covered (manifest or explicit bulk-exclude).`);
+}
+
+main();

--- a/tests/backend/backup_roundtrip.test.ts
+++ b/tests/backend/backup_roundtrip.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Backup round-trip integration test (#2154).
+ *
+ * The #1584 lesson — "the restore mechanism fired, the payload was empty, nobody
+ * noticed" — was never encoded as a test. This exercises the FULL cycle against
+ * REAL code, per manifest-covered service shape:
+ *
+ *   seed fixtures matching the manifest include-set
+ *     → produce the tar   (backup-worker `buildServiceBackupTar` — the real staging path)
+ *     → wipe the data dir  (rm -rf, simulating a disk-loss reinstall)
+ *     → restore            (`safeTarExtract` — the real #580-hardened restore path)
+ *     → assert every included file's CONTENT round-tripped
+ *     → assert `strip` rules removed the secrets
+ *
+ * Crucially it FAILS on silent path drift: if a manifest `include` entry stops
+ * matching a real seeded file, `buildServiceBackupTar` stages nothing and throws
+ * "No config files to back up" — exactly the drift #2154 asks us to catch (e.g.
+ * the old authelia `users_database.yml` mismatch).
+ *
+ * Requires GNU tar on $PATH (same as backup_restore_security.test.ts); skipped
+ * automatically if absent.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { buildServiceBackupTar } from '../../packages/backup-worker/src/engine/staging';
+import { getServiceManifest } from '../../packages/backup-worker/src/engine/serviceManifest';
+import { safeTarExtract } from '@/lib/systemBackup';
+
+function tarPresent(): boolean {
+  try {
+    execFileSync('tar', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const maybeIt = tarPresent() ? it : it.skip;
+
+let tmpDirs: string[] = [];
+async function mkTmp(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), `sb-roundtrip-${prefix}-`));
+  tmpDirs.push(dir);
+  return dir;
+}
+async function write(base: string, rel: string, content: string): Promise<void> {
+  const full = path.join(base, rel);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, content);
+}
+async function read(base: string, rel: string): Promise<string> {
+  return fs.readFile(path.join(base, rel), 'utf8');
+}
+
+beforeEach(() => { tmpDirs = []; });
+afterEach(async () => {
+  await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+});
+
+/**
+ * Run one full backup→wipe→restore cycle for a service and return the restored
+ * data dir. `seed` writes the fixtures; the tar is built from `src` (which is
+ * then wiped), and extracted into a fresh dir.
+ */
+async function roundTrip(
+  service: string,
+  seed: (src: string) => Promise<void>,
+): Promise<string> {
+  const manifest = getServiceManifest(service)!;
+  expect(manifest, `manifest for ${service} must exist`).toBeDefined();
+  const src = await mkTmp(`${service}-src`);
+  await seed(src);
+
+  const tarDir = await mkTmp(`${service}-tar`);
+  const tarPath = path.join(tarDir, `${service}.tar`);
+  const { files } = await buildServiceBackupTar(src, manifest, tarPath);
+  expect(files, 'the manifest include-set must match seeded files (path-drift guard)').toBeGreaterThan(0);
+
+  // Wipe — the disk-loss reinstall.
+  await fs.rm(src, { recursive: true, force: true });
+
+  // Restore through the real hardened extract path. buildServiceBackupTar makes
+  // a plain (non-gzip) tar, so gzip:false.
+  const restored = await mkTmp(`${service}-restored`);
+  await safeTarExtract(tarPath, restored, { gzip: false });
+  return restored;
+}
+
+describe('backup round-trip (#2154) — content survives backup→wipe→restore', () => {
+  maybeIt('adguard: config content round-trips, querylog is not backed up', async () => {
+    const restored = await roundTrip('adguard', async src => {
+      await write(src, 'conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0\nusers:\n  - name: admin\n');
+      await write(src, 'data/querylog.json', '[{"secret":"log"}]'); // excluded
+    });
+    expect(await read(restored, 'conf/AdGuardHome.yaml')).toContain('bind_host: 0.0.0.0');
+    // The excluded bulk file never entered the tarball.
+    await expect(fs.access(path.join(restored, 'data/querylog.json'))).rejects.toThrow();
+  });
+
+  maybeIt('lldap: users.db identity store round-trips verbatim (#2153)', async () => {
+    const restored = await roundTrip('lldap', async src => {
+      await write(src, 'users.db', 'SQLITE-IDENTITY-BYTES');
+    });
+    expect(await read(restored, 'users.db')).toBe('SQLITE-IDENTITY-BYTES');
+  });
+
+  maybeIt('vaultwarden: vault db + JWT keys round-trip, attachments excluded (#2153)', async () => {
+    const restored = await roundTrip('vaultwarden', async src => {
+      await write(src, 'db.sqlite3', 'VAULT-CIPHERTEXT');
+      await write(src, 'rsa_key.pem', 'PRIVATE-JWT-KEY');
+      await write(src, 'config.json', '{"domain":"vault.dopp.cloud"}');
+      await write(src, 'attachments/big.bin', 'HEAVY-USER-DATA'); // excluded/data
+    });
+    expect(await read(restored, 'db.sqlite3')).toBe('VAULT-CIPHERTEXT');
+    expect(await read(restored, 'rsa_key.pem')).toBe('PRIVATE-JWT-KEY');
+    expect(await read(restored, 'config.json')).toContain('vault.dopp.cloud');
+    await expect(fs.access(path.join(restored, 'attachments/big.bin'))).rejects.toThrow();
+  });
+
+  maybeIt('radicale: calendar/contact collections round-trip (#2153)', async () => {
+    const restored = await roundTrip('radicale', async src => {
+      await write(src, 'collections/collection-root/user/calendar.ics', 'BEGIN:VCALENDAR');
+    });
+    expect(await read(restored, 'collections/collection-root/user/calendar.ics')).toBe('BEGIN:VCALENDAR');
+  });
+
+  maybeIt('jellyfin: server config + db round-trip, caches/metadata excluded (#2153)', async () => {
+    const restored = await roundTrip('jellyfin', async src => {
+      await write(src, 'config/system.xml', '<ServerConfiguration/>');
+      await write(src, 'data/jellyfin.db', 'JELLYFIN-USERS-DB');
+      await write(src, 'metadata/artwork/poster.jpg', 'BULK-ARTWORK'); // excluded
+      await write(src, 'cache/temp', 'REGENERABLE'); // excluded
+    });
+    expect(await read(restored, 'config/system.xml')).toContain('ServerConfiguration');
+    expect(await read(restored, 'data/jellyfin.db')).toBe('JELLYFIN-USERS-DB');
+    await expect(fs.access(path.join(restored, 'metadata/artwork/poster.jpg'))).rejects.toThrow();
+    await expect(fs.access(path.join(restored, 'cache/temp'))).rejects.toThrow();
+  });
+
+  maybeIt('file-share: samba passdb + filebrowser config round-trip (#2153)', async () => {
+    const restored = await roundTrip('file-share', async src => {
+      await write(src, 'samba-private/passdb.tdb', 'SAMBA-ACCOUNTS');
+      await write(src, 'filebrowser-db/filebrowser.db', 'FB-USERS');
+      await write(src, 'filebrowser-config/settings.json', '{"port":80}');
+    });
+    expect(await read(restored, 'samba-private/passdb.tdb')).toBe('SAMBA-ACCOUNTS');
+    expect(await read(restored, 'filebrowser-db/filebrowser.db')).toBe('FB-USERS');
+    expect(await read(restored, 'filebrowser-config/settings.json')).toContain('"port":80');
+  });
+
+  maybeIt('authelia: db.sqlite3 secret store round-trips, legacy YAML is gone (#2153)', async () => {
+    const restored = await roundTrip('authelia', async src => {
+      await write(src, 'db.sqlite3', 'TOTP-WEBAUTHN-SECRETS');
+      // The legacy file-backend YAML is no longer in the include-set — seeding
+      // it must NOT make it into the tar (it's dead state).
+      await write(src, 'users_database.yml', 'users:\n  a:\n    password: LEGACY\n');
+    });
+    expect(await read(restored, 'db.sqlite3')).toBe('TOTP-WEBAUTHN-SECRETS');
+    await expect(fs.access(path.join(restored, 'users_database.yml'))).rejects.toThrow();
+  });
+
+  maybeIt('hermes: strip removes LLM api keys before the tar (secret never lands)', async () => {
+    const restored = await roundTrip('hermes', async src => {
+      await write(src, 'config.yaml', 'api_key: SUPER-SECRET-KEY\nmodel: gemma-e4b\n');
+    });
+    const cfg = await read(restored, 'config.yaml');
+    // The strip rule removed the secret but kept the rest of the config.
+    expect(cfg).not.toContain('SUPER-SECRET-KEY');
+    expect(cfg).toContain('gemma-e4b');
+  });
+
+  maybeIt('path-drift guard: a manifest include that matches nothing fails the round-trip', async () => {
+    // Seed a file that does NOT match any include (mimics a manifest path that
+    // silently stopped matching real template paths). buildServiceBackupTar must
+    // throw rather than ship an empty backup unnoticed.
+    await expect(
+      roundTrip('lldap', async src => {
+        await write(src, 'wrong-name.db', 'ORPHANED');
+      }),
+    ).rejects.toThrow(/No config files/);
+  });
+});


### PR DESCRIPTION
## What
Batch of install/backup/proxy reliability fixes plus a release-image smoke gate.

## Why
Closes #2153
Closes #2154
Closes #2156
Closes #2157
Closes #2155
Closes #2162
Closes #2158
Closes #2160
Closes #2161

- **backup**: close manifest coverage gaps, add a round-trip test + a CI backup-coverage contract.
- **nginx**: stop swallowing reload / nginx_online failures on proxy hosts.
- **reverseProxy**: set `busy_timeout` + WAL on the NPM rekey DB open (SQLite `database is locked` on rekey).
- **release CI**: smoke-test the built image before pushing `:latest`; align build-images PR paths.
- **install**: surface silent install / capability-handler / NAS-restore failures via a persistent store + `install_handler_failed` diagnose probe with a retry/reconcile action.
- follow-up build fix: import `EmitResult` from `capabilities/types` (the canonical contract) instead of `capabilities/bus`, which doesn't re-export it — the Next.js build caught the unresolved import.

## Risk
Medium — touches path-mandated install/backup/proxy paths; owed a `:dev` box `/verify`.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run check:arch
- [x] npm test (full — 3434 passed, 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated paths present)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._