### PR TITLE
feat(mcp): task-assist catalog + list_assists/get_assist (#2146, #2145)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,11 @@ the next agent/operator finds it via the `list_assists` / `get_assist` MCP tools
   under `DATA_DIR/local-assists/` (no release needed). Loader:
   `packages/backend/src/lib/assists/catalog.ts`.
 - Each is markdown with frontmatter: `title`, `whenToUse` (one line — this drives
-  self-selection), `kind` (`guide | recipe | template | checklist | footgun |
-  snippet`), `tags`.
+  self-selection), `kind` (`guide | recipe | adr | template | checklist | footgun
+  | snippet`), `tags`.
+- Overviews of the platform itself are assists too — see `servicebay-overview`
+  and `solaris-overview`, and the `new-service-architecture` ADR-style
+  recommendations. A client should read those instead of re-deriving structure.
 - **Abstract, don't transcribe.** Turn "how I fixed tor.dopp.cloud today" into
   "how to add a public SSO subdomain, and the acme footgun to avoid." Reference
   files/functions by path, not by a specific deployment's values.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# ServiceBay — working notes for assistants
+
+ServiceBay is the control plane that installs and manages self-hosted services
+on a home box (templates → Podman kube pods, NPM reverse proxy, Authelia SSO).
+The management app is `packages/{frontend,backend,api-client}`; services ship as
+**templates** under `templates/` (not as code in `packages/`).
+
+Orientation:
+- `docs/ARCHITECTURE_INVARIANTS.md` — invariants; run `npm run check:arch && npm run lint` before architecture changes.
+- `docs/TEMPLATE_AUTHORING.md` + `templates/CLAUDE.md` — the template contract (auto-loads under `templates/`).
+- `docs/UX_DECISIONS.md` — locked UX decisions; don't re-litigate.
+
+## Capturing reusable knowledge (assists)
+
+When you work out something non-trivial — a recipe, a sequence of steps, a
+sharp-edged gotcha, a config incantation — **stop and ask: will this be needed
+again?** If yes, don't leave it buried in a session or a single PR. Abstract it
+one level (strip the one-off specifics) and add it to the **assist catalog** so
+the next agent/operator finds it via the `list_assists` / `get_assist` MCP tools.
+
+- Assists live in `assists/<id>.md` (shipped in the image) or dropped at runtime
+  under `DATA_DIR/local-assists/` (no release needed). Loader:
+  `packages/backend/src/lib/assists/catalog.ts`.
+- Each is markdown with frontmatter: `title`, `whenToUse` (one line — this drives
+  self-selection), `kind` (`guide | recipe | template | checklist | footgun |
+  snippet`), `tags`.
+- **Abstract, don't transcribe.** Turn "how I fixed tor.dopp.cloud today" into
+  "how to add a public SSO subdomain, and the acme footgun to avoid." Reference
+  files/functions by path, not by a specific deployment's values.
+- Prefer the assist catalog for *task know-how*; keep architecture invariants in
+  `docs/`, and the template contract in `docs/TEMPLATE_AUTHORING.md`.
+
+The same instinct applies to **templates**: if a service you built for one box is
+generally useful, generalize it (configurable variables, no hard-coded host
+specifics) and offer it as a template others can install.
+
+## Secret hygiene — never commit keys or passwords
+
+Committed files (templates, assists, tests, fixtures, docs) must contain **no
+real secrets**: no private keys, API tokens, passwords, or `sb_` box tokens.
+
+- Templates express secrets as `type: "secret"` variables in `variables.json`.
+  The wizard generates/injects the value at deploy time; the template never
+  carries a literal. Placeholders (`{{VAR}}`) are fine — concrete values are not.
+- Assists describe *how* to obtain/rotate a credential; they never embed one.
+  When you abstract a session into an assist, scrub tokens, hostnames-with-auth,
+  and any value you pulled from the live box.
+- A build-time scan (`tests/backend/assist_consistency.test.ts`) fails the suite
+  on known secret signatures in `assists/` and `templates/`. It is a backstop,
+  not a licence to be careless — assume it won't catch every shape.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,20 @@ Orientation:
 - `docs/TEMPLATE_AUTHORING.md` + `templates/CLAUDE.md` — the template contract (auto-loads under `templates/`).
 - `docs/UX_DECISIONS.md` — locked UX decisions; don't re-litigate.
 
+## Workflow: issues first, then the autoloop
+
+Capture work as **GitHub issues first**, then let the **autoloop-issues** pipeline
+work them — issues are the unit of work, not ad-hoc edits.
+
+- File an issue before starting non-trivial work. Body = symptom + goal + repro +
+  starting-point files; an acceptance/goal section is good. Leave out the
+  fix-plan — the "how" evolves in the PR.
+- Then burn the backlog down via `autoloop-issues` (Planner → Builder →
+  Box-Verify through a shared work queue). Don't hand-edit the tree while an
+  autoloop batch is active (use a worktree or file an issue).
+- Releases go through **release-please only** — never bump versions by hand
+  (ADR 0003).
+
 ## Capturing reusable knowledge (assists)
 
 When you work out something non-trivial — a recipe, a sequence of steps, a

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,9 @@ COPY --from=builder /app/packages/frontend/.next ./packages/frontend/.next
 # Copy templates and stacks
 COPY --from=builder /app/templates ./templates
 COPY --from=builder /app/stacks ./stacks
+# Task-assist catalog (#2146) — served by the list_assists / get_assist MCP
+# tools; resolves at /app/assists via process.cwd(), like templates/ + stacks/.
+COPY --from=builder /app/assists ./assists
 
 # Markdown content rendered at runtime by /api/help (per-page contextual
 # help, plus the CHANGELOG entry for the sidebar "What's new" modal). The

--- a/assists/create-service.md
+++ b/assists/create-service.md
@@ -81,5 +81,8 @@ WAL and shows a stale snapshot). A public host with no rendered `.conf` answers
 with an SSL connect error (000).
 
 ## Reference material
+- Assist `new-service-architecture` — recommended language/structure/libraries/
+  tests/storage/secrets before you design. Assists `servicebay-overview` +
+  `solaris-overview` — what the platforms are.
 - `docs/TEMPLATE_AUTHORING.md`, `templates/CLAUDE.md` — the full template contract.
 - Worked examples in-repo: `templates/file-share/` (forward-auth), `templates/vaultwarden/` (OIDC).

--- a/assists/create-service.md
+++ b/assists/create-service.md
@@ -1,0 +1,85 @@
+---
+title: Create & deploy a new ServiceBay service
+whenToUse: You need to build a new service (its own repo/image) and deploy it to the box as a template, optionally behind Authelia SSO on a subdomain.
+kind: recipe
+tags: [service, template, deploy, subdomain, sso, proxy, image, install]
+---
+
+# Create & deploy a new ServiceBay service
+
+A service is a **standalone container** shipped as a **template**, not code inside
+this repo's `packages/`. The app lives in its own repo/image; a template deploys
+that image and wires ports, mounts, subdomain, SSO, and health.
+
+## Repo & image
+- App code + `Dockerfile` + CI live in their **own repo**; CI builds a container
+  image (e.g. `ghcr.io/<you>/<name>:latest`). The box must be able to **pull** it
+  (public package, or registry credentials configured on the box).
+- The **template** references that image; it does not build code.
+
+## Template contract (`template.yml`, kube `Pod`)
+Required annotations on `metadata.annotations`:
+- `servicebay.label` — friendly name.
+- `servicebay.ports` — e.g. `"{{MYAPP_PORT}}/tcp"`.
+- `servicebay.schema-version` — `"1"` for a new template.
+- `servicebay.dependencies` — comma-separated install-time deps, e.g.
+  `"nginx,auth"` when you need the proxy + SSO (add `home-assistant` etc. if you
+  mount another service's files).
+- `servicebay.healthcheck` — an HTTP/TCP probe; gates install completion.
+
+The pod MUST satisfy one of: `hostNetwork: true` **or** every `containerPort` has
+an explicit `hostPort` — otherwise the deploy is silently unreachable. Use
+`hostNetwork: true` if the app must reach another on-box service on loopback
+(e.g. Home Assistant at `127.0.0.1:8123`).
+
+Path resolution: `{{DATA_DIR}}` renders to **`/mnt/data/stacks`** (per-service
+data), while ServiceBay's own data dir is **`/mnt/data/servicebay`** (config,
+tokens, and `local-templates`/`local-assists` drop dirs).
+
+## Subdomain + SSO (`variables.json`)
+Add a `type: "subdomain"` variable — the install runner turns it into an NPM
+proxy host at `<sub>.<PUBLIC_DOMAIN>`:
+```json
+"MYAPP_SUBDOMAIN": {
+  "type": "subdomain",
+  "default": "myapp",
+  "exposure": "public",
+  "proxyPort": "MYAPP_PORT",
+  "proxyConfig": { "block_exploits": true, "ssl_forced": true,
+                   "advanced_config": "__authelia_forward_auth__" }
+}
+```
+- `advanced_config: "__authelia_forward_auth__"` = the classic Authelia login
+  (forward-auth). The app itself needs no login; NPM injects a `Remote-User`
+  header — require it in the app to prevent a direct-LAN bypass.
+- **The template MUST reference `{{PUBLIC_DOMAIN}}`** somewhere (e.g. an env var),
+  or the assembler won't inject it and the proxy host is silently skipped — see
+  assist `footgun-subdomain-needs-public-domain`.
+- On a **public** forward-auth host, do NOT rely on the sentinel's ACME bypass —
+  it collides with NPM's own cert challenge location. See assist
+  `footgun-forward-auth-acme-collision`.
+
+## Ordered actions
+1. **Image** — build + push it; confirm the box can `podman pull` it.
+2. **Place the template** — push to a template registry, OR drop it under
+   `/mnt/data/servicebay/local-templates/templates/<name>/` (survives reinstall,
+   no git needed).
+3. **Install** — `POST /api/install/assemble` `{items:[{name,checked:true}],
+   prefilled:{...}, templateSource:"Local"}` → returns `{items, variables}` →
+   `POST /api/install/start` `{source, input:{items, variables, wipeMode:"install",
+   templateSource:"Local", host}}` → poll `/api/install/progress?jobId=…` until
+   `phase:"done"`. (All accept a `lifecycle`-scoped `sb_` token.)
+4. **Verify** — healthcheck 200; `https://<sub>.<PUBLIC_DOMAIN>/` unauthenticated
+   returns **302 → auth.<domain>** (Authelia); the app's function works; and a
+   request missing `Remote-User` is rejected (no SSO bypass).
+
+## Verify the proxy actually loaded
+The install log can say "proxy hosts ensured" while nginx reverted the conf.
+Check the host is really live: read NPM's DB `proxy_host.meta.nginx_online` /
+`nginx_err` (open the sqlite `?mode=ro`, **not** `immutable=1` — that ignores the
+WAL and shows a stale snapshot). A public host with no rendered `.conf` answers
+with an SSL connect error (000).
+
+## Reference material
+- `docs/TEMPLATE_AUTHORING.md`, `templates/CLAUDE.md` — the full template contract.
+- Worked examples in-repo: `templates/file-share/` (forward-auth), `templates/vaultwarden/` (OIDC).

--- a/assists/footgun-forward-auth-acme-collision.md
+++ b/assists/footgun-forward-auth-acme-collision.md
@@ -1,0 +1,44 @@
+---
+title: Forward-auth sentinel breaks NEW public LE subdomains (duplicate acme-challenge)
+whenToUse: You created a new public subdomain with __authelia_forward_auth__ and it returns an SSL error / 000, or NPM shows nginx_online=false with a "duplicate location" error.
+kind: footgun
+tags: [authelia, forward-auth, nginx, npm, acme, letsencrypt, subdomain, sso, proxy]
+---
+
+# Forward-auth sentinel collides with NPM's acme-challenge on public LE hosts
+
+## Symptom
+A brand-new **public** subdomain gated with `__authelia_forward_auth__` gets its
+NPM proxy host + LE cert created, but the site answers with an SSL connect error
+(curl code 000). No error appears in the install/job log.
+
+## Cause
+NPM writes the host conf, then `nginx -t` fails and NPM **reverts** it:
+```
+nginx: [emerg] duplicate location "/.well-known/acme-challenge/" in <id>.conf
+```
+The sentinel-expanded forward-auth snippet includes a
+`location /.well-known/acme-challenge/ { auth_request off; ... }` bypass. On a
+public/internal (Let's Encrypt) host, **NPM already injects its own**
+acme-challenge location for the cert → two identical locations → `[emerg]`. Older
+forward-auth hosts predate the bypass in the snippet, so only *newly created*
+public forward-auth subdomains collide.
+
+## Diagnose
+Read NPM's DB (open `?mode=ro`, **not** `immutable=1` — that ignores the WAL):
+```
+proxy_host.meta.nginx_online = false
+proxy_host.meta.nginx_err    = 'nginx: [emerg] duplicate location "/.well-known/acme-challenge/" ...'
+```
+
+## Fix / workaround
+Don't use the sentinel for a public forward-auth host. Set `advanced_config` to
+the forward-auth block **literally, minus** the `location /.well-known/acme-challenge/`
+block (NPM supplies that itself for LE hosts). Keep the `auth_request /authelia`
+line and the `proxy_set_header Remote-*` lines so the app still gets its identity
+headers. Do NOT include the `servicebay-proxy-error` / `forward-auth-denied`
+blocks — the proxy-hosts route appends those (keyed on `auth_request /authelia`),
+so a literal still gets them; including your own would duplicate them.
+
+Proper fix lives in `packages/backend/src/lib/stackInstall/forwardAuth.ts`: make
+the acme bypass conditional on non-LE exposure (tracked as a bug).

--- a/assists/footgun-subdomain-needs-public-domain.md
+++ b/assists/footgun-subdomain-needs-public-domain.md
@@ -1,0 +1,37 @@
+---
+title: Subdomain proxy host silently skipped when the template omits {{PUBLIC_DOMAIN}}
+whenToUse: Your template declares a type:subdomain variable but no proxy host / route was created, and there's no error in the install log.
+kind: footgun
+tags: [subdomain, proxy, npm, public-domain, install, assembler, template]
+---
+
+# A subdomain host is skipped silently without a PUBLIC_DOMAIN reference
+
+## Symptom
+Your template has a `type: "subdomain"` variable, the install succeeds, but no
+NPM proxy host / route exists for `<sub>.<domain>` — and **nothing** in the
+install log says why.
+
+## Cause
+`buildProxyHosts` forms the FQDN from a `PUBLIC_DOMAIN` variable in the assembled
+manifest. The manifest assembler injects a global (like `PUBLIC_DOMAIN` or
+`DATA_DIR`) **only if the template's YAML references it** (`{{PUBLIC_DOMAIN}}`).
+If nothing references it, `PUBLIC_DOMAIN` is absent, `domain` is `undefined`, and
+`ensureProxyHosts` does `if (!domain) return;` — the host is dropped with no log.
+
+## Fix
+Reference `{{PUBLIC_DOMAIN}}` somewhere in `template.yml` so the assembler
+injects it. A clean, useful place is a container env var:
+```yaml
+env:
+  - name: PUBLIC_DOMAIN
+    value: "{{PUBLIC_DOMAIN}}"
+```
+Re-assemble → the manifest now carries `PUBLIC_DOMAIN` → `ensureProxyHosts`
+creates the `<sub>.<PUBLIC_DOMAIN>` host. Re-running the install is idempotent.
+
+## Verify
+After install, confirm the host exists AND nginx loaded it (see assist
+`footgun-forward-auth-acme-collision` for the `nginx_online` / `nginx_err` check).
+The proper fix (auto-inject PUBLIC_DOMAIN when any subdomain var exists, or warn
+loudly) is tracked as a bug.

--- a/assists/new-service-architecture.md
+++ b/assists/new-service-architecture.md
@@ -10,6 +10,33 @@ tags: [architecture, adr, new-service, language, libraries, tests, storage, secr
 Recommended defaults, not mandates — deviate when you have a reason, and say why.
 These sit on top of the platform ADRs in `docs/adr/` (respect those; see bottom).
 
+An architecture recommendation must say **how** a need is solved — and the first
+decision is **where it lives**. Only then do language/structure/etc. follow.
+
+## Where should it live? (decide the shape first)
+
+A new need is usually solved as one of these — pick deliberately:
+
+- **A capability in Solaris** — when it's about *this household*: identity,
+  memory, conversation, per-resident privacy, or a home-control behavior driven
+  through the assistant. Lives in `mdopp/solbay` (the Solaris Engine / tools).
+  Example: "remember the family's book list and answer questions about it."
+- **A service in ServiceBay** — when it's a *generic, installable capability* any
+  box could want, standing on its own (a web app, an API, a data store, a device
+  bridge). Ships as a template. Example: "a photo library", "an office-light
+  dashboard".
+- **Upstream / reuse** — when the runtime already provides it. Before building an
+  agent/LLM/gateway/tool feature, check whether **Hermes** (or HA, Authelia,
+  Ollama, NPM) already ships it, and consume/extend that instead of forking.
+- **Both** — a ServiceBay service exposes the capability (e.g. an MCP surface or
+  API), and Solaris consumes it as a tool. Prefer this over duplicating logic:
+  generic mechanism in ServiceBay, household-specific behavior in Solaris.
+
+Rule of thumb (the "three projects, three jobs" boundary): **generic → ServiceBay
+or upstream; household-specific → Solaris.** If you'd want it on someone else's
+box unchanged, it's a service; if it only makes sense for *this* family, it's a
+Solaris capability. State this choice explicitly in the design.
+
 ## Language & runtime
 - **Any language works** — a service is just a container. Pick the smallest,
   fastest-to-start stack that fits the job.

--- a/assists/new-service-architecture.md
+++ b/assists/new-service-architecture.md
@@ -19,7 +19,7 @@ A new need is usually solved as one of these — pick deliberately:
 
 - **A capability in Solaris** — when it's about *this household*: identity,
   memory, conversation, per-resident privacy, or a home-control behavior driven
-  through the assistant. Lives in `mdopp/solbay` (the Solaris Engine / tools).
+  through the assistant. Lives in `mdopp/solarisbay` (the Solaris Engine / tools).
   Example: "remember the family's book list and answer questions about it."
 - **A service in ServiceBay** — when it's a *generic, installable capability* any
   box could want, standing on its own (a web app, an API, a data store, a device

--- a/assists/new-service-architecture.md
+++ b/assists/new-service-architecture.md
@@ -1,0 +1,89 @@
+---
+title: Architecture recommendations for a new ServiceBay service (ADR-style)
+whenToUse: You're about to design a new service and want recommended defaults — language, structure, libraries, tests, data storage, secrets — plus the platform decisions a new service must respect.
+kind: adr
+tags: [architecture, adr, new-service, language, libraries, tests, storage, secrets, recommendations]
+---
+
+# Architecture recommendations for a new service
+
+Recommended defaults, not mandates — deviate when you have a reason, and say why.
+These sit on top of the platform ADRs in `docs/adr/` (respect those; see bottom).
+
+## Language & runtime
+- **Any language works** — a service is just a container. Pick the smallest,
+  fastest-to-start stack that fits the job.
+- Sensible defaults by shape:
+  - Small web/API/proxy service → **Python (FastAPI+uvicorn)** or **Node/TS
+    (Fastify)** or **Go** (single static binary, tiniest image).
+  - AI / data / HA-adjacent → **Python** (matches Solaris; rich HA/ML libs).
+  - Control-plane-adjacent tooling → **Node/TS** (matches ServiceBay).
+- Keep the image lean (slim/alpine/distroless base, multi-stage build) and
+  startup fast — the health gate and reconcile loop reward quick boots.
+
+## Basic structure (two pieces)
+1. **App repo** — code + `Dockerfile` + CI that builds & pushes an image the box
+   can pull. Keep it independently buildable/testable.
+2. **Template** — a `templates/<name>/` (or registry / local-drop) that deploys
+   that image and declares ports, mounts, subdomain, SSO, health. See the
+   `create-service` recipe and `docs/TEMPLATE_AUTHORING.md`.
+
+The app should be: **stateless-restartable** (all state on a mounted volume),
+**config-by-env**, and **health-observable**.
+
+## Recommended libraries
+- Lean over heavy: a minimal web framework + a good HTTP client, not a kitchen
+  sink. (Python: `fastapi`+`uvicorn`+`httpx`. Node: `fastify`+`undici`. Go: std
+  `net/http`.)
+- Reuse the platform instead of reimplementing: **Authelia** for auth (don't roll
+  your own login), **NPM** for TLS/proxy, **Home Assistant** for device control,
+  **Ollama** for local LLM. Talk to them, don't rebuild them.
+
+## Recommended tests
+- **Unit tests** for real logic (parsing, control flow, error handling) — fast,
+  no network.
+- **A health endpoint** (`/healthz` → 200) wired to `servicebay.healthcheck`;
+  it's both a test seam and the install gate.
+- **Box-verify** the deployed service end-to-end (deploy → healthcheck →
+  functional check → SSO returns 302 unauthenticated → the feature actually
+  works). See `create-service`. Don't trust green CI alone for box behavior.
+- If the app enforces the forward-auth `Remote-User` header, test that a request
+  missing it is rejected (no SSO bypass).
+
+## Data storage
+- Persist under a **mounted hostPath volume** at `{{DATA_DIR}}/<name>/…`
+  (= `/mnt/data/stacks/<name>/…`). Nothing important in the container's ephemeral
+  fs — it's wiped on every pod recreate.
+- **Small structured state → SQLite in WAL mode** (WAL avoids "database is
+  locked" under concurrent reads/writes; a repeatedly-hit lesson on this box).
+- Larger/bulk data → its own dir on the volume; keep it out of the config tree so
+  backup tiering works (config/state → NAS, bulk → secondary drive; ADR 0002).
+- Under rootless Podman + SELinux, prefer `type: Directory` with a pre-created
+  dir over `DirectoryOrCreate` when mounting shared/foreign-owned trees, and
+  disable relabel per-container when mounting another service's files.
+
+## Secrets
+- **Never bake a secret into the image, template, or repo.** Express credentials
+  as `type: "secret"` variables — the wizard generates/injects the value at
+  deploy. Read them from env or a mounted file at runtime. See root `CLAUDE.md`
+  "Secret hygiene" (a build-time scan enforces this).
+
+## Networking & SSO
+- Default to an **isolated netns** with explicit `hostPort`s; use
+  `hostNetwork: true` only when the app must reach another on-box service on
+  loopback (ADR 0007). A pod with neither is silently unreachable.
+- User-facing? Put it on a subdomain with Authelia forward-auth (ADR 0001/0006).
+  Reference `{{PUBLIC_DOMAIN}}` in the template or the proxy host is skipped —
+  see `footgun-subdomain-needs-public-domain`.
+
+## Platform ADRs a new service must respect
+- **0001 / 0006** — authenticate via Authelia (SSO) / LLDAP; apex is default-deny.
+- **0002** — make config/state NAS-backupable; keep bulk separate.
+- **0003** — release via release-please; parser-clean commit subjects.
+- **0004 / 0009** — installs/redeploys are non-destructive; repair is
+  reconciliation, not reinstallation. Your `post-deploy.py` must be idempotent.
+- **0005** — DNS Pattern A (AdGuard as LAN DNS).
+- **0007** — network isolation with named carve-outs.
+- **0009-service-tokens** — use scoped service tokens for cross-service trust.
+
+Read the actual ADRs in `docs/adr/` before making a decision that touches one.

--- a/assists/new-service-architecture.md
+++ b/assists/new-service-architecture.md
@@ -33,10 +33,10 @@ A new need is usually solved as one of these — pick deliberately:
   API), and Solaris consumes it as a tool. Prefer this over duplicating logic:
   generic mechanism in ServiceBay, household-specific behavior in Solaris.
 
-Rule of thumb (the "three projects, three jobs" boundary): **generic → ServiceBay
-or upstream; household-specific → Solaris.** If you'd want it on someone else's
-box unchanged, it's a service; if it only makes sense for *this* family, it's a
-Solaris capability. State this choice explicitly in the design.
+Rule of thumb (the ServiceBay ↔ Solaris boundary): **generic → ServiceBay (or an
+upstream project); household-specific → Solaris.** If you'd want it on someone
+else's box unchanged, it's a service; if it only makes sense for *this* family,
+it's a Solaris capability. State this choice explicitly in the design.
 
 ## Language & runtime
 - **Any language works** — a service is just a container. Pick the smallest,

--- a/assists/new-service-architecture.md
+++ b/assists/new-service-architecture.md
@@ -25,9 +25,10 @@ A new need is usually solved as one of these — pick deliberately:
   box could want, standing on its own (a web app, an API, a data store, a device
   bridge). Ships as a template. Example: "a photo library", "an office-light
   dashboard".
-- **Upstream / reuse** — when the runtime already provides it. Before building an
-  agent/LLM/gateway/tool feature, check whether **Hermes** (or HA, Authelia,
-  Ollama, NPM) already ships it, and consume/extend that instead of forking.
+- **Reuse what's there** — when the runtime already provides it. Before building
+  an agent/LLM/tool or device feature, check whether **HA, Authelia, Ollama, NPM,
+  or the Solaris Engine** already provides it, and consume/extend that instead of
+  rebuilding.
 - **Both** — a ServiceBay service exposes the capability (e.g. an MCP surface or
   API), and Solaris consumes it as a tool. Prefer this over duplicating logic:
   generic mechanism in ServiceBay, household-specific behavior in Solaris.

--- a/assists/servicebay-overview.md
+++ b/assists/servicebay-overview.md
@@ -1,0 +1,63 @@
+---
+title: ServiceBay — structure & capabilities (orientation)
+whenToUse: You (a client/agent) need to understand what ServiceBay is, how it's structured, and what it can do — before authoring a service, driving the MCP, or answering questions about the platform.
+kind: guide
+tags: [servicebay, overview, architecture, platform, mcp, templates, orientation]
+---
+
+# ServiceBay — what it is and what it can do
+
+ServiceBay is the **control plane for a self-hosted home box**: it installs and
+manages containerized services on a single node (Fedora CoreOS + rootless
+Podman), fronts them with a reverse proxy + SSO, and keeps them healthy and
+backed up. Think "a private, opinionated PaaS for one household server."
+
+## Structure
+- **Control-plane app** — `packages/{frontend,backend,api-client}` (Node/React/
+  TypeScript), built into one image. The wizard/portal + REST API + the MCP
+  server live here. This is NOT where services' code lives.
+- **Services = templates** — `templates/<name>/` (a Podman kube `Pod` +
+  `variables.json` + README, optional `post-deploy.py`, migrations, mustache
+  configs). `stacks/<name>/` bundle templates. Contract: `docs/TEMPLATE_AUTHORING.md`,
+  `templates/CLAUDE.md`.
+- **Registries** — services come from built-in `templates/`, external git
+  registries, or a `DATA_DIR/local-templates/` drop (precedence: Local > registry
+  > built-in). `packages/backend/src/lib/registry.ts`.
+- **On-disk layout** — per-service data at `/mnt/data/stacks/<name>/` (this is
+  what `{{DATA_DIR}}` renders to); ServiceBay's own config/tokens at
+  `/mnt/data/servicebay/`.
+
+## Core capabilities
+- **Install / reconcile** — a wizard-driven runner assembles a manifest
+  (`/api/install/assemble`) and deploys it (`/api/install/start`) as Quadlet
+  `.kube` units (`podman kube play`), wiring proxy hosts, SSO, certs, health,
+  and running post-deploy hooks. Redeploy is idempotent reconciliation, never a
+  wipe (ADR 0004, 0009).
+- **Reverse proxy + SSO** — Nginx Proxy Manager publishes `<sub>.<PUBLIC_DOMAIN>`
+  with Let's Encrypt certs; Authelia provides forward-auth (classic login) and
+  OIDC. Every user-facing service authenticates (ADR 0001, 0006).
+- **Identity** — LLDAP for users/groups; Authelia sessions; per-service tokens
+  with scopes (ADR 0009-service-tokens).
+- **Health & diagnose** — continuous health probes + a diagnose battery with
+  self-heal; the portal surfaces service state.
+- **Backup & restore** — tiered: critical config/state → NAS, bulk media →
+  secondary drive (ADR 0002); full system restore supported.
+- **DNS** — AdGuard as LAN DNS via the router (Pattern A, ADR 0005);
+  split-horizon `*.<domain>` → box.
+- **TUI + installer** — a Go/Bubble Tea TUI for the setup journey + stack
+  desired-state editing (ADR 0008); FCoS USB install/reinstall flow.
+- **MCP surface** — an agent can drive the box over `/mcp` with a scoped `sb_`
+  token: read state, logs, health, templates; deploy/rename/delete services;
+  manage proxy routes, health checks, backups; `exec_command` / `container_exec`;
+  and discover help via `list_assists` / `get_assist`. Scopes: `read` <
+  `lifecycle` < `mutate` < `reboot` < `destroy`, plus `exec`.
+
+## Key decisions (see `docs/adr/`)
+SSO-everywhere (0001), tiered backup (0002), release-please-only (0003),
+non-destructive installs (0004), DNS Pattern A (0005), apex-deny (0006), network
+isolation with carve-outs (0007), desired-state TUI (0008), repair =
+reconciliation (0009), service tokens & trust (0009-service-tokens).
+
+## Related assists
+`solaris-overview` (the household-AI tier on top), `create-service` (build +
+deploy a new service), `new-service-architecture` (recommended decisions).

--- a/assists/solaris-overview.md
+++ b/assists/solaris-overview.md
@@ -1,0 +1,58 @@
+---
+title: Solaris — structure & capabilities (orientation)
+whenToUse: You need to understand what Solaris (the household AI assistant, aka OSCAR) is, how it's structured, and how it relates to ServiceBay — before working on it or answering questions about it.
+kind: guide
+tags: [solaris, oscar, solbay, household-ai, voice, ollama, home-assistant, overview, orientation]
+---
+
+# Solaris — what it is and what it can do
+
+Solaris (repo `mdopp/solbay`) is a **private household AI assistant** that
+ServiceBay deploys as a one-click tier. It runs entirely on the box — voice at
+home, chat in the browser, one agent with long memory, per-resident privacy,
+and real control of the house through Home Assistant. Nothing leaves the house
+without an explicit, audited opt-in.
+
+> Note: `solbay-architecture.md` in the ServiceBay repo describes an earlier
+> Hermes-gateway design. The **current** architecture (v0.10+) is the native
+> **Solaris Engine** — see `mdopp/solbay` `README.md` / `solaris-architecture.md`
+> for the canonical picture.
+
+## Structure (repo `mdopp/solbay`)
+- **`solaris-chat/`** — the Solaris Engine: one process owning the agent loop
+  (direct Ollama `/api/chat`, per-turn model + reasoning), the session store
+  (`solaris.db`, SQLite/WAL), tracing, timer scheduler, tool registry, and the
+  browser chat surface (SSO-gated).
+- **`voice-gatekeeper/`** — the Wyoming/Voice PE path: identity-by-voice and the
+  distributed-satellite bridge into HA's Assist pipeline.
+- **`tts-martin/`** — the local GPU TTS voice ("Martin").
+- **`templates/` + `stacks/`** — ServiceBay templates (`ollama`, `solaris`) and
+  the `solarisbay` stack, consumed by ServiceBay as an **external registry**.
+- **`database/`, `docs/`, `scripts/`** — schema, docs, box tooling.
+
+## Capabilities
+- **One conversation** — voice at home (HA Voice PE via ESPHome → whisper GPU
+  STT → engine → Martin GPU TTS) and browser chat, same agent + memory. A spoken
+  turn answers in ≈1.3 s after speech end.
+- **Local inference** — Ollama on the box GPU (RTX 2000 Ada 16 GB) with resident
+  models: `gemma4:e2b` (fast/voice), `gemma4:12b` (thorough/admin),
+  `nomic-embed-text` (embeddings). No cloud LLM unless explicitly opted in.
+- **Home control** — drives lights/heating/scenes/timers through Home Assistant
+  (the engine calls HA tools; HA fronts the Voice PE speaker).
+- **Long memory** — the household's documents/appointments/decisions woven into
+  something the assistant can query; a notes vault + `solaris.db`.
+- **Per-resident privacy** — each resident has their own memory namespace and
+  tool scope; guests get a locked-down world. Voice is identity.
+- **Admin via ServiceBay MCP** — admin-only turns can reach the ServiceBay MCP to
+  operate the box.
+
+## How it relates to ServiceBay
+Solaris is a **consumer** of the ServiceBay platform: ServiceBay provides the
+install/reconcile runner, reverse proxy + SSO, identity, backup, health, and the
+box itself; Solaris ships as templates in an external registry and installs like
+any other service. Generic capabilities belong in ServiceBay (or upstream), not
+in Solaris.
+
+## Related assists
+`servicebay-overview` (the platform underneath), `create-service`,
+`new-service-architecture`.

--- a/assists/solaris-overview.md
+++ b/assists/solaris-overview.md
@@ -13,10 +13,10 @@ home, chat in the browser, one agent with long memory, per-resident privacy,
 and real control of the house through Home Assistant. Nothing leaves the house
 without an explicit, audited opt-in.
 
-> Note: `solbay-architecture.md` in the ServiceBay repo describes an earlier
-> Hermes-gateway design. The **current** architecture (v0.10+) is the native
-> **Solaris Engine** — see `mdopp/solbay` `README.md` / `solaris-architecture.md`
-> for the canonical picture.
+> Note: `solbay-architecture.md` in the ServiceBay repo is **stale** (a pre-v0.10
+> design that mentioned an external agent gateway — no longer used). The current
+> architecture is the native **Solaris Engine**; see `mdopp/solbay` `README.md` /
+> `solaris-architecture.md` for the canonical picture.
 
 ## Structure (repo `mdopp/solbay`)
 - **`solaris-chat/`** — the Solaris Engine: one process owning the agent loop

--- a/assists/solaris-overview.md
+++ b/assists/solaris-overview.md
@@ -1,13 +1,13 @@
 ---
 title: Solaris — structure & capabilities (orientation)
-whenToUse: You need to understand what Solaris (the household AI assistant, aka OSCAR) is, how it's structured, and how it relates to ServiceBay — before working on it or answering questions about it.
+whenToUse: You need to understand what Solaris (the household AI assistant) is, how it's structured, and how it relates to ServiceBay — before working on it or answering questions about it.
 kind: guide
-tags: [solaris, oscar, solbay, household-ai, voice, ollama, home-assistant, overview, orientation]
+tags: [solaris, solarisbay, household-ai, voice, ollama, home-assistant, overview, orientation]
 ---
 
 # Solaris — what it is and what it can do
 
-Solaris (repo `mdopp/solbay`) is a **private household AI assistant** that
+Solaris (repo `mdopp/solarisbay`) is a **private household AI assistant** that
 ServiceBay deploys as a one-click tier. It runs entirely on the box — voice at
 home, chat in the browser, one agent with long memory, per-resident privacy,
 and real control of the house through Home Assistant. Nothing leaves the house
@@ -15,10 +15,10 @@ without an explicit, audited opt-in.
 
 > Note: `solbay-architecture.md` in the ServiceBay repo is **stale** (a pre-v0.10
 > design that mentioned an external agent gateway — no longer used). The current
-> architecture is the native **Solaris Engine**; see `mdopp/solbay` `README.md` /
+> architecture is the native **Solaris Engine**; see `mdopp/solarisbay` `README.md` /
 > `solaris-architecture.md` for the canonical picture.
 
-## Structure (repo `mdopp/solbay`)
+## Structure (repo `mdopp/solarisbay`)
 - **`solaris-chat/`** — the Solaris Engine: one process owning the agent loop
   (direct Ollama `/api/chat`, per-turn model + reasoning), the session store
   (`solaris.db`, SQLite/WAL), tracing, timer scheduler, tool registry, and the

--- a/packages/backend/src/lib/assists/catalog.test.ts
+++ b/packages/backend/src/lib/assists/catalog.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+// Point DATA_DIR at a fixed tmp base BEFORE catalog.ts (→ @/lib/dirs) evaluates,
+// so LOCAL_ASSISTS_DIR resolves under our sandbox. Mirrors registry.local.test.ts.
+const BASE = '/tmp/sb-assist-catalog-test';
+vi.hoisted(() => {
+  process.env.DATA_DIR = '/tmp/sb-assist-catalog-test';
+});
+
+import { listAssists, getAssist } from './catalog';
+
+const BUILTIN = path.join(BASE, 'assists');
+const LOCAL = path.join(BASE, 'local-assists');
+let origCwd: string;
+
+async function seed(dir: string, id: string, front: Record<string, string>, body = 'body') {
+  const fm = Object.entries(front).map(([k, v]) => `${k}: ${v}`).join('\n');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, `${id}.md`), `---\n${fm}\n---\n${body}\n`, 'utf-8');
+}
+
+beforeEach(async () => {
+  await fs.rm(BASE, { recursive: true, force: true });
+  await fs.mkdir(BUILTIN, { recursive: true });
+  await fs.mkdir(LOCAL, { recursive: true });
+  origCwd = process.cwd();
+  process.chdir(BASE); // BUILTIN = process.cwd()/assists
+});
+
+afterEach(() => {
+  process.chdir(origCwd);
+});
+
+afterAll(async () => {
+  await fs.rm(BASE, { recursive: true, force: true });
+});
+
+describe('assist catalog', () => {
+  it('lists built-in entries with parsed frontmatter', async () => {
+    await seed(BUILTIN, 'alpha', { title: 'Alpha guide', whenToUse: 'when alpha', kind: 'guide', tags: '[a, b]' });
+    const list = await listAssists();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ id: 'alpha', title: 'Alpha guide', kind: 'guide', source: 'Built-in' });
+    expect(list[0].tags).toEqual(['a', 'b']);
+  });
+
+  it('local drop overrides built-in by id', async () => {
+    await seed(BUILTIN, 'dup', { title: 'Built-in title', kind: 'guide' });
+    await seed(LOCAL, 'dup', { title: 'Local title', kind: 'recipe' });
+    const list = await listAssists();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ title: 'Local title', kind: 'recipe', source: 'Local' });
+  });
+
+  it('ranks + filters by query', async () => {
+    await seed(BUILTIN, 'deploy', { title: 'Deploy a service', whenToUse: 'deploy behind sso', kind: 'recipe' });
+    await seed(BUILTIN, 'backup', { title: 'Backup restore', whenToUse: 'restore data', kind: 'guide' });
+    const list = await listAssists({ query: 'deploy service' });
+    expect(list.map(a => a.id)).toEqual(['deploy']);
+  });
+
+  it('filters by kind', async () => {
+    await seed(BUILTIN, 'g', { title: 'G', kind: 'guide' });
+    await seed(BUILTIN, 'f', { title: 'F', kind: 'footgun' });
+    const list = await listAssists({ kind: 'footgun' });
+    expect(list.map(a => a.id)).toEqual(['f']);
+  });
+
+  it('defaults title to id and kind to guide when frontmatter is thin', async () => {
+    await fs.writeFile(path.join(BUILTIN, 'bare.md'), 'no frontmatter here\n', 'utf-8');
+    const list = await listAssists();
+    expect(list[0]).toMatchObject({ id: 'bare', title: 'bare', kind: 'guide' });
+  });
+
+  it('ignores dotfiles and non-markdown files', async () => {
+    await seed(BUILTIN, 'real', { title: 'Real' });
+    await fs.writeFile(path.join(BUILTIN, '.hidden.md'), '---\ntitle: Hidden\n---\n', 'utf-8');
+    await fs.writeFile(path.join(BUILTIN, 'notes.txt'), 'nope', 'utf-8');
+    const list = await listAssists();
+    expect(list.map(a => a.id)).toEqual(['real']);
+  });
+
+  it('a missing source dir is a no-op', async () => {
+    await fs.rm(LOCAL, { recursive: true, force: true }); // local gone
+    await seed(BUILTIN, 'only', { title: 'Only' });
+    const list = await listAssists();
+    expect(list.map(a => a.id)).toEqual(['only']);
+  });
+
+  it('getAssist returns raw markdown (frontmatter + body), local winning', async () => {
+    await seed(BUILTIN, 'x', { title: 'Built-in' }, 'built-in body');
+    await seed(LOCAL, 'x', { title: 'Local' }, 'local body');
+    const raw = await getAssist('x');
+    expect(raw).toContain('title: Local');
+    expect(raw).toContain('local body');
+  });
+
+  it('getAssist rejects traversal / unknown ids', async () => {
+    expect(await getAssist('../catalog')).toBeNull();
+    expect(await getAssist('..')).toBeNull();
+    expect(await getAssist('a/b')).toBeNull();
+    expect(await getAssist('does-not-exist')).toBeNull();
+  });
+});

--- a/packages/backend/src/lib/assists/catalog.ts
+++ b/packages/backend/src/lib/assists/catalog.ts
@@ -35,6 +35,7 @@ import { logger } from '@/lib/logger';
 export const ASSIST_KINDS = [
   'guide',
   'recipe',
+  'adr',
   'template',
   'checklist',
   'footgun',

--- a/packages/backend/src/lib/assists/catalog.ts
+++ b/packages/backend/src/lib/assists/catalog.ts
@@ -1,0 +1,199 @@
+/**
+ * Task-assist catalog (#2146).
+ *
+ * A small, extensible knowledge base an MCP agent can query for help on a
+ * task: guides, ordered recipes, checklists, footguns, snippets. Two tools sit
+ * on top of it — `list_assists` (discover) and `get_assist` (fetch) — keeping
+ * the MCP tool surface tiny while the catalog grows over time.
+ *
+ * Sources, mirroring the template registry's multi-source + local-drop shape:
+ *   - Built-in: the repo-root `assists/` dir, shipped into the container image
+ *     (`process.cwd()` is `/app` at runtime, so this resolves to `/app/assists`).
+ *   - Local:    `DATA_DIR/local-assists/` — a persisted drop dir so an operator
+ *     (or an agent, once write access exists) can add an assist WITHOUT a
+ *     release. A Local entry with the same id overrides the built-in one.
+ *
+ * Each assist is a single markdown file with frontmatter:
+ *
+ *   ---
+ *   title: Create & deploy a new ServiceBay service
+ *   whenToUse: You need to build a new service repo and deploy it behind SSO.
+ *   kind: recipe                 # guide | recipe | template | checklist | footgun | snippet
+ *   tags: [service, template, deploy, subdomain, sso]
+ *   ---
+ *   <body markdown>
+ *
+ * The `id` is the filename without the `.md` extension.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { DATA_DIR } from '@/lib/dirs';
+import { logger } from '@/lib/logger';
+
+export const ASSIST_KINDS = [
+  'guide',
+  'recipe',
+  'template',
+  'checklist',
+  'footgun',
+  'snippet',
+] as const;
+
+export type AssistKind = (typeof ASSIST_KINDS)[number];
+
+export interface AssistSummary {
+  id: string;
+  title: string;
+  /** One line telling the agent when this assist applies — drives self-selection. */
+  whenToUse: string;
+  kind: AssistKind;
+  tags: string[];
+  /** 'Built-in' or 'Local'. */
+  source: string;
+}
+
+// Repo-root `assists/` (shipped to /app/assists in the container), then the
+// persisted drop dir. Order matters: later sources override earlier ones by id.
+const BUILTIN_ASSISTS_DIR = () => path.join(process.cwd(), 'assists');
+const LOCAL_ASSISTS_DIR = () => path.join(DATA_DIR, 'local-assists');
+
+function assistSources(): { dir: string; source: string }[] {
+  return [
+    { dir: BUILTIN_ASSISTS_DIR(), source: 'Built-in' },
+    { dir: LOCAL_ASSISTS_DIR(), source: 'Local' },
+  ];
+}
+
+/**
+ * Collapse a request-supplied id to a single, self-contained filename and
+ * reject traversal — only a plain `<id>.md` is ever joined onto a source root,
+ * so a read can never escape it (path-injection guard; CodeQL js/path-injection).
+ * Returns null for an unsafe id.
+ */
+function assistFileName(id: string): string | null {
+  const segment = path.basename(id);
+  if (
+    !segment ||
+    segment !== id ||
+    segment === '.' ||
+    segment === '..' ||
+    segment.includes('\0')
+  ) {
+    return null;
+  }
+  return `${segment}.md`;
+}
+
+function coerceKind(value: unknown): AssistKind {
+  return (ASSIST_KINDS as readonly string[]).includes(value as string)
+    ? (value as AssistKind)
+    : 'guide';
+}
+
+function coerceTags(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(v => String(v)).filter(Boolean);
+  if (typeof value === 'string') {
+    return value.split(',').map(s => s.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+/** Parse a raw assist file into its summary. Returns null on unreadable frontmatter. */
+function parseAssistSummary(raw: string, id: string, source: string): AssistSummary | null {
+  try {
+    const { data } = matter(raw);
+    const d = data as Record<string, unknown>;
+    const title = typeof d.title === 'string' && d.title.trim() ? d.title.trim() : id;
+    // Accept either camelCase or snake_case for the human-facing hint.
+    const whenRaw = d.whenToUse ?? d.when_to_use ?? '';
+    const whenToUse = typeof whenRaw === 'string' ? whenRaw.trim() : '';
+    return { id, title, whenToUse, kind: coerceKind(d.kind), tags: coerceTags(d.tags), source };
+  } catch (e) {
+    logger.warn('assists', `Skipping unparseable assist "${id}": ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+
+async function readDirAssists(dir: string): Promise<string[]> {
+  try {
+    await fs.access(dir);
+  } catch {
+    return []; // a missing source dir is a valid no-op
+  }
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    return entries
+      .filter(e => e.isFile() && e.name.endsWith('.md') && !e.name.startsWith('.'))
+      .map(e => e.name);
+  } catch (e) {
+    logger.error('assists', `Failed to scan assist dir ${dir}: ${e instanceof Error ? e.message : String(e)}`);
+    return [];
+  }
+}
+
+/** Score an assist against free-text query tokens. 0 = no match. */
+function scoreAssist(a: AssistSummary, tokens: string[]): number {
+  if (tokens.length === 0) return 1;
+  const hay = [a.id, a.title, a.whenToUse, a.kind, a.tags.join(' ')].join(' ').toLowerCase();
+  let score = 0;
+  for (const t of tokens) if (hay.includes(t)) score++;
+  return score;
+}
+
+export interface ListAssistsOptions {
+  /** Free-text task description; ranks + filters entries that match any token. */
+  query?: string;
+  /** Restrict to one kind. */
+  kind?: AssistKind;
+}
+
+/**
+ * List catalog entries, Local overriding Built-in by id. When `query` is set,
+ * only matching entries are returned, best match first.
+ */
+export async function listAssists(opts: ListAssistsOptions = {}): Promise<AssistSummary[]> {
+  const byId = new Map<string, AssistSummary>();
+  for (const { dir, source } of assistSources()) {
+    for (const file of await readDirAssists(dir)) {
+      const id = file.slice(0, -'.md'.length);
+      let raw: string;
+      try {
+        raw = await fs.readFile(path.join(dir, file), 'utf-8');
+      } catch {
+        continue;
+      }
+      const summary = parseAssistSummary(raw, id, source);
+      if (summary) byId.set(id, summary); // later source wins
+    }
+  }
+
+  let entries = [...byId.values()];
+  if (opts.kind) entries = entries.filter(e => e.kind === opts.kind);
+
+  const tokens = (opts.query ?? '').toLowerCase().split(/\s+/).filter(Boolean);
+  const scored = entries
+    .map(e => ({ e, score: scoreAssist(e, tokens) }))
+    .filter(x => x.score > 0)
+    .sort((a, b) => b.score - a.score || a.e.title.localeCompare(b.e.title));
+  return scored.map(x => x.e);
+}
+
+/**
+ * Return the full raw markdown (frontmatter + body) of one assist, Local
+ * overriding Built-in. Returns null for an unknown or unsafe id.
+ */
+export async function getAssist(id: string): Promise<string | null> {
+  const file = assistFileName(id);
+  if (!file) return null;
+  // Local first so a drop-in override wins, mirroring registry precedence.
+  for (const { dir } of [...assistSources()].reverse()) {
+    try {
+      return await fs.readFile(path.join(dir, file), 'utf-8');
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}

--- a/packages/backend/src/lib/mcp/server.assists.test.ts
+++ b/packages/backend/src/lib/mcp/server.assists.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+// #2146: list_assists / get_assist MCP tools over the extensible assist catalog.
+// Mock the catalog so these tests assert wiring (registration, read scope, arg
+// pass-through, result shaping) independent of on-disk assist files.
+const listAssists = vi.fn();
+const getAssist = vi.fn();
+vi.mock('@/lib/assists/catalog', () => ({
+  ASSIST_KINDS: ['guide', 'recipe', 'template', 'checklist', 'footgun', 'snippet'],
+  listAssists: (...a: unknown[]) => listAssists(...a),
+  getAssist: (...a: unknown[]) => getAssist(...a),
+}));
+
+// Keep the safety gate helpers permissive (read tools don't snapshot anyway).
+vi.mock('./safety', () => ({
+  guardMutation: vi.fn(async () => null),
+  guardExec: vi.fn(async () => null),
+  snapshotBeforeMutation: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/lib/nodes', () => ({
+  listNodes: vi.fn(async () => [{ Name: 'box', URI: '', Default: true }]),
+  getNodeConnection: vi.fn(),
+}));
+
+async function connectClient() {
+  const { createMcpServer } = await import('./server');
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return { client };
+}
+
+function firstText(res: unknown): string {
+  const content = (res as { content: Array<{ text: string }> }).content;
+  return content[0].text;
+}
+
+beforeEach(() => {
+  listAssists.mockReset();
+  getAssist.mockReset();
+});
+
+describe('assist MCP tools (#2146)', () => {
+  it('registers list_assists + get_assist at read scope', async () => {
+    const { TOOL_SCOPES } = await import('./server');
+    expect(TOOL_SCOPES.list_assists).toBe('read');
+    expect(TOOL_SCOPES.get_assist).toBe('read');
+  });
+
+  it('exposes both via the tools/list handshake', async () => {
+    const { client } = await connectClient();
+    const names = (await client.listTools()).tools.map(t => t.name);
+    expect(names).toContain('list_assists');
+    expect(names).toContain('get_assist');
+    await client.close();
+  });
+
+  it('list_assists forwards query + kind and returns the catalog result', async () => {
+    listAssists.mockResolvedValue([
+      { id: 'create-service', title: 'Create & deploy a new service', kind: 'recipe', whenToUse: 'x', tags: [], source: 'Built-in' },
+    ]);
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'list_assists', arguments: { query: 'deploy a service', kind: 'recipe' } });
+    expect(listAssists).toHaveBeenCalledWith({ query: 'deploy a service', kind: 'recipe' });
+    expect(firstText(res)).toContain('create-service');
+    await client.close();
+  });
+
+  it('get_assist returns raw markdown; unknown id is an error', async () => {
+    getAssist.mockImplementation(async (id: string) =>
+      id === 'create-service' ? '---\ntitle: Create\n---\nbody' : null,
+    );
+    const { client } = await connectClient();
+
+    const ok = await client.callTool({ name: 'get_assist', arguments: { id: 'create-service' } });
+    expect(getAssist).toHaveBeenCalledWith('create-service');
+    expect(firstText(ok)).toContain('title: Create');
+    expect((ok as { isError?: boolean }).isError).toBeFalsy();
+
+    const bad = await client.callTool({ name: 'get_assist', arguments: { id: 'nope' } });
+    expect((bad as { isError?: boolean }).isError).toBe(true);
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/server.assists.test.ts
+++ b/packages/backend/src/lib/mcp/server.assists.test.ts
@@ -8,7 +8,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 const listAssists = vi.fn();
 const getAssist = vi.fn();
 vi.mock('@/lib/assists/catalog', () => ({
-  ASSIST_KINDS: ['guide', 'recipe', 'template', 'checklist', 'footgun', 'snippet'],
+  ASSIST_KINDS: ['guide', 'recipe', 'adr', 'template', 'checklist', 'footgun', 'snippet'],
   listAssists: (...a: unknown[]) => listAssists(...a),
   getAssist: (...a: unknown[]) => getAssist(...a),
 }));

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/manager';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { getTemplates, getReadme, getTemplateYaml, getTemplateVariables } from '@/lib/registry';
+import { listAssists, getAssist, ASSIST_KINDS } from '@/lib/assists/catalog';
 import { listNodes, getNodeConnection } from '@/lib/nodes';
 import { verifyNodeConnection } from '@/lib/nodes/verify';
 import { agentManager } from '@/lib/agent/manager';
@@ -188,6 +189,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   get_service_logs: 'read', get_container_logs: 'read', get_service_files: 'read',
   list_templates: 'read', get_template_readme: 'read', get_template_yaml: 'read',
   get_template_variables: 'read',
+  list_assists: 'read', get_assist: 'read',
   get_system_info: 'read', get_network_graph: 'read', get_health_checks: 'read',
   get_gateway_status: 'read', get_proxy_routes: 'read', get_config: 'read',
   get_podman_logs: 'read', list_system_services: 'read',
@@ -901,6 +903,38 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         updatedAt: job.updatedAt,
         endedAt: job.endedAt,
       });
+    },
+  );
+
+  // --- List Assists (#2146) ---
+  // Discover task-help entries (guides, ordered recipes, checklists, footguns,
+  // snippets) from the extensible catalog. Pass a free-text `query` describing
+  // the task to rank matches; each entry's `whenToUse` lets you self-select the
+  // right one, then fetch its full content with `get_assist`.
+  server.tool(
+    'list_assists',
+    'Discover task-help entries (guides, recipes, checklists, footguns, snippets) from the ServiceBay assist catalog. Pass a free-text `query` describing your task to rank relevant entries; read the returned `whenToUse` to pick one, then fetch it with get_assist. Use this before authoring/deploying a new service or when unsure how to perform a ServiceBay task.',
+    {
+      query: z.string().optional().describe('Free-text task description to rank matching entries (e.g. "deploy a new service behind SSO"). Omit to list everything.'),
+      kind: z.enum(ASSIST_KINDS).optional().describe('Restrict to one kind: guide | recipe | template | checklist | footgun | snippet.'),
+    },
+    async ({ query, kind }) => {
+      const assists = await listAssists({ query, kind });
+      return textResult(assists);
+    },
+  );
+
+  // --- Get Assist (#2146) ---
+  server.tool(
+    'get_assist',
+    'Fetch the full content (markdown: frontmatter + body) of one assist catalog entry by id. Use list_assists first to find the id.',
+    {
+      id: z.string().describe('Assist id (the entry id returned by list_assists).'),
+    },
+    async ({ id }) => {
+      const body = await getAssist(id);
+      if (!body) return errorResult(`No assist found with id "${id}". Use list_assists to see available entries.`);
+      return textResult(body);
     },
   );
 

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -913,10 +913,10 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // right one, then fetch its full content with `get_assist`.
   server.tool(
     'list_assists',
-    'Discover task-help entries (guides, recipes, checklists, footguns, snippets) from the ServiceBay assist catalog. Pass a free-text `query` describing your task to rank relevant entries; read the returned `whenToUse` to pick one, then fetch it with get_assist. Use this before authoring/deploying a new service or when unsure how to perform a ServiceBay task.',
+    'Discover task-help entries (guides, recipes, ADR-style architecture recommendations, checklists, footguns, snippets) from the ServiceBay assist catalog. Pass a free-text `query` describing your task to rank relevant entries; read the returned `whenToUse` to pick one, then fetch it with get_assist. Use this FIRST when authoring/deploying a new service, when you need an overview of ServiceBay or Solaris, or when unsure how to perform a ServiceBay task — so you don\'t re-derive knowledge that already exists.',
     {
       query: z.string().optional().describe('Free-text task description to rank matching entries (e.g. "deploy a new service behind SSO"). Omit to list everything.'),
-      kind: z.enum(ASSIST_KINDS).optional().describe('Restrict to one kind: guide | recipe | template | checklist | footgun | snippet.'),
+      kind: z.enum(ASSIST_KINDS).optional().describe('Restrict to one kind: guide | recipe | adr | template | checklist | footgun | snippet.'),
     },
     async ({ query, kind }) => {
       const assists = await listAssists({ query, kind });

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -144,3 +144,16 @@ per service. The diagnose page surfaces failures.
    and is idempotent. Run `python3 -m py_compile templates/<name>/migrations/*.py`.
 6. `npm test` passes — the consistency suite catches typos,
    dangling references, and bad migration filenames at build time.
+7. **No literal secrets.** Express every credential as a `type: "secret"`
+   variable — the wizard generates/injects the value at deploy. Never put a
+   real key/token/password in `template.yml`, `variables.json` defaults, or a
+   `*.mustache`; `{{VAR}}` placeholders only. A build-time scan
+   (`tests/backend/assist_consistency.test.ts`) fails on known secret shapes.
+
+## Reusable know-how → assists
+
+If, while authoring a template, you work out a non-trivial recipe or hit a
+sharp-edged gotcha that others will meet again, capture it as an **assist**
+(`assists/<id>.md`, surfaced by the `list_assists` / `get_assist` MCP tools) —
+abstracted, with no box-specific values or secrets. See the root `CLAUDE.md`
+("Capturing reusable knowledge").

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -150,6 +150,17 @@ per service. The diagnose page surfaces failures.
    `*.mustache`; `{{VAR}}` placeholders only. A build-time scan
    (`tests/backend/assist_consistency.test.ts`) fails on known secret shapes.
 
+## Architecture recommendations for a new service
+
+Before designing a new service, read the ADR-style recommendations assist
+**`new-service-architecture`** (via `list_assists` / `get_assist`, or
+`assists/new-service-architecture.md`): recommended language, basic structure,
+libraries, tests, data storage, and secrets — plus the platform ADRs in
+`docs/adr/` a new service must respect (SSO, non-destructive installs,
+reconciliation, network isolation, backup tiering, service tokens). Orientation
+on the platforms themselves is in the `servicebay-overview` and `solaris-overview`
+assists.
+
 ## Reusable know-how → assists
 
 If, while authoring a template, you work out a non-trivial recipe or hit a

--- a/tests/backend/assist_consistency.test.ts
+++ b/tests/backend/assist_consistency.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Assist catalog + secret-hygiene consistency suite.
+ *
+ *  1. Every built-in assist (`assists/*.md`) has valid frontmatter
+ *     (title, whenToUse, kind ∈ ASSIST_KINDS) and a unique id.
+ *  2. No committed template or assist contains a real secret. Templates express
+ *     credentials as `type: "secret"` variables (the wizard injects the value at
+ *     deploy); a literal key/token/password must never land in the repo. This is
+ *     a backstop for known secret shapes — not a substitute for care.
+ *
+ * Pure file-system + parsing. No agent / network needed.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { describe, it, expect } from 'vitest';
+import { ASSIST_KINDS } from '@/lib/assists/catalog';
+
+/** Extract + parse the YAML frontmatter block from a markdown file. */
+function frontmatter(raw: string): Record<string, unknown> {
+  const m = /^---\n([\s\S]*?)\n---/.exec(raw);
+  if (!m) return {};
+  const parsed = yaml.load(m[1]);
+  return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+}
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const ASSISTS_DIR = path.join(REPO_ROOT, 'assists');
+const TEMPLATES_DIR = path.join(REPO_ROOT, 'templates');
+
+const TEXT_EXTS = new Set(['.md', '.yml', '.yaml', '.json', '.mustache', '.py', '.txt', '.env', '.sh']);
+
+function walk(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(p));
+    else if (entry.isFile() && TEXT_EXTS.has(path.extname(entry.name))) out.push(p);
+  }
+  return out;
+}
+
+// High-signal secret formats only — matching concrete leaked values, never
+// `{{VAR}}` placeholders or file paths.
+const SECRET_PATTERNS: { name: string; re: RegExp }[] = [
+  { name: 'PEM private key', re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/ },
+  { name: 'ServiceBay token (sb_)', re: /\bsb_[a-z0-9]{6,}_[A-Za-z0-9]{20,}\b/ },
+  { name: 'AWS access key id', re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { name: 'GitHub token', re: /\bgh[posru]_[A-Za-z0-9]{20,}\b/ },
+  { name: 'GitHub fine-grained PAT', re: /\bgithub_pat_[A-Za-z0-9_]{30,}\b/ },
+  { name: 'Slack token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+];
+
+describe('assist catalog frontmatter', () => {
+  const files = fs.existsSync(ASSISTS_DIR)
+    ? fs.readdirSync(ASSISTS_DIR).filter(f => f.endsWith('.md') && !f.startsWith('.'))
+    : [];
+
+  it('has at least the seed entries', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('every assist has valid frontmatter and a unique id', () => {
+    const seen = new Set<string>();
+    const problems: string[] = [];
+    for (const f of files) {
+      const id = f.slice(0, -'.md'.length);
+      if (seen.has(id)) problems.push(`${f}: duplicate id`);
+      seen.add(id);
+      const d = frontmatter(fs.readFileSync(path.join(ASSISTS_DIR, f), 'utf-8'));
+      const when = d.whenToUse ?? d.when_to_use;
+      if (typeof d.title !== 'string' || !d.title.trim()) problems.push(`${f}: missing title`);
+      if (typeof when !== 'string' || !String(when).trim()) problems.push(`${f}: missing whenToUse`);
+      if (!(ASSIST_KINDS as readonly string[]).includes(d.kind as string)) {
+        problems.push(`${f}: kind "${String(d.kind)}" not one of ${ASSIST_KINDS.join('|')}`);
+      }
+    }
+    expect(problems, problems.join('\n')).toEqual([]);
+  });
+});
+
+describe('secret hygiene', () => {
+  it('no committed template or assist contains a real secret', () => {
+    const files = [...walk(ASSISTS_DIR), ...walk(TEMPLATES_DIR)];
+    const hits: string[] = [];
+    for (const file of files) {
+      const text = fs.readFileSync(file, 'utf-8');
+      for (const { name, re } of SECRET_PATTERNS) {
+        if (re.test(text)) hits.push(`${path.relative(REPO_ROOT, file)} — matches ${name}`);
+      }
+    }
+    expect(hits, `Possible secret(s) committed:\n${hits.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2146. Closes #2145.

## What
A **generic task-assist interface** over an extensible catalog — two small, stable MCP tools instead of one bespoke tool per knowledge domain:
- **`list_assists({ query?, kind? })`** — ranked entries `{ id, title, whenToUse, kind, tags }`; free-text `query` ranks matches, `kind ∈ guide|recipe|template|checklist|footgun|snippet`.
- **`get_assist(id)`** — full markdown (frontmatter + body) of one entry.

## Catalog (extensible, no release to grow)
- Built-in: `/app/assists` (in-repo `assists/`, copied in the Dockerfile, resolved via `process.cwd()` like `templates/`).
- Local drop: `DATA_DIR/local-assists/` — drop a `.md` with frontmatter → discoverable immediately, **no code change / no release** (the #2146 acceptance criterion).
- Each entry self-describes via `whenToUse` so the agent self-selects.

## Seed content
`create-service.md` (the #2145 service-authoring guide + scaffold — now the first catalog entry, not a special tool), `new-service-architecture.md`, `servicebay-overview.md`, `solaris-overview.md`, and two footguns (`forward-auth-acme-collision`, `subdomain-needs-public-domain`). Plus CLAUDE.md / templates/CLAUDE.md pointers.

## Tests
`catalog.test.ts`, `server.assists.test.ts`, `assist_consistency.test.ts` — 16 pass. Typecheck clean. Rebased onto current main (server.ts conflict with the #2141 install_template tools resolved — both tool sets coexist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)