### PR TITLE
fix(proxy): authSkipPaths location must not add its own proxy_pass (#2210)

### DIFF
--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -190,9 +190,14 @@ export interface ForwardAuthExpandOptions {
 
 /**
  * #2210 — Build `auth_request off` bypass locations for the given path
- * prefixes. Each still proxies to the upstream by reusing NPM's own
- * server-level `$forward_scheme`/`$server`/`$port` variables (set in the
- * generated proxy-host conf), so we never need to know the concrete upstream.
+ * prefixes. Each still proxies to the upstream via NPM's own
+ * `include conf.d/include/proxy.conf` — that include ALREADY contains the
+ * `proxy_pass $forward_scheme://$server:$port$request_uri;` (plus the Host /
+ * X-Forwarded-* headers) using NPM's server-level upstream variables, so we
+ * neither need the concrete upstream NOR our own `proxy_pass` (a second one is
+ * `nginx: [emerg] "proxy_pass" directive is duplicate`, confirmed live on the
+ * chat.dopp.cloud conf). The bypass location therefore only adds
+ * `auth_request off;` on top of that include.
  *
  * `location ^~` (longest-prefix, wins over regex) is used so a bypass beats
  * both the inherited server-level `auth_request /authelia` AND stays distinct
@@ -216,8 +221,9 @@ export function buildAuthSkipLocations(paths: string[] | undefined): string {
       [
         `location ^~ ${path} {`,
         '    auth_request off;',
+        // proxy.conf supplies proxy_pass + Host/X-Forwarded-* — do NOT add our
+        // own proxy_pass (duplicate directive → nginx refuses the conf).
         '    include conf.d/include/proxy.conf;',
-        '    proxy_pass $forward_scheme://$server:$port;',
         '}',
       ].join('\n'),
     );

--- a/tests/backend/forwardAuth.test.ts
+++ b/tests/backend/forwardAuth.test.ts
@@ -92,12 +92,15 @@ describe('AUTHELIA_FORWARD_AUTH_SNIPPET', () => {
  * Authelia while everything else stays behind auth_request.
  */
 describe('authSkipPaths (#2210)', () => {
-  it('builds an auth_request off location that still proxies upstream', () => {
+  it('builds an auth_request off location that proxies via NPM proxy.conf (no duplicate proxy_pass)', () => {
     const out = buildAuthSkipLocations(['/.well-known/assetlinks.json']);
     expect(out).toContain('location ^~ /.well-known/assetlinks.json {');
     expect(out).toContain('auth_request off;');
-    // reuses NPM's own server-level upstream vars — no concrete host needed
-    expect(out).toContain('proxy_pass $forward_scheme://$server:$port;');
+    // proxy.conf already carries proxy_pass ($forward_scheme://$server:$port…) —
+    // the location must NOT add its own (a second proxy_pass is a duplicate
+    // directive and nginx refuses the whole conf; confirmed live on 17.conf).
+    expect(out).toContain('include conf.d/include/proxy.conf;');
+    expect(out).not.toContain('proxy_pass');
   });
 
   it('emits one block per path, prefix-matched (^~), deduped', () => {


### PR DESCRIPTION
Follow-up to #2215. The bypass location emitted both `include conf.d/include/proxy.conf` AND `proxy_pass $forward_scheme://$server:$port`. NPM's proxy.conf **already** contains that proxy_pass, so the second one is `nginx: [emerg] "proxy_pass" directive is duplicate` — nginx refuses the conf and the host drops offline (**hit live on chat.dopp.cloud during rollout**; restored). Drop our proxy_pass; the include supplies it plus the Host/X-Forwarded-* headers. Verified via scratch `nginx -t` against the live conf + `curl .../.well-known/assetlinks.json` → 200 while the host stays gated (302).