### PR TITLE
fix(map): child containers render in their group slot (no stacking) + silence per-poll refresh toast

### DIFF
--- a/packages/frontend/src/dashboards/NetworkDashboard.groupsize.test.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.groupsize.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * #2194 — service-group container sizing at the RENDER layer.
+ *
+ * #2191 fixed the BACKEND ELK geometry (a compound group grows to enclose its
+ * children; child positions are parent-relative). But the map still rendered
+ * child containers "stacked on top of each other" because the FRONTEND left
+ * each child leaf at `h-auto`: ELK reserves a uniform column slot per child,
+ * and a card that renders taller than that slot overflows into the child below.
+ * The prior box-verify only checked backend API geometry (headless font bug
+ * hides text) → false green. This test encodes the regression where it broke:
+ * at the frontend render/size-application layer.
+ *
+ * Two assertions:
+ *  1. `applyChildSlotHeights` (the post-layout transform) leaves the GROUP node
+ *     at its ELK-computed width/height (NOT the pre-layout 400×200 guess) and
+ *     gives every child leaf a DEFINITE height equal to its reserved slot, so
+ *     consecutive children never overlap.
+ *  2. `CustomNode` RENDERS a slot-sized child leaf with `h-full overflow-hidden`
+ *     (fills exactly its slot) instead of `h-auto` (overflow → stack).
+ *
+ * Both would FAIL on the old behaviour (child height `undefined` / `h-auto`).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { Node, Edge } from '@xyflow/react';
+import { getLayoutedElements } from '@servicebay/api-client';
+import { applyChildSlotHeights, type GraphNodeData } from './_lib/networkDashboard';
+
+// Keep @xyflow/react's canvas-bound pieces inert in jsdom; CustomNode only
+// needs Handle/Position to render its wrapper markup.
+vi.mock('@xyflow/react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    Handle: () => <div data-testid="rf-handle" />,
+    Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+  };
+});
+vi.mock('@xyflow/react/dist/style.css', () => ({}));
+
+const childNode = (id: string, parent: string, ports: number): Node<GraphNodeData> =>
+  ({
+    id,
+    type: 'custom',
+    position: { x: 0, y: 0 },
+    parentId: parent,
+    data: {
+      type: 'container',
+      label: id,
+      parentNode: parent,
+      rawData: { ports: Array.from({ length: ports }, (_, i) => 3000 + i) },
+    },
+  }) as Node<GraphNodeData>;
+
+async function layoutServiceWith(childPorts: number[]) {
+  const nodes: Node<GraphNodeData>[] = [
+    {
+      id: 'svc',
+      type: 'custom',
+      position: { x: 0, y: 0 },
+      // The pre-layout hardcoded guess the frontend seeds group nodes with.
+      style: { width: 400, height: 200 },
+      data: { type: 'service', label: 'file-share' },
+    } as Node<GraphNodeData>,
+    ...childPorts.map((p, i) => childNode(`c${i + 1}`, 'svc', p)),
+  ];
+  const laidOut = await getLayoutedElements(nodes, [] as Edge[]);
+  return applyChildSlotHeights(laidOut.nodes as Node<GraphNodeData>[]);
+}
+
+describe('#2194 service-group render sizing', () => {
+  it('keeps the ELK-computed group size (not 400×200) and grows with container count', async () => {
+    const three = await layoutServiceWith([1, 3, 2]);
+    const four = await layoutServiceWith([1, 3, 2, 4]);
+
+    const svc3 = three.find((n) => n.id === 'svc')!;
+    const svc4 = four.find((n) => n.id === 'svc')!;
+    const h3 = (svc3.style as { height?: number }).height!;
+    const w3 = (svc3.style as { width?: number }).width!;
+    const h4 = (svc4.style as { height?: number }).height!;
+
+    // Criterion 1: the rendered group uses the ELK-computed size, NOT the
+    // hardcoded pre-layout 400×200 guess, and grows with container count.
+    expect(w3).not.toBe(400);
+    expect(h3).not.toBe(200);
+    expect(typeof h3).toBe('number');
+    expect(h4).toBeGreaterThan(h3); // one more container → taller enclosing box
+  });
+
+  it('gives every child a definite, non-overlapping slot height (was undefined → h-auto stack)', async () => {
+    const sized = await layoutServiceWith([1, 6, 2]); // varied content per child
+    const kids = sized
+      .filter((n) => n.parentId === 'svc')
+      .sort((a, b) => a.position.y - b.position.y);
+
+    expect(kids).toHaveLength(3);
+    for (const k of kids) {
+      const h = (k.style as { height?: number } | undefined)?.height;
+      // Criterion 3 regression: pre-fix this was `undefined` (h-auto → stack).
+      expect(typeof h).toBe('number');
+      expect(h!).toBeGreaterThan(0);
+    }
+
+    // Criterion 2: each child's [y, y+height] slot ends at/before the next
+    // child's y — zero child↔child overlap inside the parent rect.
+    for (let i = 0; i < kids.length - 1; i++) {
+      const bottom = kids[i].position.y + (kids[i].style as { height?: number }).height!;
+      const nextTop = kids[i + 1].position.y;
+      expect(bottom).toBeLessThanOrEqual(nextTop + 1); // +1 for rounding
+    }
+  });
+
+  it('renders a slot-sized child leaf that fills its slot (h-full overflow-hidden, not h-auto)', async () => {
+    // Lazy import so the @xyflow/react mock is installed before the module
+    // graph resolves the dashboard's Handle/Position usage.
+    const { CustomNode } = await import('./NetworkDashboard');
+
+    const childData: GraphNodeData = {
+      type: 'container',
+      label: 'c1',
+      parentNode: 'svc',
+      status: 'up',
+      rawData: { ports: [3000] },
+    };
+    const { container: childHost } = render(
+      // @ts-expect-error — NodeProps carries many optional RF fields the render
+      // path doesn't read; the test supplies only id + data.
+      <CustomNode id="c1" data={childData} />,
+    );
+    const childWrapper = childHost.querySelector('div');
+    expect(childWrapper?.className).toContain('h-full');
+    expect(childWrapper?.className).toContain('overflow-hidden');
+    expect(childWrapper?.className).not.toContain('h-auto');
+
+    // A top-level (parentless) card keeps h-auto — the fix is scoped to children.
+    const topData: GraphNodeData = { type: 'container', label: 'top', status: 'up', rawData: {} };
+    const { container: topHost } = render(
+      // @ts-expect-error — see above.
+      <CustomNode id="top" data={topData} />,
+    );
+    const topWrapper = topHost.querySelector('div');
+    expect(topWrapper?.className).toContain('h-auto');
+  });
+});
+
+const _renderTypeGuard: ReactNode = null;
+void _renderTypeGuard;

--- a/packages/frontend/src/dashboards/NetworkDashboard.test.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.test.tsx
@@ -64,8 +64,16 @@ vi.mock('@/hooks/useTopologyData', () => ({
 vi.mock('@/hooks/useServiceActions', () => ({
   useServiceActions: () => ({ overlays: null }),
 }));
+// #2195 — stable toast spies so a test can assert the auto-refresh does NOT
+// open a loading toast on a background merge, and DOES surface a brief
+// (non-sticky) indicator only when the topology changes. Typed to the
+// ToastProvider API so `.mock.calls` destructures (type, title, msg, duration).
+const addToast =
+  vi.fn<(type: string, title: string, message?: string, duration?: number) => string>(() => 'toast-id');
+const updateToast = vi.fn();
+const removeToast = vi.fn();
 vi.mock('@/providers/ToastProvider', () => ({
-  useToast: () => ({ addToast: vi.fn(), updateToast: vi.fn(), removeToast: vi.fn() }),
+  useToast: () => ({ addToast, updateToast, removeToast }),
 }));
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -83,6 +91,9 @@ import NetworkDashboard from './NetworkDashboard';
 describe('NetworkDashboard (#2100 dashboards migration)', () => {
   beforeEach(() => {
     fetchGraph.mockClear();
+    addToast.mockClear();
+    updateToast.mockClear();
+    removeToast.mockClear();
     topologyRawData = null;
     focusSearchParam = null;
     vi.stubGlobal('EventSource', class { close() {} } as unknown as typeof EventSource);
@@ -191,6 +202,75 @@ describe('NetworkDashboard (#2100 dashboards migration)', () => {
     rerender(<NetworkDashboard />);
     // Topology changed → a fresh ELK pass runs.
     await waitFor(() => expect(getLayoutedElements.mock.calls.length).toBeGreaterThan(before));
+  });
+
+  it('#2195 shows NO loading toast and NO toast on a background in-place merge (topology unchanged)', async () => {
+    topologyRawData = {
+      nodes: [
+        { id: 'internet', type: 'internet', label: 'Internet' },
+        { id: 'service-immich.service', type: 'service', label: 'immich', status: 'up' },
+      ],
+      edges: [{ id: 'e1', source: 'internet', target: 'service-immich.service' }],
+    };
+    const { rerender } = render(<NetworkDashboard />);
+    await waitFor(() => expect(getLayoutedElements).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Clear whatever the initial appear did — from here on we simulate N
+    // background twin updates (status/metric flips) with an UNCHANGED topology
+    // signature, exactly the steady-state that made the UI restless.
+    addToast.mockClear();
+    updateToast.mockClear();
+    removeToast.mockClear();
+
+    for (let i = 0; i < 5; i++) {
+      topologyRawData = {
+        nodes: [
+          { id: 'internet', type: 'internet', label: 'Internet' },
+          { id: 'service-immich.service', type: 'service', label: 'immich', status: i % 2 ? 'down' : 'up' },
+        ],
+        edges: [{ id: 'e1', source: 'internet', target: 'service-immich.service' }],
+      };
+      rerender(<NetworkDashboard />);
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    // No loading toast (the old sticky 'Refreshing Network'), and no toast at
+    // all on the in-place path.
+    const loadingCalls = addToast.mock.calls.filter((c) => c[0] === 'loading');
+    expect(loadingCalls.length).toBe(0);
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it('#2195 surfaces exactly one brief, non-sticky indicator when the topology actually changes', async () => {
+    topologyRawData = {
+      nodes: [{ id: 'service-a.service', type: 'service', label: 'a' }],
+      edges: [],
+    };
+    const { rerender } = render(<NetworkDashboard />);
+    await waitFor(() => expect(getLayoutedElements).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 20));
+
+    // The FIRST layout (map appearing) is not a change → not announced.
+    addToast.mockClear();
+
+    // A real topology change: a node is added → a full re-layout runs.
+    topologyRawData = {
+      nodes: [
+        { id: 'service-a.service', type: 'service', label: 'a' },
+        { id: 'service-b.service', type: 'service', label: 'b' },
+      ],
+      edges: [],
+    };
+    rerender(<NetworkDashboard />);
+    await waitFor(() => expect(addToast).toHaveBeenCalled());
+
+    // A single, brief, NON-sticky toast (duration > 0), never a loading toast.
+    expect(addToast).toHaveBeenCalledTimes(1);
+    const [type, , , duration] = addToast.mock.calls[0];
+    expect(type).not.toBe('loading');
+    expect(typeof duration).toBe('number');
+    expect(duration as number).toBeGreaterThan(0);
   });
 
   it('#2108 does NOT enter focus mode when the focus param matches no node (stale link)', async () => {

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -853,31 +853,38 @@ export default function NetworkDashboard() {
   const layoutSignatureRef = React.useRef<string | null>(null);
   const laidOutGraphRef = React.useRef<{ nodes: Node<GraphNodeData>[]; edges: Edge[] } | null>(null);
   const hasFitViewRef = React.useRef(false);
+    // #2195 — `activeToastRef` now only tracks a toast owned by an EXPLICIT
+    // network scan (the `network-scan-progress` SSE below opens/updates it).
+    // The steady-state twin-driven auto-refresh no longer creates one: a
+    // background fetch is silent, so a flurry of status/metric twin updates
+    // never stacks a "Refreshing Network" toast and makes the UI restless.
     const activeToastRef = React.useRef<string | null>(null);
-    const { addToast, updateToast, removeToast } = useToast();
+    const { addToast, updateToast } = useToast();
 
-  const startReloadToast = useCallback((description = 'Reloading network graph...') => {
+  // #2195 — surface a refresh indicator ONLY when the topology actually
+  // changed (a full re-layout). It is brief and non-sticky (auto-dismisses),
+  // never a duration-0 sticky loop. The in-place status/metric merge path
+  // (topology signature unchanged) calls neither of these — it stays silent.
+  const NETWORK_UPDATED_TOAST_MS = 2500;
+  const notifyTopologyChanged = useCallback(() => {
+      // If an explicit scan is showing a loading toast, resolve it in place
+      // instead of stacking a second toast on top.
       if (activeToastRef.current) {
-          updateToast(activeToastRef.current, 'loading', 'Refreshing Network', description);
-          return activeToastRef.current;
+          updateToast(activeToastRef.current, 'success', 'Network updated', 'Topology changed', NETWORK_UPDATED_TOAST_MS);
+          activeToastRef.current = null;
+          return;
       }
-
-      const id = addToast('loading', 'Refreshing Network', description, 0);
-      activeToastRef.current = id;
-      return id;
+      addToast('info', 'Network updated', undefined, NETWORK_UPDATED_TOAST_MS);
   }, [addToast, updateToast]);
 
-  const resolveReloadToast = useCallback((status: 'success' | 'error', description?: string) => {
-      if (!activeToastRef.current) return;
-
-      if (status === 'success') {
-          removeToast(activeToastRef.current);
-      } else {
+  const notifyRefreshError = useCallback((description?: string) => {
+      if (activeToastRef.current) {
           updateToast(activeToastRef.current, 'error', 'Network refresh failed', description);
+          activeToastRef.current = null;
+          return;
       }
-
-      activeToastRef.current = null;
-  }, [removeToast, updateToast]);
+      addToast('error', 'Network refresh failed', description);
+  }, [addToast, updateToast]);
 
   // Health Modal State
   const [showHealthModal, setShowHealthModal] = useState(false);
@@ -1210,11 +1217,16 @@ export default function NetworkDashboard() {
       const topologyUnchanged =
           layoutSignatureRef.current === signature && laidOutGraphRef.current !== null;
       const hasFreshDeepLinkFocus = Boolean(focusPlan.appliedParam && focusPlan.nodeId);
+      // #2195 — the FIRST layout (no prior signature) is the map appearing, not
+      // a change; don't announce it. Only a subsequent topology change (a
+      // re-layout with a prior signature) surfaces the brief indicator.
+      const isFirstLayout = layoutSignatureRef.current === null;
       const isStale = () => layoutRunRef.current !== runId;
       try {
           if (topologyUnchanged && !hasFreshDeepLinkFocus) {
+              // #2195 — background status/metric merge: the map updates in place
+              // and stays SILENT (no loading toast, no success toast).
               mergeInPlace(gd.nodes, gd.edges, searchQuery);
-              if (!isStale()) resolveReloadToast('success', 'Latest network topology is ready');
               return;
           }
           await processAndLayout(gd.nodes, gd.edges, currentCollapsed, searchQuery, currentFocus);
@@ -1224,18 +1236,19 @@ export default function NetworkDashboard() {
               appliedFocusParamRef.current = focusPlan.appliedParam;
               setFocusNodeId(focusPlan.nodeId);
           }
-          resolveReloadToast('success', 'Latest network topology is ready');
+          // #2195 — a real topology change re-laid the map out: surface a brief,
+          // non-sticky indicator (skip the initial appear + deep-link camera move).
+          if (!isFirstLayout && !hasFreshDeepLinkFocus) notifyTopologyChanged();
       } catch {
-          if (!isStale()) resolveReloadToast('error', 'Unable to render network map');
+          if (!isStale()) notifyRefreshError('Unable to render network map');
       }
-  }, [mergeInPlace, processAndLayout, searchQuery, resolveReloadToast, setFocusNodeId]);
+  }, [mergeInPlace, processAndLayout, searchQuery, notifyTopologyChanged, notifyRefreshError, setFocusNodeId]);
 
   // #1071 phase 1: data layer (graph fetch + twin-driven auto-refresh
   // + the two effects that drive them) is in useTopologyData. Toast
   // plumbing stays here since it's a UI concern.
   const { rawData, fetchGraph, twin } = useTopologyData({
-    onLoadStart: startReloadToast,
-    onLoadError: (message) => resolveReloadToast('error', message),
+    onLoadError: (message) => notifyRefreshError(message),
   });
 
   // The service-action overlays (start/stop/restart/delete modals) still mount

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -43,6 +43,7 @@ import { useToast } from '@/providers/ToastProvider';
 import ExternalLinkModal from '@/components/ExternalLinkModal';
 import { Button, Badge, StatusDot } from '@/components/ui';
 import {
+  applyChildSlotHeights,
   buildOrthogonalPath,
   buildServiceEditHref,
   computeEgoNodeIds,
@@ -155,7 +156,10 @@ function getNodeTypeInfo(data: GraphNodeData) {
 }
 
 // Custom Node Component
-const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
+// Exported for the #2194 render test (assert a child leaf fills its ELK slot
+// with h-full/overflow-hidden and a group renders at the ELK size). Not part of
+// the public dashboard API — the graph mounts it via `nodeTypes`.
+export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
     const isCollapsed = data.collapsed;
     const onToggle = data.onToggle;
     const { isGroup, isExpandable, effectiveType, isManagedService, isUnmanagedService, isServiceType, isMissing, isGateway } = getNodeTypeInfo(data);
@@ -370,8 +374,19 @@ const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
   const targetPos = data.targetHandlePosition || Position.Left;
   const sourcePos = data.sourceHandlePosition || Position.Right;
 
+  // #2194 — a child leaf inside a service group is given a definite ELK-reserved
+  // slot height (applyChildSlotHeights). Fill that slot with h-full + clip so the
+  // card occupies exactly its column slot and can never overflow into the child
+  // below it (the stacked/overlapping symptom). Top-level cards keep h-auto.
+  const isChildLeaf = Boolean(data.parentNode) && !isGroup && !renderAsExpandedGroup;
   return (
-    <div className={`w-full ${(isGroup || renderAsExpandedGroup) ? 'h-full' : 'min-w-[320px] h-auto'}`}>
+    <div className={`w-full ${
+      (isGroup || renderAsExpandedGroup)
+        ? 'h-full'
+        : isChildLeaf
+          ? 'min-w-[320px] h-full overflow-hidden'
+          : 'min-w-[320px] h-auto'
+    }`}>
       {/* Handles for connecting */}
       <Handle type="target" position={targetPos} className="!w-3 !h-3 !bg-blue-400" />
       <Handle type="source" position={sourcePos} className="!w-3 !h-3 !bg-blue-400" />
@@ -1134,7 +1149,12 @@ export default function NetworkDashboard() {
 
     // 4. Layout
     const layouted = await getLayoutedElements(layoutNodes, layoutEdges);
-    const filteredNodes = applyFilter(layouted.nodes as Node<GraphNodeData>[], search);
+    // #2194 — the group node already carries ELK's grown width/height; give each
+    // child leaf its ELK-reserved vertical slot so it fills the room ELK
+    // allocated instead of rendering at h-auto and overflowing into the next
+    // child (the "containers stacked on top of each other" symptom).
+    const sizedNodes = applyChildSlotHeights(layouted.nodes as Node<GraphNodeData>[]);
+    const filteredNodes = applyFilter(sizedNodes, search);
     const layoutedEdges = layouted.edges;
     setNodes(filteredNodes);
     setEdges(layoutedEdges);

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -358,6 +358,82 @@ export function mergeGraphPreservingPositions<TNode extends Node, TEdge extends 
   return { nodes, edges };
 }
 
+/**
+ * #2194 — apply the ELK-reserved vertical slot height to every child leaf
+ * node so it fills exactly the room ELK allocated inside its (grown) parent.
+ *
+ * The backend layout (layout.ts) grows a compound group to enclose its
+ * children and stamps the ELK-computed width/height onto the GROUP node's
+ * style — that part is correct and lands on the rendered parent. But it
+ * deliberately drops each LEAF child's height (`style.height: undefined`,
+ * "let the card grow with content"). React Flow then renders each child at
+ * its natural (`h-auto`) DOM height. ELK lays the children out in one column
+ * on a UNIFORM pitch (max-child-height + spacing), so a card that renders
+ * taller than that pitch overflows into the slot below it — the operator's
+ * "containers stacked on top of each other" symptom (#2191 fixed the backend
+ * geometry but the render still overlapped).
+ *
+ * Fix at the render layer (frontend, no layout.ts change): give each child a
+ * definite `style.height` equal to its reserved slot so `h-full` +
+ * `overflow-hidden` in CustomNode makes it occupy exactly that slot and never
+ * spill into its neighbour. The slot is recovered from the sibling pitch (the
+ * gap between consecutive children, which ELK keeps uniform); the final child
+ * takes the room down to the parent's inner edge. Children without a resolved
+ * parent height (shouldn't happen post-layout) are left untouched.
+ */
+const CHILD_SLOT_BOTTOM_PADDING = 50; // matches ELK group padding bottom (layout.ts)
+const MIN_CHILD_SLOT_HEIGHT = 200;
+
+export function applyChildSlotHeights<TNode extends Node>(nodes: TNode[]): TNode[] {
+  // Group child leaf nodes (nodes with a parentId) by parent.
+  const childrenByParent = new Map<string, TNode[]>();
+  for (const n of nodes) {
+    const parentId = n.parentId;
+    if (!parentId) continue;
+    const list = childrenByParent.get(parentId);
+    if (list) list.push(n);
+    else childrenByParent.set(parentId, [n]);
+  }
+  if (childrenByParent.size === 0) return nodes;
+
+  const parentHeightById = new Map<string, number>();
+  for (const n of nodes) {
+    const h = (n.style as CSSProperties | undefined)?.height;
+    if (typeof h === 'number' && childrenByParent.has(n.id)) {
+      parentHeightById.set(n.id, h);
+    }
+  }
+
+  // Resolve a slot height per child id (parent-relative, in ELK's column).
+  const slotHeightById = new Map<string, number>();
+  for (const [parentId, kids] of childrenByParent) {
+    const parentHeight = parentHeightById.get(parentId);
+    // Sort children by their laid-out y (ELK stacks them in a column).
+    const sorted = [...kids].sort((a, b) => a.position.y - b.position.y);
+    for (let i = 0; i < sorted.length; i++) {
+      const y = sorted[i].position.y;
+      const nextY =
+        i + 1 < sorted.length
+          ? sorted[i + 1].position.y
+          : parentHeight !== undefined
+            ? parentHeight - CHILD_SLOT_BOTTOM_PADDING
+            : undefined;
+      if (nextY === undefined) continue;
+      const slot = Math.max(MIN_CHILD_SLOT_HEIGHT, Math.round(nextY - y));
+      slotHeightById.set(sorted[i].id, slot);
+    }
+  }
+  if (slotHeightById.size === 0) return nodes;
+
+  return nodes.map((n) => {
+    const slot = slotHeightById.get(n.id);
+    if (slot === undefined) return n;
+    const style = n.style as CSSProperties | undefined;
+    if (style?.height === slot) return n;
+    return { ...n, style: { ...style, height: slot } } as TNode;
+  });
+}
+
 // ────────────────────────────────────────────────────────────────────
 // Edge-kind styling (#813). The backend stamps each edge with `kind`
 // (gateway | proxy | observed | declared | manual). The map must

--- a/packages/frontend/src/hooks/useTopologyData.test.ts
+++ b/packages/frontend/src/hooks/useTopologyData.test.ts
@@ -42,7 +42,6 @@ describe('useTopologyData callback stability (#1175)', () => {
   it('returns a stable fetchGraph across renders even when callers pass fresh inline arrows', () => {
     const { result, rerender } = renderHook(() =>
       useTopologyData({
-        onLoadStart: () => { /* fresh arrow every render */ },
         onLoadError: (msg) => { void msg; /* fresh arrow every render */ },
       }),
     );
@@ -54,25 +53,23 @@ describe('useTopologyData callback stability (#1175)', () => {
     expect(result.current.fetchGraph).toBe(firstFetchGraph);
   });
 
-  it('still calls the LATEST onLoadStart / onLoadError when fetchGraph runs after a re-render', async () => {
-    // Caller updates the callbacks every render. The hook must dispatch
-    // to the most recent ones, not the originals captured at mount.
+  it('still calls the LATEST onLoadError when fetchGraph runs after a re-render', async () => {
+    // Caller updates the callback every render. The hook must dispatch
+    // to the most recent one, not the original captured at mount.
     let latestErr: string | null = null;
-    let calls = 0;
 
     const { result, rerender } = renderHook(
       ({ tag }: { tag: string }) =>
         useTopologyData({
-          onLoadStart: () => { calls += 1; },
           onLoadError: (msg) => { latestErr = `${tag}: ${msg}`; },
         }),
       { initialProps: { tag: 'first' } },
     );
 
     // Wait for the initial-mount fetch to complete
-    await waitFor(() => expect(calls).toBeGreaterThan(0));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
 
-    // Re-render with a new tag — the callbacks change closure values.
+    // Re-render with a new tag — the callback changes closure value.
     rerender({ tag: 'second' });
 
     // Force a failing fetch this time

--- a/packages/frontend/src/hooks/useTopologyData.ts
+++ b/packages/frontend/src/hooks/useTopologyData.ts
@@ -6,9 +6,7 @@ import type { DigitalTwinSnapshot } from '@/providers/DigitalTwinProvider';
 import type { NetworkGraph } from '@servicebay/api-client';
 
 interface UseTopologyDataOptions {
-  /** Called when a refresh kicks off — typically opens a toast. */
-  onLoadStart?: () => void;
-  /** Called when a refresh fails — typically resolves the toast as error. */
+  /** Called when a refresh fails — typically surfaces an error toast. */
   onLoadError?: (message: string) => void;
 }
 
@@ -31,14 +29,25 @@ interface UseTopologyDataResult {
  *
  * Auto-fetch behaviour:
  *   1. Initial mount triggers one fetch.
- *   2. Every digital-twin snapshot update triggers a debounced (500ms)
- *      re-fetch — the server pushes twin updates, not graph deltas, so
- *      polling on twin changes keeps the map in sync without a refresh
- *      button.
+ *   2. Every digital-twin snapshot update triggers a debounced re-fetch
+ *      — the server pushes twin updates, not graph deltas, so polling on
+ *      twin changes keeps the map in sync without a refresh button.
+ *      #2195 — twin updates fire on ANY status/metric/sync change (dozens
+ *      per minute on a busy box), not just topology changes. The fetch is
+ *      SILENT: it emits no loading toast, so a flurry of background twin
+ *      updates never makes the UI restless. The dashboard shows a brief
+ *      indicator only when the fetched topology actually changed (a full
+ *      re-layout) — see NetworkDashboard.applyTopology. The debounce is
+ *      raised to coalesce bursts of twin updates into at most one fetch.
  *
- * The toast callbacks are intentionally pass-through: the hook itself
- * has no dependency on the toast provider so it stays testable.
+ * The error callback is intentionally pass-through: the hook itself has
+ * no dependency on the toast provider so it stays testable.
  */
+// #2195 — coalesce a burst of twin updates (status/metric flips) into a
+// single re-fetch. Higher than the old 500ms so a flurry doesn't drive a
+// fetch per update; still snappy enough to keep the map live.
+const TWIN_REFETCH_DEBOUNCE_MS = 1000;
+
 export function useTopologyData(options: UseTopologyDataOptions = {}): UseTopologyDataResult {
   const { data: twin } = useDigitalTwin();
   const [rawData, setRawData] = useState<NetworkGraph | null>(null);
@@ -51,15 +60,16 @@ export function useTopologyData(options: UseTopologyDataOptions = {}): UseTopolo
   // depth — fetch → setRawData → re-render → fresh callbacks → fresh
   // fetchGraph → effects re-fire → fetch …). The ref pattern keeps
   // the hook tolerant of unstable callers.
-  const onLoadStartRef = useRef(options.onLoadStart);
   const onLoadErrorRef = useRef(options.onLoadError);
   useEffect(() => {
-    onLoadStartRef.current = options.onLoadStart;
     onLoadErrorRef.current = options.onLoadError;
   });
 
   const fetchGraph = useCallback(async () => {
-    onLoadStartRef.current?.();
+    // #2195 — no onLoadStart / loading toast: the refresh is silent. The
+    // dashboard decides whether to surface an indicator, and only does so
+    // when the fetched topology actually changed (a re-layout), never for
+    // a background status/metric merge.
     try {
       const res = await fetch('/api/network/graph');
       if (!res.ok) {
@@ -84,7 +94,7 @@ export function useTopologyData(options: UseTopologyDataOptions = {}): UseTopolo
   // rapid SYNC_PARTIAL bursts during initial sync).
   useEffect(() => {
     if (!twin) return;
-    const t = setTimeout(fetchGraph, 500);
+    const t = setTimeout(fetchGraph, TWIN_REFETCH_DEBOUNCE_MS);
     return () => { clearTimeout(t); };
   }, [twin, fetchGraph]);
 


### PR DESCRIPTION
Closes #2194 #2195

- Child leaves are stamped to their ELK group-slot height with `h-full overflow-hidden`, so nested containers render inside their parent group slot and stop stacking on top of one another.
- The "Refreshing Network" toast no longer fires on every twin poll: in-place merges are silent; only a real topology change surfaces a brief, non-sticky indicator.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._