### PR TITLE
fix(immich): migrate DB from pgvecto.rs to VectorChord (immich v3)

### DIFF
--- a/templates/immich/CHANGELOG.md
+++ b/templates/immich/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Immich — template changelog
 
+## v4 — pgvecto.rs → VectorChord (breaking)
+
+immich v3 removed the deprecated **pgvecto.rs** vector extension. The template
+pinned the old `docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0` DB image while
+`immich-server:release` auto-updated past it, so the microservices worker
+crash-looped with *"No vector extension found. Available extensions: vchord,
+vector"*.
+
+Changes:
+
+1. **DB image** → `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0`
+   (immich's own image; bundles VectorChord + pgvector + pgvecto.rs and sets
+   `shared_preload_libraries` internally).
+2. **No postgres `args`** — the old `-c shared_preload_libraries=vectors.so`
+   / `listen_addresses` override is removed (the image handles preload; a
+   partial override would drop it — the #410 trap). Postgres stays pod-internal
+   (no ports), so the localhost-only bind isn't needed for isolation.
+3. **`DB_VECTOR_EXTENSION=vectorchord`** on immich-server.
+
+**Operator impact (breaking):** immich migrates the existing `vectors` data to
+VectorChord **in place** on its next startup (reindex takes seconds-to-minutes
+by library size). **Back up pgdata before redeploy** — the migration rewrites
+the vector column. The new image bundles pgvecto.rs too, so an old backup can
+still be restored. **Do not downgrade immich below 1.133.0 after migrating.**
+Photo files are untouched (they live in the upload volume, not the DB).
+
 ## v3 — #1904
 
 Disk-import photos become keyless External Libraries (Decision A):

--- a/templates/immich/README.md
+++ b/templates/immich/README.md
@@ -14,7 +14,7 @@ This template deploys a complete Immich stack in a single Pod:
 - Immich Server (web UI + API)
 - Immich Machine Learning
 - Redis
-- PostgreSQL (with pgvecto.rs for vector search)
+- PostgreSQL (with VectorChord for vector search)
 
 Data is persisted at `${DATA_DIR}/immich/` with separate directories for uploads, model cache, and database.
 

--- a/templates/immich/migrations/v3-to-v4.py
+++ b/templates/immich/migrations/v3-to-v4.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Migration: immich v3 → v4 — pgvecto.rs → VectorChord.
+
+What changed between v3 and v4:
+  - The database container image moves from the deprecated
+    `docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0` to immich's own
+    `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0`.
+    That image bundles VectorChord (`vchord`) + pgvector + pgvecto.rs and
+    sets `shared_preload_libraries` internally, so the template no longer
+    passes any postgres `args` (a partial override would drop the preload
+    — the #410 trap).
+  - immich-server gains `DB_VECTOR_EXTENSION=vectorchord`.
+
+Why: immich v3 removed support for the pgvecto.rs extension. A pinned old
+DB image + auto-updating `immich-server:release` drifted apart, and the
+microservices worker crash-looped with "No vector extension found.
+Available extensions: vchord, vector". On the new image, immich migrates
+the existing pgvecto.rs `vectors` data to VectorChord automatically on
+startup (reindex takes seconds-to-minutes by library size).
+
+No on-disk data moves — pgdata keeps its path under `${DATA_DIR}/immich/`;
+the same directory is read by the new image in place.
+
+What this script does (idempotent — probe only, never mutates):
+  - If the old pgvecto.rs `vectors` extension is present and VectorChord
+    isn't yet in place, print a LOUD reminder to back up pgdata first
+    (immich rewrites the vector column during the in-place migration).
+  - Otherwise (fresh install, or already migrated) just inform.
+  - Exit 0. Migration scripts MUST exit 0 to let the deploy continue.
+
+Do NOT downgrade immich below 1.133.0 after this migration.
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+DB_CONTAINER = "immich-database"
+
+
+def _psql(sql: str) -> str | None:
+    """Run a scalar query in the immich DB; return stdout or None if the
+    container/DB isn't reachable (fresh install — nothing to migrate)."""
+    try:
+        out = subprocess.run(
+            ["podman", "exec", DB_CONTAINER, "psql", "-U", "postgres",
+             "-d", "immich", "-tA", "-c", sql],
+            capture_output=True, text=True, timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip()
+
+
+def main() -> int:
+    data_dir = os.environ.get("DATA_DIR", "${DATA_DIR}")
+    print("Immich v3 → v4: migrating the vector search backend "
+          "pgvecto.rs → VectorChord.")
+    print(f"  DB image → ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0")
+    print("  immich-server gains DB_VECTOR_EXTENSION=vectorchord; immich migrates")
+    print("  the existing `vectors` data to VectorChord on its next startup.")
+
+    exts = _psql("SELECT string_agg(extname, ',') FROM pg_extension;")
+    if exts is None:
+        print("  Postgres not reachable yet (fresh install) — nothing to back up.")
+    elif "vectors" in exts and "vchord" not in exts:
+        print("")
+        print("  ⚠  BACK UP FIRST. immich rewrites the vector column in place during")
+        print(f"     the migration. Recommended before redeploy:")
+        print(f"       podman exec {DB_CONTAINER} pg_dump -U postgres -Fc -d immich \\")
+        print(f"         -f /var/lib/postgresql/data/immich-pre-vectorchord.dump")
+        print(f"     then copy it off pgdata (e.g. to {data_dir}/immich/).")
+        print("  The new DB image bundles pgvecto.rs too, so an old backup can still")
+        print("  be restored if needed. Do NOT downgrade immich below 1.133.0 after.")
+    else:
+        print("  Already on VectorChord (or no legacy vectors data) — nothing to do.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/immich/template.yml
+++ b/templates/immich/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: immich
   annotations:
     servicebay.label: "Photos"
-    servicebay.schema-version: "3"
+    servicebay.schema-version: "4"
     servicebay.ports: "{{IMMICH_PORT}}/tcp"
     # photos.<domain> is served via nginx; Immich's SSO uses Authelia.
     # file-share supplies the read-only photo areas for the disk-import
@@ -88,6 +88,10 @@ spec:
           value: "{{DB_PASSWORD}}"
         - name: DB_DATABASE_NAME
           value: "immich"
+        # immich v3 dropped pgvecto.rs; pin VectorChord so immich migrates the
+        # old `vectors` extension to `vchord` on startup (schema v4, #2203-repair).
+        - name: DB_VECTOR_EXTENSION
+          value: "vectorchord"
         - name: REDIS_HOSTNAME
           value: "127.0.0.1"
         - name: IMMICH_MACHINE_LEARNING_URL
@@ -124,20 +128,15 @@ spec:
       args: ["--bind", "127.0.0.1", "--protected-mode", "yes"]
 
     - name: database
-      image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0
-      # The pgvecto-rs image's default CMD sets
-      # `shared_preload_libraries=vectors.so` — overriding args to
-      # restrict listen_addresses dropped that, postgres started
-      # without the extension and immich's microservices worker
-      # crashed with "pgvecto.rs must be loaded via
-      # shared_preload_libraries" (#410 follow-up). Keep BOTH
-      # `-c` flags: extension load AND localhost-only bind.
-      args:
-        - "postgres"
-        - "-c"
-        - "shared_preload_libraries=vectors.so"
-        - "-c"
-        - "listen_addresses=127.0.0.1"
+      # immich's VectorChord postgres image (pg14). Bundles vchord + pgvector +
+      # pgvecto.rs and sets `shared_preload_libraries` internally, so we pass NO
+      # args — a partial override would drop the preload (the #410 trap). immich
+      # migrates the old pgvecto.rs `vectors` extension to VectorChord on startup
+      # (see immich upgrading docs; do not downgrade immich below 1.133.0 after).
+      # The bundled pgvecto.rs is only needed during migration / to restore an
+      # old backup. Postgres is pod-internal (no ports), so the previous
+      # localhost-only listen_addresses bind is not needed for LAN isolation.
+      image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
       env:
         - name: POSTGRES_PASSWORD
           value: "{{DB_PASSWORD}}"


### PR DESCRIPTION
## Problem (found live on the box)
immich-server was **crash-looping — `RestartCount=54568`** — with:
```
Error: No vector extension found. Available extensions: vchord, vector
```
immich v3 dropped the deprecated **pgvecto.rs** extension, but the template pinned the old `docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0` DB image while `immich-server:release` auto-updated past it. The crash-loop was the box's main CPU/zombie source.

## Fix
- **DB image** → `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0` (immich's own; bundles VectorChord + pgvector + pgvecto.rs, sets `shared_preload_libraries` internally).
- **Drop the postgres `args`** override (`-c shared_preload_libraries=vectors.so` / `listen_addresses`) — the image handles preload; a partial override would drop it (#410 trap). Postgres is pod-internal (no ports), so the localhost bind isn't needed for isolation.
- **`DB_VECTOR_EXTENSION=vectorchord`** on immich-server → immich migrates the existing `vectors` data to VectorChord in place on startup.
- **Schema 3→4** + breaking CHANGELOG (back up pgdata first; don't downgrade immich below 1.133.0) + idempotent probe-only `migrations/v3-to-v4.py`.

## Verified live
Applied the same change on the box (`ghcr.io/immich-app/postgres:14-vectorchord…`, dropped args, added env, redeployed):
- immich-server **restarts=0**, `Immich Microservices is running [v3.0.1]`
- `/api/server/ping` → **200**
- `vchord` extension **created** in the immich DB
- DB safety backup taken before the migration (505 MB `pg_dump -Fc`)

Template tests green (`template_migrations`, `template_consistency`, `template_contract`, `template_docs_in_sync` — 88 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)