### PR TITLE
fix(network): preserve collapsed/summary/onToggle across mergeInPlace (#2201)

### DIFF
--- a/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
@@ -309,6 +309,23 @@ describe('#2119 mergeGraphPreservingPositions', () => {
     expect(nodes.find((n) => n.id === 's1')!.position).toEqual({ x: 100, y: 100 });
   });
 
+  it('#2201 preserves the aggregation fields (collapsed/summary/onToggle) across a merge', () => {
+    const toggle = () => {};
+    const laidAgg: Node = {
+      id: 's1', type: 'custom', position: { x: 5, y: 5 },
+      data: { type: 'service', label: 's1', status: 'up', collapsed: true, summary: { status: 'up' }, onToggle: toggle },
+    };
+    const { nodes } = mergeGraphPreservingPositions(
+      [laidAgg], [],
+      [fresh('s1', 'down')], [], // fresh has NO collapsed/summary/onToggle
+    );
+    const d = nodes[0].data as { status?: string; collapsed?: boolean; summary?: unknown; onToggle?: unknown };
+    expect(d.status).toBe('down');        // fresh status flows through
+    expect(d.collapsed).toBe(true);       // aggregation preserved (not lost to fresh)
+    expect(d.summary).toEqual({ status: 'up' });
+    expect(d.onToggle).toBe(toggle);      // toggle handler survives the poll
+  });
+
   it('keeps the laid-out routed edge geometry, refreshing only styling/label', () => {
     const laidEdge: Edge = {
       id: 'e-s1-s2', source: 's1', target: 's2',

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -343,9 +343,22 @@ export function mergeGraphPreservingPositions<TNode extends Node, TEdge extends 
     // signature and routes to a full processAndLayout, so dropping unknowns here
     // is safe and keeps merge output consistent with the laid-out set.
     if (!prev) continue;
+    // #2201 — take the fresh status/health data, but PRESERVE the fields that
+    // processAndLayout's aggregation adds (they don't exist on the raw
+    // graphData node): `collapsed`/`summary` drive the collapsed-vs-expanded
+    // card, and `onToggle` is the collapse handler. The old `data: fresh.data`
+    // dropped all three, so after the first poll every collapsed service
+    // re-rendered as an EXPANDED-but-empty frame with a dead toggle button.
+    const prevData = prev.data as Record<string, unknown>;
+    const mergedData = {
+      ...(fresh.data as Record<string, unknown>),
+      collapsed: prevData.collapsed,
+      summary: prevData.summary,
+      onToggle: prevData.onToggle,
+    } as TNode['data'];
     nodes.push({
       ...prev,
-      data: fresh.data,
+      data: mergedData,
       // Keep the laid-out position + layout-sized style; refresh everything
       // else (className etc.) from the fresh node.
       position: prev.position,


### PR DESCRIPTION
Follow-up to the container-stacking fix (#2212). `mergeGraphPreservingPositions` took `fresh.data` wholesale, dropping the fields `processAndLayout` adds — `collapsed`/`summary` (collapsed vs expanded card) and `onToggle` (collapse handler). So after the first poll every collapsed service re-rendered as an **expanded-but-empty frame with a dead toggle**. Now preserves those three from the laid-out node while still refreshing status/health. Test added. Verified on :dev.