### PR TITLE
feat(proxy): per-path forward-auth exceptions via authSkipPaths (#2210)

### DIFF
--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -1214,10 +1214,11 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
       sslForced: z.boolean().optional().describe('Force HTTPS redirect (default true for public/internal once a cert binds).'),
       websocket: z.boolean().optional().describe('Enable WebSocket upgrade on the host.'),
       advancedConfig: z.string().optional().describe('Custom nginx directives to inject into the server block (appended after any forward-auth snippet).'),
+      authSkipPaths: z.array(z.string().startsWith('/')).optional().describe('#2210 — path prefixes that skip forward-auth while the rest of the host stays gated, e.g. ["/.well-known/", "/static/"]. Each becomes an `auth_request off` location that still proxies upstream (TWA assetlinks, ACME, PWA assets). Only meaningful with forwardAuth=true.'),
       service: z.string().optional().describe('Logical service name (default: first label of the domain).'),
       node: nodeParam,
     },
-    async ({ domain, forwardPort, forwardHost, exposure, forwardAuth, sslForced, websocket, advancedConfig, service, node }) => {
+    async ({ domain, forwardPort, forwardHost, exposure, forwardAuth, sslForced, websocket, advancedConfig, authSkipPaths, service, node }) => {
       if (forwardAuth && exposure === 'lan') {
         return errorResult('forwardAuth requires exposure "public" or "internal": Authelia forward-auth needs an https (cert-bound) host, and a "lan" host serves plain HTTP. Use exposure "internal" for a LAN-only SSO-gated service.');
       }
@@ -1242,6 +1243,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
           ...(websocket !== undefined ? { allow_websocket_upgrade: websocket } : {}),
           ...(sslForced !== undefined ? { ssl_forced: sslForced } : {}),
           ...(composedAdvanced ? { advanced_config: composedAdvanced } : {}),
+          ...(authSkipPaths?.length ? { authSkipPaths } : {}),
         },
       };
       try {

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -715,6 +715,17 @@ export interface ProxyConfig {
    * upstream sees a loopback Host regardless of the node's LAN IP.
    */
   localUpstreamHost?: boolean;
+  /**
+   * #2210 — Path prefixes that SKIP forward-auth on an otherwise Authelia-
+   * gated (`forwardAuth: true`) host. Each emits an `auth_request off`
+   * location that still proxies to the upstream, letting unauthenticated
+   * fetchers reach specific public paths — e.g. `/.well-known/assetlinks.json`
+   * (Google's Digital-Asset-Links check that drops a TWA's URL bar),
+   * `/.well-known/` (ACME, apple-app-site-association, security.txt), or
+   * `/static/` (PWA icons/manifest for reproducible app builds). Only
+   * meaningful together with the forward-auth sentinel `advanced_config`.
+   */
+  authSkipPaths?: string[];
 }
 
 export interface OidcClientConfig {

--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -178,12 +178,59 @@ export interface ForwardAuthExpandOptions {
    * swallow a challenge if one is ever served).
    */
   omitAcmeBypass?: boolean;
+  /**
+   * #2210 — Path prefixes that must SKIP forward-auth while the rest of the
+   * host stays gated. Each becomes an `auth_request off` location that still
+   * proxies to the upstream, so e.g. `/.well-known/assetlinks.json` (Google's
+   * unauthenticated Digital-Asset-Links fetch for a TWA) or `/static/` (PWA
+   * icons/manifest) pass straight through. See {@link buildAuthSkipLocations}.
+   */
+  authSkipPaths?: string[];
+}
+
+/**
+ * #2210 — Build `auth_request off` bypass locations for the given path
+ * prefixes. Each still proxies to the upstream by reusing NPM's own
+ * server-level `$forward_scheme`/`$server`/`$port` variables (set in the
+ * generated proxy-host conf), so we never need to know the concrete upstream.
+ *
+ * `location ^~` (longest-prefix, wins over regex) is used so a bypass beats
+ * both the inherited server-level `auth_request /authelia` AND stays distinct
+ * from NPM's own `location ^~ /.well-known/acme-challenge/` (a longer, more
+ * specific prefix → different location string → no `duplicate location`
+ * crash, and acme still routes to NPM's webroot). We explicitly refuse
+ * `/.well-known/acme-challenge` here for the same reason — NPM owns it.
+ */
+export function buildAuthSkipLocations(paths: string[] | undefined): string {
+  if (!paths?.length) return '';
+  const seen = new Set<string>();
+  const blocks: string[] = [];
+  for (const raw of paths) {
+    const path = raw.trim();
+    // Absolute prefixes only; never shadow NPM's acme-challenge location.
+    if (!path.startsWith('/')) continue;
+    if (path.startsWith('/.well-known/acme-challenge')) continue;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    blocks.push(
+      [
+        `location ^~ ${path} {`,
+        '    auth_request off;',
+        '    include conf.d/include/proxy.conf;',
+        '    proxy_pass $forward_scheme://$server:$port;',
+        '}',
+      ].join('\n'),
+    );
+  }
+  return blocks.join('\n\n');
 }
 
 function baseSnippet(opts?: ForwardAuthExpandOptions): string {
-  return opts?.omitAcmeBypass
+  const core = opts?.omitAcmeBypass
     ? AUTHELIA_FORWARD_AUTH_CORE
     : AUTHELIA_FORWARD_AUTH_SNIPPET;
+  const skip = buildAuthSkipLocations(opts?.authSkipPaths);
+  return skip ? `${core}\n\n${skip}` : core;
 }
 
 /**

--- a/packages/backend/src/lib/stackInstall/postInstall.ts
+++ b/packages/backend/src/lib/stackInstall/postInstall.ts
@@ -79,7 +79,12 @@ function renderProxyConfig(
   // nginx snippet before the Mustache pass so the snippet's own
   // {{PUBLIC_DOMAIN}} / {{AUTHELIA_PORT}} placeholders still get
   // substituted from `view`.
-  const expanded = expandForwardAuthSentinel(proxyConfig.advanced_config, { omitAcmeBypass }) ?? proxyConfig.advanced_config;
+  const expanded = expandForwardAuthSentinel(proxyConfig.advanced_config, {
+    omitAcmeBypass,
+    // #2210 — per-path forward-auth exceptions (e.g. /.well-known/, /static/)
+    // are baked into the expanded config so they survive NPM host rebuilds.
+    authSkipPaths: proxyConfig.authSkipPaths,
+  }) ?? proxyConfig.advanced_config;
   // #1677 — A forward-auth snippet that renders `{{AUTHELIA_PORT}}` to
   // an empty string emits `proxy_pass http://127.0.0.1:/api/authz/...`,
   // which nginx rejects with `[emerg] invalid port` — and one such bad

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -89,6 +89,13 @@ interface ProxyHostRequest {
          * regardless of the node's LAN IP.
          */
         localUpstreamHost?: boolean;
+        /**
+         * #2210 — Path prefixes that skip forward-auth (emit `auth_request
+         * off` locations that still proxy upstream) on a `forwardAuth` host,
+         * e.g. `/.well-known/` (TWA assetlinks, ACME) or `/static/` (PWA
+         * assets). Only meaningful with the forward-auth `advanced_config`.
+         */
+        authSkipPaths?: string[];
     };
 }
 
@@ -1082,7 +1089,7 @@ export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request })
                 const omitAcmeBypass = host.exposure === 'public' || host.exposure === 'internal';
                 host.proxyConfig = {
                     ...host.proxyConfig,
-                    advanced_config: renderForwardAuthAdvancedConfig(host.proxyConfig.advanced_config, authPort, { omitAcmeBypass }),
+                    advanced_config: renderForwardAuthAdvancedConfig(host.proxyConfig.advanced_config, authPort, { omitAcmeBypass, authSkipPaths: host.proxyConfig.authSkipPaths }),
                 };
             }
             // Default forward host = node LAN IP (NPM is in a container,

--- a/tests/backend/forwardAuth.test.ts
+++ b/tests/backend/forwardAuth.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_AUTHELIA_PORT,
   expandForwardAuthSentinel,
   sanitizeForwardAuthPort,
+  buildAuthSkipLocations,
 } from '@/lib/stackInstall/forwardAuth';
 
 /**
@@ -82,5 +83,60 @@ describe('AUTHELIA_FORWARD_AUTH_SNIPPET', () => {
   it('exposes the LE acme-challenge path with forward-auth disabled (#1680)', () => {
     expect(AUTHELIA_FORWARD_AUTH_SNIPPET).toContain('location /.well-known/acme-challenge/');
     expect(AUTHELIA_FORWARD_AUTH_SNIPPET).toContain('auth_request off;');
+  });
+});
+
+/**
+ * #2210 — per-path forward-auth exceptions. A gated host can let specific
+ * public path prefixes (TWA assetlinks, ACME, PWA static assets) skip
+ * Authelia while everything else stays behind auth_request.
+ */
+describe('authSkipPaths (#2210)', () => {
+  it('builds an auth_request off location that still proxies upstream', () => {
+    const out = buildAuthSkipLocations(['/.well-known/assetlinks.json']);
+    expect(out).toContain('location ^~ /.well-known/assetlinks.json {');
+    expect(out).toContain('auth_request off;');
+    // reuses NPM's own server-level upstream vars — no concrete host needed
+    expect(out).toContain('proxy_pass $forward_scheme://$server:$port;');
+  });
+
+  it('emits one block per path, prefix-matched (^~), deduped', () => {
+    const out = buildAuthSkipLocations(['/.well-known/', '/static/', '/.well-known/']);
+    expect(out.match(/location \^~ /g)?.length).toBe(2);
+    expect(out).toContain('location ^~ /.well-known/ {');
+    expect(out).toContain('location ^~ /static/ {');
+  });
+
+  it('refuses acme-challenge (NPM owns that location) and non-absolute paths', () => {
+    const out = buildAuthSkipLocations(['/.well-known/acme-challenge/', 'relative/path', '/ok/']);
+    expect(out).not.toContain('acme-challenge');
+    expect(out).not.toContain('relative/path');
+    expect(out).toContain('location ^~ /ok/ {');
+  });
+
+  it('returns empty for no paths', () => {
+    expect(buildAuthSkipLocations(undefined)).toBe('');
+    expect(buildAuthSkipLocations([])).toBe('');
+  });
+
+  it('appends skip locations onto the expanded forward-auth snippet', () => {
+    const out = expandForwardAuthSentinel(AUTHELIA_FORWARD_AUTH_SENTINEL, {
+      authSkipPaths: ['/.well-known/'],
+    });
+    // core forward-auth still present + the bypass appended
+    expect(out).toContain('auth_request /authelia;');
+    expect(out).toContain('location ^~ /.well-known/ {');
+    expect(out).toContain('auth_request off;');
+  });
+
+  it('does not collide with NPM acme on LE hosts: omitAcmeBypass + /.well-known/ skip yields distinct locations', () => {
+    const out = expandForwardAuthSentinel(AUTHELIA_FORWARD_AUTH_SENTINEL, {
+      omitAcmeBypass: true,
+      authSkipPaths: ['/.well-known/'],
+    })!;
+    // our own acme-challenge bypass is omitted (NPM provides it)...
+    expect(out).not.toContain('location /.well-known/acme-challenge/ {');
+    // ...and our /.well-known/ skip is a DIFFERENT (shorter ^~ prefix) location
+    expect(out).toContain('location ^~ /.well-known/ {');
   });
 });


### PR DESCRIPTION
Closes #2210.

## What
A forward-auth-gated public route now supports **`authSkipPaths`** — path prefixes that bypass Authelia while the rest of the host stays gated. Unblocks the Solaris Android TWA: `https://chat.dopp.cloud/.well-known/assetlinks.json` must be reachable **unauthenticated** for Google's Digital-Asset-Links check to drop the app's URL bar.

## nginx
Each path emits:
```nginx
location ^~ /.well-known/ {
    auth_request off;                            # overrides inherited server-level auth_request /authelia
    include conf.d/include/proxy.conf;           # NPM's own proxy params
    proxy_pass $forward_scheme://$server:$port;   # reuse NPM's server-level upstream vars — no concrete host needed
}
```
- `^~` (longest-prefix) beats the inherited `auth_request` **and** stays a DISTINCT location from NPM's own `^~ /.well-known/acme-challenge/` (longer prefix) → no `duplicate location` crash (#2143); acme still routes to NPM's webroot.
- `/.well-known/acme-challenge` and non-absolute paths are refused.
- **Validated against the live `chat.dopp.cloud` conf**: `set $forward_scheme/$server/$port` and `include conf.d/include/proxy.conf` match exactly.

## Plumbing
`ProxyConfig.authSkipPaths` → template-install expansion (`postInstall.renderProxyConfig`, baked into the stored config so it survives NPM host rebuilds) → direct proxy-hosts API → `create_proxy_route` MCP tool. Tests added (forwardAuth.test.ts, 15 pass).

## Scope
Generic mechanism. The Solaris side (`mdopp/solarisbay` solaris-chat template) will set `authSkipPaths: ["/.well-known/", "/static/"]` — covering assetlinks + PWA icons/manifest for reproducible TWA builds (per the operator's scope decision on #2210). Cross-repo; only this platform capability lives here.

End-to-end (`curl .../.well-known/assetlinks.json` → 200) verified after the solaris-chat template sets the paths and redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)