### PR TITLE
fix(network): anchor floating map nodes after ubiquitous-dep suppression

### DIFF
--- a/packages/backend/src/lib/network/inferredEdges.test.ts
+++ b/packages/backend/src/lib/network/inferredEdges.test.ts
@@ -6,6 +6,7 @@ import {
   type EnvSource,
   type EnvInferenceTarget,
 } from './inferredEdges';
+import { suppressUbiquitousDeps } from './ubiquitousDeps';
 import type { NetworkEdge, NetworkNode } from './types';
 
 describe('parseEnvHostPort (#2175)', () => {
@@ -185,5 +186,96 @@ describe('anchorFloatingNodes — fallback anchor (#2175)', () => {
       svc('service-child.service', { parentNode: 'group-parent' }),
     ];
     expect(anchorFloatingNodes(nodes, [], 'gateway')).toHaveLength(0);
+  });
+});
+
+// Ordering regression (#2175 box-verify #4 red): the anchor pass must run on
+// the POST-suppression edge set. A service node whose ONLY edge is a
+// suppressible ubiquitous dep (claude-dev→auth) looks "connected" before
+// suppression but ends edge-less after — it MUST get an anchor. This encodes
+// the exact getGraph sequence: suppressUbiquitousDeps → anchorFloatingNodes.
+describe('anchor after ubiquitous-dep suppression — ordering (#2175)', () => {
+  const svc = (id: string, extra: Partial<NetworkNode> = {}): NetworkNode => ({
+    id,
+    type: 'service',
+    label: id,
+    status: 'up',
+    ...extra,
+  });
+
+  it('anchors a node whose ONLY edge is a suppressed auth dep', () => {
+    const nodes: NetworkNode[] = [
+      svc('service-auth.service'),
+      svc('service-claude-dev.service'),
+    ];
+    // claude-dev's sole edge is a declared dependency on the auth hub.
+    const edges: NetworkEdge[] = [
+      {
+        id: 'declared-claude-dev-auth',
+        source: 'service-claude-dev.service',
+        target: 'service-auth.service',
+        protocol: 'tcp',
+        port: 0,
+        state: 'active',
+        kind: 'declared',
+      },
+    ];
+
+    // Step 1 — suppression removes the claude-dev→auth hub-spoke edge.
+    const { edges: afterSuppress, suppressed } = suppressUbiquitousDeps(nodes, edges);
+    expect(suppressed).toBe(1);
+    expect(afterSuppress).toHaveLength(0);
+
+    // Step 2 — anchoring on the post-suppression set now anchors claude-dev
+    // (it would NOT have been anchored on the pre-suppression `edges`, which
+    // is exactly the box-verify #4 bug).
+    const anchors = anchorFloatingNodes(nodes, afterSuppress, 'gateway');
+    const claudeDevAnchor = anchors.find(
+      (a) => a.target === 'service-claude-dev.service',
+    );
+    expect(claudeDevAnchor).toBeDefined();
+    expect(claudeDevAnchor).toMatchObject({ source: 'gateway', kind: 'inferred' });
+
+    // The claude-dev card ends with >=1 edge.
+    const finalEdges = [...afterSuppress, ...anchors];
+    expect(
+      finalEdges.some(
+        (e) =>
+          e.source === 'service-claude-dev.service' ||
+          e.target === 'service-claude-dev.service',
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT anchor a node that keeps a real surviving edge after suppression', () => {
+    const nodes: NetworkNode[] = [
+      svc('service-auth.service'),
+      svc('service-webapp.service'),
+    ];
+    // webapp has an auth dep (suppressed) AND a real gateway edge (survives).
+    const edges: NetworkEdge[] = [
+      {
+        id: 'declared-webapp-auth',
+        source: 'service-webapp.service',
+        target: 'service-auth.service',
+        protocol: 'tcp',
+        port: 0,
+        state: 'active',
+        kind: 'declared',
+      },
+      {
+        id: 'gateway-webapp',
+        source: 'gateway',
+        target: 'service-webapp.service',
+        protocol: 'tcp',
+        port: 443,
+        state: 'active',
+      },
+    ];
+
+    const { edges: afterSuppress } = suppressUbiquitousDeps(nodes, edges);
+    const anchors = anchorFloatingNodes(nodes, afterSuppress, 'gateway');
+    // No anchor for webapp — its gateway edge survived (no double edge).
+    expect(anchors.find((a) => a.target === 'service-webapp.service')).toBeUndefined();
   });
 });

--- a/packages/backend/src/lib/network/service.ts
+++ b/packages/backend/src/lib/network/service.ts
@@ -309,6 +309,25 @@ export class NetworkService {
       logger.info('NetworkService', `Suppressed ${suppressed} ubiquitous hub-spoke edge(s) (auth/dns) into node badges`);
     }
 
+    // 6. Fallback anchor (#2175) — runs on the POST-suppression edge set so a
+    // service node whose ONLY edge was a suppressed ubiquitous dep (e.g.
+    // claude-dev→auth) now anchors to the host root (`gateway`) instead of
+    // floating. Must run here in getGraph, not per-node in getNodeGraph: the
+    // suppression that leaves such a node edge-less is global (#1785), so the
+    // anchor decision is only correct against the final merged+suppressed
+    // edges over all nodes. `anchorFloatingNodes` already skips nodes that
+    // still have a surviving edge (no double-anchor) and preserves the #2175
+    // anchor-edge kind/style.
+    try {
+      const anchors = anchorFloatingNodes(allNodes, deUbiquitousEdges, 'gateway');
+      if (anchors.length > 0) {
+        logger.info('NetworkService', `Anchored ${anchors.length} floating service node(s) to gateway after suppression`);
+      }
+      deUbiquitousEdges.push(...anchors);
+    } catch (e) {
+      logger.warn('NetworkService', `fallback-anchor synthesis skipped: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
     return { nodes: allNodes, edges: deUbiquitousEdges };
   }
 
@@ -2015,14 +2034,12 @@ export class NetworkService {
       logger.warn('NetworkService', `inferred-edge synthesis skipped: ${e instanceof Error ? e.message : String(e)}`);
     }
 
-    // #2175 — fallback anchor. Any service node still edge-less anchors to
-    // the host root (`gateway`) so no card renders fully disconnected.
-    try {
-      const anchors = anchorFloatingNodes(nodes, mergedEdges, routerId);
-      mergedEdges.push(...anchors);
-    } catch (e) {
-      logger.warn('NetworkService', `fallback-anchor synthesis skipped: ${e instanceof Error ? e.message : String(e)}`);
-    }
+    // #2175 — the fallback-anchor pass does NOT run here. It must operate on
+    // the POST-suppression edge set (a node whose only edge is a suppressible
+    // ubiquitous dep — e.g. claude-dev→auth — looks "connected" at this
+    // per-node stage but ends edge-less once getGraph's suppressUbiquitousDeps
+    // drops that edge). anchorFloatingNodes is called in getGraph AFTER
+    // suppression, over the merged+suppressed edge set (#2175 order fix).
 
     return { nodes, edges: mergedEdges };
   }


### PR DESCRIPTION
Closes #2175 (box-verify #4 forward-fix: claude-dev no longer floats)

Moved the anchorFloatingNodes pass out of getNodeGraph and into getGraph so it runs AFTER suppressUbiquitousDeps, over the final merged+suppressed edge set — a node whose sole edge was a suppressed ubiquitous dep (claude-dev->auth) now still gets a gateway anchor instead of ending with zero edges.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._