### PR TITLE
fix(map): set top-level node width/height for React Flow v12 so containers position inside their group

### DIFF
--- a/packages/backend/src/lib/network/layout.test.ts
+++ b/packages/backend/src/lib/network/layout.test.ts
@@ -147,6 +147,54 @@ describe('getLayoutedElements — ELK orthogonal routing (#1782)', () => {
     ]);
   });
 
+  it('stamps ELK-computed dimensions as TOP-LEVEL width/height for RF v12 (#2201)', async () => {
+    // React Flow v12 reads layout dims from node.width/node.height, not style.
+    // Without top-level dims, children with extent:'parent' clamp to (0,0).
+    layoutMock.mockResolvedValueOnce({
+      id: 'root',
+      children: [
+        {
+          id: 'g',
+          x: 500,
+          y: 100,
+          width: 520,
+          height: 610,
+          children: [
+            { id: 'c1', x: 50, y: 80, width: 440, height: 240, children: [] },
+            { id: 'c2', x: 50, y: 340, width: 440, height: 240, children: [] },
+          ],
+        },
+      ],
+      edges: [],
+    });
+
+    const nodes: Node[] = [
+      { id: 'g', position: { x: 0, y: 0 }, data: { type: 'group' } },
+      { id: 'c1', parentId: 'g', position: { x: 0, y: 0 }, data: { type: 'container' } },
+      { id: 'c2', parentId: 'g', position: { x: 0, y: 0 }, data: { type: 'container' } },
+    ];
+
+    const result = await getLayoutedElements(nodes, []);
+    const byId = new Map(result.nodes.map((n) => [n.id, n]));
+
+    // Group parent: top-level dims carry the ELK box (RF v12 uses these to
+    // compute parent bounds for extent-clamped children).
+    const g = byId.get('g')!;
+    expect(g.width).toBe(520);
+    expect(g.height).toBe(610);
+
+    // Child leaves: top-level dims carry each child's own box so the
+    // extent-clamp math places them inside the parent instead of at (0,0).
+    const c1 = byId.get('c1')!;
+    expect(c1.width).toBe(440);
+    expect(c1.height).toBe(240);
+    expect(c1.position).toEqual({ x: 50, y: 80 });
+    const c2 = byId.get('c2')!;
+    expect(c2.width).toBe(440);
+    expect(c2.height).toBe(240);
+    expect(c2.position).toEqual({ x: 50, y: 340 });
+  });
+
   it('leaves an edge untouched when ELK produced no section for it', async () => {
     layoutMock.mockResolvedValueOnce({
       id: 'root',

--- a/packages/backend/src/lib/network/layout.ts
+++ b/packages/backend/src/lib/network/layout.ts
@@ -106,18 +106,34 @@ function toElkEdge(edge: Edge): ElkExtendedEdge {
   };
 }
 
-// Append one React Flow node with its ELK-computed box. Groups MUST take ELK's
-// height to enclose their children. #2198 — a CHILD leaf (has a parentId) also
-// takes ELK's height: root INCLUDE_CHILDREN lays each child out at a real box
-// inside its grown parent, and the child card renders `h-full` to fill exactly
-// that slot (NetworkDashboard.CustomNode), so it can't spill into the sibling
-// below it. A parentless leaf keeps h-auto (grows with content) → undefined.
+// Append one React Flow node with its ELK-computed box.
+//
+// #2201 — React Flow **v12** (`@xyflow/react` v12.x) reads a node's layout
+// dimensions from the TOP-LEVEL `node.width`/`node.height`, NOT from `style`
+// (the v11 convention). Without top-level parent dimensions RF v12 can't
+// compute parent bounds, so child nodes with `extent:'parent'` clamp to the
+// parent origin → they render at (0,0) with no size and the containers stack.
+// So we stamp the ELK-computed box as top-level `width`/`height` on EVERY laid
+// out node — group parents AND child leaves alike (children need their own box
+// so the extent-clamp math works). We keep the same values mirrored into
+// `style` for the visual card sizing the CustomNode already relies on.
+//
+// Groups MUST take ELK's height to enclose their children. #2198 — a CHILD leaf
+// (has a parentId) also takes ELK's height: root INCLUDE_CHILDREN lays each
+// child out at a real box inside its grown parent, and the child card renders
+// `h-full` to fill exactly that slot (NetworkDashboard.CustomNode), so it can't
+// spill into the sibling below it. A parentless leaf keeps h-auto (grows with
+// content) → its style height stays undefined, but its top-level width/height
+// still carry the ELK box for RF v12.
 function pushLayoutedNode(out: Node[], original: Node, elkNode: ElkNode): void {
   const isGroup = GROUP_NODE_TYPES.has(original.data?.type as string);
   const isChildLeaf = original.parentId !== undefined;
   out.push({
     ...original,
     position: { x: elkNode.x!, y: elkNode.y! },
+    // #2201 — top-level dims are what RF v12 uses for layout + extent bounds.
+    width: elkNode.width,
+    height: elkNode.height,
     style: {
       ...original.style,
       width: elkNode.width,

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -1311,7 +1311,11 @@ export default function NetworkDashboard() {
             parentId: n.parentNode,
             extent: n.parentNode ? 'parent' : undefined,
             className: isGroup ? 'border border-dashed border-slate-300 dark:border-white/10 bg-slate-500/[0.02] dark:bg-white/[0.01] rounded-2xl backdrop-blur-[2px]' : undefined,
-            style: isGroup ? { 
+            // #2201 — React Flow v12 reads layout dims from top-level
+            // width/height, not style. Set the initial group guess top-level so
+            // it doesn't fight the top-level dims getLayoutedElements stamps.
+            ...(isGroup ? { width: 400, height: 200 } : {}),
+            style: isGroup ? {
                 width: 400, // Initial guess, ELK will resize
                 height: 200,
             } : undefined


### PR DESCRIPTION
Closes #2201

React Flow v12 reads node dimensions from top-level `width`/`height`, not `style.*` (the v11 convention the layout used). Without them, child containers with `extent:'parent'` clamped to (0,0) and stacked. Sets ELK-computed dims top-level on every laid-out node.

Browser-measured verification on :dev to follow before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- sb-ai-comment -->