### PR TITLE
fix(network): grow service group around its containers (per-node INCLUDE_CHILDREN)

### DIFF
--- a/packages/backend/src/lib/network/layout.overlap.test.ts
+++ b/packages/backend/src/lib/network/layout.overlap.test.ts
@@ -113,6 +113,112 @@ describe('getLayoutedElements — same-layer overlap (#2176 criterion 1)', () =>
   });
 });
 
+/** A leaf container card that declares `parentId` so it nests inside a group. */
+function containerNode(id: string, parentId: string): Node {
+  return {
+    id,
+    parentId,
+    position: { x: 0, y: 0 },
+    data: {
+      type: 'container',
+      label: id,
+      status: 'up',
+      subLabel: `image/${id}:latest`,
+      rawData: { type: 'container', status: 'running', created: '2026-01-01' },
+    },
+  } as unknown as Node;
+}
+
+/** An expanded (NOT collapsed) service group that owns `childIds` containers. */
+function serviceGroupWithChildren(id: string): Node {
+  return {
+    id,
+    position: { x: 0, y: 0 },
+    data: {
+      type: 'service',
+      label: id,
+      status: 'up',
+      rawData: { type: 'service', active: true, load: '0.1' },
+    },
+  } as unknown as Node;
+}
+
+describe('getLayoutedElements — nested group grows around children (#2191 criterion 1+3)', () => {
+  it('grows a multi-container service to enclose its children AND fans out disconnected components in the SAME graph', async () => {
+    // The #2191 HARD case: one expanded service that OWNS 4 containers (must
+    // grow to enclose them, zero child-child overlap) PLUS several disconnected
+    // top-level components (must still fan out, not stack into one column) — in
+    // ONE layout. Pre-#2191 the `hasNesting` gate turned INCLUDE_CHILDREN on
+    // globally, which broke the fan-out; or off, which stacked the containers.
+    const svc = serviceGroupWithChildren('big-service');
+    const containers = ['c-alpha', 'c-beta', 'c-gamma', 'c-delta'].map((c) =>
+      containerNode(c, 'big-service'),
+    );
+    // Disconnected top-level floaters (the #2175/#2176 shape) in the same graph.
+    const floaters = Array.from({ length: 5 }, (_, i) =>
+      largeGroupNode(`float-${i}`, 3, [`float${i}.example.com`]),
+    );
+
+    const nodes: Node[] = [svc, ...containers, ...floaters];
+    const edges: Edge[] = []; // service↔container nesting needs no edges; floaters disconnected
+
+    const { nodes: laid } = await getLayoutedElements(nodes, edges);
+
+    // --- Criterion 1: the service group bbox encloses ALL its children,
+    //     children laid out inside it with zero child-child overlap. ---
+    const parent = laid.find((n) => n.id === 'big-service')!;
+    expect(parent).toBeDefined();
+    const pw = (parent.style?.width as number | undefined) ?? 0;
+    const ph = (parent.style?.height as number | undefined) ?? 0;
+    // The group must have grown well beyond the ~240px leaf init guess.
+    expect(ph).toBeGreaterThan(300);
+    expect(pw).toBeGreaterThan(300);
+
+    // Child positions are LOCAL to the parent (React Flow parent/extent);
+    // absolute = parent.position + child.position. The child must sit inside
+    // the parent's box.
+    const kids = laid.filter((n) => n.parentId === 'big-service');
+    expect(kids.length).toBe(containers.length);
+    const kidRects: Rect[] = kids.map((k) => ({
+      x: k.position.x,
+      y: k.position.y,
+      w: (k.style?.width as number | undefined) ?? 440,
+      h: (k.style?.height as number | undefined) ?? 240,
+    }));
+    for (const r of kidRects) {
+      // Enclosed within the parent's LOCAL coordinate box [0,0,pw,ph].
+      expect(r.x).toBeGreaterThanOrEqual(-1);
+      expect(r.y).toBeGreaterThanOrEqual(-1);
+      expect(r.x + r.w).toBeLessThanOrEqual(pw + 1);
+      expect(r.y + r.h).toBeLessThanOrEqual(ph + 1);
+    }
+    // Zero child-child overlap.
+    for (let i = 0; i < kidRects.length; i++) {
+      for (let j = i + 1; j < kidRects.length; j++) {
+        expect(
+          overlaps(kidRects[i], kidRects[j]),
+          `children ${kids[i].id} and ${kids[j].id} overlap`,
+        ).toBe(false);
+      }
+    }
+
+    // --- Criterion 2 (in the same graph): top-level components don't overlap
+    //     and use the canvas (fan-out preserved). ---
+    const topBoxes = boundingBoxes(laid); // parentless only
+    for (let i = 0; i < topBoxes.length; i++) {
+      for (let j = i + 1; j < topBoxes.length; j++) {
+        expect(
+          overlaps(topBoxes[i], topBoxes[j]),
+          `top-level ${i} and ${j} overlap`,
+        ).toBe(false);
+      }
+    }
+    // Floaters + the grown service fan out into more than one x-band.
+    const distinctXBands = new Set(topBoxes.map((b) => Math.round(b.x / 50))).size;
+    expect(distinctXBands).toBeGreaterThan(1);
+  });
+});
+
 describe('getLayoutedElements — component spread (#2176 criterion 2)', () => {
   it('spreads disconnected components into a bounded aspect ratio, not one column', async () => {
     // Six independent (edge-less) service cards — the #2175 anchored/floating

--- a/packages/backend/src/lib/network/layout.ts
+++ b/packages/backend/src/lib/network/layout.ts
@@ -6,15 +6,23 @@ const elk = new ELK();
 
 const GROUP_NODE_TYPES = new Set(['group', 'proxy', 'service', 'pod', 'unmanaged-service']);
 
-// ELK options for layout. #2176 — `elk.hierarchyHandling: INCLUDE_CHILDREN`
-// is required for laying out nested (compound) group nodes, but it disables
-// ELK's connected-component packer — with it on, disconnected components (and
-// the anchored floating cards from #2175) stack into a single dense column
-// beside an empty half of the canvas. So we only add it when the graph
-// actually has nesting (some node declares a parentId); a flat graph gets the
-// component packer instead, which fans components out toward the aspect ratio.
-function buildLayoutOptions(hasNesting: boolean): Record<string, string> {
-  const options: Record<string, string> = {
+// ELK options for the ROOT graph.
+//
+// #2176 — `elk.hierarchyHandling: INCLUDE_CHILDREN` on the root disables ELK's
+// connected-component packer: with it set globally, disconnected components
+// (and the anchored floating cards from #2175) stack into a single dense column
+// beside an empty half of the canvas. So the root NEVER gets INCLUDE_CHILDREN —
+// it keeps `separateConnectedComponents` + `aspectRatio` so components fan out.
+//
+// #2191 — nested (compound) group nodes still need INCLUDE_CHILDREN to grow and
+// enclose their children. The two are NOT in tension once you stop relying on a
+// single global flag: `hierarchyHandling` can be set PER NODE, so each compound
+// node carries its own INCLUDE_CHILDREN in buildHierarchy (see the group
+// per-node layoutOptions) while the root keeps the component packer. This lets a
+// multi-container service GROW around its containers AND disconnected components
+// fan out, in the same graph (the #2191 hard case).
+function buildLayoutOptions(): Record<string, string> {
+  return {
     'elk.algorithm': 'layered',
     'elk.direction': 'RIGHT', // Horizontal flow (Internet -> Router -> Proxy -> Services)
     // #2176 — vertical gap *between* same-layer nodes. This is a MINIMUM added
@@ -48,10 +56,6 @@ function buildLayoutOptions(hasNesting: boolean): Record<string, string> {
     // horizontally (using the empty left half) rather than piling in a column.
     'elk.aspectRatio': '1.6',
   };
-  if (hasNesting) {
-    options['elk.hierarchyHandling'] = 'INCLUDE_CHILDREN'; // Crucial for nesting
-  }
-  return options;
 }
 
 // #1783 — approximate the pixel box a monospace port chip occupies so ELK
@@ -376,14 +380,20 @@ function buildHierarchy(nodes: Node[], edges: Edge[]): ElkNode {
             // If it becomes a parent (has children), we will remove width/height later to let ELK calculate it.
             width: node.measured?.width ?? calculateNodeWidth(node),
             height: node.measured?.height ?? calculateNodeHeight(node),
-            layoutOptions: isGroup ? { 
+            layoutOptions: isGroup ? {
                 'elk.padding': '[top=80,left=50,bottom=50,right=50]',
                 'elk.direction': 'RIGHT', // Horizontal layout for contents (Containers side-by-side)
-                'elk.algorithm': 'layered', 
+                'elk.algorithm': 'layered',
                 'elk.resize': 'true',
                 'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-                'elk.spacing.nodeNode': '80', 
+                'elk.spacing.nodeNode': '80',
                 'elk.layered.spacing.nodeNodeBetweenLayers': '120',
+                // #2191 — INCLUDE_CHILDREN is set PER compound node (here), not on
+                // the root, so this node grows to enclose its children while the
+                // root keeps the connected-component packer (see buildLayoutOptions).
+                // It's harmless on a group whose children were all filtered out
+                // (collapsed) — such a node has no children[] to include.
+                'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
             } : undefined,
             labels: [{ text: (node.data.label as string) || '' }],
             children: []
@@ -415,14 +425,13 @@ function buildHierarchy(nodes: Node[], edges: Edge[]): ElkNode {
     // However, putting them at root usually works for basic layout.
     const elkEdges: ElkExtendedEdge[] = edges.map(toElkEdge);
 
-    // #2176 — INCLUDE_CHILDREN is only needed (and only worth disabling the
-    // component packer for) when the graph actually nests. A group whose
-    // children were all filtered out (collapsed) is a leaf card here.
-    const hasNesting = nodes.some(n => n.parentId && nodeMap.has(n.parentId));
-
+    // #2191 — the root NEVER gets INCLUDE_CHILDREN (that would disable the
+    // connected-component packer, #2176). Nesting is handled per compound node
+    // via each group's own layoutOptions above, so a multi-container service
+    // grows around its containers AND disconnected components still fan out.
     return {
         id: 'root',
-        layoutOptions: buildLayoutOptions(hasNesting),
+        layoutOptions: buildLayoutOptions(),
         children: rootChildren,
         edges: elkEdges
     };


### PR DESCRIPTION
Closes #2191

Fixes the #2176 regression where service boxes didn't grow → child containers stacked; root graph keeps component fan-out, each compound group grows via its own per-node hierarchy option.

---
AI-generated
<!-- sb-ai-comment -->