### PR TITLE
fix(approvals): dispatch MCP tools from the Settings Approvals approve route

### DIFF
--- a/packages/backend/src/lib/approvals/lazyMcpDispatcher.test.ts
+++ b/packages/backend/src/lib/approvals/lazyMcpDispatcher.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression for #2237 / #2234: approving an `on_approve.mcp` approval must run
+ * the tool in a module graph where `registerMcpDispatcher` was NOT called
+ * eagerly at import time — it only becomes available once the MCP server module
+ * is imported (its top-level side effect).
+ *
+ * In production the dispatcher is registered by a top-level side effect of
+ * `mcp/server`. The backend server imports it at startup, but the Next.js
+ * `/api/approvals/[id]/approve` route runs in a SEPARATE Turbopack bundle
+ * instance of `lib/approvals` where that startup import never ran — so
+ * `mcpDispatcher` was null there and the approve threw HTTP 400 ("MCP tool
+ * dispatcher is not registered"), the tool never running (box-verified RED on
+ * #2234). The fix makes that route import the registration seam so the
+ * dispatcher is present in its bundle; this test pins the underlying contract:
+ * with no eager registration, importing the seam registers a dispatcher and
+ * `approveApproval` then actually dispatches the tool.
+ *
+ * A dedicated test file (fresh module graph) is required because the sibling
+ * index.test.ts eagerly calls `registerMcpDispatcher` at module load, which
+ * would otherwise mask the null-dispatcher context this test reproduces.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+
+const { TMP } = vi.hoisted(() => ({
+  TMP: `${process.env.TMPDIR || '/tmp'}/approvals-lazy-test-${process.pid}`,
+}));
+vi.mock('@/lib/dirs', () => ({ DATA_DIR: TMP }));
+vi.mock('@/lib/executor', () => ({ getExecutor: vi.fn(() => ({})) }));
+vi.mock('@/lib/nodes', () => ({ listNodes: vi.fn(() => Promise.resolve([{ Name: 'box1' }])) }));
+vi.mock('@/lib/services/ServiceManager', () => ({ ServiceManager: { restartService: vi.fn() } }));
+
+// The tool the registered dispatcher runs. Its call is the assertion that the
+// tool actually ran (rather than a 400 "dispatcher not registered").
+const dispatchMcpTool = vi.fn(() => Promise.resolve({ content: [{ type: 'text', text: 'ok' }] }));
+
+// Stand in for @/lib/mcp/server: importing it registers the dispatcher via the
+// seam — mirroring the real module's top-level `registerMcpDispatcher(...)`
+// call — without pulling the whole MCP server graph into this unit test. The
+// route (packages/frontend/.../approvals/[id]/approve/route.ts) does exactly
+// this side-effect import so its bundle instance has a dispatcher.
+let registeredViaServerImport = false;
+
+import { submitApproval, approveApproval, getApproval, registerMcpDispatcher } from './index';
+
+/** Simulate the route's `import '@/lib/mcp/server'` side effect. */
+function importMcpServerSeam(): void {
+  registerMcpDispatcher(dispatchMcpTool);
+  registeredViaServerImport = true;
+}
+
+beforeEach(() => {
+  dispatchMcpTool.mockClear();
+  dispatchMcpTool.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+});
+
+afterEach(async () => {
+  await fs.rm(TMP, { recursive: true, force: true });
+});
+
+describe('#2237 MCP dispatcher registered via the server-import seam on approve', () => {
+  it('a pre-registration approve fails (reproduces the Next.js route null context)', async () => {
+    // No dispatcher registered in this module graph yet — exactly the RED path.
+    expect(registeredViaServerImport).toBe(false);
+    const r = await submitApproval({
+      service: 'honcho',
+      title: 'delete_service: honcho',
+      on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+    });
+    await expect(approveApproval(r.id)).rejects.toThrow(/dispatcher is not registered/);
+    // The request must NOT be marked approved when the tool could not run.
+    expect((await getApproval(r.id))?.status).toBe('pending');
+    expect(dispatchMcpTool).not.toHaveBeenCalled();
+  });
+
+  it('after the server-import seam registers the dispatcher, approve runs the tool', async () => {
+    importMcpServerSeam();
+    expect(registeredViaServerImport).toBe(true);
+
+    const r = await submitApproval({
+      service: 'honcho',
+      title: 'delete_service: honcho',
+      payload: { toolName: 'delete_service', args: { name: 'honcho' }, caller: 'token:ci-bot' },
+      on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+    });
+    const res = await approveApproval(r.id);
+
+    // The tool actually ran (the #2234 RED was that it never did).
+    expect(dispatchMcpTool).toHaveBeenCalledWith('delete_service', { name: 'honcho' });
+    expect(res.request.status).toBe('approved');
+    expect((await getApproval(r.id))?.status).toBe('approved');
+  });
+});

--- a/packages/frontend/src/app/api/approvals/[id]/approve/route.ts
+++ b/packages/frontend/src/app/api/approvals/[id]/approve/route.ts
@@ -1,6 +1,16 @@
 import { NextResponse } from 'next/server';
 import { withApiHandlerParams } from '@/lib/api/handler';
 import { approveApproval } from '@/lib/approvals';
+// Side-effect import (#2237): loading mcp/server runs its top-level
+// registerMcpDispatcher(...) call, so this route's bundle instance of
+// lib/approvals HAS a dispatcher when approving an on_approve.mcp approval.
+// Without it, Turbopack bundles the App-Router route with its OWN copy of
+// lib/approvals — one where the backend server's startup import never ran —
+// leaving mcpDispatcher null and the approve failing with HTTP 400 "MCP tool
+// dispatcher is not registered" (box-verified RED on #2234). Importing the
+// registration seam here makes the single generic /api/approvals approve path
+// run the tool, so Settings → Approvals "Approve" works for MCP approvals too.
+import '@/lib/mcp/server';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';


### PR DESCRIPTION
## What
Forward-fix for the RED box-verify on #2234 (@54d844f8). The Settings → Approvals "Approve" button failed for destroy-tier MCP approvals with HTTP 400 "MCP tool dispatcher is not registered" — the Next.js `/api/approvals/[id]/approve` route ran in a separate Turbopack bundle instance of `lib/approvals` where the backend MCP server's startup `registerMcpDispatcher` side effect never ran, so `mcpDispatcher` was null and the `on_approve.mcp` re-dispatch threw before running the tool. The route now side-effect imports `@/lib/mcp/server` so its top-level `registerMcpDispatcher(...)` populates that bundle instance's dispatcher. Single generic approve path preserved — no `ApprovalsSection` change, no second UI path.

## Why
Closes #2237

## Risk
low — one side-effect import + a regression test; approve path logic unchanged, session/CSRF gating on the mutating route untouched (Bearer-only agent still cannot self-approve). No dependency cycle (check:arch clean, 1022 modules 0 violations).

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors, 358 warnings == baseline)
- [x] npm run typecheck (tsc --noEmit exit 0)
- [x] npm run check:arch (1022 modules, 0 violations)
- [x] npm test (full — 3677 passed; only the documented McpSection toggle-under-load flake, passes isolated 2/2)
- [ ] /verify on FCoS :dev box (path-mandated: packages/backend/src/lib/mcp/ imported by the route; security=true) — live delete_service{honcho} → Settings→Approvals → Approve via /api/approvals/:id/approve → pod actually deleted; reject cancels; token cannot self-approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqUTDYDUbxStiSftPBXqPb