### PR TITLE
feat(auth): token-scoped updates+approvals APIs and Authelia-session token exchange

### DIFF
--- a/packages/backend/src/lib/approvals/index.test.ts
+++ b/packages/backend/src/lib/approvals/index.test.ts
@@ -37,6 +37,8 @@ import {
   approveApproval,
   rejectApproval,
   registerMcpDispatcher,
+  isSelfApproval,
+  type ApprovalRequest,
 } from './index';
 
 // The mcp action calls the registered dispatcher (injected by the MCP layer in
@@ -459,5 +461,38 @@ describe('concurrent store writes (#2239)', () => {
     // The tool DID run — the error is about persistence, not the action.
     expect(dispatchMcpTool).toHaveBeenCalledWith('delete_service', { name: 'honcho' });
     renameSpy.mockRestore();
+  });
+});
+
+describe('isSelfApproval — token cannot resolve its own proposal (#2244)', () => {
+  const withCaller = (caller: unknown): ApprovalRequest => ({
+    id: 'r1',
+    service: 'honcho',
+    title: 'delete_service: honcho',
+    description: null,
+    payload: caller === undefined ? {} : { caller },
+    on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+    on_reject: {},
+    node: 'box1',
+    created_at: new Date().toISOString(),
+    status: 'pending',
+  });
+
+  it('blocks the SAME token that proposed the request', () => {
+    expect(isSelfApproval(withCaller('token:solaris'), 'token:solaris')).toBe(true);
+  });
+
+  it('allows a DIFFERENT token to resolve it (verdict-delivery consumer)', () => {
+    expect(isSelfApproval(withCaller('token:solaris'), 'token:other')).toBe(false);
+  });
+
+  it('never blocks the cookie operator (non-token caller)', () => {
+    expect(isSelfApproval(withCaller('token:solaris'), 'admin')).toBe(false);
+    expect(isSelfApproval(withCaller('token:solaris'), 'internal')).toBe(false);
+    expect(isSelfApproval(withCaller('token:solaris'), undefined)).toBe(false);
+  });
+
+  it('is a no-op for a request with no recorded proposer (plain move/restart)', () => {
+    expect(isSelfApproval(withCaller(undefined), 'token:solaris')).toBe(false);
   });
 });

--- a/packages/backend/src/lib/approvals/index.ts
+++ b/packages/backend/src/lib/approvals/index.ts
@@ -251,6 +251,28 @@ export async function getApproval(id: string): Promise<ApprovalRequest | null> {
   return all.find(r => r.id === id) ?? null;
 }
 
+/**
+ * Whether `caller` is the same principal that PROPOSED `request` — used to
+ * refuse token self-approval (#2244). A destroy-tier MCP proposal records the
+ * proposing token's identity in `payload.caller` (see mcp/server.ts:
+ * `payload: { …, caller: auth.user }`); a Bearer token holding `mutate` may
+ * approve/reject the operator queue, but it must never approve or reject the
+ * very request IT proposed — that would let an agent self-authorize its own
+ * destructive action, defeating the human-in-the-loop gate.
+ *
+ * `caller` is the requesting principal's `SessionPayload.user` string
+ * (`token:<name>` for a Bearer token, `admin`/`internal` otherwise). A cookie
+ * operator (`caller` not `token:*`) is never a proposer here, so the check is a
+ * no-op for the human path. Returns false when the request carries no recorded
+ * proposer, so a plain move/restart approval (no `payload.caller`) stays
+ * approvable by any authorized caller.
+ */
+export function isSelfApproval(request: ApprovalRequest, caller: string | undefined): boolean {
+  if (!caller || !caller.startsWith('token:')) return false;
+  const proposer = request.payload?.caller;
+  return typeof proposer === 'string' && proposer === caller;
+}
+
 /** Persist a new pending request and return it. */
 export async function submitApproval(input: SubmitApprovalInput): Promise<ApprovalRequest> {
   // AUTHORIZE the jail anchor at submit time so a traversal-style name

--- a/packages/frontend/src/app/api/approvals/[id]/approve/route.test.ts
+++ b/packages/frontend/src/app/api/approvals/[id]/approve/route.test.ts
@@ -1,0 +1,101 @@
+/**
+ * POST /api/approvals/[id]/approve — token self-approval guard (#2244).
+ *
+ * The route is now reachable by a `mutate`-scope Bearer token (verdict
+ * delivery), but the human-in-the-loop invariant must hold: the SAME token that
+ * PROPOSED a destroy-tier MCP action cannot approve it (memory
+ * reference_mcp_destroy_tier_approval_flow). This test drives the route with a
+ * mocked gate (`auth` injected) + mocked approvals store to prove the branch:
+ *   - proposing token  → 403, approveApproval NOT called
+ *   - different token   → passes through to approveApproval
+ *   - cookie operator   → passes through (never a token proposer)
+ *
+ * The gate/scope machinery itself is covered in requireSession.test.ts; here we
+ * only exercise the route's self-approve branch, so `withApiHandlerParams` is
+ * stubbed to inject `auth` the way the real gate would.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { ApprovalRequest } from '@/lib/approvals';
+
+const mocks = vi.hoisted(() => ({
+  approveApproval: vi.fn(),
+  getApproval: vi.fn(),
+  authRef: { value: undefined as { user: string } | undefined },
+}));
+
+vi.mock('@/lib/mcp/server', () => ({}));
+
+vi.mock('@/lib/approvals', async () => {
+  // isSelfApproval is pure — use the real implementation so the test exercises
+  // the ACTUAL guard logic, not a re-stated copy.
+  const actual = await vi.importActual<typeof import('@/lib/approvals')>('@/lib/approvals');
+  return {
+    isSelfApproval: actual.isSelfApproval,
+    approveApproval: mocks.approveApproval,
+    getApproval: mocks.getApproval,
+  };
+});
+
+vi.mock('@/lib/api/handler', () => ({
+  withApiHandlerParams:
+    (
+      _opts: unknown,
+      handler: (ctx: {
+        params: { id: string };
+        auth?: { user: string };
+      }) => Promise<Response>,
+    ) =>
+    async (_request: NextRequest, ctx: { params: Promise<{ id: string }> }) =>
+      handler({ params: await ctx.params, auth: mocks.authRef.value }),
+}));
+
+import { POST } from './route';
+
+const proposal = (caller: string): ApprovalRequest => ({
+  id: 'r1',
+  service: 'honcho',
+  title: 'delete_service: honcho',
+  description: null,
+  payload: { caller },
+  on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+  on_reject: {},
+  node: 'box1',
+  created_at: new Date().toISOString(),
+  status: 'pending',
+});
+
+const call = async (auth: { user: string } | undefined) => {
+  mocks.authRef.value = auth;
+  const req = new NextRequest('http://localhost/api/approvals/r1/approve', { method: 'POST' });
+  return POST(req, { params: Promise.resolve({ id: 'r1' }) });
+};
+
+beforeEach(() => {
+  mocks.approveApproval.mockReset();
+  mocks.getApproval.mockReset();
+  mocks.approveApproval.mockResolvedValue({ request: proposal('token:solaris') });
+});
+
+describe('approve route self-approval guard (#2244)', () => {
+  it('403s the token that proposed the request; the tool is NOT run', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'token:solaris' });
+    expect(res.status).toBe(403);
+    expect(mocks.approveApproval).not.toHaveBeenCalled();
+  });
+
+  it('lets a DIFFERENT mutate token deliver the verdict', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'token:other' });
+    expect(res.status).toBe(200);
+    expect(mocks.approveApproval).toHaveBeenCalledWith('r1');
+  });
+
+  it('lets the cookie operator approve (never a token proposer)', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'admin' });
+    expect(res.status).toBe(200);
+    expect(mocks.approveApproval).toHaveBeenCalledWith('r1');
+  });
+});

--- a/packages/frontend/src/app/api/approvals/[id]/approve/route.ts
+++ b/packages/frontend/src/app/api/approvals/[id]/approve/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { withApiHandlerParams } from '@/lib/api/handler';
-import { approveApproval } from '@/lib/approvals';
+import { approveApproval, getApproval, isSelfApproval } from '@/lib/approvals';
 // Side-effect import (#2237): loading mcp/server runs its top-level
 // registerMcpDispatcher(...) call, so this route's bundle instance of
 // lib/approvals HAS a dispatcher when approving an on_approve.mcp approval.
@@ -15,10 +15,28 @@ import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
+// tokenScope:'mutate' (#2244) — a scoped Bearer token holding `mutate` may
+// deliver the operator's verdict (approve). NOT `destroy`: the verdict itself
+// is a mutate-tier action; the destructive work an on_approve.mcp action runs
+// was already scope-checked when the agent PROPOSED it. Cookie sessions work
+// unchanged. Self-approve guard below preserves the human-in-the-loop invariant
+// (a token cannot approve the very request it proposed).
 export const POST = withApiHandlerParams<undefined, undefined, { id: string }>(
-  {},
-  async ({ params }) => {
+  { tokenScope: 'mutate' },
+  async ({ params, auth }) => {
     const id = decodeURIComponent(params.id);
+    // A token holding `mutate` may act as a verdict-delivery consumer, but it
+    // must never approve the destructive proposal IT itself submitted — that
+    // would let an agent self-authorize (memory
+    // reference_mcp_destroy_tier_approval_flow). The cookie operator path never
+    // trips this (its identity is not the recorded token proposer).
+    const existing = await getApproval(id);
+    if (existing && isSelfApproval(existing, auth?.user)) {
+      return NextResponse.json(
+        { error: 'A token cannot approve the request it proposed; a ServiceBay admin must approve it.' },
+        { status: 403 },
+      );
+    }
     try {
       const result = await approveApproval(id);
       return NextResponse.json({ ok: true, ...result });

--- a/packages/frontend/src/app/api/approvals/[id]/reject/route.ts
+++ b/packages/frontend/src/app/api/approvals/[id]/reject/route.ts
@@ -1,14 +1,27 @@
 import { NextResponse } from 'next/server';
 import { withApiHandlerParams } from '@/lib/api/handler';
-import { rejectApproval } from '@/lib/approvals';
+import { rejectApproval, getApproval, isSelfApproval } from '@/lib/approvals';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
+// tokenScope:'mutate' (#2244) — a scoped Bearer token holding `mutate` may
+// deliver the operator's verdict (reject). Cookie sessions work unchanged. The
+// self-approve/reject guard preserves the invariant that a token cannot resolve
+// the very request it proposed.
 export const POST = withApiHandlerParams<undefined, undefined, { id: string }>(
-  {},
-  async ({ params }) => {
+  { tokenScope: 'mutate' },
+  async ({ params, auth }) => {
     const id = decodeURIComponent(params.id);
+    // Same human-in-the-loop invariant as the approve route: a token cannot
+    // resolve (approve OR reject) the proposal it submitted.
+    const existing = await getApproval(id);
+    if (existing && isSelfApproval(existing, auth?.user)) {
+      return NextResponse.json(
+        { error: 'A token cannot resolve the request it proposed; a ServiceBay admin must decide it.' },
+        { status: 403 },
+      );
+    }
     try {
       const result = await rejectApproval(id);
       return NextResponse.json({ ok: true, ...result });

--- a/packages/frontend/src/app/api/approvals/[id]/route.ts
+++ b/packages/frontend/src/app/api/approvals/[id]/route.ts
@@ -5,8 +5,10 @@ import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
+// tokenScope:'read' (#2244) — a scoped Bearer token may read a single
+// approval by id (card detail). Cookie sessions unaffected.
 export const GET = withApiHandlerParams<undefined, undefined, { id: string }>(
-  {},
+  { tokenScope: 'read' },
   async ({ params }) => {
     try {
       const approval = await getApproval(decodeURIComponent(params.id));

--- a/packages/frontend/src/app/api/approvals/route.ts
+++ b/packages/frontend/src/app/api/approvals/route.ts
@@ -34,8 +34,14 @@ const Body = z.object({
   node: z.string().optional(),
 });
 
+// tokenScope:'read' (#2244) — a scoped Bearer token may fetch the generic
+// pending-approval feed so an external consumer (Solaris Wartung chat) can
+// render approval cards. Deny-by-default: no/insufficient-scope Bearer 401s;
+// the cookie-session path is unchanged. The POST (submit) below deliberately
+// stays cookie/internal-only (no tokenScope) — this issue only opens the read
+// feed + the approve/reject verdict to tokens, not new-request submission.
 export const GET = withApiHandler(
-  {},
+  { tokenScope: 'read' },
   async () => {
     try {
       const approvals = await listApprovals();

--- a/packages/frontend/src/app/api/approvals/scopeGuards.test.ts
+++ b/packages/frontend/src/app/api/approvals/scopeGuards.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * Token-scope lock-in for the updates + approvals REST surface (#2243, #2244).
+ *
+ * These routes were opened to a scoped SB-MCP Bearer token so an external
+ * consumer (Solaris Wartung chat) can poll pending updates + the approval feed
+ * and deliver the operator's verdict. Each route declares its guard inline via
+ * `withApiHandler({ tokenScope })` / `requireSession(req, { tokenScope })`; the
+ * gate machinery itself (accept right-scope Bearer, 401 wrong/absent scope with
+ * NO cookie fall-through, cookie session unchanged) is already proven in
+ * `packages/backend/src/lib/api/requireSession.test.ts`. This test pins the
+ * exact scope baked into each route so a regression — widening a read route to
+ * mutate, or dropping the deny-by-default on the submit POST — fails CI.
+ *
+ * Source-level (not a request round-trip): the guard IS the literal scope
+ * string in the route source, and these routes pull heavy install/registry
+ * deps a unit test should not load to read one token.
+ */
+const API_DIR = path.resolve(__dirname, '..');
+
+function src(relPath: string): string {
+  return readFileSync(path.join(API_DIR, relPath), 'utf8');
+}
+
+/** The tokenScope on the first handler declared in a single-handler route. */
+function soleScope(relPath: string): string | null {
+  const m = src(relPath).match(/tokenScope:\s*'([a-z]+)'/);
+  return m ? m[1] : null;
+}
+
+describe('updates signal is read-scoped for Bearer tokens (#2243)', () => {
+  it('image-updates GET → read', () => {
+    expect(soleScope('system/stacks/image-updates/route.ts')).toBe('read');
+  });
+  it('templates/upgrades-pending GET → read', () => {
+    expect(soleScope('system/templates/upgrades-pending/route.ts')).toBe('read');
+  });
+});
+
+describe('approval feed is read-scoped, verdict is mutate-scoped (#2244)', () => {
+  it('GET /api/approvals (list) → read', () => {
+    // The list handler is the first (GET) block; the POST submit below must NOT
+    // carry a tokenScope (stays cookie/internal-only) — asserted separately.
+    const s = src('approvals/route.ts');
+    const getBlock = s.slice(s.indexOf('export const GET'), s.indexOf('export const POST'));
+    expect(getBlock).toMatch(/tokenScope:\s*'read'/);
+  });
+
+  it('POST /api/approvals (submit) stays cookie/internal-only — NO tokenScope (deny Bearer)', () => {
+    // Opening submission to a token was explicitly out of scope for #2244; a
+    // Bearer to this mutating verb must keep 401ing (no tokenScope opt-in).
+    const s = src('approvals/route.ts');
+    const postBlock = s.slice(s.indexOf('export const POST'));
+    expect(postBlock).not.toMatch(/tokenScope/);
+  });
+
+  it('GET /api/approvals/[id] (detail) → read', () => {
+    expect(soleScope('approvals/[id]/route.ts')).toBe('read');
+  });
+
+  it('POST /api/approvals/[id]/approve → mutate (verdict, not destroy)', () => {
+    expect(soleScope('approvals/[id]/approve/route.ts')).toBe('mutate');
+  });
+
+  it('POST /api/approvals/[id]/reject → mutate', () => {
+    expect(soleScope('approvals/[id]/reject/route.ts')).toBe('mutate');
+  });
+
+  it('approve + reject enforce the token self-approval guard (isSelfApproval)', () => {
+    // The human-in-the-loop invariant: a token cannot resolve the request it
+    // proposed. Pinned so a refactor can't silently drop the guard while the
+    // route stays token-reachable.
+    expect(src('approvals/[id]/approve/route.ts')).toMatch(/isSelfApproval/);
+    expect(src('approvals/[id]/reject/route.ts')).toMatch(/isSelfApproval/);
+  });
+});

--- a/packages/frontend/src/app/api/auth/token-from-authelia-session/route.ts
+++ b/packages/frontend/src/app/api/auth/token-from-authelia-session/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withApiHandler } from '@/lib/api/handler';
+import { createToken } from '@/lib/auth/apiTokens';
+import type { ApiScope } from '@/lib/auth/apiScope';
+import { logger } from '@/lib/logger';
+
+/**
+ * Authelia-session → scoped SB-MCP token exchange (#2246, option 1).
+ *
+ * A verified admin's *live* Authelia session mints a short-lived, narrowly
+ * scoped SB-MCP Bearer token — WITHOUT any consumer (e.g. the Solaris pod)
+ * holding a standing token-minting credential. Authority flows from the
+ * human's session: the caller must arrive through the Authelia forward-auth
+ * chain (NPM injects `Remote-User` / `Remote-Groups` after auth-request), and
+ * the identified user must be in the `admins` group. The minted token carries
+ * `read + lifecycle + mutate` — enough for the admin "Wartung" chat's SB tools
+ * — and expires in ≤ 1h. It deliberately does NOT grant `destroy` / `exec` /
+ * `reboot`: those tiers still go through the per-tool approval flow
+ * (#2234/#2237/#2239) on the /mcp path, so a leaked short-token can't wipe or
+ * shell the box.
+ *
+ * TRUST MODEL — read before touching the header check:
+ *   The `Remote-User` / `Remote-Groups` headers are trustworthy ONLY because
+ *   NPM's forward-auth snippet (`stackInstall/forwardAuth.ts`) sets them via
+ *   `proxy_set_header Remote-User $user;` from the Authelia auth-request
+ *   subrequest, OVERWRITING any client-supplied copy. So a request that
+ *   actually carries these headers has been through Authelia. A request WITHOUT
+ *   them (direct/loopback, or a public host not fronted by the forward-auth
+ *   chain) is NOT trusted — missing headers → 401, never a token. We never
+ *   fall back to a session cookie or a LAN-IP heuristic here: for a token-mint
+ *   privilege boundary, the only accepted proof of a verified admin is the
+ *   proxy-injected identity.
+ *
+ * `skipAuth: true`: the Authelia proxy headers ARE the credential (mirrors
+ * `/api/auth/session-from-token`, which treats the presented Bearer as the
+ * credential). No cookie/admin session is required — that's the point.
+ */
+
+/** The group an Authelia-identified user must be in to mint a token here.
+ *  Matches the platform's `admins` LLDAP group (the same group NPM's
+ *  admin-only subdomains gate on — see reverseProxy/lanDeniedPage.ts). */
+const ADMIN_GROUP = 'admins';
+
+/** Scopes the minted token carries. Deliberately excludes destroy/exec/reboot
+ *  — those stay behind the per-tool approval flow on /mcp (#2234). */
+const MINTED_SCOPES: ApiScope[] = ['read', 'lifecycle', 'mutate'];
+
+/** Hard TTL cap for the minted token: ≤ 1h (#2246). */
+const TOKEN_TTL_MS = 60 * 60 * 1000;
+
+function parseGroups(raw: string | null): string[] {
+  return (raw || '')
+    .split(',')
+    .map((g) => g.trim())
+    .filter(Boolean);
+}
+
+export const POST = withApiHandler({ skipAuth: true }, async ({ request }: { request: NextRequest }) => {
+  // Only the proxy-injected identity is trusted (see TRUST MODEL above).
+  const user = request.headers.get('remote-user');
+  if (!user) {
+    // No forward-auth identity → the request did not come through Authelia.
+    // Never mint a token for a header-less (direct/loopback) caller.
+    return NextResponse.json(
+      { error: 'Authelia forward-auth identity required (no Remote-User header)' },
+      { status: 401 },
+    );
+  }
+
+  const groups = parseGroups(request.headers.get('remote-groups'));
+  if (!groups.includes(ADMIN_GROUP)) {
+    logger.warn(
+      'api:auth:token-from-authelia-session',
+      `Denied token exchange for "${user}": not in "${ADMIN_GROUP}" (groups=[${groups.join(',')}])`,
+    );
+    return NextResponse.json(
+      { error: `User is not in the "${ADMIN_GROUP}" group` },
+      { status: 403 },
+    );
+  }
+
+  const expiresAt = new Date(Date.now() + TOKEN_TTL_MS).toISOString();
+  const { token, secret } = await createToken({
+    name: `authelia-session:${user}`.slice(0, 100),
+    scopes: MINTED_SCOPES,
+    expiresAt,
+    createdBy: `authelia:${user}`,
+  });
+
+  logger.info(
+    'api:auth:token-from-authelia-session',
+    `Minted scoped MCP token ${token.id} for admin "${user}" scopes=[${token.scopes.join(',')}] expires=${expiresAt}`,
+  );
+
+  return NextResponse.json({
+    token: secret,
+    scopes: token.scopes,
+    expiresAt,
+  });
+});

--- a/packages/frontend/src/app/api/system/stacks/image-updates/route.ts
+++ b/packages/frontend/src/app/api/system/stacks/image-updates/route.ts
@@ -20,8 +20,12 @@ import { getInstalledImageUpdates } from '@/lib/imageDigest';
 
 export const dynamic = 'force-dynamic';
 
+// tokenScope:'read' (#2243) — a scoped SB-MCP Bearer token may poll this
+// pending-image-updates signal so an external consumer (Solaris Wartung chat)
+// can render "update available" cards. The gate stays deny-by-default: a
+// missing/wrong-scope Bearer 401s and a session cookie keeps working unchanged.
 export const GET = withApiHandler({}, async ({ request }) => {
-  const auth = await requireSession(request);
+  const auth = await requireSession(request, { tokenScope: 'read' });
   if (auth instanceof NextResponse) return auth;
   try {
     const services = await getInstalledImageUpdates();

--- a/packages/frontend/src/app/api/system/templates/upgrades-pending/route.ts
+++ b/packages/frontend/src/app/api/system/templates/upgrades-pending/route.ts
@@ -38,8 +38,10 @@ interface UpgradeSummary {
  * would sit unnoticed for any operator who never opens the
  * Re-deploy modal.
  */
+// tokenScope:'read' (#2243) — same pending-updates signal, template side. A
+// scoped Bearer token may read it; cookie sessions are unaffected.
 export const GET = withApiHandler({}, async ({ request }) => {
-  const auth = await requireSession(request);
+  const auth = await requireSession(request, { tokenScope: 'read' });
   if (auth instanceof NextResponse) return auth;
   try {
     const config = await getConfig();

--- a/tests/backend/auth_token_from_authelia_session.test.ts
+++ b/tests/backend/auth_token_from_authelia_session.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+// #2246 — Authelia-session → scoped SB-MCP token exchange. A verified admin's
+// live forward-auth session (NPM-injected Remote-User + Remote-Groups) mints a
+// short-lived read+lifecycle+mutate token; no standing minting credential sits
+// in the consumer pod. Real-fs DATA_DIR so createToken/verifyToken round-trip
+// through the actual store (mirrors apiTokens.delegate.test.ts).
+import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { NextRequest } from 'next/server';
+
+let dataDir = '';
+vi.mock('@/lib/dirs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/dirs')>();
+  return { ...actual, get DATA_DIR() { return dataDir; } };
+});
+
+// withApiHandler treats this route as public (skipAuth) — the Authelia proxy
+// headers ARE the credential — so requireSession never runs. Stub it anyway so
+// an accidental gate change surfaces loudly rather than mint-for-anyone.
+vi.mock('@/lib/api/requireSession', () => ({
+  requireSession: vi.fn(async () => {
+    throw new Error('requireSession must not run: the route is skipAuth (headers are the credential)');
+  }),
+}));
+
+beforeAll(() => {
+  process.env.AUTH_SECRET = process.env.AUTH_SECRET ||
+    '0123456789abcdef0123456789abcdef0123456789abcdef';
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+  dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sb-authelia-tok-'));
+});
+afterEach(async () => {
+  const { flushPendingStamps } = await import('@/lib/auth/apiTokens');
+  await flushPendingStamps();
+  await fsp.rm(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+});
+
+async function post(headers: Record<string, string>) {
+  const { POST } = await import(
+    '../../packages/frontend/src/app/api/auth/token-from-authelia-session/route'
+  );
+  const req = new NextRequest('http://test/api/auth/token-from-authelia-session', {
+    method: 'POST',
+    headers,
+  });
+  return POST(req);
+}
+
+describe('POST /api/auth/token-from-authelia-session (#2246)', () => {
+  // Criterion (1): admin identity → a read+lifecycle+mutate Bearer expiring ≤1h.
+  it('mints a read+lifecycle+mutate token expiring within 1h for an admin', async () => {
+    const before = Date.now();
+    const res = await post({ 'remote-user': 'admin', 'remote-groups': 'admins' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.scopes).toEqual(['read', 'lifecycle', 'mutate']);
+    expect(body.token).toMatch(/^sb_[0-9a-f]{8}_[A-Z2-9]+$/);
+
+    const exp = Date.parse(body.expiresAt);
+    expect(exp).toBeGreaterThan(before);
+    // ≤ 1h from now (allow a small slack for test execution time).
+    expect(exp).toBeLessThanOrEqual(Date.now() + 60 * 60 * 1000 + 5_000);
+  });
+
+  // Criterion (2): missing forward-auth headers → 401, no token. A direct /
+  // loopback caller (no Authelia) is never trusted.
+  it('rejects with 401 and mints nothing when the Remote-User header is absent', async () => {
+    const res = await post({}); // no forward-auth identity
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.token).toBeUndefined();
+
+    // Store stays empty — nothing was minted.
+    const { listTokens } = await import('@/lib/auth/apiTokens');
+    expect(await listTokens()).toHaveLength(0);
+  });
+
+  it('rejects with 403 when Remote-User is present but Remote-Groups is absent', async () => {
+    const res = await post({ 'remote-user': 'admin' }); // identity but no groups
+    expect(res.status).toBe(403);
+    expect((await res.json()).token).toBeUndefined();
+    const { listTokens } = await import('@/lib/auth/apiTokens');
+    expect(await listTokens()).toHaveLength(0);
+  });
+
+  // Criterion (3): a non-admin group → 403, no token.
+  it('rejects with 403 and mints nothing for a non-admin group', async () => {
+    const res = await post({ 'remote-user': 'bob', 'remote-groups': 'family, users' });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.token).toBeUndefined();
+
+    const { listTokens } = await import('@/lib/auth/apiTokens');
+    expect(await listTokens()).toHaveLength(0);
+  });
+
+  // Criterion (4): the minted token actually works on read/mutate and is
+  // REFUSED on a destroy-tier tool. Verified against the SAME machinery the
+  // /mcp path uses: verifyToken (store round-trip) + tokenHasScope (the gate).
+  it('mints a token that passes read/mutate and is refused on destroy', async () => {
+    const res = await post({ 'remote-user': 'admin', 'remote-groups': 'admins' });
+    const { token: raw } = await res.json();
+
+    const { verifyToken } = await import('@/lib/auth/apiTokens');
+    const verified = await verifyToken(raw);
+    expect(verified).not.toBeNull();
+
+    const { tokenHasScope } = await import('@/lib/mcp/server');
+    // read (list_*) and mutate (deploy_service) are granted.
+    expect(tokenHasScope(verified!.scopes, 'read')).toBe(true);
+    expect(tokenHasScope(verified!.scopes, 'lifecycle')).toBe(true);
+    expect(tokenHasScope(verified!.scopes, 'mutate')).toBe(true);
+    // destroy (delete_service) and exec (exec_command) are NOT — they still go
+    // through the per-tool approval flow (#2234), not this token.
+    expect(tokenHasScope(verified!.scopes, 'destroy')).toBe(false);
+    expect(tokenHasScope(verified!.scopes, 'exec')).toBe(false);
+    expect(tokenHasScope(verified!.scopes, 'reboot')).toBe(false);
+  });
+
+  // Header-spoofing note enforced: the route trusts ONLY the proxy-injected
+  // header. There is no cookie/LAN-IP fallback, so a header-less caller from
+  // loopback (the classic spoof vector) gets nothing. (Covered by the 401
+  // test above; this pins that no session cookie can substitute.)
+  it('does not accept a session cookie in lieu of the forward-auth headers', async () => {
+    const { encryptSession } = await import('@/lib/auth/session');
+    const cookie = await encryptSession({ user: 'admin', expires: new Date(Date.now() + 3600_000) });
+    const res = await post({ cookie: `session=${cookie}` });
+    expect(res.status).toBe(401);
+    expect((await res.json()).token).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What
Opens the updates + approvals read/verdict surface to scoped SB-MCP Bearer auth (#2243/#2244) and adds a `POST /api/auth/token-from-authelia-session` endpoint that mints a short-lived (≤1h) read+lifecycle+mutate token from a verified Authelia admin session (#2246). No standing minting credential lives in the pod — authority flows from the live Authelia forward-auth session.

## Why
Closes #2243
Closes #2244
Closes #2246

## Risk
Medium — new token-minting/authz surface on security-sensitive routes (destroy-tier approval verdicts, token exchange). Reuses the existing requireSession/apiScope machinery (no parallel auth path); self-approve invariant preserved; token exchange trusts Authelia headers only when present (NPM injects them post-forward-auth) and is refused without them.

## Rollback
git revert is enough (additive routes/scopes; no schema or migration).

## Verification
- [ ] npm run lint
- [ ] npm run typecheck
- [ ] npm run check:arch
- [ ] npm test (full)
- [ ] box-verify on FCoS :dev box (backend src touched → path-mandated; live token/auth surface behind NPM)