### PR TITLE
feat(napi): companion-app operate + verdict endpoints and deep-link docs

### DIFF
--- a/docs/COMPANION_APP.md
+++ b/docs/COMPANION_APP.md
@@ -1,0 +1,103 @@
+# Companion-app native API (`/napi/*`) & deep-links
+
+The companion (phone) app talks to ServiceBay over a **token-only, proxy-bypassed**
+surface under `/napi/*`, and opens the web UI via a small set of **deep-link
+URLs** when a widget is tapped. This is epic #2242 (Native token-only API +
+Device-Token-Pairing).
+
+Design rule for the whole `/napi/*` surface: each route is a **lean twin** of an
+existing `/api/*` route, reusing the same backend primitive (no second store, no
+duplicated logic). The `/api/*` route stays the rich, cookie-authenticated
+browser surface; the `/napi/*` twin is the token-only path that never touches
+Authelia. The scope required is declared in the `withApiHandler` /
+`withApiHandlerParams` **options object** (the only place the gate reads it — a
+scope on an inner `requireSession` 401s a valid Bearer, #2249), so a device
+token that lacks the scope is rejected before the handler runs.
+
+## Pairing → token (#2251)
+
+1. A signed-in admin opens **Settings → Access → Connect Device**, which POSTs
+   `POST /napi/pair` (browser Authelia session only — a Bearer is refused, #2249)
+   and gets back a short-lived 6-char pairing code + a QR-encodable redeem URL.
+2. The phone redeems it at the public `POST /napi/pair/redeem` and receives a
+   **read-scoped** `sb_` Bearer token (30-day expiry).
+
+> **Scope note (open sub-decision, #2253).** The redeem path mints a **`read`
+> token only** — by hard invariant (`REDEEM_SCOPES = ['read']`, "never widen").
+> The mutating `/napi/*` endpoints below therefore require a token minted through
+> the admin **API Tokens** UI (`Settings → Access → API Tokens`) with the
+> `lifecycle` / `mutate` scope, not the default paired read token. Whether the
+> *pairing* flow should offer a scope choice (mint a combined
+> `read`+`lifecycle`+`mutate` token) is a product decision tracked on the epic;
+> the endpoints ship scope-gated regardless of how the device acquires the token.
+
+## Read endpoints (#2252) — `read` scope
+
+| Method | Path | Twin of |
+|---|---|---|
+| GET | `/napi/home` | dashboard summary |
+| GET | `/napi/approvals` | `/api/approvals` (pending only) |
+| GET | `/napi/services` | `/api/services` (lean projection) |
+| GET | `/napi/upgrades` | template + image update signals |
+
+## Operate endpoints (#2253)
+
+### `POST /napi/services/:name/operate` — `lifecycle` scope
+
+Start / stop / restart a managed service. Reuses
+`ServiceManager.{start,stop,restart}Service` (the same primitive the browser
+`/api/services/[name]/action` route drives).
+
+```
+POST /napi/services/immich/operate
+Authorization: Bearer sb_…            # must hold `lifecycle` (or higher)
+Content-Type: application/json
+
+{ "action": "start" | "stop" | "restart" }
+→ 200 { "ok": true, "name": "immich", "action": "start" }
+```
+
+- A `read`-only token → **401** (wrong scope). No-token → **401**.
+- Invalid service name → **400**. A lifecycle failure → **500** (never a
+  false-green `ok`).
+- `update` is intentionally NOT offered here — it is a heavier upgrade operation,
+  outside the reversible `lifecycle` tier. Surfaced in the app as
+  "sensitive — confirmation required."
+- Optional `?node=<name>` targets a non-`Local` node.
+
+### `POST /napi/approvals/:id/approve` and `POST /napi/approvals/:id/deny` — `mutate` scope
+
+Deliver the operator's verdict on a pending approval from the app. Reuse the same
+`approveApproval` / `rejectApproval` store as the browser routes.
+
+```
+POST /napi/approvals/<id>/approve       # or /deny
+Authorization: Bearer sb_…              # must hold `mutate`
+→ 200 { "ok": true, … }
+```
+
+- A `read`-only token → **401**. No-token → **401**.
+- **Self-approve guard preserved** (memory
+  `reference_mcp_destroy_tier_approval_flow`): the token that *proposed* a
+  destroy-tier action cannot approve or deny it — a **different** operator's
+  verdict is required → **403**. Any destructive work an approval carries was
+  scope-checked when it was *proposed*; delivering the verdict is a mutate-tier
+  action, so these routes are `mutate`, not `destroy`.
+
+## Deep-links — open the web UI from a widget tap
+
+Widget taps open the **browser** UI (a normal Authelia-session cookie flow, NOT
+a Bearer token — these are Next.js pages behind the proxy, not `/napi/*` routes).
+Canonical URLs (relative to the box's public admin origin, `<sb_url>`):
+
+| Intent | URL | Route |
+|---|---|---|
+| Approvals | `<sb_url>/settings/access#approvals` | `(dashboard)/settings/access`, section `id="approvals"` |
+| Services | `<sb_url>/services` | `(dashboard)/services` |
+| Status | `<sb_url>/status` | `(dashboard)/status` |
+
+> The approvals link resolves to `/settings/access#approvals` (the Approvals
+> section lives on the **Access** settings page under an `#approvals` anchor) —
+> there is no standalone `/settings/approvals` route. When opened in the phone
+> browser with an active Authelia session the page renders directly; without a
+> session Authelia intercepts and returns the user to the target after login.

--- a/packages/frontend/src/app/napi/approvals/[id]/approve/route.test.ts
+++ b/packages/frontend/src/app/napi/approvals/[id]/approve/route.test.ts
@@ -1,0 +1,91 @@
+/**
+ * POST /napi/approvals/:id/approve — companion-app verdict delivery (#2253).
+ *
+ * Mirrors the browser /api/approvals/[id]/approve self-approve guard test: the
+ * route is reachable by a `mutate`-scope Bearer (pinned in
+ * ../../../scopeGuards.test.ts), but the human-in-the-loop invariant must hold —
+ * the SAME token that PROPOSED a destroy-tier action cannot approve it (memory
+ * reference_mcp_destroy_tier_approval_flow). Gate/scope machinery is covered in
+ * requireSession.test.ts; here we stub the wrapper to inject `auth` and prove
+ * the self-approve branch + the pass-through effect.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { ApprovalRequest } from '@/lib/approvals';
+
+const mocks = vi.hoisted(() => ({
+  approveApproval: vi.fn(),
+  getApproval: vi.fn(),
+  authRef: { value: undefined as { user: string } | undefined },
+}));
+
+vi.mock('@/lib/mcp/server', () => ({}));
+
+vi.mock('@/lib/approvals', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/approvals')>('@/lib/approvals');
+  return {
+    isSelfApproval: actual.isSelfApproval,
+    approveApproval: mocks.approveApproval,
+    getApproval: mocks.getApproval,
+  };
+});
+
+vi.mock('@/lib/api/handler', () => ({
+  withApiHandlerParams:
+    (
+      _opts: unknown,
+      handler: (ctx: { params: { id: string }; auth?: { user: string } }) => Promise<Response>,
+    ) =>
+    async (_request: NextRequest, ctx: { params: Promise<{ id: string }> }) =>
+      handler({ params: await ctx.params, auth: mocks.authRef.value }),
+}));
+
+import { POST } from './route';
+
+const proposal = (caller: string): ApprovalRequest => ({
+  id: 'r1',
+  service: 'honcho',
+  title: 'delete_service: honcho',
+  description: null,
+  payload: { caller },
+  on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+  on_reject: {},
+  node: 'box1',
+  created_at: new Date().toISOString(),
+  status: 'pending',
+});
+
+const call = async (auth: { user: string } | undefined) => {
+  mocks.authRef.value = auth;
+  const req = new NextRequest('http://localhost/napi/approvals/r1/approve', { method: 'POST' });
+  return POST(req, { params: Promise.resolve({ id: 'r1' }) });
+};
+
+beforeEach(() => {
+  mocks.approveApproval.mockReset();
+  mocks.getApproval.mockReset();
+  mocks.approveApproval.mockResolvedValue({ request: proposal('token:solaris') });
+});
+
+describe('POST /napi/approvals/:id/approve — self-approval guard (#2253, #2244)', () => {
+  it('403s the token that proposed the request; the tool is NOT run', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'token:solaris' });
+    expect(res.status).toBe(403);
+    expect(mocks.approveApproval).not.toHaveBeenCalled();
+  });
+
+  it('lets a DIFFERENT mutate token deliver the verdict (acceptance #2)', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'token:other' });
+    expect(res.status).toBe(200);
+    expect(mocks.approveApproval).toHaveBeenCalledWith('r1');
+  });
+
+  it('lets the cookie operator approve (never a token proposer)', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'admin' });
+    expect(res.status).toBe(200);
+    expect(mocks.approveApproval).toHaveBeenCalledWith('r1');
+  });
+});

--- a/packages/frontend/src/app/napi/approvals/[id]/approve/route.ts
+++ b/packages/frontend/src/app/napi/approvals/[id]/approve/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { approveApproval, getApproval, isSelfApproval } from '@/lib/approvals';
+// Side-effect import (#2237): loading mcp/server runs its top-level
+// registerMcpDispatcher(...) call, so THIS route's bundle instance of
+// lib/approvals has a dispatcher when approving an on_approve.mcp approval.
+// Same reason as the browser /api/approvals/[id]/approve route — the App-Router
+// route would otherwise bundle its own copy of lib/approvals with a null
+// dispatcher and 400 with "MCP tool dispatcher is not registered" (box-verified
+// RED on #2234). Import the registration seam here so the /napi verdict path
+// runs the tool too.
+import '@/lib/mcp/server';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /napi/approvals/:id/approve — deliver an operator "approve" verdict from
+ * the companion app (#2253, child 3 of epic #2242).
+ *
+ * The token-only, proxy-bypassed twin of `POST /api/approvals/[id]/approve`.
+ * Reuses the SAME `approveApproval()` store + `isSelfApproval` guard — no second
+ * store, no duplicated logic; a phone tap and a browser click resolve the same
+ * queue. The browser route stays cookie + mutate-Bearer; this `/napi/*` twin is
+ * the token-only path that never touches Authelia.
+ *
+ * TOKEN-GATED, `mutate`-scoped. `tokenScope: 'mutate'` in the
+ * withApiHandlerParams OPTIONS (#2249 — scope in the wrapper the gate reads, not
+ * an inner requireSession). NOT `destroy`: delivering the verdict is a
+ * mutate-tier action; the destructive work an on_approve.mcp action runs was
+ * already scope-checked when the agent PROPOSED it. A `read`-only device token
+ * (the pairing default, #2251) is rejected.
+ *
+ * SELF-APPROVE GUARD preserved (memory reference_mcp_destroy_tier_approval_flow):
+ * a token can never approve the very request it proposed — the destructive
+ * action must route through a DIFFERENT operator's verdict.
+ */
+export const POST = withApiHandlerParams<undefined, undefined, { id: string }>(
+  { tokenScope: 'mutate' },
+  async ({ params, auth }) => {
+    const id = decodeURIComponent(params.id);
+    const existing = await getApproval(id);
+    if (existing && isSelfApproval(existing, auth?.user)) {
+      return NextResponse.json(
+        { error: 'A token cannot approve the request it proposed; a ServiceBay admin must approve it.' },
+        { status: 403 },
+      );
+    }
+    try {
+      const result = await approveApproval(id);
+      return NextResponse.json({ ok: true, ...result });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('napi:approvals', `approve ${id} failed`, error);
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+  },
+);

--- a/packages/frontend/src/app/napi/approvals/[id]/deny/route.test.ts
+++ b/packages/frontend/src/app/napi/approvals/[id]/deny/route.test.ts
@@ -1,0 +1,86 @@
+/**
+ * POST /napi/approvals/:id/deny — companion-app verdict delivery (#2253).
+ *
+ * Same self-approve guard as the approve twin: a `mutate`-scope Bearer may
+ * deliver a "deny" verdict, but the token that PROPOSED the request cannot
+ * resolve it. Gate/scope machinery lives in requireSession.test.ts; the exact
+ * `mutate` scope in OPTIONS is pinned in ../../../scopeGuards.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { ApprovalRequest } from '@/lib/approvals';
+
+const mocks = vi.hoisted(() => ({
+  rejectApproval: vi.fn(),
+  getApproval: vi.fn(),
+  authRef: { value: undefined as { user: string } | undefined },
+}));
+
+vi.mock('@/lib/approvals', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/approvals')>('@/lib/approvals');
+  return {
+    isSelfApproval: actual.isSelfApproval,
+    rejectApproval: mocks.rejectApproval,
+    getApproval: mocks.getApproval,
+  };
+});
+
+vi.mock('@/lib/api/handler', () => ({
+  withApiHandlerParams:
+    (
+      _opts: unknown,
+      handler: (ctx: { params: { id: string }; auth?: { user: string } }) => Promise<Response>,
+    ) =>
+    async (_request: NextRequest, ctx: { params: Promise<{ id: string }> }) =>
+      handler({ params: await ctx.params, auth: mocks.authRef.value }),
+}));
+
+import { POST } from './route';
+
+const proposal = (caller: string): ApprovalRequest => ({
+  id: 'r1',
+  service: 'honcho',
+  title: 'delete_service: honcho',
+  description: null,
+  payload: { caller },
+  on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+  on_reject: {},
+  node: 'box1',
+  created_at: new Date().toISOString(),
+  status: 'pending',
+});
+
+const call = async (auth: { user: string } | undefined) => {
+  mocks.authRef.value = auth;
+  const req = new NextRequest('http://localhost/napi/approvals/r1/deny', { method: 'POST' });
+  return POST(req, { params: Promise.resolve({ id: 'r1' }) });
+};
+
+beforeEach(() => {
+  mocks.rejectApproval.mockReset();
+  mocks.getApproval.mockReset();
+  mocks.rejectApproval.mockResolvedValue({ request: proposal('token:solaris') });
+});
+
+describe('POST /napi/approvals/:id/deny — self-approval guard (#2253, #2244)', () => {
+  it('403s the token that proposed the request; the reject is NOT run', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'token:solaris' });
+    expect(res.status).toBe(403);
+    expect(mocks.rejectApproval).not.toHaveBeenCalled();
+  });
+
+  it('lets a DIFFERENT mutate token deliver the deny verdict (acceptance #2)', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'token:other' });
+    expect(res.status).toBe(200);
+    expect(mocks.rejectApproval).toHaveBeenCalledWith('r1');
+  });
+
+  it('lets the cookie operator deny (never a token proposer)', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'admin' });
+    expect(res.status).toBe(200);
+    expect(mocks.rejectApproval).toHaveBeenCalledWith('r1');
+  });
+});

--- a/packages/frontend/src/app/napi/approvals/[id]/deny/route.ts
+++ b/packages/frontend/src/app/napi/approvals/[id]/deny/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { rejectApproval, getApproval, isSelfApproval } from '@/lib/approvals';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /napi/approvals/:id/deny — deliver an operator "deny" verdict from the
+ * companion app (#2253, child 3 of epic #2242).
+ *
+ * The token-only, proxy-bypassed twin of `POST /api/approvals/[id]/reject`
+ * (named `deny` on the /napi surface to match the companion-app verb). Reuses
+ * the SAME `rejectApproval()` store + `isSelfApproval` guard — no second store.
+ * The browser reject route stays cookie + mutate-Bearer; this `/napi/*` twin is
+ * the token-only path that never touches Authelia.
+ *
+ * TOKEN-GATED, `mutate`-scoped. `tokenScope: 'mutate'` in the
+ * withApiHandlerParams OPTIONS (#2249 — scope in the wrapper the gate reads).
+ * A `read`-only device token (the pairing default, #2251) is rejected.
+ *
+ * SELF-APPROVE GUARD preserved: a token can never resolve (approve OR deny) the
+ * very request it proposed.
+ */
+export const POST = withApiHandlerParams<undefined, undefined, { id: string }>(
+  { tokenScope: 'mutate' },
+  async ({ params, auth }) => {
+    const id = decodeURIComponent(params.id);
+    const existing = await getApproval(id);
+    if (existing && isSelfApproval(existing, auth?.user)) {
+      return NextResponse.json(
+        { error: 'A token cannot resolve the request it proposed; a ServiceBay admin must decide it.' },
+        { status: 403 },
+      );
+    }
+    try {
+      const result = await rejectApproval(id);
+      return NextResponse.json({ ok: true, ...result });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('napi:approvals', `deny ${id} failed`, error);
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+  },
+);

--- a/packages/frontend/src/app/napi/scopeGuards.test.ts
+++ b/packages/frontend/src/app/napi/scopeGuards.test.ts
@@ -52,3 +52,28 @@ describe('/napi/* read endpoints are read-scoped in the handler OPTIONS (#2252, 
     });
   }
 });
+
+/**
+ * The MUTATING `/napi/*` companion-app surface (#2253). Same anti-false-green
+ * pin as the read routes, but each mutating route must carry the CORRECT
+ * higher scope in the withApiHandlerParams OPTIONS — a `read`-only device token
+ * (the pairing default, #2251) must be unable to reach these:
+ *   - operate (start/stop/restart) → 'lifecycle'
+ *   - approve / deny verdict       → 'mutate'
+ * Pinning the exact scope here is what stops a future edit from silently
+ * widening a read token's reach into service control or approval verdicts.
+ */
+const MUTATE_ROUTES: Array<{ path: string; scope: string }> = [
+  { path: 'services/[name]/operate/route.ts', scope: 'lifecycle' },
+  { path: 'approvals/[id]/approve/route.ts', scope: 'mutate' },
+  { path: 'approvals/[id]/deny/route.ts', scope: 'mutate' },
+];
+
+describe('/napi/* mutating endpoints carry the correct scope in the handler OPTIONS (#2253, #2249)', () => {
+  for (const { path, scope } of MUTATE_ROUTES) {
+    it(`${path} → tokenScope '${scope}' in withApiHandlerParams options, not an inner call`, () => {
+      expect(optionsScope(path)).toBe(scope);
+      expect(hasInnerRequireSessionScope(path)).toBe(false);
+    });
+  }
+});

--- a/packages/frontend/src/app/napi/services/[name]/operate/route.test.ts
+++ b/packages/frontend/src/app/napi/services/[name]/operate/route.test.ts
@@ -1,0 +1,109 @@
+/**
+ * POST /napi/services/:name/operate — companion-app service control (#2253).
+ *
+ * The gate/scope machinery (accept a `lifecycle` Bearer, 401 a read/absent
+ * token) is proven in requireSession.test.ts, and the EXACT `lifecycle` scope
+ * baked into this route's OPTIONS is pinned in ../../../scopeGuards.test.ts.
+ * Here we exercise the route body: each action forwards to the matching
+ * ServiceManager lifecycle primitive, an invalid name 400s, and the node query
+ * threads through — with `withApiHandlerParams` stubbed to inject `auth` the way
+ * the real gate would (same shape as the browser approve route test).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  startService: vi.fn(),
+  stopService: vi.fn(),
+  restartService: vi.fn(),
+  authRef: { value: { user: 'token:device' } as { user: string } | undefined },
+}));
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: {
+    startService: mocks.startService,
+    stopService: mocks.stopService,
+    restartService: mocks.restartService,
+  },
+}));
+
+vi.mock('@/lib/api/handler', () => ({
+  withApiHandlerParams:
+    (
+      _opts: unknown,
+      handler: (ctx: {
+        body: { action: string };
+        query: { node?: string };
+        params: { name: string };
+        auth?: { user: string };
+      }) => Promise<Response>,
+    ) =>
+    async (
+      request: NextRequest,
+      ctx: { params: Promise<{ name: string }> },
+    ) => {
+      const raw = await request.text();
+      const body = raw ? JSON.parse(raw) : {};
+      const node = new URL(request.url).searchParams.get('node') ?? undefined;
+      return handler({ body, query: { node }, params: await ctx.params, auth: mocks.authRef.value });
+    },
+}));
+
+import { POST } from './route';
+
+function call(name: string, action: string, node?: string) {
+  const url = `http://localhost:5888/napi/services/${name}/operate${node ? `?node=${node}` : ''}`;
+  const req = new NextRequest(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ action }),
+  });
+  return POST(req, { params: Promise.resolve({ name }) });
+}
+
+describe('POST /napi/services/:name/operate — lifecycle control', () => {
+  beforeEach(() => {
+    mocks.startService.mockReset().mockResolvedValue(undefined);
+    mocks.stopService.mockReset().mockResolvedValue(undefined);
+    mocks.restartService.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('start → calls startService(Local, name) and returns ok (acceptance #1)', async () => {
+    const res = await call('immich', 'start');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, name: 'immich', action: 'start' });
+    expect(mocks.startService).toHaveBeenCalledWith('Local', 'immich');
+    expect(mocks.stopService).not.toHaveBeenCalled();
+  });
+
+  it('stop → calls stopService', async () => {
+    const res = await call('immich', 'stop');
+    expect(res.status).toBe(200);
+    expect(mocks.stopService).toHaveBeenCalledWith('Local', 'immich');
+  });
+
+  it('restart → calls restartService', async () => {
+    const res = await call('immich', 'restart');
+    expect(res.status).toBe(200);
+    expect(mocks.restartService).toHaveBeenCalledWith('Local', 'immich');
+  });
+
+  it('threads the node query through to the lifecycle call', async () => {
+    await call('immich', 'restart', 'box2');
+    expect(mocks.restartService).toHaveBeenCalledWith('box2', 'immich');
+  });
+
+  it('invalid service name → 400, no lifecycle call', async () => {
+    const res = await call('bad name!', 'start');
+    expect(res.status).toBe(400);
+    expect(mocks.startService).not.toHaveBeenCalled();
+  });
+
+  it('a lifecycle failure surfaces as 500, not a false-green ok', async () => {
+    mocks.startService.mockRejectedValue(new Error('unit failed'));
+    const res = await call('immich', 'start');
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).not.toBe(true);
+  });
+});

--- a/packages/frontend/src/app/napi/services/[name]/operate/route.ts
+++ b/packages/frontend/src/app/napi/services/[name]/operate/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { ServiceName } from '@/lib/api/schemas';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /napi/services/:name/operate — start / stop / restart a service from the
+ * companion app (#2253, child 3 of epic #2242).
+ *
+ * The token-only, proxy-bypassed mutating twin of the browser
+ * `/api/services/[name]/action` route. Reuses the SAME
+ * `ServiceManager.{start,stop,restart}Service` lifecycle primitives — no second
+ * code path — so a companion-app tap and a browser button do the identical
+ * thing. `/api/services/[name]/action` stays the browser surface (cookie); this
+ * is the `/napi/*` twin that never touches Authelia.
+ *
+ * TOKEN-GATED, `lifecycle`-scoped. `tokenScope: 'lifecycle'` in the
+ * withApiHandlerParams OPTIONS (#2249 — the scope lives in the wrapper options
+ * the gate actually reads, NOT an inner requireSession that would 401 a valid
+ * Bearer). A `read`-only device token (the default the pairing flow #2251 mints)
+ * is REJECTED here — start/stop/restart is a state change, so it needs the
+ * `lifecycle` tier or higher; a read token can never operate a service.
+ *
+ * `update` is intentionally NOT offered here: a template/image upgrade is a
+ * heavier operation the app surfaces via its own upgrade path, and keeping this
+ * route to the three reversible lifecycle verbs matches the `lifecycle` scope
+ * tier exactly (start/stop/restart, per apiScope.ts).
+ */
+const Body = z.object({
+  action: z.enum(['start', 'stop', 'restart']),
+});
+const Query = z.object({ node: z.string().optional() });
+type BodyT = z.infer<typeof Body>;
+type QueryT = z.infer<typeof Query>;
+
+export const POST = withApiHandlerParams<BodyT, QueryT, { name: string }>(
+  { tokenScope: 'lifecycle', body: Body, query: Query },
+  async ({ body, query, params }) => {
+    const check = ServiceName.safeParse(decodeURIComponent(params.name));
+    if (!check.success) {
+      return NextResponse.json({ ok: false, error: 'invalid service name' }, { status: 400 });
+    }
+    const name = check.data;
+    const nodeName = query.node || 'Local';
+
+    try {
+      switch (body.action) {
+        case 'start':
+          await ServiceManager.startService(nodeName, name);
+          break;
+        case 'stop':
+          await ServiceManager.stopService(nodeName, name);
+          break;
+        case 'restart':
+          await ServiceManager.restartService(nodeName, name);
+          break;
+      }
+      return NextResponse.json({ ok: true, name, action: body.action });
+    } catch (e) {
+      return apiError(e, { tag: 'napi:services:operate', status: 500 });
+    }
+  },
+);


### PR DESCRIPTION
## What
Adds three token-gated /napi mutation endpoints for the companion app (second slice): POST /napi/services/:name/operate (lifecycle scope → start/stop/restart), POST /napi/approvals/:id/approve and POST /napi/approvals/:id/deny (mutate scope → approve/reject). Documents the deep-link URL scheme in docs/COMPANION_APP.md.

## Why
Closes #2253

## Risk
Medium — new token-gated mutation surface; reuses the established withApiHandler(Params) tokenScope OPTIONS gating (#2249) and the existing ServiceManager lifecycle + approveApproval/rejectApproval primitives; self-approve guard preserved.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full — 3815 passed)
- [ ] /verify on FCoS :dev box (path-mandated: /napi mutation flows — operate + verdict round-trip, scope gating, self-approve 403, deep-link resolution)