### PR TITLE
fix(frontend): async button feedback + Escape-close; test: cover reset/authelia/crashloop/backup-collector

### DIFF
--- a/packages/backend/src/lib/diagnose/isContainerCurrentlyStable.test.ts
+++ b/packages/backend/src/lib/diagnose/isContainerCurrentlyStable.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isContainerCurrentlyStable, restartCountIndicatesLoop } from './runDiagnose';
+import { isContainerCurrentlyStable, restartCountIndicatesLoop, psLineIndicatesLoop } from './runDiagnose';
 
 // The cumulative-RestartCount crash-loop signal is gated on this predicate so a
 // container with a high LIFETIME restart count that has since been up for hours
@@ -41,5 +41,66 @@ describe('restartCountIndicatesLoop', () => {
   });
   it('never trips on a non-numeric / NaN count', () => {
     expect(restartCountIndicatesLoop(NaN, 'Restarting', T)).toBe(false);
+  });
+});
+
+// psLineIndicatesLoop is the FULL per-container crash-loop verdict the crash_loop
+// probe applies to each `podman ps` row — the composite decision path (restart-count
+// first, then status heuristics gated on treatYoungAsLoop). Pinning it directly keeps
+// the orchestrator's crash_loop branch from silently flipping (a boundary/inversion
+// slip there masks a crash-looping service as green — memory: "don't mask failures").
+describe('psLineIndicatesLoop', () => {
+  const T = 3;
+  const past = { treatYoungAsLoop: true, threshold: T }; // system past its boot/install grace
+  const grace = { treatYoungAsLoop: false, threshold: T }; // still inside grace (fresh boot/install)
+
+  describe('detects a genuine restart loop', () => {
+    it('flags an explicit Restarting status regardless of grace or count', () => {
+      expect(psLineIndicatesLoop('Restarting (1) 2 seconds ago', 0, past)).toBe(true);
+      // Restarting fires even inside the grace window — it is unambiguous.
+      expect(psLineIndicatesLoop('Restarting (1) 2 seconds ago', 0, grace)).toBe(true);
+    });
+    it('flags an Initialized (never-started) container', () => {
+      expect(psLineIndicatesLoop('Initialized', 0, past)).toBe(true);
+      expect(psLineIndicatesLoop('Initialized', 0, grace)).toBe(true);
+    });
+    it('flags a high cumulative restart count on a not-currently-stable container', () => {
+      // Authelia #622 had 13801 restarts, freshly-up — fires even through the grace window.
+      expect(psLineIndicatesLoop('Up 4 seconds', 13801, grace)).toBe(true);
+      expect(psLineIndicatesLoop('Up 4 seconds', 3, past)).toBe(true);
+    });
+    it('flags a young Up container once past the boot/install grace window', () => {
+      expect(psLineIndicatesLoop('Up 29 seconds', 0, past)).toBe(true);
+      expect(psLineIndicatesLoop('Up Less than a second', 0, past)).toBe(true);
+    });
+  });
+
+  describe('healthy / all-stable case', () => {
+    it('does NOT flag a long-stable container with no restarts', () => {
+      for (const s of ['Up 44 hours', 'Up 2 days', 'Up 5 minutes', 'Up About a minute', 'Up About an hour']) {
+        expect(psLineIndicatesLoop(s, 0, past)).toBe(false);
+      }
+    });
+  });
+
+  describe('no false positive on a normal restart', () => {
+    it('does NOT flag a high LIFETIME count on a container that is now long-stable', () => {
+      // solaris-tts-bridge: RestartCount=24 yet Up 44h → historical, not an active loop.
+      expect(psLineIndicatesLoop('Up 44 hours', 24, past)).toBe(false);
+      expect(psLineIndicatesLoop('Up 5 minutes', 99, past)).toBe(false);
+    });
+    it('does NOT flag a below-threshold count on its own (sporadic OOM recovery)', () => {
+      // 1-2 restarts on an otherwise-stable container is not a loop.
+      expect(psLineIndicatesLoop('Up 10 minutes', 2, past)).toBe(false);
+    });
+    it('does NOT flag a young container while still inside the boot/install grace window', () => {
+      // Right after boot/install every container is young — expected, not a loop.
+      expect(psLineIndicatesLoop('Up 5 seconds', 0, grace)).toBe(false);
+      expect(psLineIndicatesLoop('Up Less than a second', 0, grace)).toBe(false);
+    });
+    it('respects the 30s boundary once past grace (30s is not young enough to be a loop)', () => {
+      expect(psLineIndicatesLoop('Up 30 seconds', 0, past)).toBe(false);
+      expect(psLineIndicatesLoop('Up 29 seconds', 0, past)).toBe(true);
+    });
   });
 });

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -194,6 +194,38 @@ export function restartCountIndicatesLoop(restartCount: number, status: string, 
   return Number.isFinite(restartCount) && restartCount >= threshold && !isContainerCurrentlyStable(status);
 }
 
+/**
+ * The complete per-container crash-loop verdict for one `podman ps` row, given
+ * its Status string, cumulative RestartCount, and whether the system has been up
+ * long enough that a *young* container must be a fresh restart (`treatYoungAsLoop`).
+ * This is the exact decision path the `crash_loop` probe applies to each line;
+ * factored out (and exported) so the boundary/inversion cases are unit-testable
+ * without standing up the whole diagnose orchestrator:
+ *  - a restart-count at/over `threshold` on a not-currently-stable container → loop
+ *    (the only signal that survives the boot/install grace window);
+ *  - an explicit `Restarting…`/`Initialized…` status → loop;
+ *  - once past the grace window (`treatYoungAsLoop`), a container up < 30 s (or
+ *    "Up Less than a second") → loop; below the grace window young is expected → not a loop.
+ * A high lifetime count on a long-stable container (Up hours) does NOT fire (the
+ * solaris-tts-bridge false positive), and a below-threshold count never fires on
+ * its own. Order matters: the restart-count check runs first, then status.
+ */
+export function psLineIndicatesLoop(
+  status: string,
+  restartCount: number,
+  opts: { treatYoungAsLoop: boolean; threshold: number },
+): boolean {
+  const s = status.trim();
+  if (restartCountIndicatesLoop(restartCount, s, opts.threshold)) return true;
+  if (/^Restarting/i.test(s)) return true;
+  if (/^Initialized/i.test(s)) return true;
+  if (!opts.treatYoungAsLoop) return false;
+  if (/^Up Less than a second/i.test(s)) return true;
+  const m = s.match(/^Up (\d+) seconds?\b/);
+  if (m && parseInt(m[1], 10) < 30) return true;
+  return false;
+}
+
 function withHistory(probes: DiagnoseProbe[]): DiagnoseProbe[] {
   return probes.map(p => {
     const history = buildProbeHistory(p.id);
@@ -605,19 +637,12 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     const status = (parts[1] ?? '').trim();
     const restartCountRaw = (parts[2] ?? '').trim();
     const restartCount = parseInt(restartCountRaw, 10);
-    // Restart-count check first — it's the only signal that survives
-    // the status-string heuristics' boot/install grace window. (The CUMULATIVE-
-    // count vs current-stability nuance lives in restartCountIndicatesLoop.)
-    if (restartCountIndicatesLoop(restartCount, status, RESTART_COUNT_LOOP_THRESHOLD)) return true;
-    if (/^Restarting/i.test(status)) return true;
-    if (/^Initialized/i.test(status)) return true;
-    // Only flag "Up <30s" when the system has been up long enough that a
-    // young container *must* be a fresh restart — see comment above.
-    if (!treatYoungAsLoop) return false;
-    if (/^Up Less than a second/i.test(status)) return true;
-    const m = status.match(/^Up (\d+) seconds?\b/);
-    if (m && parseInt(m[1], 10) < 30) return true;
-    return false;
+    // Full per-line verdict (restart-count-first, then status heuristics gated on
+    // treatYoungAsLoop) lives in psLineIndicatesLoop, exported for unit testing.
+    return psLineIndicatesLoop(status, restartCount, {
+      treatYoungAsLoop,
+      threshold: RESTART_COUNT_LOOP_THRESHOLD,
+    });
   });
   // Pull the actual crash reason for each restart-looping container instead
   // of leaving the operator to run `podman logs <name>` by hand. Three lines

--- a/packages/backend/src/lib/externalBackup/producer.test.ts
+++ b/packages/backend/src/lib/externalBackup/producer.test.ts
@@ -312,6 +312,89 @@ describe('runBackupCollector (NPM in-container sqlite snapshot, #1528)', () => {
     expect(msg).not.toMatch(/\(unknown\)/);
     warn.mockRestore();
   });
+
+  it('remaps the include to the snapshot even when the live DB is absent (nodb sentinel, code 0)', async () => {
+    // The script prints `nodb` (exit 0) when /data/database.sqlite doesn't exist.
+    // `nodb` is NOT a failure — it must fall through to the remap, not the
+    // live-file fallback. The (never-created) .sb-backup is then a no-op at
+    // staging (stageServiceBackup skips a missing include), so the remap is safe.
+    mockSendCommand
+      .mockResolvedValueOnce({ stdout: 'npm_proxy-manager img', code: 0 })
+      .mockResolvedValueOnce({ stdout: 'nodb', stderr: '', code: 0 });
+    const out = await runBackupCollector(npm, 'Local');
+    // Regression guard: `nodb` must not be swallowed into the live-file fallback.
+    expect(out).not.toBe(npm);
+    expect(out.include).toContain('data/database.sqlite.sb-backup');
+    expect(out.include).not.toContain('data/database.sqlite');
+    expect(out.renames).toEqual({ 'data/database.sqlite.sb-backup': 'data/database.sqlite' });
+  });
+
+  it('drives the snapshot exec against the container name discovered by the ps/awk probe', async () => {
+    // The awk probe returns "<name> <image>"; the collector must parse the FIRST
+    // token as the container and target THAT name in the podman-exec snapshot.
+    mockSendCommand
+      .mockResolvedValueOnce({ stdout: 'npm_proxy-manager  docker.io/jc21/nginx-proxy-manager', code: 0 })
+      .mockResolvedValueOnce({ stdout: 'ok', code: 0 });
+    await runBackupCollector(npm, 'Local');
+    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+    const [op, args] = mockSendCommand.mock.calls[1];
+    expect(op).toBe('exec');
+    // The snapshot script is base64-piped into `podman exec -i <container> sh -`.
+    expect((args as { command: string }).command).toContain('podman exec -i npm_proxy-manager sh -');
+    // …and it must NOT leak the image token into the container name.
+    expect((args as { command: string }).command).not.toContain('docker.io/jc21');
+  });
+
+  it('falls back to the live file on an unrecognized snapshot output even at exit 0', async () => {
+    // A zero exit code with neither ok/nodb/no-sqlite3 is still a failure — the
+    // snapshot did not complete, so we must degrade to the live file, never
+    // remap to a snapshot that isn't there.
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    mockSendCommand
+      .mockResolvedValueOnce({ stdout: 'npm_proxy-manager img', code: 0 })
+      .mockResolvedValueOnce({ stdout: 'partial garbage', stderr: '', code: 0 });
+    const out = await runBackupCollector(npm, 'Local');
+    expect(out).toBe(npm);
+    expect(out.include).toContain('data/database.sqlite');
+    const msg = warn.mock.calls.map(c => String(c[1])).join('\n');
+    expect(msg).toMatch(/snapshot failed/i);
+    warn.mockRestore();
+  });
+
+  it('does NOT turn a rejecting sendCommand into a silent green — degrades to the live file and logs (feedback_agent_sendcommand_rejects)', async () => {
+    // agent.sendCommand REJECTS on an error reply (write_file EACCES etc.); it does
+    // not resolve with {error}. The collector's catch must degrade honestly to the
+    // live file AND log the real reason — never swallow the throw into a snapshot
+    // that was never taken. Regression: an uncaught throw or a false-green remap.
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    mockSendCommand
+      .mockResolvedValueOnce({ stdout: 'npm_proxy-manager img', code: 0 })
+      .mockRejectedValueOnce(new Error('agent exec EACCES'));
+    const out = await runBackupCollector(npm, 'Local');
+    expect(out).toBe(npm); // live file, not a phantom snapshot remap
+    expect(out.include).toContain('data/database.sqlite');
+    const msg = warn.mock.calls.map(c => String(c[1])).join('\n');
+    expect(msg).toContain('agent exec EACCES'); // the real error is surfaced
+    warn.mockRestore();
+  });
+
+  it('rejecting ensureAgent (node unreachable) degrades to the live file, not a crash', async () => {
+    // The FIRST await (ensureAgent) can also reject if the node is unreachable.
+    // That throw must land in the same honest-degrade catch, not propagate and
+    // fail the whole backup run.
+    const { agentManager } = await import('../agent/manager');
+    const spy = vi
+      .spyOn(agentManager, 'ensureAgent')
+      .mockRejectedValueOnce(new Error('node offline'));
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    const out = await runBackupCollector(npm, 'Local');
+    expect(out).toBe(npm);
+    expect(mockSendCommand).not.toHaveBeenCalled();
+    const msg = warn.mock.calls.map(c => String(c[1])).join('\n');
+    expect(msg).toContain('node offline');
+    warn.mockRestore();
+    spy.mockRestore();
+  });
 });
 
 describe('buildServiceBackupTar', () => {

--- a/packages/backend/src/lib/install/credentialResolver.test.ts
+++ b/packages/backend/src/lib/install/credentialResolver.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  waitForCredentials,
+  provideCredentials,
+  skipCredentials,
+  clearPendingCredentials,
+} from './credentialResolver';
+
+/**
+ * Pins the pause/resume promise bookkeeping that gates an unattended
+ * install on operator-supplied NPM credentials. A regression here
+ * either freezes an install forever on the credential prompt or leaks
+ * a dangling resolver — both invisible until the box hangs.
+ *
+ * The module owns a process-wide Map keyed by jobId, so each test uses
+ * a UNIQUE jobId to stay isolated (there is no reset export by design —
+ * pending prompts don't survive a restart).
+ */
+
+let seq = 0;
+const jobId = (tag: string) => `test-job-${tag}-${seq++}`;
+
+describe('credentialResolver — waitForCredentials / provideCredentials', () => {
+  it('resolves with the exact object passed to provideCredentials', async () => {
+    const id = jobId('provide');
+    const pending = waitForCredentials(id);
+    const creds = { email: 'admin@example.com', password: 's3cr3t' };
+
+    expect(provideCredentials(id, creds)).toBe(true);
+    await expect(pending).resolves.toEqual(creds);
+  });
+
+  it('provideCredentials returns false when no job is waiting', () => {
+    // A resolve-signature or bookkeeping bug that "provides" to a
+    // non-waiting id must be a no-op, not a throw or a silent success.
+    expect(provideCredentials(jobId('nowait'), { email: 'a@b.c', password: 'x' })).toBe(false);
+  });
+
+  it('a second provideCredentials for the same job is a no-op (returns false, does not throw)', async () => {
+    const id = jobId('double-provide');
+    const pending = waitForCredentials(id);
+    const first = { email: 'first@example.com', password: 'p1' };
+
+    expect(provideCredentials(id, first)).toBe(true);
+    // The entry was deleted on first provide; the second must not resolve
+    // again (a double-resolve would corrupt the resumed install path).
+    expect(provideCredentials(id, { email: 'second@example.com', password: 'p2' })).toBe(false);
+    await expect(pending).resolves.toEqual(first);
+  });
+});
+
+describe('credentialResolver — skipCredentials', () => {
+  it('resolves null on skip (signature: null, not a creds object)', async () => {
+    const id = jobId('skip');
+    const pending = waitForCredentials(id);
+
+    expect(skipCredentials(id)).toBe(true);
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it('skipCredentials returns false when no job is waiting', () => {
+    expect(skipCredentials(jobId('skip-nowait'))).toBe(false);
+  });
+
+  it('provide-then-skip is a no-op on skip (entry already consumed)', async () => {
+    const id = jobId('provide-then-skip');
+    const pending = waitForCredentials(id);
+    const creds = { email: 'admin@example.com', password: 'pw' };
+
+    expect(provideCredentials(id, creds)).toBe(true);
+    expect(skipCredentials(id)).toBe(false);
+    await expect(pending).resolves.toEqual(creds);
+  });
+});
+
+describe('credentialResolver — clearPendingCredentials (abortJob path)', () => {
+  it('resolves the pending promise with null and removes the entry', async () => {
+    const id = jobId('clear');
+    const pending = waitForCredentials(id);
+
+    clearPendingCredentials(id);
+    // abortJob must unblock the waiting runner, not leave it hanging.
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it('after clear, a later provide/skip is a safe no-op (no leak, no double-resolve)', async () => {
+    const id = jobId('clear-then-provide');
+    const pending = waitForCredentials(id);
+
+    clearPendingCredentials(id);
+    await expect(pending).resolves.toBeNull();
+
+    // The entry is gone — a stale provide/skip from a racing route must
+    // not find a resolver to fire twice.
+    expect(provideCredentials(id, { email: 'a@b.c', password: 'x' })).toBe(false);
+    expect(skipCredentials(id)).toBe(false);
+  });
+
+  it('is idempotent — clearing a non-pending job does nothing and does not throw', () => {
+    const id = jobId('clear-idempotent');
+    expect(() => clearPendingCredentials(id)).not.toThrow();
+    // And a second clear on an already-cleared job is also safe.
+    waitForCredentials(id);
+    clearPendingCredentials(id);
+    expect(() => clearPendingCredentials(id)).not.toThrow();
+  });
+
+  it('no resolver leaks after resolve — provide fully consumes the entry', () => {
+    // If provide left the entry behind, a subsequent clear would resolve
+    // an already-settled promise (harmless) but signal a bookkeeping leak.
+    const id = jobId('no-leak');
+    waitForCredentials(id);
+    expect(provideCredentials(id, { email: 'a@b.c', password: 'x' })).toBe(true);
+    // Entry gone: provide/skip/clear all find nothing.
+    expect(provideCredentials(id, { email: 'a@b.c', password: 'x' })).toBe(false);
+    expect(skipCredentials(id)).toBe(false);
+    expect(() => clearPendingCredentials(id)).not.toThrow();
+  });
+});

--- a/packages/backend/src/lib/install/resetGroups.test.ts
+++ b/packages/backend/src/lib/install/resetGroups.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RESET_GROUPS,
+  DEFAULT_PRESERVE,
+  isAlwaysWipe,
+  getChildExclusions,
+  type ResetGroup,
+} from './resetGroups';
+
+/**
+ * These tests pin the destructive-reset semantics that caused the
+ * 2026-05-15 system-wide data-loss incident. A silent drift in the
+ * path topology, the preserve defaults, or the alwaysWipe flag would
+ * either delete system-critical data (NPM certs / identity provider)
+ * or resurrect deleted services after an OS reinstall — CI's per-PR
+ * diff-coverage floor doesn't catch a regression in old, untested
+ * code, so these assertions ARE the guard.
+ */
+
+describe('resetGroups — RESET_GROUPS path topology', () => {
+  it('gives every group at least one absolute path under /var/mnt/data', () => {
+    for (const [name, def] of Object.entries(RESET_GROUPS)) {
+      expect(def.paths.length, `${name} must declare a path`).toBeGreaterThanOrEqual(1);
+      for (const p of def.paths) {
+        expect(p.startsWith('/var/mnt/data'), `${name} path ${p} must be absolute under /var/mnt/data`).toBe(true);
+        // A relative or `~`-based path would make a `rm -rf` resolve
+        // against the runner CWD — never let that regress in.
+        expect(p.startsWith('/'), `${name} path ${p} must be absolute`).toBe(true);
+        expect(p).not.toContain('..');
+      }
+    }
+  });
+
+  it('nests certs and identity under service-data (parent/child topology holds)', () => {
+    // getChildExclusions relies on service-data being a strict parent of
+    // both certs and identity. If someone flattens the tree this breaks.
+    const serviceData = RESET_GROUPS['service-data'].paths[0];
+    expect(RESET_GROUPS.certs.paths[0].startsWith(serviceData + '/')).toBe(true);
+    expect(RESET_GROUPS.identity.paths[0].startsWith(serviceData + '/')).toBe(true);
+  });
+});
+
+describe('resetGroups — getChildExclusions', () => {
+  it('service-data excludes exactly the nginx-proxy-manager and auth basenames', () => {
+    // The whole point: a `service-data` wipe must SKIP the certs
+    // (nginx-proxy-manager) and identity (auth) child dirs, which are
+    // preserved by default. If this derivation drifts, a clean install
+    // would delete NPM certs or the identity provider.
+    const excl = getChildExclusions('service-data');
+    expect(excl.sort()).toEqual(['auth', 'nginx-proxy-manager']);
+  });
+
+  it('returns only direct-child basenames, never deep paths', () => {
+    const excl = getChildExclusions('service-data');
+    for (const e of excl) {
+      expect(e).not.toContain('/');
+    }
+  });
+
+  it('returns nothing for a leaf group with no nested siblings', () => {
+    // secrets' path (/var/mnt/data/servicebay) has quadlet-backup nested
+    // under it, so it DOES exclude that child. certs/identity are leaves.
+    expect(getChildExclusions('certs')).toEqual([]);
+    expect(getChildExclusions('identity')).toEqual([]);
+  });
+
+  it('secrets excludes quadlet-backup (its nested child group)', () => {
+    // /var/mnt/data/servicebay/quadlet-backup is a direct child of the
+    // secrets path, so sizing/wiping secrets must account for it separately.
+    expect(getChildExclusions('secrets')).toEqual(['quadlet-backup']);
+  });
+
+  it('never excludes a group from itself', () => {
+    for (const group of Object.keys(RESET_GROUPS) as ResetGroup[]) {
+      const excl = getChildExclusions(group);
+      const myBasenames = RESET_GROUPS[group].paths.map(p => p.split('/').pop());
+      for (const e of excl) {
+        expect(myBasenames).not.toContain(e);
+      }
+    }
+  });
+
+  it('is symmetric with the topology — an excluded child is a real nested group', () => {
+    // Guards against getChildExclusions inventing a basename that doesn't
+    // correspond to a declared group nested under the parent.
+    for (const group of Object.keys(RESET_GROUPS) as ResetGroup[]) {
+      const parentPaths = RESET_GROUPS[group].paths;
+      for (const child of getChildExclusions(group)) {
+        const matchesSomeNestedGroup = (Object.keys(RESET_GROUPS) as ResetGroup[])
+          .filter(g => g !== group)
+          .some(g =>
+            RESET_GROUPS[g].paths.some(cp =>
+              parentPaths.some(pp => cp === `${pp}/${child}`),
+            ),
+          );
+        expect(matchesSomeNestedGroup, `${child} excluded from ${group} must be a real nested group`).toBe(true);
+      }
+    }
+  });
+});
+
+describe('resetGroups — DEFAULT_PRESERVE', () => {
+  it('preserves exactly the three system-critical groups', () => {
+    // Dropping any entry silently turns preserve into wipe. Pin all three.
+    expect([...DEFAULT_PRESERVE].sort()).toEqual(['certs', 'identity', 'secrets']);
+  });
+
+  it('does NOT preserve service-data by default (the "clean" in clean install)', () => {
+    expect(DEFAULT_PRESERVE).not.toContain('service-data');
+  });
+
+  it('does NOT list quadlet-backup (it is alwaysWipe, cannot be preserved)', () => {
+    expect(DEFAULT_PRESERVE).not.toContain('quadlet-backup');
+  });
+
+  it('only names real declared groups', () => {
+    for (const g of DEFAULT_PRESERVE) {
+      expect(Object.keys(RESET_GROUPS)).toContain(g);
+    }
+  });
+});
+
+describe('resetGroups — isAlwaysWipe', () => {
+  it('is true only for quadlet-backup', () => {
+    // quadlet-backup MUST always wipe or an OS reinstall resurrects
+    // deleted services. No other group may become alwaysWipe silently.
+    const alwaysWiped = (Object.keys(RESET_GROUPS) as ResetGroup[]).filter(isAlwaysWipe);
+    expect(alwaysWiped).toEqual(['quadlet-backup']);
+  });
+
+  it('is false for every preserve-able group', () => {
+    for (const g of DEFAULT_PRESERVE) {
+      expect(isAlwaysWipe(g)).toBe(false);
+    }
+    expect(isAlwaysWipe('service-data')).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/reverseProxy/autheliaRewrite.test.ts
+++ b/packages/backend/src/lib/reverseProxy/autheliaRewrite.test.ts
@@ -252,8 +252,13 @@ describe('rewriteAutheliaConfig — OIDC redirect_uris (additive, deduped)', () 
   it('does NOT twin a third-party (non-lan) callback', () => {
     const doc = load(rewrite(LAN_CONFIG).yaml);
     const immich = doc.identity_providers.oidc.clients[0];
+    // match on the exact host, not a substring, so the assertion can't be
+    // satisfied by an attacker-shaped URL like https://example.com.evil/ (CodeQL
+    // js/incomplete-url-substring-sanitization)
     expect(
-      immich.redirect_uris.filter((u: string) => u.includes('example.com')),
+      immich.redirect_uris.filter(
+        (u: string) => new URL(u).hostname === 'third-party.example.com',
+      ),
     ).toEqual(['https://third-party.example.com/callback']);
   });
 

--- a/packages/backend/src/lib/reverseProxy/autheliaRewrite.test.ts
+++ b/packages/backend/src/lib/reverseProxy/autheliaRewrite.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import { rewriteAutheliaConfig } from './autheliaRewrite';
+
+/**
+ * Structural view of the parsed Authelia config the tests reach into.
+ * Fields are non-optional because every test drives a well-formed
+ * rewritten doc and asserts the leaf directly; the `load` cast is the
+ * single unsafe boundary.
+ */
+interface ParsedConfig {
+  session: {
+    cookies: {
+      name?: string;
+      domain?: string;
+      authelia_url?: string;
+      default_redirection_url?: string;
+    }[];
+  };
+  access_control: {
+    default_policy?: string;
+    rules: { domain?: string | string[]; policy?: string }[];
+  };
+  identity_providers: {
+    oidc: {
+      clients: { client_id?: string; client_secret?: string; redirect_uris: string[] }[];
+    };
+  };
+}
+
+const load = (s: string): ParsedConfig => yaml.load(s) as unknown as ParsedConfig;
+
+const LAN = 'home.arpa';
+const PUB = 'dopp.cloud';
+
+/**
+ * A representative install-time LAN Authelia `configuration.yml`:
+ * a session cookie bound to the lan root, one access_control rule with a
+ * list of lan domains, and two OIDC clients with redirect_uris (one of
+ * which mixes a lan callback with a third-party one).
+ */
+const LAN_CONFIG = `
+session:
+  cookies:
+    - name: authelia_session
+      domain: home.arpa
+      authelia_url: https://auth.home.arpa
+      default_redirection_url: https://home.arpa
+access_control:
+  default_policy: deny
+  rules:
+    - domain:
+        - home.arpa
+        - immich.home.arpa
+      policy: one_factor
+    - domain: 'files.home.arpa'
+      policy: two_factor
+identity_providers:
+  oidc:
+    clients:
+      - client_id: immich
+        redirect_uris:
+          - https://immich.home.arpa/auth/login
+          - https://third-party.example.com/callback
+      - client_id: vault
+        redirect_uris:
+          - https://vault.home.arpa/oidc/callback
+`;
+
+function rewrite(config: string) {
+  return rewriteAutheliaConfig(config, LAN, PUB);
+}
+
+describe('rewriteAutheliaConfig — session cookie (hard cutover)', () => {
+  it('flips the cookie domain from the lan root to the public domain', () => {
+    const { yaml: out, changes } = rewrite(LAN_CONFIG);
+    const doc = load(out);
+    expect(doc.session.cookies[0].domain).toBe(PUB);
+    expect(changes.cookieDomain).toEqual({ from: 'home.arpa', to: PUB });
+  });
+
+  it('rewrites authelia_url onto the public auth subdomain', () => {
+    const { yaml: out, changes } = rewrite(LAN_CONFIG);
+    const doc = load(out);
+    expect(doc.session.cookies[0].authelia_url).toBe('https://auth.dopp.cloud/');
+    expect(changes.cookieAutheliaUrl.from).toBe('https://auth.home.arpa');
+    expect(changes.cookieAutheliaUrl.to).toBe('https://auth.dopp.cloud/');
+  });
+
+  it('preserves a non-default PORT on the existing authelia_url', () => {
+    const cfg = `
+session:
+  cookies:
+    - name: authelia_session
+      domain: home.arpa
+      authelia_url: https://auth.home.arpa:9091
+`;
+    const doc = load(rewrite(cfg).yaml);
+    // host twinned, port survives (a mis-parse here corrupts the auth endpoint)
+    expect(doc.session.cookies[0].authelia_url).toBe('https://auth.dopp.cloud:9091/');
+  });
+
+  it('preserves a non-default PATH on the existing authelia_url', () => {
+    const cfg = `
+session:
+  cookies:
+    - name: authelia_session
+      domain: home.arpa
+      authelia_url: https://auth.home.arpa/authenticate
+`;
+    const doc = load(rewrite(cfg).yaml);
+    expect(doc.session.cookies[0].authelia_url).toBe('https://auth.dopp.cloud/authenticate');
+  });
+
+  it('twins the sub-domain of a non-auth authelia_url host, not hard-coding "auth"', () => {
+    const cfg = `
+session:
+  cookies:
+    - name: authelia_session
+      domain: home.arpa
+      authelia_url: https://sso.home.arpa
+`;
+    const doc = load(rewrite(cfg).yaml);
+    expect(doc.session.cookies[0].authelia_url).toBe('https://sso.dopp.cloud/');
+  });
+
+  it('falls back to https://auth.<publicDomain> when authelia_url is missing', () => {
+    const cfg = `
+session:
+  cookies:
+    - name: authelia_session
+      domain: home.arpa
+`;
+    const { yaml: out, changes } = rewrite(cfg);
+    const doc = load(out);
+    expect(doc.session.cookies[0].authelia_url).toBe('https://auth.dopp.cloud');
+    expect(changes.cookieAutheliaUrl.from).toBeNull();
+  });
+
+  it('falls back to https://auth.<publicDomain> when authelia_url is malformed', () => {
+    const cfg = `
+session:
+  cookies:
+    - name: authelia_session
+      domain: home.arpa
+      authelia_url: 'not a url'
+`;
+    const doc = load(rewrite(cfg).yaml);
+    expect(doc.session.cookies[0].authelia_url).toBe('https://auth.dopp.cloud');
+  });
+
+  it('leaves an already-public authelia_url untouched (idempotency)', () => {
+    const cfg = `
+session:
+  cookies:
+    - name: authelia_session
+      domain: dopp.cloud
+      authelia_url: https://auth.dopp.cloud
+`;
+    const doc = load(rewrite(cfg).yaml);
+    expect(doc.session.cookies[0].authelia_url).toBe('https://auth.dopp.cloud');
+  });
+
+  it('leaves config with no session cookies untouched', () => {
+    const cfg = `theme: light\n`;
+    const { changes } = rewrite(cfg);
+    expect(changes.cookieDomain.from).toBeNull();
+  });
+});
+
+describe('rewriteAutheliaConfig — access_control rules (additive twin)', () => {
+  it('adds public-domain twins WITHOUT dropping the lan entries (list form)', () => {
+    const doc = load(rewrite(LAN_CONFIG).yaml);
+    const listRule = doc.access_control.rules[0].domain;
+    // both lan originals preserved, both public twins appended
+    expect(listRule).toEqual([
+      'home.arpa',
+      'dopp.cloud',
+      'immich.home.arpa',
+      'immich.dopp.cloud',
+    ]);
+  });
+
+  it('twins a single-string domain into [lan, public]', () => {
+    const doc = load(rewrite(LAN_CONFIG).yaml);
+    expect(doc.access_control.rules[1].domain).toEqual([
+      'files.home.arpa',
+      'files.dopp.cloud',
+    ]);
+  });
+
+  it('records per-rule before/after in changes', () => {
+    const { changes } = rewrite(LAN_CONFIG);
+    expect(changes.accessControlRuleDomains).toHaveLength(2);
+    expect(changes.accessControlRuleDomains[0].from).toEqual([
+      'home.arpa',
+      'immich.home.arpa',
+    ]);
+    expect(changes.accessControlRuleDomains[0].to).toEqual([
+      'home.arpa',
+      'dopp.cloud',
+      'immich.home.arpa',
+      'immich.dopp.cloud',
+    ]);
+  });
+
+  it('leaves a non-lan domain rule unchanged and does not record it', () => {
+    const cfg = `
+access_control:
+  rules:
+    - domain: '*.example.com'
+      policy: one_factor
+`;
+    const { yaml: out, changes } = rewrite(cfg);
+    const doc = load(out);
+    expect(doc.access_control.rules[0].domain).toBe('*.example.com');
+    expect(changes.accessControlRuleDomains).toHaveLength(0);
+  });
+
+  it('is idempotent — a second run adds no further twins', () => {
+    const once = rewrite(LAN_CONFIG).yaml;
+    const twice = rewrite(once);
+    const doc = load(twice.yaml);
+    expect(doc.access_control.rules[0].domain).toEqual([
+      'home.arpa',
+      'dopp.cloud',
+      'immich.home.arpa',
+      'immich.dopp.cloud',
+    ]);
+    // no domain rules re-recorded as changed on the migrated config
+    expect(twice.changes.accessControlRuleDomains).toHaveLength(0);
+  });
+});
+
+describe('rewriteAutheliaConfig — OIDC redirect_uris (additive, deduped)', () => {
+  it('appends public-domain twins and preserves the lan + third-party uris', () => {
+    const doc = load(rewrite(LAN_CONFIG).yaml);
+    const immich = doc.identity_providers.oidc.clients[0];
+    expect(immich.redirect_uris).toEqual([
+      'https://immich.home.arpa/auth/login',
+      'https://third-party.example.com/callback',
+      'https://immich.dopp.cloud/auth/login',
+    ]);
+  });
+
+  it('preserves the callback PATH when twinning a redirect_uri', () => {
+    const doc = load(rewrite(LAN_CONFIG).yaml);
+    const vault = doc.identity_providers.oidc.clients[1];
+    expect(vault.redirect_uris).toContain('https://vault.dopp.cloud/oidc/callback');
+  });
+
+  it('does NOT twin a third-party (non-lan) callback', () => {
+    const doc = load(rewrite(LAN_CONFIG).yaml);
+    const immich = doc.identity_providers.oidc.clients[0];
+    expect(
+      immich.redirect_uris.filter((u: string) => u.includes('example.com')),
+    ).toEqual(['https://third-party.example.com/callback']);
+  });
+
+  it('records the additions per client, keyed by client_id', () => {
+    const { changes } = rewrite(LAN_CONFIG);
+    expect(changes.oidcRedirectUriAdditions).toEqual([
+      { clientId: 'immich', added: ['https://immich.dopp.cloud/auth/login'] },
+      { clientId: 'vault', added: ['https://vault.dopp.cloud/oidc/callback'] },
+    ]);
+  });
+
+  it('dedups — does not re-append a twin that is already present (idempotency)', () => {
+    const cfg = `
+identity_providers:
+  oidc:
+    clients:
+      - client_id: immich
+        redirect_uris:
+          - https://immich.home.arpa/auth/login
+          - https://immich.dopp.cloud/auth/login
+`;
+    const { yaml: out, changes } = rewrite(cfg);
+    const doc = load(out);
+    const uris = doc.identity_providers.oidc.clients[0].redirect_uris;
+    expect(uris).toHaveLength(2);
+    expect(uris.filter((u: string) => u === 'https://immich.dopp.cloud/auth/login'))
+      .toHaveLength(1);
+    expect(changes.oidcRedirectUriAdditions).toHaveLength(0);
+  });
+
+  it('running the whole rewrite twice adds no new redirect twins', () => {
+    const once = rewrite(LAN_CONFIG).yaml;
+    const twice = rewrite(once);
+    expect(twice.changes.oidcRedirectUriAdditions).toHaveLength(0);
+    const doc = load(twice.yaml);
+    expect(doc.identity_providers.oidc.clients[0].redirect_uris).toEqual([
+      'https://immich.home.arpa/auth/login',
+      'https://third-party.example.com/callback',
+      'https://immich.dopp.cloud/auth/login',
+    ]);
+  });
+});
+
+describe('rewriteAutheliaConfig — round-trip & robustness', () => {
+  it('round-trips: every non-twinned field survives the rewrite unchanged', () => {
+    const doc = load(rewrite(LAN_CONFIG).yaml);
+    expect(doc.session.cookies[0].name).toBe('authelia_session');
+    expect(doc.session.cookies[0].default_redirection_url).toBe('https://home.arpa');
+    expect(doc.access_control.default_policy).toBe('deny');
+    expect(doc.access_control.rules[0].policy).toBe('one_factor');
+    expect(doc.identity_providers.oidc.clients[0].client_id).toBe('immich');
+  });
+
+  it('preserves a special-char / quoted secret value verbatim', () => {
+    const cfg = `
+identity_providers:
+  oidc:
+    clients:
+      - client_id: immich
+        client_secret: '$argon2id$v=19$m=65536,t=3,p=4$abc: def#ghi'
+        redirect_uris:
+          - https://immich.home.arpa/auth/login
+`;
+    const doc = load(rewrite(cfg).yaml);
+    expect(doc.identity_providers.oidc.clients[0].client_secret).toBe(
+      '$argon2id$v=19$m=65536,t=3,p=4$abc: def#ghi',
+    );
+  });
+
+  it('returns the input unchanged for empty / non-object yaml', () => {
+    expect(rewrite('').yaml).toBe('');
+    expect(rewrite('   ').yaml).toBe('   ');
+    const scalar = rewrite('just a string');
+    expect(scalar.yaml).toBe('just a string');
+    expect(scalar.changes.accessControlRuleDomains).toHaveLength(0);
+  });
+
+  it('emits parseable yaml (no dump crash on the migrated doc)', () => {
+    const out = rewrite(LAN_CONFIG).yaml;
+    expect(() => yaml.load(out)).not.toThrow();
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/frontend/src/components/ServiceForm.test.tsx
+++ b/packages/frontend/src/components/ServiceForm.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * ServiceForm — rename modal Escape-to-close (#2188).
+ *
+ * The rename-service modal now closes on Escape like every other modal in
+ * the app (ConfirmModal etc.), via the shared `useEscapeKey` hook. These
+ * tests assert Escape dismisses the modal, guarded so it can't dismiss
+ * while a rename request is in flight.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock('@/providers/ToastProvider', () => ({
+  useToast: () => ({ addToast: vi.fn(), updateToast: vi.fn() }),
+}));
+vi.mock('@/app/actions/system', () => ({ getNodes: () => Promise.resolve([]) }));
+// Keep the history panel out of the render.
+vi.mock('./HistoryViewer', () => ({ __esModule: true, default: () => <div /> }));
+
+import ServiceForm from './ServiceForm';
+
+function openRenameModal() {
+  render(
+    <ServiceForm
+      isEdit
+      initialData={{
+        name: 'my-service',
+        yamlFileName: 'my-service.yml',
+        kubeContent: '',
+        yamlContent: '',
+      }}
+    />,
+  );
+  fireEvent.click(screen.getByTitle('Rename Service & Files'));
+  return screen.getByRole('heading', { name: /rename service/i });
+}
+
+describe('ServiceForm — rename modal Escape-to-close (#2188)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('closes the rename modal when Escape is pressed', async () => {
+    openRenameModal();
+    expect(screen.getByRole('heading', { name: /rename service/i })).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() =>
+      expect(screen.queryByRole('heading', { name: /rename service/i })).toBeNull(),
+    );
+  });
+
+  it('does not close the modal while a rename request is in flight', async () => {
+    // A rename POST that never resolves — keeps isRenaming latched true.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+
+    openRenameModal();
+    // Trigger the rename (button enabled once newServiceName is set, which the
+    // open-handler seeds with the current name).
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Service' }));
+
+    await waitFor(() => expect(screen.getByText('Renaming...')).toBeTruthy());
+
+    // Escape must be ignored while the request is in flight.
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.getByRole('heading', { name: /rename service/i })).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/components/ServiceForm.tsx
+++ b/packages/frontend/src/components/ServiceForm.tsx
@@ -14,6 +14,7 @@ import HistoryViewer from './HistoryViewer';
 import { getNodes } from '@/app/actions/system';
 import { PodmanConnection } from '@servicebay/api-client';
 import { useToast } from '@/providers/ToastProvider';
+import { useEscapeKey } from '@/hooks/useEscapeKey';
 
 interface KubeContainerPort {
     containerPort: number;
@@ -103,6 +104,13 @@ export default function ServiceForm({ initialData, isEdit, defaultNode, onClose,
   const [isRenaming, setIsRenaming] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [activeTab, setActiveTab] = useState<'yaml' | 'kube' | 'service' | 'history'>('yaml');
+
+  // Escape closes the rename modal like every other modal in the app
+  // (ConfirmModal etc.), but not while a rename request is in flight (#2188).
+  useEscapeKey(
+    () => setShowRenameModal(false),
+    showRenameModal && !isRenaming,
+  );
 
   // Options for generation
   const [autoUpdate, setAutoUpdate] = useState(() => {

--- a/packages/frontend/src/components/StackVariableField.test.tsx
+++ b/packages/frontend/src/components/StackVariableField.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * StackVariableField — secret regenerate feedback (#2186).
+ *
+ * The 'Regenerate' button on a `secret` variable now shows an in-flight
+ * affordance (disabled + spinner) and surfaces a visible error on failure
+ * instead of failing silently. These tests assert:
+ *   - the button disables while the /api/install/generate-secret POST is in
+ *     flight (and a second click is a no-op — no double-fire),
+ *   - a successful response updates the value,
+ *   - a failed request surfaces a visible inline error, and the field stays
+ *     typeable.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import StackVariableField from './StackVariableField';
+
+const secretVar = {
+  name: 'API_SECRET',
+  value: 'old-secret',
+  meta: { type: 'secret' as const },
+};
+
+describe('StackVariableField — secret regenerate feedback (#2186)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('disables the regenerate button while the request is in flight and guards a double-click', async () => {
+    let release: (r: Response) => void = () => {};
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        calls += 1;
+        return new Promise<Response>((resolve) => {
+          release = resolve;
+        });
+      }),
+    );
+
+    const onChange = vi.fn();
+    render(<StackVariableField variable={secretVar} onChange={onChange} />);
+
+    const btn = screen.getByTitle('Regenerate') as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(btn.disabled).toBe(true));
+    // A second click while pending must not fire another request.
+    fireEvent.click(btn);
+    expect(calls).toBe(1);
+
+    release(new Response(JSON.stringify({ secret: 'fresh-secret' }), { status: 200 }));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('fresh-secret'));
+    await waitFor(() => expect(btn.disabled).toBe(false));
+  });
+
+  it('surfaces a visible error when the request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('nope', { status: 500 }))),
+    );
+
+    const onChange = vi.fn();
+    render(<StackVariableField variable={secretVar} onChange={onChange} />);
+
+    fireEvent.click(screen.getByTitle('Regenerate'));
+
+    // Visible inline error, no silent failure; value not changed.
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Field is still typeable after the failure.
+    const input = screen.getByDisplayValue('old-secret');
+    fireEvent.change(input, { target: { value: 'manual' } });
+    expect(onChange).toHaveBeenCalledWith('manual');
+  });
+});

--- a/packages/frontend/src/components/StackVariableField.tsx
+++ b/packages/frontend/src/components/StackVariableField.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { RefreshCw } from 'lucide-react';
 import type { VariableMeta } from '@servicebay/api-client';
 import { typedFetch, GenerateSecretResponseSchema } from '@servicebay/api-client';
@@ -211,45 +212,11 @@ export default function StackVariableField({
   }
 
   // Secret (auto-generated default; regenerate button picks a fresh
-  // random value)
+  // random value). Delegated to a small stateful subcomponent so the
+  // regenerate request can drive a pending/disabled/error affordance
+  // (hooks can't live behind these early-return branches).
   if (v.meta?.type === 'secret') {
-    return (
-      <div className="flex gap-2">
-        <input
-          type="text"
-          value={v.value}
-          onChange={(e) => onChange(e.target.value)}
-          className={`${cls} font-mono text-xs flex-1`}
-          spellCheck={false}
-          autoComplete="off"
-        />
-        <button
-          type="button"
-          onClick={async () => {
-            try {
-              const { secret } = await typedFetch(
-                '/api/install/generate-secret',
-                GenerateSecretResponseSchema,
-                {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({}),
-                },
-              );
-              onChange(secret);
-            } catch {
-              // If the server is unreachable mid-edit the operator can
-              // still type a value manually; swallowing keeps the form
-              // responsive instead of throwing into React.
-            }
-          }}
-          className="p-2 border border-gray-300 dark:border-gray-700 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-          title="Regenerate"
-        >
-          <RefreshCw size={16} />
-        </button>
-      </div>
-    );
+    return <SecretField value={v.value} onChange={onChange} cls={cls} />;
   }
 
   // Default — plain text. Placeholder prefers `meta.example`, then
@@ -264,5 +231,71 @@ export default function StackVariableField({
         ? `e.g. ${v.meta.example}`
         : (v.meta?.default ? `Default: ${v.meta.default}` : `Value for ${v.name}`)}
     />
+  );
+}
+
+const fetchGeneratedSecret = () =>
+  typedFetch('/api/install/generate-secret', GenerateSecretResponseSchema, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+
+/**
+ * Secret variable input + regenerate button. Owns the in-flight state so
+ * the operator gets feedback while `/api/install/generate-secret` is
+ * pending: the button disables + spins, and a failed request surfaces a
+ * visible inline hint instead of silence (#2186). The field stays typeable
+ * throughout — the operator can always enter a value manually.
+ */
+function SecretField({
+  value,
+  onChange,
+  cls,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  cls: string;
+}) {
+  const [regenerating, setRegenerating] = useState(false);
+  const [error, setError] = useState(false);
+
+  // Unreachable mid-edit surfaces a visible hint rather than failing silently;
+  // the operator can still type a value manually. The `regenerating` guard
+  // stops a double-fire from a second click while the request is pending.
+  const regenerate = async () => {
+    if (regenerating) return;
+    setRegenerating(true);
+    setError(false);
+    try {
+      onChange((await fetchGeneratedSecret()).secret);
+    } catch {
+      setError(true);
+    } finally {
+      setRegenerating(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex gap-2">
+        <input
+          type="text" value={value} onChange={(e) => onChange(e.target.value)}
+          className={`${cls} font-mono text-xs flex-1`} spellCheck={false} autoComplete="off"
+        />
+        <button
+          type="button" onClick={regenerate} disabled={regenerating} aria-busy={regenerating}
+          title="Regenerate"
+          className="p-2 border border-gray-300 dark:border-gray-700 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <RefreshCw size={16} className={regenerating ? 'animate-spin' : ''} />
+        </button>
+      </div>
+      {error && (
+        <p role="alert" className="mt-1 text-xs text-red-600 dark:text-red-400">
+          Couldn&apos;t generate a secret — check your connection or type one manually.
+        </p>
+      )}
+    </div>
   );
 }

--- a/packages/frontend/src/dashboards/HealthDashboard.test.tsx
+++ b/packages/frontend/src/dashboards/HealthDashboard.test.tsx
@@ -115,4 +115,54 @@ describe('HealthDashboard (#2100 dashboards migration)', () => {
     // The checks panel unmounts when a non-checks tab is active.
     await waitFor(() => expect(screen.queryByTestId('health-checks')).toBeNull());
   });
+
+  // #2187 — Save Check disables + spins while the POST is in flight, so a
+  // double-click can't create two checks.
+  it('Save Check disables while saving and guards against a double-submit', async () => {
+    // A save POST that stays pending until we release it, so we can observe
+    // the in-flight state and fire a second click.
+    let releaseSave: (r: Response) => void = () => {};
+    let saveCalls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, init?: RequestInit) => {
+        if (url === '/api/health/checks' && init?.method === 'POST') {
+          saveCalls += 1;
+          return new Promise<Response>((resolve) => {
+            releaseSave = resolve;
+          });
+        }
+        if (url === '/api/health/checks') {
+          return Promise.resolve(new Response(JSON.stringify(checks), { status: 200 }));
+        }
+        return Promise.resolve(new Response('[]', { status: 200 }));
+      }),
+    );
+
+    render(<HealthDashboard />);
+    await waitFor(() => expect(screen.getByTestId('health-checks')).toBeDefined());
+
+    fireEvent.click(screen.getByRole('button', { name: /add check/i }));
+    await screen.findByText('Create Health Check');
+
+    // Give the (http) check a name so it's a real save; type stays 'http'
+    // (a non-system check), so the Save button renders.
+    fireEvent.change(screen.getByPlaceholderText('e.g. Production API'), {
+      target: { value: 'My Check' },
+    });
+
+    const save = screen.getByRole('button', { name: /save check/i }) as HTMLButtonElement;
+    fireEvent.click(save);
+
+    // In flight: button is disabled + a second click is a no-op.
+    await waitFor(() => expect(save.disabled).toBe(true));
+    fireEvent.click(save);
+
+    // Only one POST despite two clicks.
+    expect(saveCalls).toBe(1);
+
+    // Release the request; the button re-enables via the modal closing.
+    releaseSave(new Response('{}', { status: 200 }));
+    await waitFor(() => expect(screen.queryByText('Create Health Check')).toBeNull());
+  });
 });

--- a/packages/frontend/src/dashboards/HealthDashboard.tsx
+++ b/packages/frontend/src/dashboards/HealthDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { Plus, RefreshCw, X, Search } from 'lucide-react';
+import { Plus, RefreshCw, X, Search, Loader2 } from 'lucide-react';
 import { useToast, ToastType } from '@/providers/ToastProvider';
 import { useSocket } from '@/hooks/useSocket';
 import PageHeader from '@/components/PageHeader';
@@ -41,6 +41,7 @@ export default function HealthDashboard() {
   const [managedServices, setManagedServices] = useState<string[]>([]);
   // const [loading, setLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [checkToDelete, setCheckToDelete] = useState<string | null>(null);
   const [editingCheck, setEditingCheck] = useState<CheckConfig | null>(null);
@@ -261,6 +262,8 @@ export default function HealthDashboard() {
   };
 
   const handleSave = async () => {
+    if (isSaving) return; // guard against a double-submit creating duplicate checks
+    setIsSaving(true);
     try {
       const url = '/api/health/checks';
       // const method = editingCheck ? 'PUT' : 'POST'; // Note: PUT not implemented in API yet, need to fix that
@@ -285,6 +288,8 @@ export default function HealthDashboard() {
     } catch (error) {
       console.error(error);
       addToast('error', 'Failed to save check');
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -942,8 +947,9 @@ export default function HealthDashboard() {
                 {isSystemCheck() ? 'Close' : 'Cancel'}
               </Button>
               {!isSystemCheck() && (
-              <Button onClick={handleSave}>
-                Save Check
+              <Button onClick={handleSave} disabled={isSaving} aria-busy={isSaving}>
+                {isSaving && <Loader2 size={14} className="animate-spin" />}
+                {isSaving ? 'Saving...' : 'Save Check'}
               </Button>
               )}
             </div>

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -605,6 +605,7 @@ describe('OIDC client_id single source of truth', () => {
     'packages/backend/src/lib/capabilities/autheliaClientMerge.test.ts',    // unit tests use fixture client_id literals to drive the merge
     'packages/backend/src/lib/diagnose/probes/reconcileOidcClients.test.ts', // unit tests use fixture oidcClient meta to drive the reconcile action
     'packages/backend/src/lib/diagnose/ssoVerify.ts',                        // SSO probe maps each gated subdomain → its client_id + registered redirect to drive the real OIDC handshake (the value it TESTS, not a declaration)
+    'packages/backend/src/lib/reverseProxy/autheliaRewrite.test.ts',         // unit tests use a fixture Authelia config's client_id literals to drive + assert the LAN->Public rewrite
   ]);
 
   it('no src/ file hardcodes a client_id / username literal that mirrors an OIDC declaration', () => {


### PR DESCRIPTION
Closes #2186
Closes #2187
Closes #2188
Closes #2181
Closes #2183
Closes #2182
Closes #2184
Closes #2185

## UX papercuts (user-facing)
- Async feedback on regenerate-secret + save buttons (busy/disabled state, no double-fire).
- Escape closes the rename modal.

## Test coverage (no defects found — pinning box-critical behaviour)
- install: `resetGroups` topology + `credentialResolver` pause/resume.
- reverseProxy: `autheliaRewrite` LAN->Public YAML twin transform.
- diagnose: `crash_loop` per-line verdict at its boundaries.
- externalBackup: collector nodb/reject/container-name branches.

## Risk
Low — 3 frontend interaction tweaks + test-only additions; the OIDC single-source consistency rule was extended with one fixture-file exemption (matching existing sibling test exemptions).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full — 3555 passed)
- [ ] /verify on FCoS :dev box (frontend papercuts are user-facing — owed to box-verify)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._