### PR TITLE
fix(ui): calm the mobile "ServiceBay restarted" reload prompt

### DIFF
--- a/packages/frontend/src/components/ServerIdentityWatcher.test.tsx
+++ b/packages/frontend/src/components/ServerIdentityWatcher.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+// A controllable mock socket: tests drive `server:identity` emits directly.
+const handlers: Record<string, ((data: unknown) => void)[]> = {};
+const mockSocket = {
+  on: (ev: string, fn: (data: unknown) => void) => {
+    (handlers[ev] ||= []).push(fn);
+  },
+  off: (ev: string, fn: (data: unknown) => void) => {
+    handlers[ev] = (handlers[ev] || []).filter((h) => h !== fn);
+  },
+};
+function emitIdentity(data: { sessionId: string; setupCompleted: boolean }) {
+  act(() => {
+    (handlers['server:identity'] || []).forEach((h) => h(data));
+  });
+}
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => ({ socket: mockSocket, isConnected: true }),
+}));
+
+import ServerIdentityWatcher from './ServerIdentityWatcher';
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+}
+
+describe('ServerIdentityWatcher — calm update prompt (#2203)', () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    for (const k of Object.keys(handlers)) delete handlers[k];
+    reload.mockClear();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+    setVisibility('visible');
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('shows no banner on the first identity or on a same-session reconnect', () => {
+    render(<ServerIdentityWatcher />);
+    emitIdentity({ sessionId: 'A', setupCompleted: true });
+    emitIdentity({ sessionId: 'A', setupCompleted: true }); // reconnect, same process
+    expect(screen.queryByText(/ServiceBay updated/i)).toBeNull();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('on restart shows a calm pill and does NOT auto-reload while visible (no countdown)', () => {
+    render(<ServerIdentityWatcher />);
+    emitIdentity({ sessionId: 'A', setupCompleted: true });
+    emitIdentity({ sessionId: 'B', setupCompleted: true }); // restart
+
+    expect(screen.getByText(/ServiceBay updated/i)).toBeTruthy();
+    // No ticking countdown text, and crucially no forced reload while the
+    // user is actively viewing the page.
+    expect(screen.queryByText(/Reloading in/i)).toBeNull();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('applies the pending reload quietly when the tab is hidden', () => {
+    render(<ServerIdentityWatcher />);
+    emitIdentity({ sessionId: 'A', setupCompleted: true });
+    emitIdentity({ sessionId: 'B', setupCompleted: true });
+
+    expect(reload).not.toHaveBeenCalled();
+    setVisibility('hidden'); // screen lock / app switch
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces — repeated restarts never stack or re-trigger the pill', () => {
+    render(<ServerIdentityWatcher />);
+    emitIdentity({ sessionId: 'A', setupCompleted: true });
+    emitIdentity({ sessionId: 'B', setupCompleted: true });
+    emitIdentity({ sessionId: 'C', setupCompleted: true });
+    expect(screen.getAllByText(/ServiceBay updated/i)).toHaveLength(1);
+  });
+
+  it('Dismiss hides the pill and suppresses further detection', () => {
+    render(<ServerIdentityWatcher />);
+    emitIdentity({ sessionId: 'A', setupCompleted: true });
+    emitIdentity({ sessionId: 'B', setupCompleted: true });
+
+    act(() => screen.getByLabelText('Dismiss').click());
+    expect(screen.queryByText(/ServiceBay updated/i)).toBeNull();
+
+    emitIdentity({ sessionId: 'D', setupCompleted: true }); // another restart
+    expect(screen.queryByText(/ServiceBay updated/i)).toBeNull();
+    // Dismissed → a later tab-hide must not reload.
+    setVisibility('hidden');
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('setupCompleted → false forces an immediate reload (reinstall wizard)', () => {
+    render(<ServerIdentityWatcher />);
+    emitIdentity({ sessionId: 'A', setupCompleted: true });
+    emitIdentity({ sessionId: 'A', setupCompleted: false });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/src/components/ServerIdentityWatcher.tsx
+++ b/packages/frontend/src/components/ServerIdentityWatcher.tsx
@@ -9,17 +9,21 @@
  * `{ sessionId, setupCompleted }`. `sessionId` is regenerated per process
  * start, so:
  *   - normal reconnect (network blip)   → same sessionId, no action
- *   - server restart                    → new sessionId, banner + 10s
- *                                          auto-reload
+ *   - server restart                    → new sessionId, calm update pill
  *   - reinstall (setupCompleted: false) → forced immediate reload, since
  *                                          the wizard is binding anyway
  *
- * Mounted once at the root layout. Renders a small fixed banner at the
- * top of the viewport when a restart is detected; auto-reloads after
- * `RELOAD_GRACE_SECONDS`. The user can click "Reload now" to skip the
- * countdown or "Dismiss" to hide the banner for the current session
- * (useful if they're mid-form and want to copy something out first —
- * they still control when to refresh).
+ * UX (#2203): the box is a heavily-exercised target and restarts often, so
+ * a ticking countdown that force-reloads the page out from under the user
+ * felt restless on mobile. Good practice for an "app updated, reload" prompt
+ * is to be calm and never yank the page mid-interaction:
+ *   - show a small, dismissible pill — no countdown, no surprise reload;
+ *   - apply the pending reload QUIETLY the next time the tab is hidden
+ *     (screen lock / app switch), so a mobile user returns to a fresh page;
+ *   - the user can still Reload now (explicit) or Dismiss;
+ *   - coalesce — once a reload is pending, further restarts don't re-trigger.
+ *
+ * Mounted once at the root layout.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -31,15 +35,14 @@ interface ServerIdentity {
   setupCompleted: boolean;
 }
 
-const RELOAD_GRACE_SECONDS = 10;
-
 export default function ServerIdentityWatcher() {
   const { socket } = useSocket();
   /** First identity received this page-load. Compared against every
    *  subsequent emit to detect a restart. */
   const initial = useRef<ServerIdentity | null>(null);
-  /** When non-null, the banner is shown with `remaining` seconds left. */
-  const [reload, setReload] = useState<{ remaining: number } | null>(null);
+  /** True once a restart is detected — a reload is queued but NOT forced;
+   *  the pill is shown and the reload applies quietly on next tab-hide. */
+  const [pending, setPending] = useState(false);
   /** True once the user clicks Dismiss; suppresses further detection
    *  until the page is reloaded. */
   const [dismissed, setDismissed] = useState(false);
@@ -67,13 +70,15 @@ export default function ServerIdentityWatcher() {
       if (setupReverted) {
         // The install wizard is showing again — every API call from this
         // page will redirect / 401. There's no useful state to preserve;
-        // skip the banner and reload immediately.
+        // skip the pill and reload immediately.
         window.location.reload();
         return;
       }
 
       if (restarted) {
-        setReload({ remaining: RELOAD_GRACE_SECONDS });
+        // Coalesce: setState to the same `true` is a no-op, so repeated
+        // restarts never re-trigger or stack the pill.
+        setPending(true);
       }
     }
     socket.on('server:identity', onIdentity);
@@ -82,44 +87,45 @@ export default function ServerIdentityWatcher() {
     };
   }, [socket, dismissed]);
 
-  // Countdown + auto-reload at zero.
+  // Quiet reload: once a reload is pending, apply it the next time the tab
+  // is backgrounded (screen lock / app switch / tab change). The user is not
+  // looking, so they return to a fresh page instead of being yanked.
   useEffect(() => {
-    if (!reload) return;
-    if (reload.remaining <= 0) {
-      window.location.reload();
-      return;
+    if (!pending) return;
+    function onHidden() {
+      if (document.visibilityState === 'hidden') {
+        window.location.reload();
+      }
     }
-    const t = setTimeout(() => {
-      setReload(r => (r ? { ...r, remaining: r.remaining - 1 } : null));
-    }, 1000);
-    return () => clearTimeout(t);
-  }, [reload]);
+    document.addEventListener('visibilitychange', onHidden);
+    return () => document.removeEventListener('visibilitychange', onHidden);
+  }, [pending]);
 
-  if (!reload) return null;
+  if (!pending) return null;
 
   return (
     <div
-      role="alert"
+      role="status"
       aria-live="polite"
-      className="fixed top-3 left-1/2 -translate-x-1/2 z-[60] max-w-md px-4 py-2.5 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 shadow-lg flex items-center gap-3"
+      className="fixed top-3 left-1/2 -translate-x-1/2 z-[60] max-w-md px-3.5 py-2 rounded-full border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 shadow-lg flex items-center gap-2.5"
     >
-      <RefreshCcw size={16} className="shrink-0 text-amber-700 dark:text-amber-300" />
+      <RefreshCcw size={15} className="shrink-0 text-amber-700 dark:text-amber-300" />
       <span className="text-sm text-amber-900 dark:text-amber-100">
-        ServiceBay was restarted. Reloading in {reload.remaining}s…
+        ServiceBay updated
       </span>
       <button
         type="button"
         onClick={() => window.location.reload()}
-        className="text-xs font-medium px-2.5 py-1 rounded bg-amber-600 hover:bg-amber-700 text-white"
+        className="text-xs font-medium px-2.5 py-1 rounded-full bg-amber-600 hover:bg-amber-700 text-white"
       >
-        Reload now
+        Reload
       </button>
       <button
         type="button"
         aria-label="Dismiss"
         onClick={() => {
           setDismissed(true);
-          setReload(null);
+          setPending(false);
         }}
         className="text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-100"
       >


### PR DESCRIPTION
Closes #2203.

On mobile the "ServiceBay was restarted. Reloading in Xs…" banner appeared very frequently and felt restless: a ticking countdown that then **force-reloaded the page out from under the user**. Because the box restarts often (self-updates, deploys), it nagged repeatedly.

### Change
Good-practice "app updated, reload" pattern in `ServerIdentityWatcher`:
- **No countdown, no surprise reload** while the user is actively viewing.
- Small, dismissible **pill** ("ServiceBay updated · Reload").
- Pending reload applies **quietly on next tab-hide** (`visibilitychange` → hidden: screen lock / app switch) → mobile user returns to a fresh page.
- Restarts **coalesce** (one pill, never re-triggers).
- **Reload now** / **Dismiss** preserved; **reinstall** (`setupCompleted:false`) immediate-reload unchanged.

### Verify
`ServerIdentityWatcher.test.tsx` (new, 6 cases): first-identity/reconnect = silent · restart shows pill + no reload while visible · tab-hide → quiet reload · coalesce · dismiss suppresses + blocks later hide-reload · setupCompleted-false forces reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)