### PR TITLE
fix(approvals): serialize store writes + unique temp path to survive concurrency

### DIFF
--- a/packages/backend/src/lib/approvals/index.test.ts
+++ b/packages/backend/src/lib/approvals/index.test.ts
@@ -380,3 +380,84 @@ describe('mcp-tool re-dispatch action (#2234)', () => {
     expect(reloaded?.on_approve.mcp).toEqual({ toolName: 'delete_service', args: { name: 'honcho' } });
   });
 });
+
+// The store is atomic-written via a temp file + rename. `process.pid` alone is
+// a constant (1 in the container), so before #2239 two concurrent writes shared
+// ONE temp path — one rename moved it away, the other renamed a now-missing
+// temp → ENOENT → the approve handler threw AFTER the tool already ran, and the
+// UI hung forever. These fire genuinely-concurrent writes against the REAL fs
+// store (only the executor is faked) to prove no ENOENT and no lost update.
+describe('concurrent store writes (#2239)', () => {
+  it('two concurrent submits both persist — no ENOENT, no lost update', async () => {
+    const [a, b] = await Promise.all([
+      submitApproval({ service: 'svc-a', title: 'a' }),
+      submitApproval({ service: 'svc-b', title: 'b' }),
+    ]);
+    const list = await listApprovals();
+    const ids = list.map(r => r.id);
+    // Both requests survive — neither write clobbered the other.
+    expect(ids).toContain(a.id);
+    expect(ids).toContain(b.id);
+    expect(list).toHaveLength(2);
+  });
+
+  it('a burst of concurrent submits all persist (no writes lost to a temp collision)', async () => {
+    const N = 12;
+    const created = await Promise.all(
+      Array.from({ length: N }, (_, i) => submitApproval({ service: 'svc', title: `t${i}` })),
+    );
+    const list = await listApprovals();
+    expect(list).toHaveLength(N);
+    for (const r of created) {
+      expect(list.some(x => x.id === r.id)).toBe(true);
+    }
+  });
+
+  it('two concurrent approvals both succeed and both leave the pending list', async () => {
+    const r1 = await submitApproval({ service: 'svc', title: 'one' });
+    const r2 = await submitApproval({ service: 'svc', title: 'two' });
+    // Approve both at once — before the fix, one throws ENOENT on rename.
+    const results = await Promise.all([approveApproval(r1.id), approveApproval(r2.id)]);
+    expect(results.map(x => x.request.status)).toEqual(['approved', 'approved']);
+    // Persisted status reflects both approvals — no lost update.
+    expect((await getApproval(r1.id))?.status).toBe('approved');
+    expect((await getApproval(r2.id))?.status).toBe('approved');
+    const stillPending = (await listApprovals()).filter(r => r.status === 'pending');
+    expect(stillPending).toHaveLength(0);
+  });
+
+  it('concurrent approve of a move + an mcp tool both persist and run their side effects', async () => {
+    fakeFs['/mnt/data/stacks/svc/draft'] = 'c';
+    const mover = await submitApproval({
+      service: 'svc',
+      title: 'promote',
+      on_approve: { move: { src: '/mnt/data/stacks/svc/draft', dst: '/mnt/data/stacks/svc/published' } },
+    });
+    const runner = await submitApproval({
+      service: 'honcho',
+      title: 'delete_service: honcho',
+      on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+    });
+    const [mv, mc] = await Promise.all([approveApproval(mover.id), approveApproval(runner.id)]);
+    expect(mv.request.status).toBe('approved');
+    expect(mc.request.status).toBe('approved');
+    expect('/mnt/data/stacks/svc/published' in fakeFs).toBe(true);
+    expect(dispatchMcpTool).toHaveBeenCalledWith('delete_service', { name: 'honcho' });
+  });
+
+  it('a persist failure AFTER the tool ran surfaces a clear "ran but not saved" error (client not stranded)', async () => {
+    const r = await submitApproval({
+      service: 'honcho',
+      title: 'delete_service: honcho',
+      on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+    });
+    // The destructive tool runs, THEN the final store write fails — the handler
+    // must reject with a distinct message (not a raw ENOENT) so the UI leaves
+    // its loading state and the operator learns the tool already ran.
+    const renameSpy = vi.spyOn(fs, 'rename').mockRejectedValueOnce(new Error('disk full'));
+    await expect(approveApproval(r.id)).rejects.toThrow(/approved and executed, but saving the result failed/);
+    // The tool DID run — the error is about persistence, not the action.
+    expect(dispatchMcpTool).toHaveBeenCalledWith('delete_service', { name: 'honcho' });
+    renameSpy.mockRestore();
+  });
+});

--- a/packages/backend/src/lib/approvals/index.ts
+++ b/packages/backend/src/lib/approvals/index.ts
@@ -190,9 +190,46 @@ async function readStore(): Promise<ApprovalRequest[]> {
 
 async function writeStore(requests: ApprovalRequest[]): Promise<void> {
   await fs.mkdir(DATA_DIR, { recursive: true });
-  const tmp = `${STORE_PATH}.${process.pid}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(requests, null, 2), 'utf-8');
-  await fs.rename(tmp, STORE_PATH);
+  // A UNIQUE temp path per write. `process.pid` alone is a constant (1 in the
+  // container) so two concurrent writes would share ONE temp file
+  // (`approvals.json.1.tmp`): the first `rename` moves it to the store, the
+  // second then `rename`s a now-missing temp → `ENOENT` → the approve handler
+  // throws AFTER the destructive tool already ran, and the UI hangs (#2239).
+  // Appending a random UUID makes every in-flight write use its own temp file.
+  const tmp = `${STORE_PATH}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(tmp, JSON.stringify(requests, null, 2), 'utf-8');
+    await fs.rename(tmp, STORE_PATH);
+  } catch (err) {
+    // Best-effort cleanup so a failed write doesn't strand its temp file.
+    await fs.rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+/**
+ * In-process serialization for the read-modify-write mutators (#2239).
+ *
+ * Every mutator does `readStore()` → mutate → `writeStore()`. Without
+ * serialization, two concurrent approvals both read the same snapshot, each
+ * flips its own field, and the second write clobbers the first (lost update).
+ * A module-level promise chain funnels the critical sections through one at a
+ * time — cheap, in-process, and sufficient because a single Node process owns
+ * the JSON store. Callers get their turn in submission order.
+ */
+let storeMutex: Promise<unknown> = Promise.resolve();
+
+function withStoreLock<T>(fn: () => Promise<T>): Promise<T> {
+  // Chain onto the tail regardless of the previous result (a rejected prior
+  // critical section must not deadlock the queue), then run `fn`.
+  const run = storeMutex.then(fn, fn);
+  // Swallow the result/rejection on the chained tail so one failing mutator
+  // never rejects the shared mutex for the next caller.
+  storeMutex = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
 }
 
 /** Resolve the node a request targets, defaulting to the first known node. */
@@ -232,9 +269,13 @@ export async function submitApproval(input: SubmitApprovalInput): Promise<Approv
     created_at: new Date().toISOString(),
     status: 'pending',
   };
-  const all = await readStore();
-  all.push(request);
-  await writeStore(all);
+  // Serialize the read-modify-write so a concurrent submit/approve can't read a
+  // stale snapshot and clobber the other's update (#2239).
+  await withStoreLock(async () => {
+    const all = await readStore();
+    all.push(request);
+    await writeStore(all);
+  });
   logger.info(TAG, `submitted approval ${request.id} for service ${request.service}`);
   return request;
 }
@@ -291,19 +332,44 @@ async function runAction(action: ApprovalAction, node: string, service: string):
 }
 
 async function resolve(id: string, status: 'approved' | 'rejected', action: ApprovalAction): Promise<{ request: ApprovalRequest; restarted?: boolean; restartError?: string }> {
-  const all = await readStore();
-  const request = all.find(r => r.id === id);
-  if (!request) {
-    throw new Error(`Approval request not found: ${id}`);
-  }
-  if (request.status !== 'pending') {
-    throw new Error(`Approval request ${id} is already ${request.status}`);
-  }
-  const result = await runAction(action, request.node, request.service);
-  request.status = status;
-  await writeStore(all);
-  logger.info(TAG, `${status} approval ${id} (service ${request.service})`);
-  return { request, ...result };
+  // The whole read → run side effect → persist sequence runs under the store
+  // lock so a concurrent approve/reject/submit can't read a stale snapshot and
+  // clobber the status flip (lost update, #2239). Serializing per-item is fine:
+  // the destructive side effect (`runAction`) is the point of the gate, so at
+  // most one approval executes at a time regardless.
+  return withStoreLock(async () => {
+    const all = await readStore();
+    const request = all.find(r => r.id === id);
+    if (!request) {
+      throw new Error(`Approval request not found: ${id}`);
+    }
+    if (request.status !== 'pending') {
+      throw new Error(`Approval request ${id} is already ${request.status}`);
+    }
+    const result = await runAction(action, request.node, request.service);
+    // The side effect has now run (a destructive MCP tool may already have
+    // deleted a service). Flip the status and persist. If persistence itself
+    // fails HERE — after the side effect — we must NOT re-throw the raw error:
+    // the client would stay in its loading state believing nothing happened,
+    // even though the tool ran (#2239). Surface a clear, distinct error that
+    // tells the operator the action ran but its record could not be saved, so
+    // the UI leaves the spinner and shows an honest message.
+    request.status = status;
+    try {
+      await writeStore(all);
+    } catch (persistErr) {
+      const detail = persistErr instanceof Error ? persistErr.message : String(persistErr);
+      logger.error(
+        TAG,
+        `${status} approval ${id} ran its action but the store write failed: ${detail}`,
+      );
+      throw new Error(
+        `The action was ${status === 'approved' ? 'approved and executed' : 'rejected'}, but saving the result failed (${detail}). It may show as still pending; do not re-run it.`,
+      );
+    }
+    logger.info(TAG, `${status} approval ${id} (service ${request.service})`);
+    return { request, ...result };
+  });
 }
 
 /** Approve a pending request: run its `on_approve` action, mark approved. */


### PR DESCRIPTION
## What
The destroy-tier approval store (`packages/backend/src/lib/approvals/`) crashed under concurrent writes: `writeStore` used a constant temp path `${STORE_PATH}.${process.pid}.tmp`, and since `process.pid` is `1` in the container, two concurrent writes shared one temp file — one rename succeeded, the other renamed a now-missing temp → `ENOENT: rename '…approvals.json.1.tmp'`. This threw *after* the destructive MCP tool had already run, so the operator's Approve hung forever while the tool executed. Also fixes a latent lost-update race (unserialized read-modify-write).

Fix (all three): (1) unique temp path per write `${STORE_PATH}.${pid}.${randomUUID()}.tmp` + best-effort cleanup so concurrent writes never collide; (2) module-level async mutex serializing the read-modify-write across submit/approve/reject so a concurrent pair can't lose an update; (3) `resolve()` now catches a persist failure *after* the action ran and throws a distinct "approved and executed, but saving the result failed; do not re-run it" instead of a raw ENOENT, so the client leaves its loading state rather than hanging.

## Why
Closes #2239

## Risk
Medium — touches the destroy-tier approval execution path (security-sensitive). Mitigated by real-fs concurrency regression tests that were confirmed to fail (with the exact ENOENT) when the fix is reverted.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors / 358 warnings, == baseline)
- [x] npm run typecheck (exit 0)
- [x] npm run check:arch (1022 modules, 0 violations)
- [x] npm test (full suite passes; a frontend `redirects.test.tsx` dynamic-import timeout is a full-suite-parallel-load flake — passes isolated 4/4 in 1.9s, backend-only diff cannot regress a frontend render)
- [ ] /verify on FCoS :dev box — concurrent approve/reject through the operator path, no ENOENT in logs, item leaves pending, service actually deleted, token still cannot self-approve