### PR TITLE
feat(home): surface pending MCP approvals on the Home page

### DIFF
--- a/packages/frontend/src/components/PendingApprovalsCard.test.tsx
+++ b/packages/frontend/src/components/PendingApprovalsCard.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+
+import PendingApprovalsCard from './PendingApprovalsCard';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+const APPROVAL = {
+  pendingId: 'abc-123',
+  toolName: 'remove_proxy_route',
+  args: { domain: 'tor.dopp.cloud' },
+  caller: 'token:Repair',
+  expiresAt: Date.parse('2026-07-11T12:00:00Z'),
+};
+
+describe('PendingApprovalsCard (#2203-followup)', () => {
+  beforeEach(() => vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] }));
+  afterEach(() => { vi.restoreAllMocks(); vi.useRealTimers(); });
+
+  it('renders nothing when there are no pending approvals', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ pending: [] })));
+    const { container } = render(<PendingApprovalsCard />);
+    // Flush the on-mount fetch promise, then assert the card stays absent.
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.queryByText(/Pending approvals/i)).toBeNull();
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows a proposed destructive tool call with its args and caller', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ pending: [APPROVAL] })));
+    render(<PendingApprovalsCard />);
+    expect(await screen.findByText(/Pending approvals/i)).toBeTruthy();
+    expect(screen.getByText('remove_proxy_route')).toBeTruthy();
+    expect(screen.getByText(/tor\.dopp\.cloud/)).toBeTruthy();
+    expect(screen.getByText(/from token:Repair/)).toBeTruthy();
+  });
+
+  it('approves via POST to the pendingId endpoint', async () => {
+    const fetchMock = vi.fn(async (url: string, opts?: RequestInit) => {
+      if (url.includes('/approve/') && opts?.method === 'POST') return jsonResponse({ ok: true });
+      // after approval the list is reloaded empty
+      return jsonResponse({ pending: fetchMock.mock.calls.some(c => String(c[0]).includes('/approve/')) ? [] : [APPROVAL] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    render(<PendingApprovalsCard />);
+    const btn = await screen.findByText(/Approve & run/i);
+    await act(async () => { btn.click(); });
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith('/api/system/mcp/approve/abc-123', { method: 'POST' }),
+    );
+  });
+});

--- a/packages/frontend/src/components/PendingApprovalsCard.tsx
+++ b/packages/frontend/src/components/PendingApprovalsCard.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { ShieldAlert, ShieldCheck } from 'lucide-react';
+import { Button, Card } from '@/components/ui';
+
+/**
+ * Pending MCP destructive-tool approvals, surfaced on Home (#2203-followup).
+ *
+ * A token-authenticated MCP agent can only *propose* a destructive tool call;
+ * it parks as a pending approval that a human (session cookie) must confirm.
+ * These live in-memory with a short (~5 min) TTL, so if the operator isn't
+ * looking they expire unseen — which is exactly what happened when a route
+ * deletion was proposed and the Settings-only approval list stayed empty.
+ *
+ * This card puts the same list on Home so a pending approval is visible where
+ * the operator already looks ("is my box OK?"). It renders nothing when there's
+ * nothing to approve, polls on a short interval to stay fresh against the TTL,
+ * and drives the same `/api/system/mcp/approve` endpoints as the Settings list.
+ */
+
+export interface PendingApproval {
+  pendingId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  caller?: string;
+  expiresAt: number;
+}
+
+/** Poll cadence — well under the ~5 min approval TTL so the list stays fresh. */
+const POLL_MS = 15_000;
+
+export function usePendingApprovals() {
+  const [pending, setPending] = useState<PendingApproval[] | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    fetch('/api/system/mcp/approve')
+      .then(r => (r.ok ? r.json() : { pending: [] }))
+      .then((data: { pending?: PendingApproval[] }) => setPending(data.pending ?? []))
+      .catch(() => setPending([]));
+  }, []);
+
+  const approve = useCallback(async (id: string) => {
+    setBusyId(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/system/mcp/approve/${id}`, { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusyId(null);
+    }
+  }, [load]);
+
+  useEffect(() => {
+    load();
+    const t = setInterval(load, POLL_MS);
+    return () => clearInterval(t);
+  }, [load]);
+
+  return { pending, busyId, error, approve };
+}
+
+function ApprovalRow({ entry, busy, onApprove }: { entry: PendingApproval; busy: boolean; onApprove: (id: string) => void }) {
+  // Absolute expiry time (not a Date.now()-derived countdown) so render stays
+  // pure; the poll drops expired entries off the list anyway.
+  const expiresAtLabel = new Date(entry.expiresAt).toLocaleTimeString();
+  return (
+    <li className="text-xs rounded-card border border-status-warn/40 bg-status-warn/10 p-2">
+      <div className="flex items-center gap-2">
+        <span className="font-mono font-semibold text-status-warn">{entry.toolName}</span>
+        {entry.caller && <span className="text-text-subtle">from {entry.caller}</span>}
+        <span className="text-text-subtle ml-auto">expires {expiresAtLabel}</span>
+      </div>
+      <pre className="mt-1 whitespace-pre-wrap break-words text-[11px] text-text-muted font-mono">{JSON.stringify(entry.args, null, 2)}</pre>
+      <div className="mt-1.5 flex justify-end">
+        <Button type="button" size="sm" disabled={busy} onClick={() => onApprove(entry.pendingId)}>
+          <ShieldCheck size={12} />
+          {busy ? 'Approving…' : 'Approve & run'}
+        </Button>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Renders nothing when there are no pending approvals, so it's safe to drop at
+ * the top of Home unconditionally.
+ */
+export default function PendingApprovalsCard() {
+  const { pending, busyId, error, approve } = usePendingApprovals();
+  if (!pending || pending.length === 0) return null;
+
+  return (
+    <Card padding="lg" className="border-status-warn/50 bg-status-warn/5">
+      <div className="flex items-center gap-1.5 mb-2">
+        <ShieldAlert size={16} className="text-status-warn shrink-0" />
+        <h2 className="text-sm font-semibold text-text">Pending approvals</h2>
+        <span className="text-xs font-normal text-text-subtle">({pending.length})</span>
+      </div>
+      <p className="text-xs text-text-muted mb-2">
+        An MCP agent proposed these destructive actions. They run only after you approve —
+        the agent cannot approve its own request. Approvals expire after a few minutes.
+      </p>
+      {error && <p className="text-xs text-status-fail mb-2">{error}</p>}
+      <ul className="space-y-2">
+        {pending.map(p => (
+          <ApprovalRow key={p.pendingId} entry={p} busy={busyId === p.pendingId} onApprove={approve} />
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/packages/frontend/src/dashboards/OverviewDashboard.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.tsx
@@ -10,6 +10,7 @@ import { useImageUpdates, type ServiceImageUpdate } from '@/hooks/useImageUpdate
 import { useServiceActions } from '@/hooks/useServiceActions';
 import ImageUpdatesPendingBanner from '@/components/ImageUpdatesPendingBanner';
 import ServiceBayUpdateCard from '@/components/ServiceBayUpdateCard';
+import PendingApprovalsCard from '@/components/PendingApprovalsCard';
 import { Card, SectionHeading, StatusDot } from '@/components/ui';
 import { cn } from '@/components/ui';
 
@@ -294,6 +295,11 @@ export default function OverviewDashboard() {
 
         {/* Headline status — the single sentence that answers "is everything OK?" */}
         <HealthHeadline tone={healthHeadline.tone} text={healthHeadline.text} />
+
+        {/* Pending MCP destructive-tool approvals — surfaced here (not just in
+            Settings) because they're short-lived and easy to miss otherwise.
+            Renders nothing when there's nothing to approve. */}
+        <PendingApprovalsCard />
 
         {/* Updates — one coherent area (#2082): the ServiceBay self-updater
             (version status + "Update now", GET/POST /api/system/update) and the


### PR DESCRIPTION
Your request: **show open approvals on the Home page.**

## Why
Destructive MCP tool calls (e.g. `remove_proxy_route`) can only be *proposed* by a token-authenticated agent — a human must approve them. That approval list lived **only in Settings → MCP**, and approvals are **in-memory with a ~5 min TTL**. So a proposal made while you're on Home expires unseen — exactly what happened today (a route-deletion proposal; by the time you looked, the Settings list was empty because it had expired).

## Change
- New reusable `PendingApprovalsCard` (+ `usePendingApprovals` hook) at the **top of Home**, right under the health headline.
- Polls `GET /api/system/mcp/approve` every 15s (well under the TTL), renders **nothing when there's nothing to approve**, and drives the same `POST /api/system/mcp/approve/{id}` endpoint as the Settings list.
- Shows each proposed tool call: tool name, caller, args, expiry, and **Approve & run**.
- Focused test (renders-nothing / shows-proposal / approves-via-POST).

Note: approvals are inherently short-lived by design (a stale destructive proposal should evaporate, not linger). This makes them **visible where you already look**, but a very old proposal can still expire before you act — re-trigger it if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)