### PR TITLE
fix(install,reverseProxy): preserve omitted secrets + escape multi-line pod YAML; strip duplicate websocket proxy_http_version

### DIFF
--- a/packages/backend/src/lib/install/manifestAssembler.test.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.test.ts
@@ -245,6 +245,45 @@ describe('assembleManifest', () => {
     expect(persistSingleSecret).not.toHaveBeenCalled();
   });
 
+  it('partial prefilled preserves stored secrets omitted from the map (#2206)', async () => {
+    // A partial install_template that supplies only ONE new variable must NOT
+    // wipe the other stored secrets to empty — that silently took HA + Jellyfin
+    // offline on the solaris service (2026-07-11).
+    getTemplateYaml.mockResolvedValue(tmplYaml('svc', []));
+    getTemplateVariables.mockResolvedValue({
+      HASS_TOKEN: { type: 'secret', noAutoGenerate: true },
+      JELLYFIN_PASSWORD: { type: 'secret', noAutoGenerate: true },
+      VAPID_PUBLIC: { type: 'secret', noAutoGenerate: true },
+    });
+    loadSavedSecrets.mockReturnValue({ HASS_TOKEN: 'ha-tok', JELLYFIN_PASSWORD: 'jf-pw' });
+
+    const r = await assembleManifest({
+      items: [{ name: 'svc', checked: true }],
+      prefilled: { VAPID_PUBLIC: 'new-vapid-pub' }, // only the new var supplied
+      templateSource: 'Built-in',
+    });
+
+    // Omitted secrets keep their stored value, not empty.
+    expect(r.variables.find(v => v.name === 'HASS_TOKEN')?.value).toBe('ha-tok');
+    expect(r.variables.find(v => v.name === 'JELLYFIN_PASSWORD')?.value).toBe('jf-pw');
+    // The supplied var wins.
+    expect(r.variables.find(v => v.name === 'VAPID_PUBLIC')?.value).toBe('new-vapid-pub');
+  });
+
+  it('an explicit empty prefilled value does not clobber a stored secret (#2206)', async () => {
+    getTemplateYaml.mockResolvedValue(tmplYaml('svc', []));
+    getTemplateVariables.mockResolvedValue({ SVC_SECRET: { type: 'secret' } });
+    loadSavedSecrets.mockReturnValue({ SVC_SECRET: 'stored-value' });
+
+    const r = await assembleManifest({
+      items: [{ name: 'svc', checked: true }],
+      prefilled: { SVC_SECRET: '' }, // explicitly empty — must fall back to stored
+      templateSource: 'Built-in',
+    });
+
+    expect(r.variables.find(v => v.name === 'SVC_SECRET')?.value).toBe('stored-value');
+  });
+
   it('always resolves LLDAP_HOST to localhost', async () => {
     getTemplateYaml.mockResolvedValue(tmplYaml('svc', [], '    # {{LLDAP_HOST}}'));
     getTemplateVariables.mockResolvedValue({});

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -24,7 +24,7 @@
  * `crashed` by `jobStore.markCrashedOnStartup()` (see server.ts).
  */
 import crypto from 'node:crypto';
-import { renderTemplate } from '../template/render';
+import { renderTemplate, renderPodYaml } from '../template/render';
 // Direct lib imports (#600) — the actions.ts wrappers are RPC bridges
 // for client components, not appropriate for server-side lib code.
 import {
@@ -510,8 +510,11 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
 
   // Inject dynamic variables for self-healing and template rendering.
   Object.assign(view, authDynamicVars(item.name));
-  // Render YAML with unified template renderer
-  const yamlContent = renderTemplate(item.yaml, view);
+  // Render YAML with the pod renderer — it escapes control chars (newlines in
+  // a multi-line PEM/token) so they emit as `\n` inside the double-quoted
+  // scalar rather than splitting it across lines and producing YAML that
+  // podman's parser rejects → crash-loop on the next restart (#2206).
+  const yamlContent = renderPodYaml(item.yaml, view);
 
   // #1318 — the pod YAML had no missing-var guard (config files did), so an
   // unfilled {{VAR}} rendered empty and deployed silently. Surface a

--- a/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
@@ -3,8 +3,13 @@ import {
   AUTHELIA_FORWARD_AUTH_SENTINEL,
   expandForwardAuthSentinel,
   renderForwardAuthAdvancedConfig,
+  stripDuplicateProxyHttpVersion,
   DEFAULT_AUTHELIA_PORT,
 } from './forwardAuth';
+
+/** Count occurrences of the `proxy_http_version` directive. */
+const countHttpVersion = (s: string): number =>
+  (s.match(/proxy_http_version/gi) ?? []).length;
 
 describe('expandForwardAuthSentinel', () => {
   it('expands the bare sentinel into the auth_request snippet (still {{AUTHELIA_PORT}}-templated)', () => {
@@ -73,5 +78,70 @@ describe('renderForwardAuthAdvancedConfig — the no-Mustache (direct API) path'
     const out = renderForwardAuthAdvancedConfig(AUTHELIA_FORWARD_AUTH_SENTINEL, '9091', { omitAcmeBypass: true })!;
     expect(out).not.toContain('acme-challenge');
     expect(out).toContain('proxy_pass http://127.0.0.1:9091/api/authz/auth-request;');
+  });
+});
+
+// #2205 — a websocket host gets a server-level `proxy_http_version 1.1;` from
+// NPM; any copy in advanced_config duplicates it and nginx rejects the vhost
+// (`[emerg] "proxy_http_version" directive is duplicate`).
+describe('stripDuplicateProxyHttpVersion', () => {
+  it('removes the directive (with leading whitespace) and leaves no blank line', () => {
+    const input = 'proxy_read_timeout 1h;\n    proxy_http_version 1.1;\nproxy_buffering off;\n';
+    const out = stripDuplicateProxyHttpVersion(input);
+    expect(countHttpVersion(out)).toBe(0);
+    expect(out).toBe('proxy_read_timeout 1h;\nproxy_buffering off;\n');
+  });
+  it('removes EVERY copy (SSE blocks sometimes repeat it)', () => {
+    const input = 'proxy_http_version 1.1;\nproxy_set_header X 1;\nproxy_http_version 1.1;\n';
+    expect(countHttpVersion(stripDuplicateProxyHttpVersion(input))).toBe(0);
+  });
+  it('is idempotent when the directive is absent', () => {
+    const input = 'proxy_set_header Connection "upgrade";\n';
+    expect(stripDuplicateProxyHttpVersion(input)).toBe(input);
+  });
+});
+
+describe('websocket sanitize — exactly one proxy_http_version reaches nginx (#2205)', () => {
+  // A realistic SSE-tuning advanced_config that sets proxy_http_version itself.
+  const SSE_CONFIG = [
+    'proxy_http_version 1.1;',
+    'proxy_set_header Connection "";',
+    'proxy_buffering off;',
+    'proxy_read_timeout 3600s;',
+  ].join('\n');
+
+  it('websocket=true strips the redundant proxy_http_version from a plain advanced_config', () => {
+    const out = expandForwardAuthSentinel(SSE_CONFIG, { websocket: true })!;
+    // ServiceBay emits ZERO (NPM adds the one server-level copy for websocket
+    // hosts), so the rendered vhost ends up with exactly one — not two.
+    expect(countHttpVersion(out)).toBe(0);
+    // the rest of the SSE tuning is preserved
+    expect(out).toContain('proxy_read_timeout 3600s;');
+    expect(out).toContain('proxy_buffering off;');
+  });
+  it('websocket unset leaves the advanced_config (and its proxy_http_version) untouched', () => {
+    const out = expandForwardAuthSentinel(SSE_CONFIG)!;
+    expect(countHttpVersion(out)).toBe(1);
+    expect(out).toContain('proxy_http_version 1.1;');
+  });
+  it('websocket=true strips the directive from the sentinel prefix-form extras too', () => {
+    const out = renderForwardAuthAdvancedConfig(
+      `${AUTHELIA_FORWARD_AUTH_SENTINEL}\n${SSE_CONFIG}`,
+      '9091',
+      { omitAcmeBypass: true, websocket: true },
+    )!;
+    // forward-auth core still renders...
+    expect(out).toContain('proxy_pass http://127.0.0.1:9091/api/authz/auth-request;');
+    // ...and the duplicate directive from the extras is gone.
+    expect(countHttpVersion(out)).toBe(0);
+    expect(out).toContain('proxy_read_timeout 3600s;');
+  });
+  it('websocket=true on the forward-auth sentinel does not touch its own body (no proxy_http_version there)', () => {
+    const out = renderForwardAuthAdvancedConfig(AUTHELIA_FORWARD_AUTH_SENTINEL, '9091', {
+      omitAcmeBypass: true,
+      websocket: true,
+    })!;
+    expect(countHttpVersion(out)).toBe(0);
+    expect(out).toContain('auth_request /authelia;');
   });
 });

--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -186,6 +186,37 @@ export interface ForwardAuthExpandOptions {
    * icons/manifest) pass straight through. See {@link buildAuthSkipLocations}.
    */
   authSkipPaths?: string[];
+  /**
+   * #2205 — Strip a redundant `proxy_http_version` directive from the
+   * `advanced_config` when the host has websocket upgrade enabled. NPM
+   * already emits `proxy_http_version 1.1;` at server level whenever
+   * `allow_websocket_upgrade` is on, so any advanced_config that ALSO sets
+   * `proxy_http_version` (e.g. an SSE-tuning block) produces a DUPLICATE
+   * directive → `nginx: [emerg] "proxy_http_version" directive is duplicate`
+   * → the vhost is invalid and the domain returns a TLS `unrecognized_name`
+   * after redeploy. Set for websocket-enabled hosts so ServiceBay never
+   * emits the second copy. See {@link stripDuplicateProxyHttpVersion}.
+   */
+  websocket?: boolean;
+}
+
+/**
+ * #2205 — Remove any `proxy_http_version` directive from an nginx config
+ * block. Used only when the host has websocket upgrade enabled: NPM emits its
+ * own server-level `proxy_http_version 1.1;` for websocket hosts, so a copy in
+ * our `advanced_config` duplicates it and nginx rejects the whole vhost with
+ * `[emerg] "proxy_http_version" directive is duplicate`. Confirmed live during
+ * the #2210 work on chat.dopp.cloud (an SSE-tuning block carried its own
+ * `proxy_http_version 1.1;`). Idempotent: a block with no such directive is
+ * returned unchanged. We strip the directive entirely (rather than dedupe to
+ * one) because on a websocket host NPM's server-level copy already provides it,
+ * so ours is always redundant.
+ */
+export function stripDuplicateProxyHttpVersion(content: string): string {
+  // Drop each full `proxy_http_version <ver>;` line, including its
+  // leading whitespace and the trailing newline, so we don't leave a
+  // blank line behind. Case-insensitive on the directive name only.
+  return content.replace(/^[ \t]*proxy_http_version\b[^;\n]*;[ \t]*\r?\n?/gim, '');
 }
 
 /**
@@ -256,6 +287,12 @@ export function expandForwardAuthSentinel(
   opts?: ForwardAuthExpandOptions,
 ): string | undefined {
   if (!advancedConfig) return advancedConfig;
+  // #2205 — on a websocket host, strip any redundant `proxy_http_version`
+  // (NPM emits its own at server level) so we never produce a duplicate
+  // directive. Applies to the sentinel's appended extras AND to a plain
+  // advanced_config that carries the directive on its own.
+  const sanitize = (s: string): string =>
+    opts?.websocket ? stripDuplicateProxyHttpVersion(s) : s;
   const snippet = baseSnippet(opts);
   if (advancedConfig === AUTHELIA_FORWARD_AUTH_SENTINEL) {
     return snippet;
@@ -263,9 +300,9 @@ export function expandForwardAuthSentinel(
   // Prefix form: `__authelia_forward_auth__\n<extras>`.
   if (advancedConfig.startsWith(`${AUTHELIA_FORWARD_AUTH_SENTINEL}\n`)) {
     const extras = advancedConfig.slice(AUTHELIA_FORWARD_AUTH_SENTINEL.length + 1);
-    return `${snippet}\n${extras}`;
+    return `${snippet}\n${sanitize(extras)}`;
   }
-  return advancedConfig;
+  return sanitize(advancedConfig);
 }
 
 /**

--- a/packages/backend/src/lib/stackInstall/postInstall.ts
+++ b/packages/backend/src/lib/stackInstall/postInstall.ts
@@ -84,6 +84,9 @@ function renderProxyConfig(
     // #2210 — per-path forward-auth exceptions (e.g. /.well-known/, /static/)
     // are baked into the expanded config so they survive NPM host rebuilds.
     authSkipPaths: proxyConfig.authSkipPaths,
+    // #2205 — websocket hosts already get a server-level `proxy_http_version`
+    // from NPM; strip any duplicate the template's advanced_config carries.
+    websocket: proxyConfig.allow_websocket_upgrade,
   }) ?? proxyConfig.advanced_config;
   // #1677 — A forward-auth snippet that renders `{{AUTHELIA_PORT}}` to
   // an empty string emits `proxy_pass http://127.0.0.1:/api/authz/...`,

--- a/packages/backend/src/lib/template/render.test.ts
+++ b/packages/backend/src/lib/template/render.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Render-layer tests (#2206).
+ *
+ * `renderPodYaml` must never let a variable value's control characters break
+ * the pod/quadlet YAML: a multi-line PEM private key substituted verbatim into
+ * a double-quoted scalar splits the scalar across lines and podman's Go YAML
+ * parser rejects it → crash-loop on the next restart. The escaping must be a
+ * faithful round-trip so the container still receives the real value.
+ */
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import { renderTemplate, renderPodYaml, escapeYamlScalar } from './render';
+
+const PEM =
+  '-----BEGIN EC PRIVATE KEY-----\n' +
+  'MHcCAQEEIB1a2b3c4d5e6f7g8h9i0jklmnop\n' +
+  '-----END EC PRIVATE KEY-----';
+
+const POD = `apiVersion: v1
+kind: Pod
+metadata:
+  name: solaris
+spec:
+  containers:
+  - name: solaris
+    env:
+    - name: VAPID_PRIVATE_KEY
+      value: "{{VAPID_PRIVATE_KEY}}"
+    - name: HASS_TOKEN
+      value: "{{HASS_TOKEN}}"
+`;
+
+describe('renderPodYaml (#2206)', () => {
+  it('escapes a multi-line PEM into a single-line \\n scalar that parses', () => {
+    const out = renderPodYaml(POD, { VAPID_PRIVATE_KEY: PEM, HASS_TOKEN: 'plain-tok' });
+    // Every line still carries a valid `key: value` shape — no bare
+    // continuation lines that podman's parser trips on.
+    expect(out).toContain('value: "-----BEGIN EC PRIVATE KEY-----\\n');
+    // Parseable, and the value round-trips back to the original multi-line PEM.
+    const parsed = yaml.load(out) as { spec: { containers: { env: { name: string; value: string }[] }[] } };
+    const env = parsed.spec.containers[0].env;
+    expect(env.find(e => e.name === 'VAPID_PRIVATE_KEY')?.value).toBe(PEM);
+    expect(env.find(e => e.name === 'HASS_TOKEN')?.value).toBe('plain-tok');
+  });
+
+  it('the pre-fix raw render produced a scalar with a literal newline', () => {
+    // Guard the regression direction: renderTemplate (no escaping) leaves the
+    // raw newline in place; renderPodYaml removes it.
+    const raw = renderTemplate(POD, { VAPID_PRIVATE_KEY: PEM, HASS_TOKEN: 't' });
+    expect(raw).toContain('-----BEGIN EC PRIVATE KEY-----\nMHc');
+    const safe = renderPodYaml(POD, { VAPID_PRIVATE_KEY: PEM, HASS_TOKEN: 't' });
+    expect(safe).not.toContain('-----BEGIN EC PRIVATE KEY-----\nMHc');
+  });
+
+  it('leaves single-line values untouched', () => {
+    const out = renderPodYaml(POD, { VAPID_PRIVATE_KEY: 'abc', HASS_TOKEN: 'xyz' });
+    expect(out).toContain('value: "abc"');
+    expect(out).toContain('value: "xyz"');
+  });
+});
+
+describe('escapeYamlScalar', () => {
+  it('escapes backslash before newline so escapes are not doubled', () => {
+    expect(escapeYamlScalar('a\\b\nc')).toBe('a\\\\b\\nc');
+  });
+
+  it('escapes carriage return and tab', () => {
+    expect(escapeYamlScalar('a\r\nb\tc')).toBe('a\\r\\nb\\tc');
+  });
+
+  it('round-trips through a YAML parser back to the original value', () => {
+    const doc = `value: "${escapeYamlScalar(PEM)}"\n`;
+    expect((yaml.load(doc) as { value: string }).value).toBe(PEM);
+  });
+});

--- a/packages/backend/src/lib/template/render.ts
+++ b/packages/backend/src/lib/template/render.ts
@@ -32,3 +32,41 @@ export function renderTemplate(template: string, view: Record<string, unknown>):
     Mustache.escape = savedEscape;
   }
 }
+
+/**
+ * Render a POD/quadlet YAML template (#2206).
+ *
+ * Pod templates carry variable values inside **double-quoted YAML scalars**
+ * (`value: "{{VAPID_PRIVATE_KEY}}"`). A value that contains a raw newline
+ * (a multi-line PEM private key, a wrapped token) substituted verbatim splits
+ * the scalar across lines, and podman's Go YAML parser rejects the result
+ * (`yaml: line NNN: could not find expected ':'`) → the pod crash-loops on the
+ * next restart, long after the install that wrote it. js-yaml tolerates the
+ * folded newline, so this only bites the real box.
+ *
+ * The fix escapes control characters (backslash first, then newline / carriage
+ * return / tab) in every string value, so they emit as YAML escape sequences
+ * (`\n`, `\r`, `\t`) inside the double-quoted scalar — valid in *every* YAML
+ * parser and a faithful round-trip back to the original value. This is applied
+ * ONLY to pod YAML; config-file rendering keeps real newlines (a PEM written to
+ * a config file needs its literal line breaks).
+ */
+export function renderPodYaml(template: string, view: Record<string, unknown>): string {
+  const escaped: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(view)) {
+    escaped[k] = typeof v === 'string' ? escapeYamlScalar(v) : v;
+  }
+  return renderTemplate(template, escaped);
+}
+
+/** Escape control chars so a value survives inside a double-quoted YAML
+ *  scalar. Backslash must be escaped first, or the escapes we add would be
+ *  double-escaped. Exported for the runner's empty-var detection, which must
+ *  compare against the pre-render view. */
+export function escapeYamlScalar(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -1087,9 +1087,12 @@ export const POST = withApiHandler({ tokenScope: 'mutate' }, async ({ request })
                 // own acme-challenge location, so omit ours to avoid the
                 // `[emerg] duplicate location` crash that reverts the conf.
                 const omitAcmeBypass = host.exposure === 'public' || host.exposure === 'internal';
+                // #2205 — a websocket host gets a server-level `proxy_http_version
+                // 1.1;` from NPM; strip any copy in advanced_config so we never
+                // emit the duplicate directive that invalidates the whole vhost.
                 host.proxyConfig = {
                     ...host.proxyConfig,
-                    advanced_config: renderForwardAuthAdvancedConfig(host.proxyConfig.advanced_config, authPort, { omitAcmeBypass, authSkipPaths: host.proxyConfig.authSkipPaths }),
+                    advanced_config: renderForwardAuthAdvancedConfig(host.proxyConfig.advanced_config, authPort, { omitAcmeBypass, authSkipPaths: host.proxyConfig.authSkipPaths, websocket: host.proxyConfig.allow_websocket_upgrade }),
                 };
             }
             // Default forward host = node LAN IP (NPM is in a container,


### PR DESCRIPTION
## What
Two fixes at the install/variable-merge and proxy-render layers:
- **#2206** `install_template` with a partial variables map no longer wipes stored secrets — omitted `secret`/`rsa-private`/`bcrypt` vars fall back to their stored values instead of rendering empty strings; and multi-line secret values (e.g. PEM keys) are now escaped so they emit as valid `\n`-escaped YAML scalars instead of raw newlines that crash-loop the service on restart.
- **#2205** A websocket proxy route no longer emits a duplicate `proxy_http_version 1.1;` directive — a sanitize step (mirroring the existing `omitAcmeBypass` logic) strips the redundant directive from the generated `advanced_config` so NPM's own server-level copy isn't duplicated, keeping the vhost valid (`nginx -t` passes, `nginx_online=true`).

## Why
Closes #2206
Closes #2205

## Risk
Medium — touches the install variable-merge + pod-YAML emit path and the proxy-route render path; both covered by new regression tests, box-verify owed for the real redeploy.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors, 355 warnings — baseline)
- [x] npm run typecheck (exit 0)
- [x] npm run check:arch
- [x] npm test (full — 417 files, 3610 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (install/variable path + proxy render — path-mandated)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
