### PR TITLE
fix(settings): strip assist frontmatter before rendering the Knowledge body

### DIFF
--- a/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/AssistDetail.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/AssistDetail.tsx
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { AlertTriangle, Check, History, Loader2, Pencil, RotateCcw, X } from 'lucide-react';
 import { Badge, Button, Card } from '@/components/ui';
-import { validateProposal } from './validation';
+import { stripFrontmatter, validateProposal } from './validation';
 import type { AssistApproval, AssistSummary, HistoryEntry } from './types';
 import type { useKnowledge } from './useKnowledge';
 
@@ -121,9 +121,14 @@ function RenderedBody({ content }: { content: string | null }) {
       </p>
     );
   }
+  // GET /api/assists/:id returns the full raw file (frontmatter + body) so the
+  // ProposalEditor can edit the frontmatter. The rendered view must strip the
+  // frontmatter — the title/kind/tags are already shown in the DetailHeader
+  // metadata; leaking the raw YAML into the body is redundant + wrong (#2231).
+  const body = stripFrontmatter(content);
   return (
     <div className="prose dark:prose-invert prose-sm max-w-none">
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <ReactMarkdown>{body}</ReactMarkdown>
     </div>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/validation.test.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/validation.test.ts
@@ -2,7 +2,7 @@
 // assert the two acceptance criteria the frontend owns pre-flight: required
 // frontmatter + the secret scan that blocks a PEM key or sb_ token.
 import { describe, it, expect } from 'vitest';
-import { validateProposal, scanForSecret, parseFrontmatterKeys } from './validation';
+import { validateProposal, scanForSecret, parseFrontmatterKeys, stripFrontmatter } from './validation';
 
 const VALID = `---
 title: Do a thing
@@ -85,5 +85,34 @@ describe('parseFrontmatterKeys', () => {
   it('strips surrounding quotes on a scalar', () => {
     const keys = parseFrontmatterKeys(`---\ntitle: "quoted"\n---\nbody`);
     expect(keys.title).toBe('quoted');
+  });
+});
+
+describe('stripFrontmatter — RenderedBody must not leak YAML (#2231)', () => {
+  it('drops the leading --- frontmatter block, keeps the body', () => {
+    const out = stripFrontmatter(VALID);
+    expect(out).toBe('Body here.');
+    // the YAML must be gone
+    expect(out).not.toMatch(/---/);
+    expect(out).not.toMatch(/title:/);
+    expect(out).not.toMatch(/whenToUse:/);
+    expect(out).not.toMatch(/kind:/);
+  });
+
+  it('returns a body with no frontmatter unchanged', () => {
+    expect(stripFrontmatter('# Just markdown\n\ntext')).toBe('# Just markdown\n\ntext');
+  });
+
+  it('does not strip a mid-document --- horizontal rule', () => {
+    const doc = `---\ntitle: x\nkind: guide\n---\nintro\n\n---\n\nafter the rule`;
+    const out = stripFrontmatter(doc);
+    expect(out).toBe('intro\n\n---\n\nafter the rule');
+    expect(out).not.toMatch(/title:/);
+  });
+
+  it('tolerates CRLF frontmatter fences', () => {
+    const out = stripFrontmatter('---\r\ntitle: x\r\nkind: guide\r\n---\r\nbody text');
+    expect(out).toBe('body text');
+    expect(out).not.toMatch(/title:/);
   });
 });

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/validation.ts
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/knowledge/validation.ts
@@ -79,6 +79,22 @@ export function parseFrontmatterKeys(content: string): Record<string, string> {
   return out;
 }
 
+/**
+ * Strip a leading `---\n…\n---` frontmatter block from an assist document,
+ * returning only the markdown body. `GET /api/assists/:id` intentionally returns
+ * the full raw file (so the editor can edit the frontmatter fields), but the
+ * rendered view must NOT show the YAML — the title/kind/tags are already surfaced
+ * as structured metadata in the DetailHeader (#2231).
+ *
+ * A document without a leading frontmatter block is returned unchanged. Tolerant
+ * of CRLF endings and of trailing whitespace after the closing fence.
+ */
+export function stripFrontmatter(content: string): string {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const stripped = normalized.replace(/^---\n[\s\S]*?\n---[ \t]*\n?/, '');
+  return stripped;
+}
+
 export interface ValidationResult {
   ok: boolean;
   /** First blocking error, caller-safe (no secret value echoed). */

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/KnowledgeSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/KnowledgeSection.test.tsx
@@ -90,6 +90,27 @@ describe('KnowledgeSection — browse, view, edit, approve, revert', () => {
     expect(screen.getByText(/first edit/)).toBeDefined();
   });
 
+  it('strips the YAML frontmatter from the rendered body (#2231)', async () => {
+    mockApi();
+    render(<KnowledgeSection />);
+    await waitFor(() => expect(screen.getByText('ServiceBay Overview')).toBeDefined());
+    fireEvent.click(screen.getByText('ServiceBay Overview'));
+    await waitFor(() => expect(screen.getByText(/rendered/)).toBeDefined());
+
+    // The raw YAML frontmatter lines must NOT leak into the DOM as body text.
+    // (CONTENT carries a `title:/whenToUse:/kind:` frontmatter block that used to
+    // render verbatim through ReactMarkdown — see #2231.)
+    const domText = document.body.textContent ?? '';
+    expect(domText).not.toMatch(/title:\s*ServiceBay Overview/);
+    expect(domText).not.toMatch(/whenToUse:\s*Understand the platform\./);
+    expect(domText).not.toMatch(/kind:\s*guide/);
+
+    // The metadata is still surfaced as structured UI (the DetailHeader kind badge),
+    // and the markdown body still renders.
+    expect(screen.getAllByText('guide').length).toBeGreaterThan(0);
+    expect(screen.getByText(/rendered/)).toBeDefined();
+  });
+
   it('shows a validation error for a secret-bearing edit and blocks submit', async () => {
     mockApi();
     render(<KnowledgeSection />);


### PR DESCRIPTION
## What
Settings→Knowledge now strips the `---…---` YAML frontmatter block from an assist's content before ReactMarkdown renders it, so the `title`/`whenToUse`/`kind`/`tags` header (and its two stray `<hr>`s) no longer appears as body text. The kind badge and metadata still render from the parsed frontmatter, and the ProposalEditor still receives the full raw content.

## Why
Closes #2231

## Risk
Low — display-only strip in RenderedBody via a new `stripFrontmatter` helper; ProposalEditor path unchanged.

## Rollback
git revert is enough.

## Verification
- [ ] npm run lint
- [ ] npm run check:arch
- [ ] npm test (full)
- [ ] /verify on FCoS :dev box (path-mandated: packages/frontend/src/app/(dashboard)/)