### PR TITLE
feat(assists): assists-catalog editor backend + config-render escaping and map-merge regression fixes

### DIFF
--- a/packages/backend/src/lib/assists/editor.test.ts
+++ b/packages/backend/src/lib/assists/editor.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Assists editor (#2221) — validation + versioned history store unit tests.
+ *
+ * A fresh temp DATA_DIR per run isolates the local-assists tree. We drive the
+ * REAL editor functions against real fs, and cross-check catalog precedence
+ * (Local overrides Built-in) by pointing the built-in dir at a temp seed via a
+ * cwd shim.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+// Computed with no module imports — vi.hoisted runs before import bindings init.
+const { TMP } = vi.hoisted(() => ({
+  TMP: `${process.env.TMPDIR || '/tmp'}/assists-editor-${process.pid}-${Date.now()}`,
+}));
+vi.mock('@/lib/dirs', () => ({ DATA_DIR: TMP }));
+
+import {
+  validateProposal,
+  scanForSecret,
+  safeAssistId,
+  writeProposal,
+  applyApproved,
+  discardRejected,
+  readHistory,
+  readHistoryVersion,
+  ProposalValidationError,
+  type AssistProposalPayload,
+} from './editor';
+
+const LOCAL_DIR = () => path.join(TMP, 'local-assists');
+
+function mkProposal(overrides: { title?: string; whenToUse?: string; kind?: string; body?: string } = {}): string {
+  const title = overrides.title ?? 'My Assist';
+  const whenToUse = overrides.whenToUse ?? 'When you need it';
+  const kind = overrides.kind ?? 'guide';
+  const body = overrides.body ?? 'Body text here.';
+  const fm: string[] = ['---'];
+  if (title !== '__omit__') fm.push(`title: ${title}`);
+  if (whenToUse !== '__omit__') fm.push(`whenToUse: ${whenToUse}`);
+  if (kind !== '__omit__') fm.push(`kind: ${kind}`);
+  fm.push('---', '', body, '');
+  return fm.join('\n');
+}
+
+beforeEach(async () => {
+  await fs.rm(TMP, { recursive: true, force: true });
+  await fs.mkdir(TMP, { recursive: true });
+});
+afterEach(async () => {
+  await fs.rm(TMP, { recursive: true, force: true });
+});
+
+describe('safeAssistId', () => {
+  it('accepts a plain id', () => {
+    expect(safeAssistId('create-service')).toBe('create-service');
+  });
+  it('rejects traversal / separators / dots', () => {
+    expect(safeAssistId('../etc/passwd')).toBeNull();
+    expect(safeAssistId('a/b')).toBeNull();
+    expect(safeAssistId('..')).toBeNull();
+    expect(safeAssistId('.')).toBeNull();
+    expect(safeAssistId('a\0b')).toBeNull();
+    expect(safeAssistId('')).toBeNull();
+  });
+});
+
+describe('validateProposal — required fields + kind', () => {
+  it('accepts a well-formed proposal', () => {
+    expect(() => validateProposal(mkProposal())).not.toThrow();
+  });
+  it('rejects a missing title', () => {
+    expect(() => validateProposal(mkProposal({ title: '__omit__' }))).toThrow(ProposalValidationError);
+    expect(() => validateProposal(mkProposal({ title: '__omit__' }))).toThrow(/title/);
+  });
+  it('rejects a missing whenToUse', () => {
+    expect(() => validateProposal(mkProposal({ whenToUse: '__omit__' }))).toThrow(/whenToUse/);
+  });
+  it('rejects a missing kind', () => {
+    expect(() => validateProposal(mkProposal({ kind: '__omit__' }))).toThrow(/kind/);
+  });
+  it('rejects an invalid kind', () => {
+    expect(() => validateProposal(mkProposal({ kind: 'banana' }))).toThrow(/invalid kind/);
+  });
+  it('accepts snake_case when_to_use', () => {
+    const raw = ['---', 'title: T', 'when_to_use: use it', 'kind: guide', '---', '', 'body'].join('\n');
+    expect(() => validateProposal(raw)).not.toThrow();
+  });
+});
+
+describe('secret scan', () => {
+  const PEM = '-----BEGIN RSA PRIVATE KEY-----\nMIIabc\n-----END RSA PRIVATE KEY-----';
+  it('flags a PEM private key', () => {
+    expect(scanForSecret(PEM)).toBe('PEM private key');
+  });
+  it('flags an sb_ token and cloud tokens', () => {
+    expect(scanForSecret('token sb_abcdef_ABCDEFGHIJKLMNOPQRSTUV here')).toMatch(/sb_/);
+    expect(scanForSecret('AKIAABCDEFGHIJKLMNOP')).toMatch(/AWS/);
+    expect(scanForSecret('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345')).toMatch(/GitHub/);
+  });
+  it('validateProposal rejects a PEM in the body', () => {
+    const raw = mkProposal({ body: `intro\n${PEM}\noutro` });
+    expect(() => validateProposal(raw)).toThrow(/secret/);
+  });
+  it('returns null for clean text', () => {
+    expect(scanForSecret('just normal markdown, no keys')).toBeNull();
+  });
+});
+
+describe('apply / reject / history mechanics', () => {
+  const payload = (assistId: string, message = 'edit'): AssistProposalPayload => ({
+    kind: 'assist-edit',
+    assistId,
+    message,
+  });
+
+  it('applyApproved writes the Local drop file and a history v1', async () => {
+    const content = mkProposal({ title: 'V1' });
+    await writeProposal('demo', 'req1', content);
+    const version = await applyApproved(payload('demo', 'first'), 'req1', 'alice');
+    expect(version).toBe(1);
+
+    const local = await fs.readFile(path.join(LOCAL_DIR(), 'demo.md'), 'utf-8');
+    expect(local).toBe(content);
+
+    const hist = await readHistory('demo');
+    expect(hist).toHaveLength(1);
+    expect(hist[0]).toMatchObject({ version: 1, author: 'alice', message: 'first' });
+    expect(typeof hist[0].timestamp).toBe('string');
+
+    // The pending proposal body is removed on apply.
+    await expect(
+      fs.access(path.join(LOCAL_DIR(), '.proposals', 'demo.req1.md')),
+    ).rejects.toThrow();
+  });
+
+  it('history entries accumulate in version order', async () => {
+    await writeProposal('demo', 'r1', mkProposal({ title: 'One' }));
+    await applyApproved(payload('demo', 'one'), 'r1', 'a');
+    await writeProposal('demo', 'r2', mkProposal({ title: 'Two' }));
+    await applyApproved(payload('demo', 'two'), 'r2', 'b');
+    await writeProposal('demo', 'r3', mkProposal({ title: 'Three' }));
+    await applyApproved(payload('demo', 'three'), 'r3', 'c');
+
+    const hist = await readHistory('demo');
+    expect(hist.map(h => h.version)).toEqual([1, 2, 3]);
+    expect(hist.map(h => h.message)).toEqual(['one', 'two', 'three']);
+
+    // The index is genuine JSONL (one JSON object per line).
+    const raw = await fs.readFile(path.join(LOCAL_DIR(), '.history', 'demo', 'index.jsonl'), 'utf-8');
+    const lines = raw.trim().split('\n');
+    expect(lines).toHaveLength(3);
+    for (const line of lines) expect(() => JSON.parse(line)).not.toThrow();
+  });
+
+  it('readHistoryVersion returns the frozen content of that version', async () => {
+    const c1 = mkProposal({ title: 'One' });
+    await writeProposal('demo', 'r1', c1);
+    await applyApproved(payload('demo'), 'r1', 'a');
+    const c2 = mkProposal({ title: 'Two' });
+    await writeProposal('demo', 'r2', c2);
+    await applyApproved(payload('demo'), 'r2', 'a');
+
+    expect(await readHistoryVersion('demo', 1)).toBe(c1);
+    expect(await readHistoryVersion('demo', 2)).toBe(c2);
+    expect(await readHistoryVersion('demo', 99)).toBeNull();
+  });
+
+  it('discardRejected removes the proposal and writes NO local file', async () => {
+    await writeProposal('demo', 'r1', mkProposal());
+    await discardRejected(payload('demo'), 'r1');
+    // No Local override.
+    await expect(fs.access(path.join(LOCAL_DIR(), 'demo.md'))).rejects.toThrow();
+    // No history.
+    expect(await readHistory('demo')).toEqual([]);
+    // Proposal body gone.
+    await expect(
+      fs.access(path.join(LOCAL_DIR(), '.proposals', 'demo.r1.md')),
+    ).rejects.toThrow();
+  });
+
+  it('applyApproved re-validates and refuses a secret-bearing body', async () => {
+    const bad = mkProposal({ body: '-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----' });
+    await writeProposal('demo', 'r1', bad);
+    await expect(applyApproved(payload('demo'), 'r1', 'a')).rejects.toThrow(/secret/);
+    // Nothing published.
+    await expect(fs.access(path.join(LOCAL_DIR(), 'demo.md'))).rejects.toThrow();
+  });
+});
+
+describe('catalog precedence — an approved proposal overrides the built-in', () => {
+  it('listAssists + getAssist serve the Local entry after apply', async () => {
+    // Seed a built-in assist under a temp cwd so catalog reads it as Built-in.
+    const builtinRoot = path.join(TMP, 'app');
+    const builtinAssists = path.join(builtinRoot, 'assists');
+    await fs.mkdir(builtinAssists, { recursive: true });
+    await fs.writeFile(
+      path.join(builtinAssists, 'demo.md'),
+      mkProposal({ title: 'Built-in title', body: 'builtin body' }),
+      'utf-8',
+    );
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(builtinRoot);
+
+    // Import catalog AFTER the DATA_DIR mock is in place (top-of-file mock).
+    const { listAssists, getAssist } = await import('./catalog');
+
+    // Before any local edit: built-in wins.
+    let list = await listAssists();
+    const beforeDemo = list.find(a => a.id === 'demo');
+    expect(beforeDemo?.source).toBe('Built-in');
+    expect(beforeDemo?.title).toBe('Built-in title');
+
+    // Approve a local edit.
+    const localContent = mkProposal({ title: 'Local override title', body: 'local body' });
+    await writeProposal('demo', 'r1', localContent);
+    await applyApproved({ kind: 'assist-edit', assistId: 'demo', message: 'override' }, 'r1', 'admin');
+
+    // Now the Local entry overrides the built-in in list_assists.
+    list = await listAssists();
+    const afterDemo = list.find(a => a.id === 'demo');
+    expect(afterDemo?.source).toBe('Local');
+    expect(afterDemo?.title).toBe('Local override title');
+    expect(await getAssist('demo')).toBe(localContent);
+
+    cwdSpy.mockRestore();
+  });
+});

--- a/packages/backend/src/lib/assists/editor.ts
+++ b/packages/backend/src/lib/assists/editor.ts
@@ -1,0 +1,260 @@
+/**
+ * Assists catalog editor (#2221, child A of #2147).
+ *
+ * The write side of the assist catalog (`catalog.ts` is the read side): an
+ * agent or operator proposes an edit, a ServiceBay admin approves or rejects,
+ * and every applied edit is versioned in an append-only history so a revert is
+ * always possible. Nothing is written to the Local drop dir until an admin
+ * approves — a revert, too, is an approval REQUEST, never a silent rewrite.
+ *
+ * Layout under DATA_DIR:
+ *   local-assists/<id>.md                 the applied Local override (catalog reads this)
+ *   local-assists/.proposals/<id>.md      a pending proposal body, keyed by approval request id
+ *   local-assists/.history/<id>/index.jsonl   append-only history index (one JSON obj per line)
+ *   local-assists/.history/<id>/<version>.md  the frozen content of each applied version
+ *
+ * The approval side reuses the generic approvals queue (`approvals/index.ts`):
+ * a proposal creates a pending request whose `payload` carries the assist id,
+ * the proposal body path, the commit message, and (for a revert) the source
+ * version. Approve/reject route through this module's `applyApproved` /
+ * `discardRejected` so the actual local-assists write + history append is one
+ * transactional step tied to the request lifecycle.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { DATA_DIR } from '@/lib/dirs';
+import { logger } from '@/lib/logger';
+import { ASSIST_KINDS } from '@/lib/assists/catalog';
+
+const TAG = 'assists:editor';
+
+const LOCAL_ASSISTS_DIR = () => path.join(DATA_DIR, 'local-assists');
+const PROPOSALS_DIR = () => path.join(LOCAL_ASSISTS_DIR(), '.proposals');
+const HISTORY_DIR = () => path.join(LOCAL_ASSISTS_DIR(), '.history');
+
+/**
+ * High-signal committed-secret formats — the SAME rules as
+ * `tests/backend/assist_consistency.test.ts` (kept in sync deliberately; that
+ * test is the repo-scan backstop, this is the runtime propose-time gate). A
+ * proposal whose body matches any of these is rejected before it can ever be
+ * approved into the Local drop dir.
+ */
+export const SECRET_PATTERNS: { name: string; re: RegExp }[] = [
+  { name: 'PEM private key', re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/ },
+  { name: 'ServiceBay token (sb_)', re: /\bsb_[a-z0-9]{6,}_[A-Za-z0-9]{20,}\b/ },
+  { name: 'AWS access key id', re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { name: 'GitHub token', re: /\bgh[posru]_[A-Za-z0-9]{20,}\b/ },
+  { name: 'GitHub fine-grained PAT', re: /\bgithub_pat_[A-Za-z0-9_]{30,}\b/ },
+  { name: 'Slack token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+];
+
+/** Name of the first secret pattern the text matches, or null if clean. */
+export function scanForSecret(text: string): string | null {
+  for (const { name, re } of SECRET_PATTERNS) {
+    if (re.test(text)) return name;
+  }
+  return null;
+}
+
+/**
+ * Collapse a request-supplied id to a single, safe filename segment and reject
+ * traversal — only a plain `<id>` is ever joined onto a data-dir root, so a
+ * write can never escape it (path-injection guard; CodeQL js/path-injection).
+ * Mirrors `catalog.ts:assistFileName`. Returns null for an unsafe id.
+ */
+export function safeAssistId(id: string): string | null {
+  if (typeof id !== 'string') return null;
+  const segment = path.basename(id);
+  if (
+    !segment ||
+    segment !== id ||
+    segment === '.' ||
+    segment === '..' ||
+    segment.includes('\0')
+  ) {
+    return null;
+  }
+  return segment;
+}
+
+export class ProposalValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProposalValidationError';
+  }
+}
+
+/**
+ * Validate a proposal body: it must parse as frontmatter+markdown and carry the
+ * required fields (`title`, `whenToUse`, a valid `kind`), and must not contain a
+ * committed secret. Throws {@link ProposalValidationError} on any failure — the
+ * message is caller-safe (no secret value echoed).
+ */
+export function validateProposal(content: string): void {
+  if (typeof content !== 'string' || !content.trim()) {
+    throw new ProposalValidationError('proposal content is empty');
+  }
+
+  const secret = scanForSecret(content);
+  if (secret) {
+    throw new ProposalValidationError(`proposal contains a possible secret (${secret}); remove it before proposing`);
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    data = matter(content).data as Record<string, unknown>;
+  } catch (e) {
+    throw new ProposalValidationError(`unparseable frontmatter: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  const title = data.title;
+  if (typeof title !== 'string' || !title.trim()) {
+    throw new ProposalValidationError('frontmatter is missing a non-empty "title"');
+  }
+
+  // Accept camelCase or snake_case for the human-facing hint, mirroring catalog.
+  const whenRaw = data.whenToUse ?? data.when_to_use;
+  if (typeof whenRaw !== 'string' || !whenRaw.trim()) {
+    throw new ProposalValidationError('frontmatter is missing a non-empty "whenToUse"');
+  }
+
+  const kind = data.kind;
+  if (typeof kind !== 'string' || !kind.trim()) {
+    throw new ProposalValidationError('frontmatter is missing "kind"');
+  }
+  if (!(ASSIST_KINDS as readonly string[]).includes(kind)) {
+    throw new ProposalValidationError(`invalid kind "${kind}"; must be one of ${ASSIST_KINDS.join('|')}`);
+  }
+}
+
+/** Metadata carried on the approval request's `payload` for the assist editor. */
+export interface AssistProposalPayload {
+  kind: 'assist-edit';
+  assistId: string;
+  message: string;
+  /** For a revert proposal: the source version being reverted to. */
+  revertOf?: number;
+  [key: string]: unknown;
+}
+
+export interface HistoryEntry {
+  version: number;
+  author: string;
+  timestamp: string;
+  message: string;
+}
+
+async function readProposalContent(assistId: string, requestId: string): Promise<string> {
+  const file = path.join(PROPOSALS_DIR(), `${assistId}.${requestId}.md`);
+  return fs.readFile(file, 'utf-8');
+}
+
+/** Persist a proposal body to the pending-proposals dir. */
+export async function writeProposal(assistId: string, requestId: string, content: string): Promise<void> {
+  const id = safeAssistId(assistId);
+  if (!id) throw new Error(`invalid assist id: "${assistId}"`);
+  await fs.mkdir(PROPOSALS_DIR(), { recursive: true });
+  const file = path.join(PROPOSALS_DIR(), `${id}.${requestId}.md`);
+  await fs.writeFile(file, content, 'utf-8');
+}
+
+async function removeProposal(assistId: string, requestId: string): Promise<void> {
+  const file = path.join(PROPOSALS_DIR(), `${assistId}.${requestId}.md`);
+  await fs.rm(file, { force: true });
+}
+
+/**
+ * Read the ordered history for an assist (oldest first). `[]` when the entry
+ * has never been edited.
+ */
+export async function readHistory(assistId: string): Promise<HistoryEntry[]> {
+  const id = safeAssistId(assistId);
+  if (!id) return [];
+  const indexFile = path.join(HISTORY_DIR(), id, 'index.jsonl');
+  let raw: string;
+  try {
+    raw = await fs.readFile(indexFile, 'utf-8');
+  } catch {
+    return [];
+  }
+  const entries: HistoryEntry[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      entries.push(JSON.parse(trimmed) as HistoryEntry);
+    } catch {
+      logger.warn(TAG, `skipping corrupt history line for "${id}"`);
+    }
+  }
+  return entries.sort((a, b) => a.version - b.version);
+}
+
+/** Read the frozen content of a specific history version, or null if unknown. */
+export async function readHistoryVersion(assistId: string, version: number): Promise<string | null> {
+  const id = safeAssistId(assistId);
+  if (!id || !Number.isInteger(version) || version < 1) return null;
+  const file = path.join(HISTORY_DIR(), id, `${version}.md`);
+  try {
+    return await fs.readFile(file, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Apply an approved proposal: write the body to the Local drop dir (so it
+ * overrides the built-in in the catalog) and append a new versioned history
+ * entry. Returns the new version number. Idempotent per requestId only in the
+ * sense that the caller (the approvals resolve) runs it exactly once.
+ */
+export async function applyApproved(
+  payload: AssistProposalPayload,
+  requestId: string,
+  author: string,
+): Promise<number> {
+  const id = safeAssistId(payload.assistId);
+  if (!id) throw new Error(`invalid assist id: "${payload.assistId}"`);
+
+  const content = await readProposalContent(id, requestId);
+  // Re-validate at apply time — the proposal was validated at submit, but this
+  // is a second gate so an approve can never write an invalid/secret-bearing
+  // body even if the on-disk proposal were tampered with.
+  validateProposal(content);
+
+  const history = await readHistory(id);
+  const version = history.length > 0 ? history[history.length - 1].version + 1 : 1;
+
+  // Freeze this version's content, THEN append the index line — so a crash
+  // between the two leaves an orphan .md (harmless) rather than an index entry
+  // pointing at a missing file.
+  const entryDir = path.join(HISTORY_DIR(), id);
+  await fs.mkdir(entryDir, { recursive: true });
+  await fs.writeFile(path.join(entryDir, `${version}.md`), content, 'utf-8');
+
+  const entry: HistoryEntry = {
+    version,
+    author,
+    timestamp: new Date().toISOString(),
+    message: payload.message,
+  };
+  await fs.appendFile(path.join(entryDir, 'index.jsonl'), `${JSON.stringify(entry)}\n`, 'utf-8');
+
+  // Publish to the Local drop dir last — once this lands the catalog serves it.
+  await fs.mkdir(LOCAL_ASSISTS_DIR(), { recursive: true });
+  await fs.writeFile(path.join(LOCAL_ASSISTS_DIR(), `${id}.md`), content, 'utf-8');
+
+  await removeProposal(id, requestId);
+  logger.info(TAG, `applied approved proposal for "${id}" as version ${version} (by ${author})`);
+  return version;
+}
+
+/** Discard a rejected proposal — remove the pending body, write NO local file. */
+export async function discardRejected(payload: AssistProposalPayload, requestId: string): Promise<void> {
+  const id = safeAssistId(payload.assistId);
+  if (!id) return;
+  await removeProposal(id, requestId);
+  logger.info(TAG, `discarded rejected proposal for "${id}" (request ${requestId})`);
+}

--- a/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
@@ -23,6 +23,22 @@ describe('expandForwardAuthSentinel', () => {
     expect(out).toContain('auth_request /authelia;');
     expect(out).toContain('client_max_body_size 0;');
   });
+  it('expands a CRLF-terminated sentinel line exactly like the LF form (#2224)', () => {
+    // A Windows/Local-authored template whose sentinel line ends in CRLF
+    // must still expand its extras — the literal sentinel must never reach
+    // the rendered .conf (nginx `[emerg] unknown directive`).
+    const out = expandForwardAuthSentinel(
+      `${AUTHELIA_FORWARD_AUTH_SENTINEL}\r\nclient_max_body_size 0;`,
+    )!;
+    expect(out).toContain('auth_request /authelia;');
+    expect(out).toContain('client_max_body_size 0;');
+    expect(out).not.toContain(AUTHELIA_FORWARD_AUTH_SENTINEL);
+    // identical to the LF form's output
+    const lf = expandForwardAuthSentinel(
+      `${AUTHELIA_FORWARD_AUTH_SENTINEL}\nclient_max_body_size 0;`,
+    )!;
+    expect(out).toBe(lf);
+  });
   it('leaves a non-sentinel config untouched, and undefined as undefined', () => {
     expect(expandForwardAuthSentinel('proxy_set_header X 1;')).toBe('proxy_set_header X 1;');
     expect(expandForwardAuthSentinel(undefined)).toBeUndefined();

--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -287,6 +287,12 @@ export function expandForwardAuthSentinel(
   opts?: ForwardAuthExpandOptions,
 ): string | undefined {
   if (!advancedConfig) return advancedConfig;
+  // #2224 — normalize CRLF → LF so a Windows/Local-authored template whose
+  // sentinel line ends `__authelia_forward_auth__\r\n<extras>` still matches
+  // the prefix form and expands its extras. Without this the `\r` breaks the
+  // `\n`-anchored prefix check, the literal sentinel survives, and nginx
+  // rejects the .conf with `[emerg] unknown directive "__authelia_..."`.
+  advancedConfig = advancedConfig.replace(/\r\n/g, '\n');
   // #2205 — on a websocket host, strip any redundant `proxy_http_version`
   // (NPM emits its own at server level) so we never produce a duplicate
   // directive. Applies to the sentinel's appended extras AND to a plain

--- a/packages/backend/src/lib/template/render.test.ts
+++ b/packages/backend/src/lib/template/render.test.ts
@@ -57,6 +57,17 @@ describe('renderPodYaml (#2206)', () => {
     expect(out).toContain('value: "abc"');
     expect(out).toContain('value: "xyz"');
   });
+
+  it('escapes a double-quote in a secret so the scalar stays valid (#2224)', () => {
+    // A password/secret containing a `"` must not close the double-quoted
+    // scalar early — it renders as `\"` and round-trips back verbatim.
+    const secret = 'p@ss"w0rd"!';
+    const out = renderPodYaml(POD, { VAPID_PRIVATE_KEY: secret, HASS_TOKEN: 'tok' });
+    expect(out).toContain('value: "p@ss\\"w0rd\\"!"');
+    const parsed = yaml.load(out) as { spec: { containers: { env: { name: string; value: string }[] }[] } };
+    const env = parsed.spec.containers[0].env;
+    expect(env.find(e => e.name === 'VAPID_PRIVATE_KEY')?.value).toBe(secret);
+  });
 });
 
 describe('escapeYamlScalar', () => {
@@ -71,5 +82,12 @@ describe('escapeYamlScalar', () => {
   it('round-trips through a YAML parser back to the original value', () => {
     const doc = `value: "${escapeYamlScalar(PEM)}"\n`;
     expect((yaml.load(doc) as { value: string }).value).toBe(PEM);
+  });
+
+  it('escapes a double-quote and round-trips (#2224)', () => {
+    const val = 'a"b\\c"d';
+    expect(escapeYamlScalar(val)).toBe('a\\"b\\\\c\\"d');
+    const doc = `value: "${escapeYamlScalar(val)}"\n`;
+    expect((yaml.load(doc) as { value: string }).value).toBe(val);
   });
 });

--- a/packages/backend/src/lib/template/render.ts
+++ b/packages/backend/src/lib/template/render.ts
@@ -61,11 +61,15 @@ export function renderPodYaml(template: string, view: Record<string, unknown>): 
 
 /** Escape control chars so a value survives inside a double-quoted YAML
  *  scalar. Backslash must be escaped first, or the escapes we add would be
- *  double-escaped. Exported for the runner's empty-var detection, which must
- *  compare against the pre-render view. */
+ *  double-escaped. The double-quote must also be escaped (`\"`), or a value
+ *  containing a `"` closes the scalar early → invalid YAML → the pod
+ *  crash-loops on the next restart (same failure class as an unescaped
+ *  newline, #2224). Exported for the runner's empty-var detection, which
+ *  must compare against the pre-render view. */
 export function escapeYamlScalar(value: string): string {
   return value
     .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
     .replace(/\n/g, '\\n')
     .replace(/\r/g, '\\r')
     .replace(/\t/g, '\\t');

--- a/packages/frontend/src/app/api/assists/[id]/approve/[requestId]/route.ts
+++ b/packages/frontend/src/app/api/assists/[id]/approve/[requestId]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { getApproval, approveApproval } from '@/lib/approvals';
+import { applyApproved, safeAssistId, type AssistProposalPayload } from '@/lib/assists/editor';
+import { requireAssistAdmin } from '../../../adminGate';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+// POST /api/assists/:id/approve/:requestId — admin only (#2221). Applies the
+// proposal: writes the body to DATA_DIR/local-assists/:id.md (overriding the
+// built-in) and appends a versioned history entry, then marks the approval
+// request approved. A valid token authenticates (tokenScope 'read'), then the
+// requireAssistAdmin gate 403s a token that lacks admin ('mutate') privilege.
+export const POST = withApiHandlerParams<undefined, undefined, { id: string; requestId: string }>(
+  { tokenScope: 'read' },
+  async ({ params, auth }) => {
+    const forbidden = requireAssistAdmin(auth);
+    if (forbidden) return forbidden;
+
+    const rawId = decodeURIComponent(params.id);
+    const id = safeAssistId(rawId);
+    const requestId = decodeURIComponent(params.requestId);
+    if (!id) {
+      return NextResponse.json({ error: `invalid assist id: ${rawId}` }, { status: 400 });
+    }
+
+    try {
+      const approval = await getApproval(requestId);
+      if (!approval) {
+        return NextResponse.json({ error: `approval request not found: ${requestId}` }, { status: 404 });
+      }
+      const payload = approval.payload as AssistProposalPayload;
+      if (payload?.kind !== 'assist-edit' || payload.assistId !== id) {
+        return NextResponse.json({ error: 'request does not match this assist' }, { status: 400 });
+      }
+      if (approval.status !== 'pending') {
+        return NextResponse.json({ error: `request already ${approval.status}` }, { status: 409 });
+      }
+
+      const author = auth?.user ?? 'admin';
+      const version = await applyApproved(payload, requestId, author);
+      // Mark the generic approval resolved (its on_approve action is empty).
+      await approveApproval(requestId);
+      logger.info('api:assists', `approved edit for "${id}" -> version ${version}`);
+      return NextResponse.json({ ok: true, id, version });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:assists', `approve ${id}/${requestId} failed`, error);
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/assists/[id]/history/route.ts
+++ b/packages/frontend/src/app/api/assists/[id]/history/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { readHistory, safeAssistId } from '@/lib/assists/editor';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/assists/:id/history — the ordered edit history for an entry (#2221),
+// oldest first. `[]` for an entry that has never been edited.
+export const GET = withApiHandlerParams<undefined, undefined, { id: string }>(
+  {},
+  async ({ params }) => {
+    const rawId = decodeURIComponent(params.id);
+    const id = safeAssistId(rawId);
+    if (!id) {
+      return NextResponse.json({ error: `invalid assist id: ${rawId}` }, { status: 400 });
+    }
+    try {
+      const history = await readHistory(id);
+      return NextResponse.json({ id, history });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:assists', `history ${id} failed`, error);
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/assists/[id]/propose/route.ts
+++ b/packages/frontend/src/app/api/assists/[id]/propose/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { submitApproval } from '@/lib/approvals';
+import {
+  validateProposal,
+  writeProposal,
+  safeAssistId,
+  ProposalValidationError,
+  type AssistProposalPayload,
+} from '@/lib/assists/editor';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const Body = z.object({
+  content: z.string().min(1),
+  message: z.string().min(1),
+});
+
+// POST /api/assists/:id/propose — submit an edit proposal (#2221). Validates
+// frontmatter + runs the secret scan, then creates a pending approval request
+// (reusing the generic approvals queue) and stashes the proposal body keyed by
+// the request id. Returns { requestId }. NOT admin-gated — anyone with a
+// session may propose; approval is the admin gate.
+export const POST = withApiHandlerParams<z.infer<typeof Body>, undefined, { id: string }>(
+  { body: Body },
+  async ({ body, params }) => {
+    const rawId = decodeURIComponent(params.id);
+    const id = safeAssistId(rawId);
+    if (!id) {
+      return NextResponse.json({ error: `invalid assist id: ${rawId}` }, { status: 400 });
+    }
+
+    try {
+      validateProposal(body.content);
+    } catch (error) {
+      if (error instanceof ProposalValidationError) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      throw error;
+    }
+
+    try {
+      const payload: AssistProposalPayload = { kind: 'assist-edit', assistId: id, message: body.message };
+      const approval = await submitApproval({
+        service: 'servicebay',
+        title: `Assist edit: ${id}`,
+        description: body.message,
+        payload,
+      });
+      await writeProposal(id, approval.id, body.content);
+      logger.info('api:assists', `proposed edit for "${id}" -> request ${approval.id}`);
+      return NextResponse.json({ requestId: approval.id }, { status: 201 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:assists', `propose ${id} failed`, error);
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/assists/[id]/reject/[requestId]/route.ts
+++ b/packages/frontend/src/app/api/assists/[id]/reject/[requestId]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { getApproval, rejectApproval } from '@/lib/approvals';
+import { discardRejected, safeAssistId, type AssistProposalPayload } from '@/lib/assists/editor';
+import { requireAssistAdmin } from '../../../adminGate';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+// POST /api/assists/:id/reject/:requestId — admin only (#2221). Discards the
+// proposal (removes the pending body, writes NO local file) and marks the
+// approval request rejected.
+export const POST = withApiHandlerParams<undefined, undefined, { id: string; requestId: string }>(
+  { tokenScope: 'read' },
+  async ({ params, auth }) => {
+    const forbidden = requireAssistAdmin(auth);
+    if (forbidden) return forbidden;
+
+    const rawId = decodeURIComponent(params.id);
+    const id = safeAssistId(rawId);
+    const requestId = decodeURIComponent(params.requestId);
+    if (!id) {
+      return NextResponse.json({ error: `invalid assist id: ${rawId}` }, { status: 400 });
+    }
+
+    try {
+      const approval = await getApproval(requestId);
+      if (!approval) {
+        return NextResponse.json({ error: `approval request not found: ${requestId}` }, { status: 404 });
+      }
+      const payload = approval.payload as AssistProposalPayload;
+      if (payload?.kind !== 'assist-edit' || payload.assistId !== id) {
+        return NextResponse.json({ error: 'request does not match this assist' }, { status: 400 });
+      }
+      if (approval.status !== 'pending') {
+        return NextResponse.json({ error: `request already ${approval.status}` }, { status: 409 });
+      }
+
+      await discardRejected(payload, requestId);
+      await rejectApproval(requestId);
+      logger.info('api:assists', `rejected edit for "${id}" (request ${requestId})`);
+      return NextResponse.json({ ok: true, id });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:assists', `reject ${id}/${requestId} failed`, error);
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/assists/[id]/revert/[version]/route.ts
+++ b/packages/frontend/src/app/api/assists/[id]/revert/[version]/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { submitApproval } from '@/lib/approvals';
+import {
+  readHistoryVersion,
+  writeProposal,
+  validateProposal,
+  safeAssistId,
+  type AssistProposalPayload,
+} from '@/lib/assists/editor';
+import { requireAssistAdmin } from '../../../adminGate';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+// POST /api/assists/:id/revert/:version — admin only (#2221). Creates a NEW
+// approval request whose body is the frozen content of history `version` — a
+// revert is never a silent rewrite; it goes through the same approve flow.
+export const POST = withApiHandlerParams<undefined, undefined, { id: string; version: string }>(
+  { tokenScope: 'read' },
+  async ({ params, auth }) => {
+    const forbidden = requireAssistAdmin(auth);
+    if (forbidden) return forbidden;
+
+    const rawId = decodeURIComponent(params.id);
+    const id = safeAssistId(rawId);
+    const version = Number(decodeURIComponent(params.version));
+    if (!id) {
+      return NextResponse.json({ error: `invalid assist id: ${rawId}` }, { status: 400 });
+    }
+    if (!Number.isInteger(version) || version < 1) {
+      return NextResponse.json({ error: `invalid version: ${params.version}` }, { status: 400 });
+    }
+
+    try {
+      const content = await readHistoryVersion(id, version);
+      if (content === null) {
+        return NextResponse.json({ error: `history version not found: ${id}@${version}` }, { status: 404 });
+      }
+      // The frozen content was valid when applied, but re-validate defensively.
+      validateProposal(content);
+
+      const message = `Revert "${id}" to version ${version}`;
+      const payload: AssistProposalPayload = { kind: 'assist-edit', assistId: id, message, revertOf: version };
+      const approval = await submitApproval({
+        service: 'servicebay',
+        title: `Assist revert: ${id} -> v${version}`,
+        description: message,
+        payload,
+      });
+      await writeProposal(id, approval.id, content);
+      logger.info('api:assists', `revert requested for "${id}" -> v${version} (request ${approval.id})`);
+      return NextResponse.json({ requestId: approval.id, revertOf: version }, { status: 201 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:assists', `revert ${id}@${version} failed`, error);
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/assists/[id]/route.ts
+++ b/packages/frontend/src/app/api/assists/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { getAssist } from '@/lib/assists/catalog';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/assists/:id — full raw markdown (frontmatter + body) of one entry,
+// Local overriding Built-in. 404 for an unknown or unsafe id (#2221).
+export const GET = withApiHandlerParams<undefined, undefined, { id: string }>(
+  {},
+  async ({ params }) => {
+    const id = decodeURIComponent(params.id);
+    try {
+      const content = await getAssist(id);
+      if (content === null) {
+        return NextResponse.json({ error: `assist not found: ${id}` }, { status: 404 });
+      }
+      return NextResponse.json({ id, content });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:assists', `get ${id} failed`, error);
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  },
+);

--- a/packages/frontend/src/app/api/assists/adminGate.ts
+++ b/packages/frontend/src/app/api/assists/adminGate.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import type { SessionPayload } from '@/lib/auth/session';
+import { scopeSatisfiedBy } from '@/lib/auth/apiScope';
+
+/**
+ * Admin gate for the assists-editor mutating routes (approve/reject/revert,
+ * #2221). These routes carry `tokenScope: 'read'`, so `requireSession` has
+ * already 401'd an unauthenticated caller but ADMITS any authenticated
+ * principal: a session cookie (a logged-in admin, all scopes) or any valid
+ * `Bearer sb_…` token (which holds at least `read`).
+ *
+ * This second check is the AUTHORIZATION step: it turns an authenticated-but-
+ * under-scoped principal into a 403 (Forbidden) rather than 401
+ * (Unauthenticated). A scoped API token whose scopes do NOT satisfy `mutate` is
+ * a non-admin caller and must be refused with 403, per the acceptance criteria.
+ * A cookie/internal session carries all scopes (its `scopes` field is omitted,
+ * meaning "all") and always passes.
+ *
+ * Returns a 403 NextResponse to short-circuit, or null to proceed.
+ */
+export function requireAssistAdmin(auth: SessionPayload | undefined): NextResponse | null {
+  if (!auth) {
+    // Should not happen on a mutate-gated route, but fail closed.
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  // Omitted scopes == all scopes (cookie / internal session). A scoped token
+  // must actually hold (or imply) `mutate`.
+  if (auth.scopes && !scopeSatisfiedBy(auth.scopes, 'mutate')) {
+    return NextResponse.json({ error: 'Forbidden: admin (mutate) scope required' }, { status: 403 });
+  }
+  return null;
+}

--- a/packages/frontend/src/app/api/assists/assists-routes.test.ts
+++ b/packages/frontend/src/app/api/assists/assists-routes.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Assists editor REST routes (#2221) — all 7 endpoints, driven through the REAL
+ * withApiHandler(+Params) → requireSession path. We mock only the auth
+ * primitives and the catalog/approvals/editor lib layer, so the test pins the
+ * route wiring: validation dispatch, status codes, and the admin (403) gate.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// --- lib layer mocks -------------------------------------------------------
+const catalog = vi.hoisted(() => ({
+  listAssists: vi.fn(),
+  getAssist: vi.fn(),
+}));
+vi.mock('@/lib/assists/catalog', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/assists/catalog')>('@/lib/assists/catalog');
+  return { ...actual, listAssists: catalog.listAssists, getAssist: catalog.getAssist };
+});
+
+const approvals = vi.hoisted(() => ({
+  submitApproval: vi.fn(),
+  getApproval: vi.fn(),
+  approveApproval: vi.fn(),
+  rejectApproval: vi.fn(),
+}));
+vi.mock('@/lib/approvals', () => approvals);
+
+const editor = vi.hoisted(() => ({
+  writeProposal: vi.fn<(...a: unknown[]) => Promise<void>>(async () => {}),
+  applyApproved: vi.fn<(...a: unknown[]) => Promise<number>>(async () => 1),
+  discardRejected: vi.fn<(...a: unknown[]) => Promise<void>>(async () => {}),
+  readHistory: vi.fn<(...a: unknown[]) => Promise<Array<Record<string, unknown>>>>(async () => []),
+  readHistoryVersion: vi.fn<(...a: unknown[]) => Promise<string | null>>(),
+}));
+vi.mock('@/lib/assists/editor', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/assists/editor')>('@/lib/assists/editor');
+  // Keep the REAL validateProposal / safeAssistId / ProposalValidationError so
+  // the propose route's validation is genuinely exercised.
+  return { ...actual, ...editor };
+});
+
+// --- auth primitives (requireSession's three sources) ----------------------
+const auth = vi.hoisted(() => ({
+  internalToken: 'internal-secret',
+  session: null as null | { user: string; expires: Date },
+  token: null as null | { name: string; scopes: string[] },
+}));
+vi.mock('@/lib/auth/internalToken', () => ({ getInternalApiToken: () => auth.internalToken }));
+vi.mock('@/lib/auth/session', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth/session')>('@/lib/auth/session');
+  return { ...actual, getSessionFromCookieHeader: vi.fn(async () => auth.session) };
+});
+vi.mock('@/lib/auth/apiTokens', () => ({
+  verifyToken: vi.fn(async () => auth.token),
+  tokenIsLive: vi.fn(async () => true),
+}));
+
+import { GET as listGET } from './route';
+import { GET as getGET } from './[id]/route';
+import { POST as proposePOST } from './[id]/propose/route';
+import { POST as approvePOST } from './[id]/approve/[requestId]/route';
+import { POST as rejectPOST } from './[id]/reject/[requestId]/route';
+import { GET as historyGET } from './[id]/history/route';
+import { POST as revertPOST } from './[id]/revert/[version]/route';
+
+function req(url: string, init?: { method?: string; body?: unknown; headers?: Record<string, string> }): NextRequest {
+  const headers: Record<string, string> = { ...(init?.headers ?? {}) };
+  let body: string | undefined;
+  if (init?.body !== undefined) {
+    body = JSON.stringify(init.body);
+    headers['content-type'] = 'application/json';
+  }
+  return new NextRequest(`http://localhost${url}`, { method: init?.method ?? 'GET', headers, body });
+}
+
+const cookie = { cookie: 'sb_session=valid' }; // an admin session
+
+const goodProposal = ['---', 'title: T', 'whenToUse: use it', 'kind: guide', '---', '', 'body'].join('\n');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.session = null;
+  auth.token = null;
+  editor.applyApproved.mockResolvedValue(1);
+  editor.readHistory.mockResolvedValue([]);
+});
+
+describe('GET /api/assists (list)', () => {
+  it('returns the catalog list', async () => {
+    catalog.listAssists.mockResolvedValue([{ id: 'a', title: 'A', whenToUse: 'x', kind: 'guide', tags: [], source: 'Built-in' }]);
+    const res = await listGET(req('/api/assists'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.assists).toHaveLength(1);
+  });
+});
+
+describe('GET /api/assists/:id', () => {
+  it('returns raw content', async () => {
+    catalog.getAssist.mockResolvedValue(goodProposal);
+    const res = await getGET(req('/api/assists/demo'), { params: Promise.resolve({ id: 'demo' }) });
+    expect(res.status).toBe(200);
+    expect((await res.json()).content).toBe(goodProposal);
+  });
+  it('404s an unknown id', async () => {
+    catalog.getAssist.mockResolvedValue(null);
+    const res = await getGET(req('/api/assists/nope'), { params: Promise.resolve({ id: 'nope' }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/assists/:id/propose (validation)', () => {
+  // Propose is a mutating POST — it needs *a* session, but is NOT admin-gated
+  // (approval is the admin gate). Authenticate with an ordinary cookie here.
+  beforeEach(() => {
+    auth.session = { user: 'contributor', expires: new Date(Date.now() + 60_000) };
+  });
+
+  it('requires a session (401 for an unauthenticated caller)', async () => {
+    auth.session = null;
+    const res = await proposePOST(
+      req('/api/assists/demo/propose', { method: 'POST', body: { content: goodProposal, message: 'edit' } }),
+      { params: Promise.resolve({ id: 'demo' }) },
+    );
+    expect(res.status).toBe(401);
+    expect(approvals.submitApproval).not.toHaveBeenCalled();
+  });
+
+  it('creates an approval request and returns requestId', async () => {
+    approvals.submitApproval.mockResolvedValue({ id: 'req-1' });
+    const res = await proposePOST(
+      req('/api/assists/demo/propose', { method: 'POST', body: { content: goodProposal, message: 'edit' }, headers: cookie }),
+      { params: Promise.resolve({ id: 'demo' }) },
+    );
+    expect(res.status).toBe(201);
+    expect((await res.json()).requestId).toBe('req-1');
+    expect(editor.writeProposal).toHaveBeenCalledWith('demo', 'req-1', goodProposal);
+  });
+
+  it('rejects a missing title (400)', async () => {
+    const bad = ['---', 'whenToUse: x', 'kind: guide', '---', '', 'b'].join('\n');
+    const res = await proposePOST(
+      req('/api/assists/demo/propose', { method: 'POST', body: { content: bad, message: 'm' }, headers: cookie }),
+      { params: Promise.resolve({ id: 'demo' }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/title/);
+    expect(approvals.submitApproval).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing whenToUse (400)', async () => {
+    const bad = ['---', 'title: T', 'kind: guide', '---', '', 'b'].join('\n');
+    const res = await proposePOST(
+      req('/api/assists/demo/propose', { method: 'POST', body: { content: bad, message: 'm' }, headers: cookie }),
+      { params: Promise.resolve({ id: 'demo' }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/whenToUse/);
+  });
+
+  it('rejects an invalid kind (400)', async () => {
+    const bad = ['---', 'title: T', 'whenToUse: x', 'kind: banana', '---', '', 'b'].join('\n');
+    const res = await proposePOST(
+      req('/api/assists/demo/propose', { method: 'POST', body: { content: bad, message: 'm' }, headers: cookie }),
+      { params: Promise.resolve({ id: 'demo' }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/kind/);
+  });
+
+  it('rejects a PEM key in the body (400)', async () => {
+    const bad = ['---', 'title: T', 'whenToUse: x', 'kind: guide', '---', '', '-----BEGIN PRIVATE KEY-----', 'z', '-----END PRIVATE KEY-----'].join('\n');
+    const res = await proposePOST(
+      req('/api/assists/demo/propose', { method: 'POST', body: { content: bad, message: 'm' }, headers: cookie }),
+      { params: Promise.resolve({ id: 'demo' }) },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/secret/);
+    expect(approvals.submitApproval).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin gate — 403 for a non-admin token, 200 for a cookie session', () => {
+  const pendingAssistApproval = {
+    id: 'req-1',
+    status: 'pending',
+    payload: { kind: 'assist-edit', assistId: 'demo', message: 'm' },
+  };
+
+  it('approve: a read-only token is 403', async () => {
+    auth.token = { name: 'reader', scopes: ['read'] };
+    const res = await approvePOST(
+      req('/api/assists/demo/approve/req-1', { method: 'POST', headers: { authorization: 'Bearer sb_reader' } }),
+      { params: Promise.resolve({ id: 'demo', requestId: 'req-1' }) },
+    );
+    expect(res.status).toBe(403);
+    expect(editor.applyApproved).not.toHaveBeenCalled();
+  });
+
+  it('approve: a cookie admin applies + marks approved (200)', async () => {
+    auth.session = { user: 'admin', expires: new Date(Date.now() + 60_000) };
+    approvals.getApproval.mockResolvedValue(pendingAssistApproval);
+    const res = await approvePOST(
+      req('/api/assists/demo/approve/req-1', { method: 'POST', headers: cookie }),
+      { params: Promise.resolve({ id: 'demo', requestId: 'req-1' }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).version).toBe(1);
+    expect(editor.applyApproved).toHaveBeenCalled();
+    expect(approvals.approveApproval).toHaveBeenCalledWith('req-1');
+  });
+
+  it('approve: an unauthenticated caller is 401', async () => {
+    const res = await approvePOST(
+      req('/api/assists/demo/approve/req-1', { method: 'POST' }),
+      { params: Promise.resolve({ id: 'demo', requestId: 'req-1' }) },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('reject: a read-only token is 403', async () => {
+    auth.token = { name: 'reader', scopes: ['read'] };
+    const res = await rejectPOST(
+      req('/api/assists/demo/reject/req-1', { method: 'POST', headers: { authorization: 'Bearer sb_reader' } }),
+      { params: Promise.resolve({ id: 'demo', requestId: 'req-1' }) },
+    );
+    expect(res.status).toBe(403);
+    expect(editor.discardRejected).not.toHaveBeenCalled();
+  });
+
+  it('reject: a cookie admin discards + marks rejected (200), writes no file', async () => {
+    auth.session = { user: 'admin', expires: new Date(Date.now() + 60_000) };
+    approvals.getApproval.mockResolvedValue(pendingAssistApproval);
+    const res = await rejectPOST(
+      req('/api/assists/demo/reject/req-1', { method: 'POST', headers: cookie }),
+      { params: Promise.resolve({ id: 'demo', requestId: 'req-1' }) },
+    );
+    expect(res.status).toBe(200);
+    expect(editor.discardRejected).toHaveBeenCalled();
+    expect(approvals.rejectApproval).toHaveBeenCalledWith('req-1');
+  });
+
+  it('revert: a read-only token is 403', async () => {
+    auth.token = { name: 'reader', scopes: ['read'] };
+    const res = await revertPOST(
+      req('/api/assists/demo/revert/1', { method: 'POST', headers: { authorization: 'Bearer sb_reader' } }),
+      { params: Promise.resolve({ id: 'demo', version: '1' }) },
+    );
+    expect(res.status).toBe(403);
+    expect(approvals.submitApproval).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/assists/:id/history', () => {
+  it('returns the ordered history', async () => {
+    editor.readHistory.mockResolvedValue([
+      { version: 1, author: 'a', timestamp: 't1', message: 'one' },
+      { version: 2, author: 'b', timestamp: 't2', message: 'two' },
+    ]);
+    const res = await historyGET(req('/api/assists/demo/history'), { params: Promise.resolve({ id: 'demo' }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.history.map((h: { version: number }) => h.version)).toEqual([1, 2]);
+  });
+});
+
+describe('POST /api/assists/:id/revert/:version — creates an approval REQUEST, not a silent write', () => {
+  it('a cookie admin gets a new requestId; no local file written', async () => {
+    auth.session = { user: 'admin', expires: new Date(Date.now() + 60_000) };
+    editor.readHistoryVersion.mockResolvedValue(goodProposal);
+    approvals.submitApproval.mockResolvedValue({ id: 'revert-req' });
+    const res = await revertPOST(
+      req('/api/assists/demo/revert/1', { method: 'POST', headers: cookie }),
+      { params: Promise.resolve({ id: 'demo', version: '1' }) },
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.requestId).toBe('revert-req');
+    expect(body.revertOf).toBe(1);
+    // It creates a proposal (approval request) — never applies directly.
+    expect(approvals.submitApproval).toHaveBeenCalled();
+    expect(editor.writeProposal).toHaveBeenCalledWith('demo', 'revert-req', goodProposal);
+    expect(editor.applyApproved).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown version', async () => {
+    auth.session = { user: 'admin', expires: new Date(Date.now() + 60_000) };
+    editor.readHistoryVersion.mockResolvedValue(null);
+    const res = await revertPOST(
+      req('/api/assists/demo/revert/99', { method: 'POST', headers: cookie }),
+      { params: Promise.resolve({ id: 'demo', version: '99' }) },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/frontend/src/app/api/assists/route.ts
+++ b/packages/frontend/src/app/api/assists/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandler } from '@/lib/api/handler';
+import { listAssists, ASSIST_KINDS } from '@/lib/assists/catalog';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const Query = z
+  .object({
+    query: z.string().optional(),
+    kind: z.enum(ASSIST_KINDS).optional(),
+  })
+  .partial();
+
+// GET /api/assists — list catalog entries (built-in + local), Local overriding
+// Built-in by id. The HTTP twin of the `list_assists` MCP tool (#2221).
+export const GET = withApiHandler<undefined, z.infer<typeof Query>>(
+  { query: Query },
+  async ({ query }) => {
+    try {
+      const assists = await listAssists({ query: query?.query, kind: query?.kind });
+      return NextResponse.json({ assists });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('api:assists', 'list failed', error);
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  },
+);

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.test.ts
@@ -326,6 +326,33 @@ describe('#2119 mergeGraphPreservingPositions', () => {
     expect(d.onToggle).toBe(toggle);      // toggle handler survives the poll
   });
 
+  it('#2225 surfaces a fresh className/type while preserving the laid-out position/style', () => {
+    // Same id + same topology signature (in-place merge path), but the fresh
+    // node changed its className and type. The merge must take className/type
+    // from the FRESH node (they are non-position/style fields), while position
+    // and the layout-sized style stay from the laid-out (prev) node.
+    const laidNode: Node = {
+      id: 's1', type: 'oldType', className: 'old-class',
+      position: { x: 100, y: 100 }, style: { width: 320 },
+      data: { type: 'service', label: 's1', status: 'up' },
+    };
+    const freshNode: Node = {
+      id: 's1', type: 'newType', className: 'new-class',
+      position: { x: 0, y: 0 }, style: { width: 9999 },
+      data: { type: 'service', label: 's1', status: 'down' },
+    };
+    const { nodes } = mergeGraphPreservingPositions([laidNode], [], [freshNode], []);
+    const merged = nodes[0];
+    // className/type come from the FRESH node
+    expect(merged.className).toBe('new-class');
+    expect(merged.type).toBe('newType');
+    // position + layout-sized style stay from the laid-out node
+    expect(merged.position).toEqual({ x: 100, y: 100 });
+    expect(merged.style).toEqual({ width: 320 });
+    // fresh data still flows through
+    expect((merged.data as { status?: string }).status).toBe('down');
+  });
+
   it('keeps the laid-out routed edge geometry, refreshing only styling/label', () => {
     const laidEdge: Edge = {
       id: 'e-s1-s2', source: 's1', target: 's2',

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -356,11 +356,17 @@ export function mergeGraphPreservingPositions<TNode extends Node, TEdge extends 
       summary: prevData.summary,
       onToggle: prevData.onToggle,
     } as TNode['data'];
+    // #2225 — spread `...fresh` FIRST so non-position/style fields
+    // (className, type, parentId, measured) come from the FRESH node, then
+    // override with the merged data + the laid-out position and layout-sized
+    // style. The old order spread `...prev` first and only overrode
+    // data/position/style, so a fresh className/type/parentId change was
+    // silently discarded on every in-place poll merge — contradicting this
+    // function's own "refresh everything else from the fresh node" intent.
     nodes.push({
-      ...prev,
+      ...fresh,
       data: mergedData,
-      // Keep the laid-out position + layout-sized style; refresh everything
-      // else (className etc.) from the fresh node.
+      // Keep the laid-out position + layout-sized style from the prev node.
       position: prev.position,
       style: prev.style,
     } as TNode);


### PR DESCRIPTION
## What
Ships the assists-catalog editor backend (7 REST endpoints, child A of #2147) plus two eval-found regression fixes on the install/render and network-map paths.

- **#2221** — backend REST API for the assists catalog editor: list/get/propose/approve/reject/history/revert, reusing the approvals queue + secret-scan rules; versioned history store under `DATA_DIR/local-assists/.history/:id/`; admin routes 403 an under-scoped token; a revert is an approval *request*, never a silent write.
- **#2224** — config-render escaping gaps (post-#2205/#2206): `escapeYamlScalar` now also escapes the double-quote char so an operator secret containing `"` stays a valid double-quoted YAML scalar (no pod crash-loop); `expandForwardAuthSentinel` normalizes CRLF→LF so a Windows/Local-authored template's sentinel line expands instead of emitting the literal `__authelia_forward_auth__` (no nginx emerg).
- **#2225** — network-map in-place merge: `mergeGraphPreservingPositions` now spreads `...fresh` first, then overrides `data:mergedData, position:prev.position, style:prev.style`, so fresh `className`/`type`/`parentId`/`measured` survive a poll while the laid-out position+style carry forward (matches its own stated intent; foot-gun for future className/type-on-poll updates).

## Why
Closes #2221
Closes #2224
Closes #2225

## Risk
low — #2224 tightens escaping (strictly more-correct output, pinned by round-trip tests); #2225 flips a spread order with no live-visible change today; #2221 is self-contained new backend surface behind admin gating.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors / 355 warnings, unchanged)
- [x] npm run typecheck (tsc --noEmit, exit 0)
- [x] npm run check:arch (1017 modules, 0 violations)
- [x] npm test (419 files / 3650 passed / 2 skipped)
- [ ] /verify on FCoS :dev box — PATH-MANDATED (#2224 template/render + forwardAuth expansion; #2225 network-map render): real redeploy of a quote-bearing/CRLF-authored template + rendered-DOM map layout owed to box-verify

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
