### PR TITLE
fix(network): stop mergeInPlace stacking collapsed-service containers (#2201)

### DIFF
--- a/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
@@ -292,6 +292,23 @@ describe('#2119 mergeGraphPreservingPositions', () => {
     expect(nodes.find((x) => x.id === 's1')!.style).toEqual({ width: 320 });
   });
 
+  it('#2201 DROPS a fresh node that was not in the laid-out set (no (0,0) injection)', () => {
+    // Simulates a poll after a collapsed layout: `fresh` carries the collapsed
+    // service's containers (position {0,0}), but they were filtered out of the
+    // laid-out set. They must NOT be re-introduced at the origin (which stacked
+    // every container on its parent) — they're dropped until a real re-layout.
+    const child = (id: string, parentId: string): Node =>
+      ({ id, type: 'custom', position: { x: 0, y: 0 }, parentId, data: { type: 'container', label: id } });
+    const { nodes } = mergeGraphPreservingPositions(
+      [laid('s1', 100, 'up')], // laid-out set: just the (collapsed) service
+      [],
+      [fresh('s1', 'up'), child('c1', 's1'), child('c2', 's1')], // fresh carries the containers
+      [],
+    );
+    expect(nodes.map((n) => n.id)).toEqual(['s1']); // containers dropped, not stacked at (0,0)
+    expect(nodes.find((n) => n.id === 's1')!.position).toEqual({ x: 100, y: 100 });
+  });
+
   it('keeps the laid-out routed edge geometry, refreshing only styling/label', () => {
     const laidEdge: Edge = {
       id: 'e-s1-s2', source: 's1', target: 's2',

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -313,8 +313,11 @@ export function topologyLayoutSignature(
  * re-running the layout: for every existing node, carry its `position` (and
  * layout-affecting `style` width/height) forward while taking the new `data`
  * (status / metadata / label). Nodes that vanished are dropped; nodes that
- * appeared are kept at their incoming position (shouldn't happen when the
- * topology signature is unchanged, but handled defensively). Edges adopt the
+ * appeared but were NOT in the laid-out set are ALSO dropped (#2201) — never
+ * injected at their raw (0,0) incoming position, which stacked collapsed-service
+ * containers at the origin. A real topology change flips the signature and
+ * routes to a full re-layout, so this path only sees the laid-out visible set.
+ * Edges adopt the
  * fresh styling/label but are matched to the laid-out edge by source→target
  * so the routed `points`/`hops`/positions survive the poll.
  */
@@ -325,18 +328,30 @@ export function mergeGraphPreservingPositions<TNode extends Node, TEdge extends 
   freshEdges: TEdge[],
 ): { nodes: TNode[]; edges: TEdge[] } {
   const laidOutById = new Map(laidOutNodes.map((n) => [n.id, n]));
-  const nodes = freshNodes.map((fresh) => {
+  const nodes: TNode[] = [];
+  for (const fresh of freshNodes) {
     const prev = laidOutById.get(fresh.id);
-    if (!prev) return fresh;
-    return {
+    // #2201 — DROP fresh nodes that were not in the laid-out set instead of
+    // injecting them at their raw (0,0) position. This merge path only runs when
+    // the topology SIGNATURE is unchanged, so the visible node set is supposed to
+    // match the last full layout. A fresh node with no prior layout is one the
+    // layout deliberately excluded — e.g. a container whose service is collapsed
+    // (processAndLayout filters it, but graphData.nodes still carries it). The old
+    // `return fresh` re-introduced every such container at its parent's origin,
+    // which is exactly what stacked all containers at (0,0) on the first poll
+    // after the initial collapsed layout. A genuine topology change flips the
+    // signature and routes to a full processAndLayout, so dropping unknowns here
+    // is safe and keeps merge output consistent with the laid-out set.
+    if (!prev) continue;
+    nodes.push({
       ...prev,
       data: fresh.data,
       // Keep the laid-out position + layout-sized style; refresh everything
       // else (className etc.) from the fresh node.
       position: prev.position,
       style: prev.style,
-    } as TNode;
-  });
+    } as TNode);
+  }
 
   const laidOutEdgeByPair = new Map(
     laidOutEdges.map((e) => [`${e.source}->${e.target}`, e]),


### PR DESCRIPTION
## Root cause (pinned via runtime trace on :dev)
The network map auto-collapses all services on first load → `processAndLayout` renders only the service nodes (children filtered out). The next steady-state poll takes the **mergeInPlace** path (topology signature unchanged), but `mergeGraphPreservingPositions` merged **all** fresh `graphData` nodes — including the collapsed services' containers, which have **no laid-out position** and were injected at their raw **(0,0)**. React Flow rendered every container at its parent's origin → the stacked pile the operator saw ~1s after load ("the system opens all containers unprompted and stacks them").

Trace (`window.__mapdbg` on :dev):
```
processAndLayout collapsed=16 outNodes=19 authKids=[]
mergeInPlace     prevNodes=19 freshNodes=45 authKids=[(0,0) prevHad=false, (0,0) prevHad=false]  ← stacked
```

## Fix
`mergeGraphPreservingPositions` now **drops** fresh nodes absent from the laid-out set instead of returning them at (0,0). The merge path only runs when the signature is unchanged, so the visible set must match the last full layout; a real topology change flips the signature and routes to a full `processAndLayout` (which lays containers out correctly inside their grown service box). Regression test added.

## Verification
Browser-measured on :dev after this lands (map stays consistent with the laid-out set; expanding a service shows its containers laid out, non-overlapping). The temporary `__mapdbg` instrumentation (#2211) will be reverted separately.