### PR TITLE
feat(settings): Knowledge section for the assists catalog editor

### DIFF
--- a/packages/frontend/src/app/(dashboard)/settings/_lib/ia.test.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/ia.test.ts
@@ -7,12 +7,13 @@ describe('settings IA — cross-cutting only, no Services group (spec §4.4 / §
     expect(SETTINGS_GROUPS.find(g => g.id === 'services')).toBeUndefined();
   });
 
-  it('exposes exactly the cross-cutting groups + Maintenance', () => {
+  it('exposes exactly the cross-cutting groups + Knowledge + Maintenance', () => {
     expect(SETTINGS_GROUPS.map(g => g.id)).toEqual([
       'network-domain',
       'access',
       'notifications',
       'system',
+      'knowledge',
       'maintenance',
     ]);
   });
@@ -59,6 +60,31 @@ describe('settings IA — Maintenance launcher (#1958 follow-up)', () => {
   it('non-launcher entries still deep-link to their in-page settings anchor', () => {
     const updates = SEARCH_INDEX.find(h => h.entry.id === 'updates');
     expect(updates?.href).toBe('/settings/system#updates');
+  });
+});
+
+describe('settings IA — Knowledge group (assists catalog editor #2228)', () => {
+  it('has a top-level Knowledge group with the assist-catalog entry', () => {
+    const group = SETTINGS_GROUPS.find(g => g.id === 'knowledge');
+    expect(group).toBeDefined();
+    const entry = group!.entries.find(e => e.id === 'catalog');
+    expect(entry).toBeDefined();
+    expect(entry!.tier).toBe('essential');
+  });
+
+  it('deep-links the catalog entry to its group anchor', () => {
+    const hit = SEARCH_INDEX.find(h => h.entry.id === 'catalog');
+    expect(hit).toBeDefined();
+    expect(hit!.href).toBe('/settings/knowledge#catalog');
+  });
+
+  it('is findable by name + synonyms (assist, knowledge, adr, recipe)', () => {
+    for (const term of ['assist', 'knowledge', 'adr', 'recipe', 'catalog']) {
+      expect(
+        searchSettings(term).some(h => h.entry.id === 'catalog'),
+        `"${term}" must surface the assist-catalog entry`,
+      ).toBe(true);
+    }
   });
 });
 

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/ia.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/ia.ts
@@ -22,6 +22,7 @@
 
 import {
   Bell,
+  BookOpen,
   Network,
   Server,
   Users,
@@ -127,6 +128,20 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
       // the heavy job runs in a resource-capped worker container reached via a
       // dashboard tile, so it is no longer a Settings entry here.
       { id: 'factory-reset', label: 'Factory reset', tier: 'advanced', keywords: ['reset', 'wipe', 'erase', 'danger'] },
+    ],
+  },
+  {
+    // The assist catalog editor (#2228, epic #2147): browse/view/edit the
+    // knowledge base (guides, recipes, ADRs, footguns…) that MCP agents self-
+    // select from, with an approval gate on every edit. Its own group because the
+    // list/view/edit/history UI needs full-page real estate, not a disclosure
+    // strip in an existing cross-cutting group.
+    id: 'knowledge',
+    label: 'Knowledge',
+    intent: 'The assist catalog — guides, recipes and ADRs agents draw on, editable behind an approval gate.',
+    icon: BookOpen,
+    entries: [
+      { id: 'catalog', label: 'Assist catalog', tier: 'essential', keywords: ['assist', 'assists', 'knowledge', 'catalog', 'adr', 'guide', 'recipe', 'footgun', 'docs', 'edit'] },
     ],
   },
   {

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/AssistDetail.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/AssistDetail.tsx
@@ -1,0 +1,314 @@
+// The right-hand detail pane of the Knowledge editor (#2228): view the rendered
+// markdown + metadata, edit inline (with frontmatter + secret validation),
+// submit a proposal, review pending proposals (approve/reject), and browse the
+// version history with a revert action.
+
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { AlertTriangle, Check, History, Loader2, Pencil, RotateCcw, X } from 'lucide-react';
+import { Badge, Button, Card } from '@/components/ui';
+import { validateProposal } from './validation';
+import type { AssistApproval, AssistSummary, HistoryEntry } from './types';
+import type { useKnowledge } from './useKnowledge';
+
+type Api = ReturnType<typeof useKnowledge>;
+
+interface AssistDetailProps {
+  summary: AssistSummary;
+  approvals: AssistApproval[];
+  api: Api;
+}
+
+export default function AssistDetail({ summary, approvals, api }: AssistDetailProps) {
+  const [content, setContent] = useState<string | null>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [editing, setEditing] = useState(false);
+
+  const reload = useCallback(async () => {
+    const [nextContent, nextHistory] = await Promise.all([
+      api.loadContent(summary.id),
+      api.loadHistory(summary.id),
+    ]);
+    setContent(nextContent);
+    setHistory(nextHistory);
+  }, [api, summary.id]);
+
+  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps --
+     Reset the editor + async-load content on entry change; setEditing is a
+     one-shot reset, the load itself is async (below), and depending on the
+     summary id alone is intentional (reload is id-stable). */
+  useEffect(() => {
+    setEditing(false);
+    void reload();
+  }, [summary.id]);
+  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
+
+  const pending = approvals.filter(a => a.payload?.assistId === summary.id && a.status === 'pending');
+  const lastEdited = history.length > 0 ? history[history.length - 1] : null;
+
+  return (
+    <Card padding="none" className="overflow-hidden">
+      <DetailHeader summary={summary} lastEdited={lastEdited} editing={editing} onEdit={() => setEditing(true)} />
+      <div className="p-space-5 space-y-6">
+        {pending.length > 0 && (
+          <ReviewPanel assistId={summary.id} pending={pending} api={api} onResolved={reload} />
+        )}
+        {editing ? (
+          <ProposalEditor
+            initial={content ?? ''}
+            assistId={summary.id}
+            api={api}
+            onDone={() => { setEditing(false); void reload(); }}
+            onCancel={() => setEditing(false)}
+          />
+        ) : (
+          <RenderedBody content={content} />
+        )}
+        <HistoryTimeline assistId={summary.id} history={history} api={api} onReverted={reload} />
+      </div>
+    </Card>
+  );
+}
+
+function DetailHeader({
+  summary,
+  lastEdited,
+  editing,
+  onEdit,
+}: {
+  summary: AssistSummary;
+  lastEdited: HistoryEntry | null;
+  editing: boolean;
+  onEdit: () => void;
+}) {
+  return (
+    <div className="flex items-start gap-space-3 px-space-4 py-space-3 border-b border-border bg-surface-2">
+      <div className="flex-1 min-w-0">
+        <h3 className="font-semibold text-text flex items-center gap-space-2 flex-wrap">
+          {summary.title}
+          <Badge variant="neutral" className="font-mono">{summary.kind}</Badge>
+          <Badge variant={summary.source === 'Local' ? 'accent' : 'info'}>{summary.source}</Badge>
+        </h3>
+        <p className="text-xs text-text-muted mt-1">{summary.whenToUse}</p>
+        <div className="mt-2 flex items-center gap-space-2 flex-wrap">
+          {summary.tags.map(tag => (
+            <span key={tag} className="text-[11px] text-text-subtle font-mono">#{tag}</span>
+          ))}
+        </div>
+        {lastEdited && (
+          <p className="text-[11px] text-text-subtle mt-1">
+            Last modified v{lastEdited.version} · {lastEdited.author} · {new Date(lastEdited.timestamp).toLocaleString()}
+          </p>
+        )}
+      </div>
+      {!editing && (
+        <Button variant="secondary" size="sm" onClick={onEdit} className="shrink-0">
+          <Pencil size={14} /> Edit
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function RenderedBody({ content }: { content: string | null }) {
+  if (content === null) {
+    return (
+      <p className="text-sm text-text-muted">
+        <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+        Loading…
+      </p>
+    );
+  }
+  return (
+    <div className="prose dark:prose-invert prose-sm max-w-none">
+      <ReactMarkdown>{content}</ReactMarkdown>
+    </div>
+  );
+}
+
+function ProposalEditor({
+  initial,
+  assistId,
+  api,
+  onDone,
+  onCancel,
+}: {
+  initial: string;
+  assistId: string;
+  api: Api;
+  onDone: () => void;
+  onCancel: () => void;
+}) {
+  const [body, setBody] = useState(initial);
+  const [message, setMessage] = useState('');
+  const [busy, setBusy] = useState(false);
+  const validation = useMemo(() => validateProposal(body), [body]);
+
+  const submit = async () => {
+    if (!validation.ok) return;
+    setBusy(true);
+    const ok = await api.propose(assistId, body, message.trim() || `Edit ${assistId}`);
+    setBusy(false);
+    if (ok) onDone();
+  };
+
+  return (
+    <div className="space-y-3">
+      <textarea
+        value={body}
+        onChange={e => setBody(e.target.value)}
+        spellCheck={false}
+        rows={20}
+        aria-label="Assist markdown source"
+        className="w-full p-3 rounded-card border border-border bg-surface-2 text-text font-mono text-xs focus:ring-2 focus:ring-accent outline-none"
+        placeholder="---&#10;title: …&#10;whenToUse: …&#10;kind: guide&#10;---&#10;body…"
+      />
+      {!validation.ok && <ValidationBanner error={validation.error} />}
+      <input
+        type="text"
+        value={message}
+        onChange={e => setMessage(e.target.value)}
+        className="w-full p-2 rounded-card border border-border bg-surface-2 text-text text-sm focus:ring-2 focus:ring-accent outline-none"
+        placeholder="Change summary (commit message)"
+      />
+      <div className="flex items-center gap-2">
+        <Button onClick={() => void submit()} disabled={!validation.ok || busy}>
+          {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+          Submit proposal
+        </Button>
+        <Button variant="ghost" onClick={onCancel} disabled={busy}>
+          <X size={14} /> Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ValidationBanner({ error }: { error?: string }) {
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 text-xs text-status-fail bg-status-fail/10 rounded-card p-space-3"
+    >
+      <AlertTriangle size={14} className="shrink-0 mt-0.5" />
+      <span>{error}</span>
+    </div>
+  );
+}
+
+function ReviewPanel({
+  assistId,
+  pending,
+  api,
+  onResolved,
+}: {
+  assistId: string;
+  pending: AssistApproval[];
+  api: Api;
+  onResolved: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  const act = async (requestId: string, decision: 'approve' | 'reject') => {
+    setBusy(true);
+    const ok = await api.resolve(assistId, requestId, decision);
+    setBusy(false);
+    if (ok) onResolved();
+  };
+
+  return (
+    <div className="space-y-2">
+      <Badge variant="warn">{pending.length} pending proposal{pending.length === 1 ? '' : 's'}</Badge>
+      {pending.map(req => (
+        <Card key={req.id} padding="none">
+          <div className="p-3 flex items-start gap-3">
+            <div className="flex-1 min-w-0">
+              <span className="text-sm font-medium text-text">
+                {req.payload?.revertOf ? `Revert to v${req.payload.revertOf}` : 'Edit proposal'}
+              </span>
+              {req.description && <p className="mt-1 text-xs text-text-muted">{req.description}</p>}
+              <span className="text-[11px] text-text-subtle">{new Date(req.created_at).toLocaleString()}</span>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              <Button variant="primary" size="sm" disabled={busy} onClick={() => void act(req.id, 'approve')}>
+                <Check size={14} /> Approve
+              </Button>
+              <Button variant="danger" size="sm" disabled={busy} onClick={() => void act(req.id, 'reject')}>
+                <X size={14} /> Reject
+              </Button>
+            </div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function HistoryTimeline({
+  assistId,
+  history,
+  api,
+  onReverted,
+}: {
+  assistId: string;
+  history: HistoryEntry[];
+  api: Api;
+  onReverted: () => void;
+}) {
+  const [busy, setBusy] = useState<number | null>(null);
+
+  const doRevert = async (version: number) => {
+    setBusy(version);
+    const ok = await api.revert(assistId, version);
+    setBusy(null);
+    if (ok) onReverted();
+  };
+
+  return (
+    <div className="border-t border-border pt-4">
+      <h4 className="text-sm font-semibold text-text flex items-center gap-2 mb-2">
+        <History size={14} /> History
+      </h4>
+      {history.length === 0 ? (
+        <p className="text-xs text-text-muted italic">No edits yet — this entry is the shipped built-in.</p>
+      ) : (
+        <ul className="space-y-1">
+          {[...history].reverse().map(entry => (
+            <HistoryRow key={entry.version} entry={entry} busy={busy} onRevert={v => void doRevert(v)} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function HistoryRow({
+  entry,
+  busy,
+  onRevert,
+}: {
+  entry: HistoryEntry;
+  busy: number | null;
+  onRevert: (version: number) => void;
+}) {
+  return (
+    <li className="flex items-center gap-3 text-xs py-1">
+      <Badge variant="neutral" className="font-mono">v{entry.version}</Badge>
+      <span className="flex-1 min-w-0 text-text-muted truncate">
+        {entry.message} · {entry.author} · {new Date(entry.timestamp).toLocaleString()}
+      </span>
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={busy !== null}
+        onClick={() => onRevert(entry.version)}
+        title={`Request a revert to version ${entry.version}`}
+      >
+        {busy === entry.version ? <Loader2 size={12} className="animate-spin" /> : <RotateCcw size={12} />}
+        Revert
+      </Button>
+    </li>
+  );
+}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/types.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/types.ts
@@ -1,0 +1,41 @@
+// Shared types for the Knowledge (assists catalog) editor UI (#2228).
+// The HTTP twins of the backend catalog + editor shapes.
+
+import type { AssistKind } from './validation';
+
+export type { AssistKind };
+
+/** GET /api/assists → { assists: AssistSummary[] }. Mirrors backend AssistSummary. */
+export interface AssistSummary {
+  id: string;
+  title: string;
+  whenToUse: string;
+  kind: AssistKind;
+  tags: string[];
+  /** 'Built-in' | 'Local'. */
+  source: string;
+}
+
+/** GET /api/assists/:id/history → { history: HistoryEntry[] }. */
+export interface HistoryEntry {
+  version: number;
+  author: string;
+  timestamp: string;
+  message: string;
+}
+
+/** A pending assist-edit approval request, derived from GET /api/approvals. */
+export interface AssistApproval {
+  id: string;
+  title: string;
+  description: string | null;
+  created_at: string;
+  status: 'pending' | 'approved' | 'rejected';
+  payload: {
+    kind?: string;
+    assistId?: string;
+    message?: string;
+    revertOf?: number;
+    [key: string]: unknown;
+  };
+}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/useKnowledge.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/useKnowledge.ts
@@ -1,0 +1,148 @@
+// Data layer for the Knowledge (assists) editor (#2228) — all calls against the
+// `/api/assists/*` REST API shipped in #2221 plus the generic `/api/approvals`
+// list (assist-edit requests are surfaced there). Kept out of the component so
+// the view stays declarative.
+
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useToast } from '@/providers/ToastProvider';
+import type { AssistApproval, AssistSummary, HistoryEntry } from './types';
+
+async function readError(res: Response): Promise<string> {
+  const data = await res.json().catch(() => ({}));
+  return (data as { error?: string }).error ?? `HTTP ${res.status}`;
+}
+
+export function useKnowledge() {
+  const { addToast } = useToast();
+  const [assists, setAssists] = useState<AssistSummary[]>([]);
+  const [approvals, setApprovals] = useState<AssistApproval[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  /** Load the catalog list (optionally filtered by free-text query + kind). */
+  const loadList = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [listRes, apprRes] = await Promise.all([
+        fetch('/api/assists'),
+        fetch('/api/approvals'),
+      ]);
+      if (listRes.ok) {
+        const data = await listRes.json();
+        setAssists(Array.isArray(data.assists) ? data.assists : []);
+      } else {
+        addToast('error', 'Could not load the knowledge catalog', await readError(listRes));
+      }
+      if (apprRes.ok) {
+        const data = await apprRes.json();
+        const all: AssistApproval[] = Array.isArray(data.approvals) ? data.approvals : [];
+        setApprovals(all.filter(a => a.payload?.kind === 'assist-edit'));
+      }
+    } catch (e) {
+      addToast('error', 'Could not load the knowledge catalog', e instanceof Error ? e.message : 'Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [addToast]);
+
+  /** Fetch the raw markdown (frontmatter + body) of one entry. */
+  const loadContent = useCallback(async (id: string): Promise<string | null> => {
+    try {
+      const res = await fetch(`/api/assists/${encodeURIComponent(id)}`);
+      if (res.ok) {
+        const data = await res.json();
+        return typeof data.content === 'string' ? data.content : '';
+      }
+      addToast('error', 'Could not load entry', await readError(res));
+    } catch (e) {
+      addToast('error', 'Could not load entry', e instanceof Error ? e.message : 'Network error');
+    }
+    return null;
+  }, [addToast]);
+
+  /** Fetch the ordered edit history for an entry. */
+  const loadHistory = useCallback(async (id: string): Promise<HistoryEntry[]> => {
+    try {
+      const res = await fetch(`/api/assists/${encodeURIComponent(id)}/history`);
+      if (res.ok) {
+        const data = await res.json();
+        return Array.isArray(data.history) ? data.history : [];
+      }
+    } catch {
+      /* non-fatal — history is auxiliary */
+    }
+    return [];
+  }, []);
+
+  /** Submit an edit proposal. Surfaces the backend 400/422 (frontmatter/secret) cleanly. */
+  const propose = useCallback(async (id: string, content: string, message: string): Promise<boolean> => {
+    try {
+      const res = await fetch(`/api/assists/${encodeURIComponent(id)}/propose`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content, message }),
+      });
+      if (res.ok) {
+        addToast('success', 'Proposal submitted', 'An admin must approve it before it takes effect.');
+        await loadList();
+        return true;
+      }
+      addToast('error', 'Proposal rejected', await readError(res));
+    } catch (e) {
+      addToast('error', 'Could not submit proposal', e instanceof Error ? e.message : 'Network error');
+    }
+    return false;
+  }, [addToast, loadList]);
+
+  /** Approve or reject a pending assist-edit request. */
+  const resolve = useCallback(async (
+    assistId: string,
+    requestId: string,
+    decision: 'approve' | 'reject',
+  ): Promise<boolean> => {
+    try {
+      const res = await fetch(
+        `/api/assists/${encodeURIComponent(assistId)}/${decision}/${encodeURIComponent(requestId)}`,
+        { method: 'POST' },
+      );
+      if (res.ok) {
+        addToast('success', decision === 'approve' ? 'Approved' : 'Rejected', undefined);
+        await loadList();
+        return true;
+      }
+      addToast('error', `Could not ${decision}`, await readError(res));
+    } catch (e) {
+      addToast('error', `Could not ${decision}`, e instanceof Error ? e.message : 'Network error');
+    }
+    return false;
+  }, [addToast, loadList]);
+
+  /** Request a revert to a historical version (creates an approval request). */
+  const revert = useCallback(async (id: string, version: number): Promise<boolean> => {
+    try {
+      const res = await fetch(`/api/assists/${encodeURIComponent(id)}/revert/${version}`, { method: 'POST' });
+      if (res.ok) {
+        addToast('success', `Revert to v${version} requested`, 'An admin must approve it before it takes effect.');
+        await loadList();
+        return true;
+      }
+      addToast('error', 'Could not request revert', await readError(res));
+    } catch (e) {
+      addToast('error', 'Could not request revert', e instanceof Error ? e.message : 'Network error');
+    }
+    return false;
+  }, [addToast, loadList]);
+
+  return {
+    assists,
+    approvals,
+    loading,
+    loadList,
+    loadContent,
+    loadHistory,
+    propose,
+    resolve,
+    revert,
+  };
+}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/validation.test.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/validation.test.ts
@@ -1,0 +1,89 @@
+// Client-side proposal validation mirrors the backend gate (#2228). These
+// assert the two acceptance criteria the frontend owns pre-flight: required
+// frontmatter + the secret scan that blocks a PEM key or sb_ token.
+import { describe, it, expect } from 'vitest';
+import { validateProposal, scanForSecret, parseFrontmatterKeys } from './validation';
+
+const VALID = `---
+title: Do a thing
+whenToUse: You need to do a thing.
+kind: guide
+tags: [a, b]
+---
+Body here.`;
+
+describe('validateProposal — frontmatter contract', () => {
+  it('accepts a well-formed body', () => {
+    expect(validateProposal(VALID)).toEqual({ ok: true });
+  });
+
+  it('rejects empty content', () => {
+    expect(validateProposal('   ').ok).toBe(false);
+  });
+
+  it('rejects a missing title', () => {
+    const r = validateProposal(`---\nwhenToUse: x\nkind: guide\n---\nbody`);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/title/);
+  });
+
+  it('rejects a missing whenToUse', () => {
+    const r = validateProposal(`---\ntitle: x\nkind: guide\n---\nbody`);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/whenToUse/);
+  });
+
+  it('accepts snake_case when_to_use', () => {
+    const r = validateProposal(`---\ntitle: x\nwhen_to_use: y\nkind: recipe\n---\nbody`);
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects an invalid kind enum', () => {
+    const r = validateProposal(`---\ntitle: x\nwhenToUse: y\nkind: nonsense\n---\nbody`);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/kind/);
+  });
+});
+
+describe('secret scan — blocks committed credentials', () => {
+  it('blocks a PEM private key', () => {
+    const body = `${VALID}\n-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----`;
+    expect(scanForSecret(body)).toMatch(/PEM/);
+    const r = validateProposal(body);
+    expect(r.ok).toBe(false);
+    // Error must not echo the secret material.
+    expect(r.error).not.toMatch(/BEGIN RSA/);
+  });
+
+  it('blocks an sb_ box token', () => {
+    const body = `${VALID}\ntoken: sb_abc123_ABCDEFGHIJKLMNOPQRSTUVWX`;
+    expect(scanForSecret(body)).toMatch(/sb_/);
+    expect(validateProposal(body).ok).toBe(false);
+  });
+
+  it('blocks a GitHub token', () => {
+    const body = `${VALID}\nghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345`;
+    expect(validateProposal(body).ok).toBe(false);
+  });
+
+  it('passes clean content', () => {
+    expect(scanForSecret(VALID)).toBeNull();
+  });
+});
+
+describe('parseFrontmatterKeys', () => {
+  it('returns {} for a body without a frontmatter block', () => {
+    expect(parseFrontmatterKeys('no frontmatter here')).toEqual({});
+  });
+
+  it('handles CRLF line endings', () => {
+    const keys = parseFrontmatterKeys('---\r\ntitle: x\r\nkind: guide\r\n---\r\nbody');
+    expect(keys.title).toBe('x');
+    expect(keys.kind).toBe('guide');
+  });
+
+  it('strips surrounding quotes on a scalar', () => {
+    const keys = parseFrontmatterKeys(`---\ntitle: "quoted"\n---\nbody`);
+    expect(keys.title).toBe('quoted');
+  });
+});

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/validation.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/validation.ts
@@ -1,0 +1,127 @@
+// Client-side proposal validation for the Knowledge (assists) editor (#2228).
+//
+// This mirrors the backend gate in `packages/backend/src/lib/assists/editor.ts`
+// (frontmatter requirements + the committed-secret scan) so the editor can flag
+// an invalid or secret-bearing body BEFORE it is ever POSTed. It is a UX
+// convenience, not the security boundary — the backend re-runs the same checks
+// on `POST /api/assists/:id/propose` and on approve, so a bypassed client check
+// still can't write a secret into the catalog.
+//
+// Lives in the feature `_lib/` with relative imports only — the `@/lib` alias
+// resolves to the BACKEND (reference_at_lib_alias_is_backend), so we cannot pull
+// the backend's editor module here; the rules are re-stated (kept in sync
+// deliberately, same as the backend keeps them in sync with the repo-scan test).
+
+/** The catalog kinds — mirrors ASSIST_KINDS in the backend catalog. */
+export const ASSIST_KINDS = [
+  'guide',
+  'recipe',
+  'adr',
+  'template',
+  'checklist',
+  'footgun',
+  'snippet',
+] as const;
+
+export type AssistKind = (typeof ASSIST_KINDS)[number];
+
+/**
+ * High-signal committed-secret formats — the SAME rules as the backend
+ * `SECRET_PATTERNS` (editor.ts) and the repo-scan backstop
+ * (tests/backend/assist_consistency.test.ts). A body matching any of these is
+ * blocked before it can be proposed.
+ */
+export const SECRET_PATTERNS: { name: string; re: RegExp }[] = [
+  { name: 'PEM private key', re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/ },
+  { name: 'ServiceBay token (sb_)', re: /\bsb_[a-z0-9]{6,}_[A-Za-z0-9]{20,}\b/ },
+  { name: 'AWS access key id', re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { name: 'GitHub token', re: /\bgh[posru]_[A-Za-z0-9]{20,}\b/ },
+  { name: 'GitHub fine-grained PAT', re: /\bgithub_pat_[A-Za-z0-9_]{30,}\b/ },
+  { name: 'Slack token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+];
+
+/** Name of the first secret pattern the text matches, or null if clean. */
+export function scanForSecret(text: string): string | null {
+  for (const { name, re } of SECRET_PATTERNS) {
+    if (re.test(text)) return name;
+  }
+  return null;
+}
+
+/**
+ * Extract the frontmatter block's raw key/value lines without a YAML parser
+ * (avoids pulling gray-matter into the client bundle). Returns the map of
+ * top-level scalar keys we care about; nested/array values are returned as
+ * their raw string form (enough to check presence + the `kind` enum).
+ *
+ * A document with no leading `---` block yields an empty map, which then fails
+ * the "missing title" check — exactly the behaviour we want.
+ */
+export function parseFrontmatterKeys(content: string): Record<string, string> {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const match = normalized.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const out: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/);
+    if (!kv) continue;
+    const key = kv[1];
+    let value = kv[2].trim();
+    // Strip surrounding quotes on a simple scalar for the presence/enum check.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in out)) out[key] = value;
+  }
+  return out;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  /** First blocking error, caller-safe (no secret value echoed). */
+  error?: string;
+}
+
+/**
+ * Validate a proposal body against the same contract the backend enforces:
+ * non-empty, no committed secret, and required frontmatter
+ * (`title`, `whenToUse`, a valid `kind`). Returns the first failure — the error
+ * string never echoes a secret value.
+ */
+export function validateProposal(content: string): ValidationResult {
+  if (typeof content !== 'string' || !content.trim()) {
+    return { ok: false, error: 'Content is empty.' };
+  }
+
+  const secret = scanForSecret(content);
+  if (secret) {
+    return {
+      ok: false,
+      error: `Body contains a possible secret (${secret}); remove it before proposing.`,
+    };
+  }
+
+  const keys = parseFrontmatterKeys(content);
+
+  if (!keys.title?.trim()) {
+    return { ok: false, error: 'Frontmatter is missing a non-empty "title".' };
+  }
+
+  const when = keys.whenToUse ?? keys.when_to_use;
+  if (!when?.trim()) {
+    return { ok: false, error: 'Frontmatter is missing a non-empty "whenToUse".' };
+  }
+
+  const kind = keys.kind?.trim();
+  if (!kind) {
+    return { ok: false, error: 'Frontmatter is missing "kind".' };
+  }
+  if (!(ASSIST_KINDS as readonly string[]).includes(kind)) {
+    return { ok: false, error: `Invalid kind "${kind}"; must be one of ${ASSIST_KINDS.join(' | ')}.` };
+  }
+
+  return { ok: true };
+}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/KnowledgeSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/KnowledgeSection.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * KnowledgeSection (#2228) — acceptance-criteria coverage for the Settings →
+ * Knowledge assists editor. Drives the real component against a mocked
+ * `/api/assists/*` + `/api/approvals` surface, asserting: browse/search/filter,
+ * view rendered markdown + metadata, edit with secret-scan validation error,
+ * submit-as-proposal POST, approve POST, revert POST.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import KnowledgeSection, { filterAssists } from './KnowledgeSection';
+import type { AssistSummary } from '../knowledge/types';
+
+vi.mock('@/providers/ToastProvider', () => ({ useToast: () => ({ addToast: vi.fn() }) }));
+
+const ASSISTS: AssistSummary[] = [
+  { id: 'servicebay-overview', title: 'ServiceBay Overview', whenToUse: 'Understand the platform.', kind: 'guide', tags: ['overview'], source: 'Built-in' },
+  { id: 'my-local-recipe', title: 'Local Recipe', whenToUse: 'A locally added recipe.', kind: 'recipe', tags: ['local'], source: 'Local' },
+];
+
+const CONTENT = `---
+title: ServiceBay Overview
+whenToUse: Understand the platform.
+kind: guide
+---
+The rendered **body** text.`;
+
+const HISTORY = [
+  { version: 1, author: 'admin', timestamp: '2026-07-10T10:00:00Z', message: 'first edit' },
+];
+
+const APPROVAL = {
+  id: 'req-1',
+  title: 'Assist edit: servicebay-overview',
+  description: 'tweak wording',
+  created_at: '2026-07-11T10:00:00Z',
+  status: 'pending' as const,
+  payload: { kind: 'assist-edit', assistId: 'servicebay-overview', message: 'tweak wording' },
+};
+
+function mockApi(opts: { approvals?: unknown[] } = {}) {
+  const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+    if (url === '/api/assists') {
+      return Promise.resolve(new Response(JSON.stringify({ assists: ASSISTS }), { status: 200 }));
+    }
+    if (url === '/api/approvals') {
+      return Promise.resolve(new Response(JSON.stringify({ approvals: opts.approvals ?? [] }), { status: 200 }));
+    }
+    if (url.endsWith('/history')) {
+      return Promise.resolve(new Response(JSON.stringify({ history: HISTORY }), { status: 200 }));
+    }
+    if (url.startsWith('/api/assists/servicebay-overview')) {
+      return Promise.resolve(new Response(JSON.stringify({ id: 'servicebay-overview', content: CONTENT }), { status: 200 }));
+    }
+    return Promise.resolve(new Response('{}', { status: 200 }));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('filterAssists', () => {
+  it('filters by kind and source and free-text', () => {
+    expect(filterAssists(ASSISTS, '', 'recipe', 'all').map(a => a.id)).toEqual(['my-local-recipe']);
+    expect(filterAssists(ASSISTS, '', 'all', 'Local').map(a => a.id)).toEqual(['my-local-recipe']);
+    expect(filterAssists(ASSISTS, 'overview', 'all', 'all').map(a => a.id)).toEqual(['servicebay-overview']);
+    expect(filterAssists(ASSISTS, 'nomatch', 'all', 'all')).toEqual([]);
+  });
+});
+
+describe('KnowledgeSection — browse, view, edit, approve, revert', () => {
+  beforeEach(() => vi.unstubAllGlobals());
+
+  it('lists the catalog and searches it', async () => {
+    mockApi();
+    render(<KnowledgeSection />);
+    await waitFor(() => expect(screen.getByText('ServiceBay Overview')).toBeDefined());
+    expect(screen.getByText('Local Recipe')).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText('Search the catalog'), { target: { value: 'recipe' } });
+    await waitFor(() => expect(screen.queryByText('ServiceBay Overview')).toBeNull());
+    expect(screen.getByText('Local Recipe')).toBeDefined();
+  });
+
+  it('renders the selected entry markdown + metadata', async () => {
+    mockApi();
+    render(<KnowledgeSection />);
+    await waitFor(() => expect(screen.getByText('ServiceBay Overview')).toBeDefined());
+    fireEvent.click(screen.getByText('ServiceBay Overview'));
+    await waitFor(() => expect(screen.getByText(/rendered/)).toBeDefined());
+    // history metadata surfaces
+    expect(screen.getByText(/first edit/)).toBeDefined();
+  });
+
+  it('shows a validation error for a secret-bearing edit and blocks submit', async () => {
+    mockApi();
+    render(<KnowledgeSection />);
+    await waitFor(() => expect(screen.getByText('ServiceBay Overview')).toBeDefined());
+    fireEvent.click(screen.getByText('ServiceBay Overview'));
+    await waitFor(() => expect(screen.getByText(/rendered/)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+
+    const textarea = await screen.findByLabelText('Assist markdown source');
+    fireEvent.change(textarea, {
+      target: { value: `${CONTENT}\n-----BEGIN RSA PRIVATE KEY-----` },
+    });
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toMatch(/secret/i));
+    const submit = screen.getByRole('button', { name: /submit proposal/i });
+    expect(submit.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('submits a clean edit as a proposal (POST /propose)', async () => {
+    const fetchMock = mockApi();
+    render(<KnowledgeSection />);
+    await waitFor(() => expect(screen.getByText('ServiceBay Overview')).toBeDefined());
+    fireEvent.click(screen.getByText('ServiceBay Overview'));
+    await waitFor(() => expect(screen.getByText(/rendered/)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await screen.findByLabelText('Assist markdown source');
+
+    fireEvent.click(screen.getByRole('button', { name: /submit proposal/i }));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/assists/servicebay-overview/propose',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+  });
+
+  it('approves a pending proposal (POST /approve/:requestId)', async () => {
+    const fetchMock = mockApi({ approvals: [APPROVAL] });
+    render(<KnowledgeSection />);
+    await waitFor(() => expect(screen.getByText('ServiceBay Overview')).toBeDefined());
+    fireEvent.click(screen.getByText('ServiceBay Overview'));
+    await waitFor(() => expect(screen.getByRole('button', { name: /approve/i })).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/assists/servicebay-overview/approve/req-1',
+        { method: 'POST' },
+      ),
+    );
+  });
+
+  it('requests a revert of a historical version (POST /revert/:version)', async () => {
+    const fetchMock = mockApi();
+    render(<KnowledgeSection />);
+    await waitFor(() => expect(screen.getByText('ServiceBay Overview')).toBeDefined());
+    fireEvent.click(screen.getByText('ServiceBay Overview'));
+    await waitFor(() => expect(screen.getByText(/first edit/)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /revert/i }));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/assists/servicebay-overview/revert/1',
+        { method: 'POST' },
+      ),
+    );
+  });
+});

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/KnowledgeSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/KnowledgeSection.tsx
@@ -1,0 +1,195 @@
+// Settings → Knowledge (#2228, child B of the assists-editor epic #2147).
+//
+// Browse, view, edit, approve, and revert the assist catalog + ADRs via the
+// `/api/assists/*` REST API (#2221). Master list (searchable + filterable by
+// kind and source) on the left; the selected entry's rendered markdown,
+// metadata, inline editor, review panel and history on the right (AssistDetail).
+
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { BookOpen, Loader2, Search } from 'lucide-react';
+import { Badge, Card } from '@/components/ui';
+import { ASSIST_KINDS, type AssistKind } from '../knowledge/validation';
+import { useKnowledge } from '../knowledge/useKnowledge';
+import AssistDetail from '../knowledge/AssistDetail';
+import type { AssistSummary } from '../knowledge/types';
+
+type KindFilter = AssistKind | 'all';
+type SourceFilter = 'all' | 'Built-in' | 'Local';
+
+export default function KnowledgeSection() {
+  const api = useKnowledge();
+  const [query, setQuery] = useState('');
+  const [kind, setKind] = useState<KindFilter>('all');
+  const [source, setSource] = useState<SourceFilter>('all');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    void api.loadList();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const filtered = useMemo(
+    () => filterAssists(api.assists, query, kind, source),
+    [api.assists, query, kind, source],
+  );
+
+  const selected = api.assists.find(a => a.id === selectedId) ?? null;
+  const pendingCount = (id: string) =>
+    api.approvals.filter(a => a.payload?.assistId === id && a.status === 'pending').length;
+
+  if (api.loading && api.assists.length === 0) return <LoadingCatalog />;
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[minmax(260px,340px)_1fr] gap-4">
+      <div className="space-y-3">
+        <Filters query={query} kind={kind} source={source} onQuery={setQuery} onKind={setKind} onSource={setSource} />
+        <CatalogList assists={filtered} selectedId={selectedId} pendingCount={pendingCount} onSelect={setSelectedId} />
+      </div>
+      <div>
+        {selected ? (
+          <AssistDetail summary={selected} approvals={api.approvals} api={api} />
+        ) : (
+          <EmptyDetail />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LoadingCatalog() {
+  return (
+    <p className="text-sm text-text-muted">
+      <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
+      Loading knowledge catalog…
+    </p>
+  );
+}
+
+export function filterAssists(
+  assists: AssistSummary[],
+  query: string,
+  kind: KindFilter,
+  source: SourceFilter,
+): AssistSummary[] {
+  const q = query.trim().toLowerCase();
+  return assists.filter(a => {
+    if (kind !== 'all' && a.kind !== kind) return false;
+    if (source !== 'all' && a.source !== source) return false;
+    if (!q) return true;
+    const hay = [a.id, a.title, a.whenToUse, a.kind, a.tags.join(' ')].join(' ').toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+function Filters({
+  query,
+  kind,
+  source,
+  onQuery,
+  onKind,
+  onSource,
+}: {
+  query: string;
+  kind: KindFilter;
+  source: SourceFilter;
+  onQuery: (v: string) => void;
+  onKind: (v: KindFilter) => void;
+  onSource: (v: SourceFilter) => void;
+}) {
+  const selectClass =
+    'p-2 rounded-card border border-border bg-surface-2 text-text text-sm focus:ring-2 focus:ring-accent outline-none';
+  return (
+    <div className="space-y-2">
+      <div className="relative">
+        <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-subtle" />
+        <input
+          type="search"
+          value={query}
+          onChange={e => onQuery(e.target.value)}
+          placeholder="Search the catalog"
+          aria-label="Search the catalog"
+          className="w-full pl-8 pr-3 py-2 rounded-card border border-border bg-surface-2 text-text text-sm focus:ring-2 focus:ring-accent outline-none"
+        />
+      </div>
+      <div className="flex gap-2">
+        <select
+          value={kind}
+          onChange={e => onKind(e.target.value as KindFilter)}
+          aria-label="Filter by kind"
+          className={`${selectClass} flex-1`}
+        >
+          <option value="all">All kinds</option>
+          {ASSIST_KINDS.map(k => (
+            <option key={k} value={k}>{k}</option>
+          ))}
+        </select>
+        <select
+          value={source}
+          onChange={e => onSource(e.target.value as SourceFilter)}
+          aria-label="Filter by source"
+          className={`${selectClass} flex-1`}
+        >
+          <option value="all">All sources</option>
+          <option value="Built-in">Built-in</option>
+          <option value="Local">Local</option>
+        </select>
+      </div>
+    </div>
+  );
+}
+
+function CatalogList({
+  assists,
+  selectedId,
+  pendingCount,
+  onSelect,
+}: {
+  assists: AssistSummary[];
+  selectedId: string | null;
+  pendingCount: (id: string) => number;
+  onSelect: (id: string) => void;
+}) {
+  if (assists.length === 0) {
+    return <p className="text-sm text-text-muted italic px-1">No entries match.</p>;
+  }
+  return (
+    <ul className="space-y-1 max-h-[70vh] overflow-y-auto">
+      {assists.map(a => {
+        const pending = pendingCount(a.id);
+        const active = a.id === selectedId;
+        return (
+          <li key={a.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(a.id)}
+              aria-current={active}
+              className={`w-full text-left p-2 rounded-card border transition-colors ${
+                active ? 'border-accent bg-accent/10' : 'border-transparent hover:bg-surface-2'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-text truncate flex-1">{a.title}</span>
+                {pending > 0 && <Badge variant="warn">{pending}</Badge>}
+                <Badge variant={a.source === 'Local' ? 'accent' : 'neutral'} className="font-mono text-[10px]">
+                  {a.kind}
+                </Badge>
+              </div>
+              <p className="text-[11px] text-text-subtle truncate mt-0.5">{a.whenToUse}</p>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function EmptyDetail() {
+  return (
+    <Card className="h-full flex flex-col items-center justify-center text-center p-8 text-text-muted">
+      <BookOpen size={32} className="mb-3 text-text-subtle" />
+      <p className="text-sm">Select an entry to view its content, edit it, or review pending changes.</p>
+    </Card>
+  );
+}

--- a/packages/frontend/src/app/(dashboard)/settings/knowledge/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/knowledge/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { BookOpen } from 'lucide-react';
+import GroupIntro from '../_lib/GroupIntro';
+import SettingDisclosure from '../_lib/SettingDisclosure';
+import { SETTINGS_GROUPS } from '../_lib/ia';
+import KnowledgeSection from '../_lib/sections/KnowledgeSection';
+
+const GROUP = SETTINGS_GROUPS.find(g => g.id === 'knowledge')!;
+
+export default function KnowledgeSettingsPage() {
+  return (
+    <div className="space-y-6">
+      <GroupIntro intent={GROUP.intent} />
+      <SettingDisclosure
+        id="catalog"
+        tier="essential"
+        label="Assist catalog"
+        icon={BookOpen}
+        description="Browse, view, edit and revert the assist knowledge base (guides, recipes, ADRs, footguns). Every edit goes through the admin approval gate; the secret scan blocks a key or token before it can be proposed."
+      >
+        <KnowledgeSection />
+      </SettingDisclosure>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds a new top-level Settings→Knowledge section (frontend, child B of the assists-editor epic #2147) that consumes the `/api/assists` REST API shipped in #2221. Admins can browse/search the assists + ADR catalog, view rendered markdown with metadata, edit and submit a proposal with client-side frontmatter + secret validation, approve/reject proposals, view version history, and initiate a revert.

## Why
Closes #2228

## Risk
Low — additive frontend section (new `knowledge/page.tsx` + `ia.ts` registration + feature `_lib/knowledge/`), no changes to existing routes; backend `/api/assists` already shipped and CI-green in #2221.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors / 358 warnings, == baseline)
- [x] npm run typecheck (exit 0)
- [x] npm run check:arch (1025 modules, 0 violations)
- [x] npm test (421 files / 3673 passed / 2 skipped)
- [ ] /verify on FCoS :dev box — real `/api/assists` round-trip (list/view/propose/approve/revert), live secret-scan blocks PEM/`sb_`/`ghp_`, headless-browser pixel layout of the Knowledge section

<!-- sb-ai-comment -->
AI-generated