### PR TITLE
fix(api): wire tokenScope into handler options + block authelia-session token spoof

### DIFF
--- a/packages/frontend/src/app/api/approvals/scopeGuards.test.ts
+++ b/packages/frontend/src/app/api/approvals/scopeGuards.test.ts
@@ -25,18 +25,43 @@ function src(relPath: string): string {
   return readFileSync(path.join(API_DIR, relPath), 'utf8');
 }
 
-/** The tokenScope on the first handler declared in a single-handler route. */
-function soleScope(relPath: string): string | null {
-  const m = src(relPath).match(/tokenScope:\s*'([a-z]+)'/);
-  return m ? m[1] : null;
+/**
+ * The tokenScope baked into the route's `withApiHandler(...)` / `withApiHandlerParams(...)`
+ * OPTIONS object — the ONLY place the built-in gate reads it (#2249).
+ *
+ * We deliberately do NOT match a bare `tokenScope:'read'` anywhere in the file:
+ * the old regex matched the scope written in a CODE COMMENT, so the test passed
+ * even when the routes wired the scope into an INNER `requireSession(req, {…})`
+ * call that the wrapper gate never saw → a valid read Bearer 401'd (box-verify
+ * #2243 RED, CI false-green). This scopes the match to the handler options.
+ */
+function optionsScope(relPath: string): string | null {
+  const s = src(relPath);
+  // Grab the options object literal that is the FIRST argument to
+  // withApiHandler / withApiHandlerParams, then read tokenScope out of it.
+  const m = s.match(/withApiHandler(?:Params)?\s*(?:<[^>]*>)?\s*\(\s*(\{[^}]*\})/);
+  if (!m) return null;
+  const opts = m[1];
+  const scope = opts.match(/tokenScope:\s*'([a-z]+)'/);
+  return scope ? scope[1] : null;
 }
 
-describe('updates signal is read-scoped for Bearer tokens (#2243)', () => {
-  it('image-updates GET → read', () => {
-    expect(soleScope('system/stacks/image-updates/route.ts')).toBe('read');
+/** Assert the route does NOT hide the scope in an inner requireSession call —
+ *  that shape 401s a valid Bearer because the wrapper gate runs scopeless. */
+function hasInnerRequireSessionScope(relPath: string): boolean {
+  return /requireSession\([^)]*tokenScope/.test(src(relPath));
+}
+
+describe('updates signal is read-scoped for Bearer tokens (#2243, #2249)', () => {
+  it('image-updates GET → read (in withApiHandler options, not a comment/inner call)', () => {
+    expect(optionsScope('system/stacks/image-updates/route.ts')).toBe('read');
+    // #2249: the scope must NOT live on an inner requireSession — that 401s a
+    // valid Bearer because handler.ts's own gate ran scopeless first.
+    expect(hasInnerRequireSessionScope('system/stacks/image-updates/route.ts')).toBe(false);
   });
-  it('templates/upgrades-pending GET → read', () => {
-    expect(soleScope('system/templates/upgrades-pending/route.ts')).toBe('read');
+  it('templates/upgrades-pending GET → read (in withApiHandler options)', () => {
+    expect(optionsScope('system/templates/upgrades-pending/route.ts')).toBe('read');
+    expect(hasInnerRequireSessionScope('system/templates/upgrades-pending/route.ts')).toBe(false);
   });
 });
 
@@ -58,15 +83,15 @@ describe('approval feed is read-scoped, verdict is mutate-scoped (#2244)', () =>
   });
 
   it('GET /api/approvals/[id] (detail) → read', () => {
-    expect(soleScope('approvals/[id]/route.ts')).toBe('read');
+    expect(optionsScope('approvals/[id]/route.ts')).toBe('read');
   });
 
   it('POST /api/approvals/[id]/approve → mutate (verdict, not destroy)', () => {
-    expect(soleScope('approvals/[id]/approve/route.ts')).toBe('mutate');
+    expect(optionsScope('approvals/[id]/approve/route.ts')).toBe('mutate');
   });
 
   it('POST /api/approvals/[id]/reject → mutate', () => {
-    expect(soleScope('approvals/[id]/reject/route.ts')).toBe('mutate');
+    expect(optionsScope('approvals/[id]/reject/route.ts')).toBe('mutate');
   });
 
   it('approve + reject enforce the token self-approval guard (isSelfApproval)', () => {

--- a/packages/frontend/src/app/api/auth/token-from-authelia-session/route.test.ts
+++ b/packages/frontend/src/app/api/auth/token-from-authelia-session/route.test.ts
@@ -1,0 +1,90 @@
+/**
+ * POST /api/auth/token-from-authelia-session — privilege-escalation guard
+ * (#2246 / #2249, SECURITY).
+ *
+ * This endpoint mints a scoped SB-MCP token from a *browser* Authelia session:
+ * authority flows from NPM's forward-auth `Remote-User` / `Remote-Groups`
+ * headers, which NPM overwrites from the Authelia auth-request subrequest.
+ *
+ * The box-verify escalation (#2246 RED): on a DIRECT `:5888` call (bypassing
+ * NPM), a valid Bearer holder passes proxy.ts's `isValidBearerToken()` gate and
+ * can supply its OWN `Remote-User: evil` + `Remote-Groups: admins` headers
+ * (nothing upstream overwrote them) → mint an admin-scoped token = self-elevation.
+ *
+ * The route runs `skipAuth: true`, so the real `withApiHandler` does not gate —
+ * we drive the ACTUAL route module and assert:
+ *   - a request carrying a client Bearer + spoofed admin headers → 403, NO token
+ *   - a legit browser forward-auth request (admin headers, NO Bearer)   → token
+ *   - forward-auth headers but not in `admins`                          → 403, NO token
+ *   - no forward-auth identity at all                                   → 401, NO token
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  createToken: vi.fn(),
+}));
+
+// The route only calls createToken when it decides to mint. If createToken is
+// never called on a refused request, no token was minted — the assertion.
+vi.mock('@/lib/auth/apiTokens', () => ({
+  createToken: mocks.createToken,
+}));
+
+import { POST } from './route';
+
+function req(headers: Record<string, string>): NextRequest {
+  return new NextRequest('http://localhost:5888/api/auth/token-from-authelia-session', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('token-from-authelia-session privilege-escalation guard (#2249)', () => {
+  beforeEach(() => {
+    mocks.createToken.mockReset();
+    mocks.createToken.mockResolvedValue({
+      token: { id: 't1', name: 'authelia-session:admin', scopes: ['read', 'lifecycle', 'mutate'] },
+      secret: 'sb_minted_secret',
+    });
+  });
+
+  it('REFUSES a client Bearer + spoofed Remote-Groups:admins → 403, mints nothing', async () => {
+    const res = await POST(
+      req({
+        authorization: 'Bearer sb_some_scoped_token',
+        'remote-user': 'evil-hacker',
+        'remote-groups': 'admins',
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.createToken).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.token).toBeUndefined();
+  });
+
+  it('mints for a real browser forward-auth admin session (admin headers, NO Bearer)', async () => {
+    const res = await POST(
+      req({ 'remote-user': 'alice', 'remote-groups': 'admins,users' }),
+    );
+    expect(res.status).toBe(200);
+    expect(mocks.createToken).toHaveBeenCalledOnce();
+    const body = await res.json();
+    expect(body.token).toBe('sb_minted_secret');
+    expect(body.scopes).toEqual(['read', 'lifecycle', 'mutate']);
+  });
+
+  it('forward-auth identity not in admins → 403, mints nothing', async () => {
+    const res = await POST(
+      req({ 'remote-user': 'bob', 'remote-groups': 'users' }),
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.createToken).not.toHaveBeenCalled();
+  });
+
+  it('no forward-auth identity → 401, mints nothing', async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(401);
+    expect(mocks.createToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/app/api/auth/token-from-authelia-session/route.ts
+++ b/packages/frontend/src/app/api/auth/token-from-authelia-session/route.ts
@@ -31,6 +31,20 @@ import { logger } from '@/lib/logger';
  *   privilege boundary, the only accepted proof of a verified admin is the
  *   proxy-injected identity.
  *
+ * PRIVILEGE-ESCALATION GUARD (#2246/#2249, SECURITY):
+ *   This endpoint mints authority from a *browser* Authelia session — the
+ *   legitimate caller is a signed-in admin behind NPM, whose request carries
+ *   the Authelia cookie (consumed by NPM's forward-auth) and NO client
+ *   `Authorization: Bearer` token. A token client, by contrast, must NEVER be
+ *   able to reach here: on a DIRECT `:5888` call (bypassing NPM) a Bearer holder
+ *   passes `proxy.ts`'s `isValidBearerToken()` gate and could then supply its
+ *   OWN `Remote-User: evil` / `Remote-Groups: admins` headers (nothing upstream
+ *   overwrote them) → mint an admin-scoped token = self-elevation. So we REFUSE
+ *   any request that presents a client Bearer (403, mint nothing). Identity here
+ *   may only come from the proxy-injected forward-auth headers, never from a
+ *   caller who is already a token. This also keeps a token from bootstrapping a
+ *   higher-scoped token than it holds.
+ *
  * `skipAuth: true`: the Authelia proxy headers ARE the credential (mirrors
  * `/api/auth/session-from-token`, which treats the presented Bearer as the
  * credential). No cookie/admin session is required — that's the point.
@@ -56,6 +70,23 @@ function parseGroups(raw: string | null): string[] {
 }
 
 export const POST = withApiHandler({ skipAuth: true }, async ({ request }: { request: NextRequest }) => {
+  // PRIVILEGE-ESCALATION GUARD (#2249): refuse any caller presenting a client
+  // Bearer token. The legitimate flow is a browser Authelia session behind NPM
+  // (cookie, no Bearer). A token client reaching here on a direct :5888 call
+  // could set its OWN Remote-User/Remote-Groups (nothing overwrote them) and
+  // self-elevate to an admin-scoped token. A token must never mint identity.
+  const authz = request.headers.get('authorization');
+  if (authz && authz.startsWith('Bearer ')) {
+    logger.warn(
+      'api:auth:token-from-authelia-session',
+      'Refused token exchange: request carried a client Bearer token (not a browser Authelia session)',
+    );
+    return NextResponse.json(
+      { error: 'This endpoint is for a browser Authelia session; a token client may not exchange for a token here' },
+      { status: 403 },
+    );
+  }
+
   // Only the proxy-injected identity is trusted (see TRUST MODEL above).
   const user = request.headers.get('remote-user');
   if (!user) {

--- a/packages/frontend/src/app/api/system/stacks/image-updates/route.ts
+++ b/packages/frontend/src/app/api/system/stacks/image-updates/route.ts
@@ -13,20 +13,21 @@
  * consumes this; this route makes NO `(dashboard)/` changes.
  */
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
 import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getInstalledImageUpdates } from '@/lib/imageDigest';
 
 export const dynamic = 'force-dynamic';
 
-// tokenScope:'read' (#2243) — a scoped SB-MCP Bearer token may poll this
-// pending-image-updates signal so an external consumer (Solaris Wartung chat)
-// can render "update available" cards. The gate stays deny-by-default: a
+// tokenScope must live in the withApiHandler OPTIONS so handler.ts's built-in
+// requireSession runs with it (#2249): a scoped SB-MCP Bearer token may poll
+// this pending-image-updates signal so an external consumer (Solaris Wartung
+// chat) can render "update available" cards. The gate stays deny-by-default: a
 // missing/wrong-scope Bearer 401s and a session cookie keeps working unchanged.
-export const GET = withApiHandler({}, async ({ request }) => {
-  const auth = await requireSession(request, { tokenScope: 'read' });
-  if (auth instanceof NextResponse) return auth;
+// (Previously the scope sat on an INNER requireSession call while the wrapper
+// gate ran scopeless first → the Bearer path was skipped → 401 on a valid
+// read token; box-verify #2243 RED.)
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
   try {
     const services = await getInstalledImageUpdates();
     return NextResponse.json({ services });

--- a/packages/frontend/src/app/api/system/templates/upgrades-pending/route.ts
+++ b/packages/frontend/src/app/api/system/templates/upgrades-pending/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/api/requireSession';
 import { withApiHandler } from '@/lib/api/handler';
 import { apiError } from '@/lib/api/errors';
 import { getConfig } from '@/lib/config';
@@ -38,11 +37,12 @@ interface UpgradeSummary {
  * would sit unnoticed for any operator who never opens the
  * Re-deploy modal.
  */
-// tokenScope:'read' (#2243) — same pending-updates signal, template side. A
-// scoped Bearer token may read it; cookie sessions are unaffected.
-export const GET = withApiHandler({}, async ({ request }) => {
-  const auth = await requireSession(request, { tokenScope: 'read' });
-  if (auth instanceof NextResponse) return auth;
+// tokenScope must live in the withApiHandler OPTIONS so handler.ts's built-in
+// requireSession runs with it (#2249) — same pending-updates signal, template
+// side. A scoped Bearer token may read it; cookie sessions are unaffected.
+// (Previously the scope sat on an INNER requireSession call while the wrapper
+// gate ran scopeless first → the Bearer path was skipped → 401; box-verify RED.)
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
   try {
     const config = await getConfig();
     const installed = config.installedTemplates ?? {};


### PR DESCRIPTION
## What
Forward-fix for the box-verify RED on batch/2026-07-13a (#2243/#2246 @54c1cf33). Two security defects: (1) image-updates + upgrades-pending GET carried `tokenScope:'read'` on an inner `requireSession` while `withApiHandler({})` gated scopeless first, so a valid read Bearer 401'd; moved `tokenScope:'read'` into `withApiHandler` options (mirrors approve/reject) and dropped the inner guard. (2) `/api/auth/token-from-authelia-session` minted an admin token for any valid client Bearer carrying spoofed `Remote-User`/`Remote-Groups:admins` on a direct :5888 call; the route now refuses any request carrying a client `Authorization: Bearer` (403, no token) — the legit flow is a browser Authelia session behind NPM (cookie, no Bearer).

## Why
Closes #2249

## Risk
Medium — auth surface (token scope wiring + identity-header trust). Legit forward-auth admin flow preserved; header-spoof escalation closed. Regression tests fail-before/pass-after.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 err / 358 warn == baseline)
- [x] npm run typecheck (exit 0)
- [x] npm run check:arch (1026 modules, 0 violations)
- [x] npm test (424 files / 3708 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (path-mandated: packages/frontend/src/app/api + proxy.ts auth surface)