### PR TITLE
feat(mcp): one-shot owner-approved elevated destroy/exec token via request_token

### DIFF
--- a/packages/backend/src/lib/approvals/index.ts
+++ b/packages/backend/src/lib/approvals/index.ts
@@ -128,6 +128,17 @@ export interface ApprovalAction {
    * unset, so rejecting simply cancels the proposal without running anything.
    */
   mcp?: { toolName: string; args: Record<string, unknown> };
+  /**
+   * Mint a one-shot, short-TTL ELEVATED-scope token for a specific op the
+   * agent requested via request_token (#2245, option b). Carried on
+   * `on_approve` so approving in the operator's Approvals UI mints the token
+   * INTO the referenced token-request row (never returned to the operator) —
+   * the requesting agent then collects it exactly once via poll_token_request.
+   * `on_reject` leaves this unset, so denying mints nothing. The minter is
+   * injected (registerTokenMinter) so this kernel module never imports the
+   * token layer directly (would close an approvals ↔ token cycle).
+   */
+  mintToken?: { tokenRequestId: string };
 }
 
 export type ApprovalStatus = 'pending' | 'approved' | 'rejected';
@@ -163,6 +174,24 @@ let mcpDispatcher: McpToolDispatcher | null = null;
 /** Register the function that executes an MCP-tool approval on approve. */
 export function registerMcpDispatcher(fn: McpToolDispatcher): void {
   mcpDispatcher = fn;
+}
+
+/**
+ * Mints the one-shot elevated token for an approved request_token one-shot
+ * request (#2245). Injected by the token layer via {@link registerTokenMinter}
+ * so this kernel module executes a `mintToken` action without importing
+ * `auth/tokenRequests` (which does not import this module, but keeping the seam
+ * symmetric with mcpDispatcher avoids any future cycle and matches the pattern).
+ * Throws if the request is unknown/not-pending so the operator sees the mint
+ * failed and the approval is NOT marked approved.
+ */
+export type TokenMinter = (tokenRequestId: string) => Promise<void>;
+
+let tokenMinter: TokenMinter | null = null;
+
+/** Register the function that mints a one-shot elevated token on approve. */
+export function registerTokenMinter(fn: TokenMinter): void {
+  tokenMinter = fn;
 }
 
 /** Input accepted by {@link submitApproval}. `id`, `created_at` and `status`
@@ -349,6 +378,17 @@ async function runAction(action: ApprovalAction, node: string, service: string):
       throw new Error('MCP tool dispatcher is not registered; cannot run this approval.');
     }
     await mcpDispatcher(action.mcp.toolName, action.mcp.args);
+  }
+  if (action.mintToken) {
+    // Mint the one-shot elevated token for the referenced request_token row
+    // (#2245). LOAD-BEARING: a failure must propagate so the approval is NOT
+    // marked approved and the operator sees the mint failed (the agent then
+    // gets nothing to poll). The minter stashes the secret on the token-request
+    // row; the operator never sees it. Injected via registerTokenMinter.
+    if (!tokenMinter) {
+      throw new Error('Token minter is not registered; cannot run this approval.');
+    }
+    await tokenMinter(action.mintToken.tokenRequestId);
   }
   return {};
 }

--- a/packages/backend/src/lib/auth/apiTokens.ts
+++ b/packages/backend/src/lib/auth/apiTokens.ts
@@ -61,6 +61,21 @@ export interface ApiToken {
   // (session/admin) tokens — existing tokens have no parentId, which is fine;
   // this is purely additive and never settable by an external caller.
   parentId?: string;
+  // One-shot owner-approved elevation (#2245). Set only when this token was
+  // minted through the approved request_token one-shot flow. It carries an
+  // ELEVATED scope (destroy/exec) but is BOUND to exactly one op:
+  //   - `toolName` — the only MCP tool this token may invoke.
+  //   - `service`  — when present, the tool's target must match (e.g. only
+  //     `delete_service` on `honcho`), so the grant can't be redirected.
+  // The MCP gate refuses any call that doesn't match this binding. Combined
+  // with `singleUse`, the elevation is exactly one approved op, once. Never
+  // settable by an external caller — only the approved-mint path sets it.
+  oneShotOp?: { toolName: string; service?: string };
+  // Single-use burn (#2245): a token that is revoked after its first
+  // successful op (see consumeSingleUseToken), so the minted elevation can
+  // never be replayed. Paired with `oneShotOp` on the one-shot flow; a normal
+  // token never sets it.
+  singleUse?: boolean;
 }
 
 /** Raised by createDelegatedToken when the parent credential or the requested
@@ -178,6 +193,12 @@ export async function createToken(input: {
   // Lineage marker (#2048). Set only by the delegated-mint path — the public
   // mint route never passes it, so an external caller can't forge a parent.
   parentId?: string;
+  // One-shot op binding + single-use burn (#2245). Set only by the approved
+  // request_token one-shot-elevation path (mintOneShotForRequest); the public
+  // mint route never passes them, so an external caller can't forge a one-shot
+  // elevated token.
+  oneShotOp?: { toolName: string; service?: string };
+  singleUse?: boolean;
 }): Promise<{ token: Omit<ApiToken, 'hash'>; secret: string }> {
   if (!input.name?.trim()) throw new Error('Token name is required');
   if (!input.scopes?.length) throw new Error('At least one scope is required');
@@ -198,6 +219,8 @@ export async function createToken(input: {
     expiresAt: input.expiresAt,
     createdBy: input.createdBy,
     ...(input.parentId ? { parentId: input.parentId } : {}),
+    ...(input.oneShotOp ? { oneShotOp: input.oneShotOp } : {}),
+    ...(input.singleUse ? { singleUse: true } : {}),
   };
   data.tokens.push(token);
   await saveFile(data);
@@ -310,6 +333,29 @@ export async function revokeToken(id: string): Promise<boolean> {
   if (data.tokens.length === before) return false;
   await saveFile(data);
   logger.info('auth:apiTokens', `Revoked API token ${id}`);
+  return true;
+}
+
+/**
+ * Burn a single-use token after its one approved op ran (#2245). Removes the
+ * row IFF it is flagged `singleUse` — so a second call with the same token
+ * fails `verifyToken` (absent from the store) and yields 401. A non-single-use
+ * id is left untouched (defensive: this is only ever called from the MCP gate
+ * for a one-shot token, but we never want a stray call to nuke a standing
+ * credential). Returns whether a row was burned.
+ *
+ * Idempotent + concurrency-safe like revokeToken: settles the in-flight stamp
+ * first so a stale snapshot can't resurrect the burned row.
+ */
+export async function consumeSingleUseToken(id: string): Promise<boolean> {
+  if (!id) return false;
+  await pendingStamp;
+  const data = await loadFile();
+  const token = data.tokens.find(t => t.id === id);
+  if (!token || !token.singleUse) return false; // only burn a real single-use row
+  data.tokens = data.tokens.filter(t => t.id !== id);
+  await saveFile(data);
+  logger.info('auth:apiTokens', `Burned single-use API token ${id} after its one approved op`);
   return true;
 }
 

--- a/packages/backend/src/lib/auth/tokenRequests.oneShot.test.ts
+++ b/packages/backend/src/lib/auth/tokenRequests.oneShot.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+// #2245 (option b) — one-shot, owner-approved ELEVATED-scope token via the
+// request_token/poll_token_request flow. A default-scoped consumer requests a
+// token bound to ONE destructive op; it PARKS as a durable approval; on owner
+// Approve the poll returns a single-use, short-TTL token carrying ONLY that
+// elevated scope; a second use fails. Real-fs DATA_DIR per test.
+let dataDir = '';
+vi.mock('@/lib/dirs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/dirs')>();
+  return { ...actual, get DATA_DIR() { return dataDir; } };
+});
+// submitApproval resolves a target node — stub it so the store doesn't reach a
+// real node registry. The executor/ServiceManager are never used by a
+// mintToken approval (no move/restart).
+vi.mock('@/lib/nodes', () => ({ listNodes: vi.fn(() => Promise.resolve([{ Name: 'box1' }])) }));
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.useRealTimers();
+  dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sb-oneshot-'));
+});
+afterEach(async () => {
+  vi.useRealTimers();
+  await (await loadTokens()).flushPendingStamps();
+  await fsp.rm(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+});
+
+const loadReq = () => import('@/lib/auth/tokenRequests');
+const loadTokens = () => import('@/lib/auth/apiTokens');
+const loadApprovals = () => import('@/lib/approvals');
+
+describe('one-shot owner-approved elevated token (#2245)', () => {
+  it('one-shot request PARKS as an approval and returns an approvalId — mints NOTHING immediately', async () => {
+    const { submitTokenRequest, pollTokenRequest } = await loadReq();
+    const { listApprovals } = await loadApprovals();
+    const { listTokens } = await loadTokens();
+
+    const view = await submitTokenRequest({
+      requestedScopes: ['destroy'],
+      requestedTtlSecs: 300,
+      reason: 'delete honcho',
+      requestedBy: 'token:wartung',
+      oneShotOp: { toolName: 'delete_service', service: 'honcho' },
+    });
+    expect(view.status).toBe('pending');
+    expect(view.approvalId).toBeTruthy();
+    expect((view as Record<string, unknown>).pendingSecret).toBeUndefined();
+    expect(view.tokenId).toBeUndefined();
+
+    // A durable approval card exists for the operator.
+    const approvals = await listApprovals();
+    expect(approvals.map(a => a.id)).toContain(view.approvalId);
+    const card = approvals.find(a => a.id === view.approvalId)!;
+    expect(card.on_approve.mintToken?.tokenRequestId).toBe(view.id);
+    expect(card.payload.caller).toBe('token:wartung'); // self-approve anchor
+
+    // NO token minted yet.
+    expect(await listTokens()).toHaveLength(0);
+    // Poll before approval → pending, no token.
+    const early = await pollTokenRequest(view.id);
+    expect(early.status).toBe('pending');
+    expect(early.token).toBeNull();
+  });
+
+  it('on owner APPROVE, poll returns a single-use token carrying ONLY the bound elevated scope', async () => {
+    const { submitTokenRequest, pollTokenRequest } = await loadReq();
+    const { approveApproval } = await loadApprovals();
+    const { verifyToken } = await loadTokens();
+
+    const view = await submitTokenRequest({
+      requestedScopes: ['destroy'], requestedTtlSecs: 300, reason: 'r',
+      requestedBy: 'token:wartung', oneShotOp: { toolName: 'delete_service', service: 'honcho' },
+    });
+
+    // Owner approves the durable approval → mintToken runs.
+    await approveApproval(view.approvalId!);
+
+    const poll = await pollTokenRequest(view.id);
+    expect(poll.status).toBe('approved');
+    expect(poll.token).toMatch(/^sb_[0-9a-f]{8}_[A-Z2-9]+$/);
+    expect((poll as { grantedScopes?: string[] }).grantedScopes).toEqual(['destroy']);
+
+    const verified = await verifyToken(poll.token!);
+    expect(verified).not.toBeNull();
+    expect(verified!.scopes).toEqual(['destroy']); // ONLY destroy, not read/lifecycle/mutate
+    expect(verified!.singleUse).toBe(true);
+    expect(verified!.oneShotOp).toEqual({ toolName: 'delete_service', service: 'honcho' });
+
+    // Second poll no longer hands over the secret.
+    const again = await pollTokenRequest(view.id);
+    expect(again.token).toBeNull();
+  });
+
+  it('on owner DENY (reject), NOTHING is minted and poll stays token-less', async () => {
+    const { submitTokenRequest, pollTokenRequest } = await loadReq();
+    const { rejectApproval } = await loadApprovals();
+    const { listTokens } = await loadTokens();
+
+    const view = await submitTokenRequest({
+      requestedScopes: ['exec'], requestedTtlSecs: 120, reason: 'r',
+      requestedBy: 'token:wartung', oneShotOp: { toolName: 'exec_command' },
+    });
+    await rejectApproval(view.approvalId!);
+
+    expect(await listTokens()).toHaveLength(0);
+    const poll = await pollTokenRequest(view.id);
+    // The token request itself never flipped to approved (mint never ran).
+    expect(poll.token).toBeNull();
+    expect(poll.status).toBe('pending');
+  });
+
+  it('single-use burn: consumeSingleUseToken revokes the token so a second verify fails', async () => {
+    const { submitTokenRequest, pollTokenRequest } = await loadReq();
+    const { approveApproval } = await loadApprovals();
+    const { verifyToken, consumeSingleUseToken } = await loadTokens();
+
+    const view = await submitTokenRequest({
+      requestedScopes: ['destroy'], requestedTtlSecs: 300, reason: 'r',
+      requestedBy: 'token:wartung', oneShotOp: { toolName: 'delete_service', service: 'honcho' },
+    });
+    await approveApproval(view.approvalId!);
+    const secret = (await pollTokenRequest(view.id)).token!;
+
+    const first = await verifyToken(secret);
+    expect(first).not.toBeNull();
+
+    // Simulate the gate burning it after the one op.
+    const burned = await consumeSingleUseToken(first!.id);
+    expect(burned).toBe(true);
+
+    // Second use → token gone → 401 (null).
+    expect(await verifyToken(secret)).toBeNull();
+  });
+
+  it('consumeSingleUseToken refuses to burn a NON-single-use token (no standing-credential nuke)', async () => {
+    const { createToken, consumeSingleUseToken, verifyToken } = await loadTokens();
+    const { token, secret } = await createToken({ name: 'standing', scopes: ['read'], createdBy: 'admin' });
+    expect(await consumeSingleUseToken(token.id)).toBe(false);
+    expect(await verifyToken(secret)).not.toBeNull(); // still alive
+  });
+
+  it('TTL is clamped to the one-shot ceiling even if the caller asks for more', async () => {
+    const { submitTokenRequest, approveApproval, pollTokenRequest, ONE_SHOT_MAX_TTL_SECS } = {
+      ...(await loadReq()), ...(await loadApprovals()),
+    } as typeof import('@/lib/auth/tokenRequests') & typeof import('@/lib/approvals');
+    const view = await submitTokenRequest({
+      requestedScopes: ['destroy'], requestedTtlSecs: 30 * 24 * 3600, reason: 'r',
+      requestedBy: 'token:wartung', oneShotOp: { toolName: 'delete_service', service: 'honcho' },
+    });
+    expect(view.requestedTtlSecs).toBe(ONE_SHOT_MAX_TTL_SECS);
+    await approveApproval(view.approvalId!);
+    const poll = await pollTokenRequest(view.id);
+    expect((poll as { expiresAt?: string }).expiresAt).toBeTruthy();
+    const ttlMs = Date.parse((poll as { expiresAt: string }).expiresAt) - Date.now();
+    expect(ttlMs).toBeLessThanOrEqual(ONE_SHOT_MAX_TTL_SECS * 1000 + 1000);
+  });
+
+  it('rejects a one-shot request that asks for a non-elevated or multi-scope grant', async () => {
+    const { submitTokenRequest } = await loadReq();
+    await expect(submitTokenRequest({
+      requestedScopes: ['read'], requestedTtlSecs: 120, reason: 'r',
+      oneShotOp: { toolName: 'delete_service' },
+    })).rejects.toThrow(/exactly one elevated scope/);
+    await expect(submitTokenRequest({
+      requestedScopes: ['destroy', 'exec'], requestedTtlSecs: 120, reason: 'r',
+      oneShotOp: { toolName: 'delete_service' },
+    })).rejects.toThrow(/exactly one elevated scope/);
+  });
+
+  it('mintOneShotForRequest refuses a double-mint (already approved) — no second token', async () => {
+    const { submitTokenRequest, mintOneShotForRequest } = await loadReq();
+    const { approveApproval } = await loadApprovals();
+    const { listTokens } = await loadTokens();
+    const view = await submitTokenRequest({
+      requestedScopes: ['destroy'], requestedTtlSecs: 300, reason: 'r',
+      requestedBy: 'token:wartung', oneShotOp: { toolName: 'delete_service', service: 'honcho' },
+    });
+    await approveApproval(view.approvalId!);
+    expect(await listTokens()).toHaveLength(1);
+    // A replayed mint on the same (now-approved) request must throw and mint nothing more.
+    await expect(mintOneShotForRequest(view.id)).rejects.toThrow(/already approved/);
+    expect(await listTokens()).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/lib/auth/tokenRequests.ts
+++ b/packages/backend/src/lib/auth/tokenRequests.ts
@@ -37,11 +37,27 @@ import { randomUUID } from 'crypto';
 import { DATA_DIR } from '@/lib/dirs';
 import { atomicWriteFile } from '@/lib/util/atomicWrite';
 import { logger } from '@/lib/logger';
+import { submitApproval, registerTokenMinter } from '@/lib/approvals';
 import { ALL_SCOPES, type ApiScope } from './apiScope';
 import { createToken, revokeToken } from './apiTokens';
 
 const TAG = 'auth:tokenRequests';
 const STORE_PATH = path.join(DATA_DIR, 'token-requests.json');
+
+/**
+ * Elevated scopes (destroy/exec) that a ONE-SHOT owner-approved token may carry
+ * (#2245, option b). A one-shot request's granted scope must be exactly ONE of
+ * these — the whole point is a single elevated op the ambient token can't do.
+ */
+const ELEVATED_SCOPES: ReadonlySet<ApiScope> = new Set<ApiScope>(['destroy', 'exec']);
+
+/**
+ * TTL ceiling for a one-shot elevated token (#2245): 10 minutes. Far tighter
+ * than MAX_TTL_SECS — a one-shot elevation is meant to be collected and used
+ * immediately after the owner approves, then it burns (single-use) or lapses.
+ * The request may ask for less; anything above this is clamped down at submit.
+ */
+export const ONE_SHOT_MAX_TTL_SECS = 10 * 60;
 
 /** Anti-spam cap on outstanding pending token requests (mirrors the
  *  access-request MAX_PENDING). A hostile caller can't fill the disk. */
@@ -83,6 +99,22 @@ export interface TokenRequest {
    * view. This is the one-time hand-off channel — poll once, or re-request.
    */
   pendingSecret?: string;
+  /**
+   * One-shot ELEVATED-op binding (#2245, option b). Present only when this is a
+   * one-shot-elevation request: the caller asked for a token authorizing ONE
+   * specific destructive op (tool + optional target service), not a standing
+   * grant. When set:
+   *   - `requestedScopes` is exactly the single elevated scope (destroy|exec).
+   *   - the request PARKS in the durable approvals store (an approval card with
+   *     the self-approve guard), not the admin token-request PATCH route.
+   *   - on owner Approve, the minted token carries ONLY this scope, is bound to
+   *     this op, is single-use, and gets the ONE_SHOT_MAX_TTL_SECS-capped TTL.
+   */
+  oneShotOp?: { toolName: string; service?: string };
+  /** Id of the durable approval that gates a one-shot request (#2245). Set on
+   *  submit for a one-shot request so the caller can surface an approval card
+   *  and the operator's generic Approvals UI drives approve/deny. */
+  approvalId?: string;
 }
 
 /** Caller-facing view: the one-time secret is stripped from every list/audit
@@ -142,17 +174,54 @@ export class TokenRequestError extends Error {
   }
 }
 
-/** File a pending token request. Returns its id + status — NO token yet. */
+/** A one-shot op's target service must be a single, safe path segment (no
+ *  separators, no traversal) — mirrors the approvals-store service guard. */
+const ONE_SHOT_SERVICE_RE = /^[a-zA-Z0-9_.-]+$/;
+
+/** File a pending token request. Returns its id + status — NO token yet.
+ *
+ * `oneShotOp` (#2245, option b) switches to the one-shot ELEVATED-elevation
+ * flow: `requestedScopes` must be exactly one elevated scope (destroy|exec),
+ * the TTL is clamped to ONE_SHOT_MAX_TTL_SECS, and the request PARKS as a
+ * durable approval (card + self-approve guard) instead of the admin token PATCH
+ * route. On owner Approve the minted token is bound to `oneShotOp`, carries
+ * ONLY that scope, and is single-use. `requestedBy` is recorded as the approval
+ * proposer so the self-approve guard refuses the requester approving itself. */
 export async function submitTokenRequest(input: {
   requestedScopes: ApiScope[];
   requestedTtlSecs: number;
   reason: string;
   requestedBy?: string;
+  oneShotOp?: { toolName: string; service?: string };
 }): Promise<TokenRequestView> {
   assertScopes(input.requestedScopes, 'requestedScopes');
   assertTtl(input.requestedTtlSecs, 'requestedTtlSecs');
   const reason = (input.reason ?? '').trim();
   if (!reason) throw new TokenRequestError('reason is required', 400);
+
+  // One-shot elevation: validate the op binding + narrow the grant hard.
+  let oneShotOp: { toolName: string; service?: string } | undefined;
+  let ttlSecs = input.requestedTtlSecs;
+  if (input.oneShotOp) {
+    const scopes = [...new Set(input.requestedScopes)];
+    if (scopes.length !== 1 || !ELEVATED_SCOPES.has(scopes[0])) {
+      throw new TokenRequestError(
+        `A one-shot elevated request must ask for exactly one elevated scope (destroy or exec); got [${scopes.join(',')}].`,
+        400,
+      );
+    }
+    const toolName = (input.oneShotOp.toolName ?? '').trim();
+    if (!toolName) throw new TokenRequestError('oneShotOp.toolName is required', 400);
+    const service = input.oneShotOp.service?.trim();
+    if (service !== undefined && service !== '') {
+      if (!ONE_SHOT_SERVICE_RE.test(service) || service === '.' || service === '..') {
+        throw new TokenRequestError(`oneShotOp.service is not a valid service name: "${service}".`, 400);
+      }
+    }
+    oneShotOp = service ? { toolName, service } : { toolName };
+    // A one-shot elevation is meant to be used immediately — clamp hard.
+    ttlSecs = Math.min(ttlSecs, ONE_SHOT_MAX_TTL_SECS);
+  }
 
   const all = await readStore();
   const pending = all.filter(r => r.status === 'pending');
@@ -166,15 +235,37 @@ export async function submitTokenRequest(input: {
   const request: TokenRequest = {
     id: randomUUID(),
     requestedScopes: [...new Set(input.requestedScopes)],
-    requestedTtlSecs: input.requestedTtlSecs,
+    requestedTtlSecs: ttlSecs,
     reason: reason.slice(0, 1000),
     ...(input.requestedBy ? { requestedBy: input.requestedBy.slice(0, 120) } : {}),
+    ...(oneShotOp ? { oneShotOp } : {}),
     status: 'pending',
     createdAt: new Date().toISOString(),
   };
+
+  // A one-shot request parks as a DURABLE approval so it (a) surfaces as an
+  // operator approval card, (b) inherits the self-approve guard (the proposer
+  // can't approve its own request), and (c) survives a restart — the same
+  // owner-approved model as #2246. The approval's on_approve.mintToken mints the
+  // one-shot token INTO this row (mintOneShotForRequest); poll_token_request
+  // then hands it to the requester once. A plain (non-one-shot) request keeps
+  // the original admin-PATCH approve path unchanged.
+  if (oneShotOp) {
+    const opLabel = oneShotOp.service ? `${oneShotOp.toolName}: ${oneShotOp.service}` : oneShotOp.toolName;
+    const approval = await submitApproval({
+      service: oneShotOp.service ?? 'mcp',
+      title: `one-shot ${request.requestedScopes[0]} token — ${opLabel}`,
+      description: `An MCP agent (${input.requestedBy ?? 'anon'}) requested a ONE-SHOT, short-lived ${request.requestedScopes[0]} token authorizing exactly "${oneShotOp.toolName}"${oneShotOp.service ? ` on ${oneShotOp.service}` : ''}, once. Approving mints the token for the agent to collect; it cannot self-approve. Reason: ${reason.slice(0, 300)}`,
+      // caller drives the self-approve guard (isSelfApproval reads payload.caller).
+      payload: { caller: input.requestedBy, tokenRequestId: request.id, oneShotOp },
+      on_approve: { mintToken: { tokenRequestId: request.id } },
+    });
+    request.approvalId = approval.id;
+  }
+
   all.push(request);
   await writeStore(all);
-  logger.info(TAG, `submitted token request ${request.id} scopes=[${request.requestedScopes.join(',')}] ttl=${request.requestedTtlSecs}s by ${input.requestedBy ?? 'anon'}`);
+  logger.info(TAG, `submitted token request ${request.id} scopes=[${request.requestedScopes.join(',')}] ttl=${request.requestedTtlSecs}s${oneShotOp ? ` one-shot=${oneShotOp.toolName}${oneShotOp.service ? '/' + oneShotOp.service : ''} approval=${request.approvalId}` : ''} by ${input.requestedBy ?? 'anon'}`);
   return publicView(request);
 }
 
@@ -249,6 +340,70 @@ export async function approveTokenRequest(
   logger.info(TAG, `approved token request ${id} → token ${minted.token.id} scopes=[${req.grantedScopes.join(',')}] ttl=${grantedTtlSecs}s`);
   return publicView(req);
 }
+
+/**
+ * Mint the one-shot ELEVATED token for an approved one-shot request (#2245).
+ * Called by the durable approval's `on_approve.mintToken` action (via the
+ * injected registerTokenMinter seam) when the OWNER approves the card. Mints a
+ * token that:
+ *   - carries ONLY the single elevated scope the request named,
+ *   - is BOUND to the one op (oneShotOp: toolName + optional service),
+ *   - is SINGLE-USE (burns after the first successful op), and
+ *   - expires on the short (ONE_SHOT_MAX_TTL_SECS-capped) TTL.
+ * Stashes the secret on the request row for the requester's single poll.
+ *
+ * Refuses (throws) if the request is unknown, not a one-shot request, or not
+ * pending — so a replay/double-approve can't mint a second token. The throw
+ * propagates through runAction so the approval is NOT marked approved.
+ */
+export async function mintOneShotForRequest(tokenRequestId: string): Promise<void> {
+  const all = await readStore();
+  const req = all.find(r => r.id === tokenRequestId);
+  if (!req) throw new TokenRequestError(`Token request not found: ${tokenRequestId}`, 404);
+  if (!req.oneShotOp) {
+    throw new TokenRequestError(`Token request ${tokenRequestId} is not a one-shot request`, 400);
+  }
+  if (req.status !== 'pending') {
+    throw new TokenRequestError(`Token request ${tokenRequestId} is already ${req.status}`, 409);
+  }
+  // The grant is exactly the single elevated scope validated at submit — we do
+  // NOT let an approval widen it (defense-in-depth; submit already narrowed).
+  const scopes = [...new Set(req.requestedScopes)];
+  if (scopes.length !== 1 || !ELEVATED_SCOPES.has(scopes[0])) {
+    throw new TokenRequestError(
+      `One-shot request ${tokenRequestId} has a non-elevated/over-broad scope set [${scopes.join(',')}]; refusing to mint.`,
+      403,
+    );
+  }
+  const grantedTtlSecs = Math.min(req.requestedTtlSecs, ONE_SHOT_MAX_TTL_SECS);
+  const expiresAt = new Date(Date.now() + grantedTtlSecs * 1000).toISOString();
+
+  const minted = await createToken({
+    name: `mcp-oneshot:${req.oneShotOp.toolName}${req.oneShotOp.service ? ':' + req.oneShotOp.service : ''}`.slice(0, 100),
+    scopes,
+    expiresAt,
+    createdBy: 'owner-approval:one-shot',
+    oneShotOp: req.oneShotOp,
+    singleUse: true,
+  });
+
+  req.status = 'approved';
+  req.resolvedAt = new Date().toISOString();
+  req.grantedScopes = scopes;
+  req.grantedTtlSecs = grantedTtlSecs;
+  req.expiresAt = expiresAt;
+  req.tokenId = minted.token.id;
+  req.pendingSecret = minted.secret; // one-time hand-off, wiped on first poll
+  await writeStore(all);
+  logger.info(TAG, `minted one-shot ${scopes[0]} token ${minted.token.id} for request ${tokenRequestId} op=${req.oneShotOp.toolName}${req.oneShotOp.service ? '/' + req.oneShotOp.service : ''} ttl=${grantedTtlSecs}s`);
+}
+
+// Wire the one-shot minter into the approvals kernel at module load (#2245), so
+// an approved one-shot approval's `on_approve.mintToken` action mints the token.
+// Symmetric with mcp/server.ts's registerMcpDispatcher call. Loaded whenever
+// this module is imported (the MCP server + the frontend approve route both do,
+// the latter via its side-effect `import '@/lib/mcp/server'`).
+registerTokenMinter(mintOneShotForRequest);
 
 /** Admin denies a pending request. No token is minted. */
 export async function denyTokenRequest(id: string): Promise<TokenRequestView> {

--- a/packages/backend/src/lib/mcp/approvalGate.test.ts
+++ b/packages/backend/src/lib/mcp/approvalGate.test.ts
@@ -26,6 +26,9 @@ vi.mock('@/lib/approvals', () => ({
   submitApproval: (input: Record<string, unknown>) => submitApproval(input),
   // server.ts registers the MCP dispatcher at module load — no-op here.
   registerMcpDispatcher: vi.fn(),
+  // tokenRequests.ts (imported transitively) registers the one-shot minter at
+  // module load (#2245) — no-op here.
+  registerTokenMinter: vi.fn(),
 }));
 
 const deleteService = vi.fn().mockResolvedValue(undefined);

--- a/packages/backend/src/lib/mcp/oneShotGate.test.ts
+++ b/packages/backend/src/lib/mcp/oneShotGate.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// One-shot elevated-token gate (#2245, option b): a token minted through the
+// approved request_token one-shot flow holds an elevated scope BOUND to exactly
+// one op. The MCP gate must:
+//   - run the bound op inline WITHOUT re-parking (it was already owner-approved),
+//   - burn the single-use token after the op succeeds,
+//   - refuse any OTHER tool the token tries, and
+//   - refuse the bound tool against a DIFFERENT service.
+// Tested at the server/safeHandler seam with the mutation + burn mocked.
+
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn().mockResolvedValue({ mcp: { allowMutations: true } }),
+  updateConfig: vi.fn(),
+}));
+vi.mock('./safety', async (orig) => {
+  const actual = await orig<typeof import('./safety')>();
+  return { ...actual, snapshotBeforeMutation: vi.fn().mockResolvedValue(undefined) };
+});
+vi.mock('./audit', () => ({ recordAudit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./notify', () => ({ notifyDestructiveOp: vi.fn().mockResolvedValue(undefined) }));
+
+// The gate must NOT park a one-shot token — assert submitApproval is never hit.
+const submitApproval = vi.fn((_input: Record<string, unknown>) => Promise.resolve({ id: 'appr-x' }));
+vi.mock('@/lib/approvals', () => ({
+  submitApproval: (input: Record<string, unknown>) => submitApproval(input),
+  registerMcpDispatcher: vi.fn(),
+  registerTokenMinter: vi.fn(),
+}));
+
+// Capture the single-use burn.
+const consumeSingleUseToken = vi.fn((_id: string) => Promise.resolve(true));
+vi.mock('@/lib/auth/apiTokens', async (orig) => {
+  const actual = await orig<typeof import('@/lib/auth/apiTokens')>();
+  return { ...actual, consumeSingleUseToken: (id: string) => consumeSingleUseToken(id) };
+});
+
+const deleteService = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: {
+    deleteService: (...a: unknown[]) => deleteService(...a),
+    listTrashedServices: vi.fn().mockResolvedValue([]),
+  },
+}));
+vi.mock('@/lib/nodes', () => ({
+  listNodes: vi.fn().mockResolvedValue([{ Name: 'Local' }]),
+  getNodeConnection: vi.fn(),
+}));
+
+import { createMcpServer } from './server';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+async function connect(opts?: Parameters<typeof createMcpServer>[0]) {
+  const server = createMcpServer(opts);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return { client };
+}
+
+// A one-shot token: elevated destroy scope, bound to delete_service on honcho.
+const ONE_SHOT_AUTH = {
+  user: 'token:mcp-oneshot',
+  scopes: ['destroy'] as const,
+  tokenId: 'ost1',
+  oneShotOp: { toolName: 'delete_service', service: 'honcho' },
+  singleUse: true,
+};
+
+describe('one-shot elevated token gate (#2245)', () => {
+  beforeEach(() => {
+    submitApproval.mockClear();
+    deleteService.mockClear();
+    consumeSingleUseToken.mockClear();
+    consumeSingleUseToken.mockResolvedValue(true);
+  });
+
+  it('runs the bound op inline (no re-parking) and BURNS the token after it succeeds', async () => {
+    const { client } = await connect({ auth: { ...ONE_SHOT_AUTH, scopes: [...ONE_SHOT_AUTH.scopes] } });
+    const res = await client.callTool({ name: 'delete_service', arguments: { name: 'honcho' } });
+    expect((res as { isError?: boolean }).isError).toBeFalsy();
+    // The destructive op ran once, inline — it did NOT park for approval.
+    expect(deleteService).toHaveBeenCalledTimes(1);
+    expect(submitApproval).not.toHaveBeenCalled();
+    // The single-use token was burned with its id.
+    expect(consumeSingleUseToken).toHaveBeenCalledWith('ost1');
+    await client.close();
+  });
+
+  it('refuses ANY other tool the one-shot token was not minted for — and does not burn', async () => {
+    const { client } = await connect({ auth: { ...ONE_SHOT_AUTH, scopes: [...ONE_SHOT_AUTH.scopes] } });
+    const res = await client.callTool({ name: 'list_trashed_services', arguments: {} });
+    expect((res as { isError?: boolean }).isError).toBe(true);
+    expect((res.content as { text: string }[])[0].text).toMatch(/one-shot token bound to "delete_service"/);
+    expect(deleteService).not.toHaveBeenCalled();
+    expect(consumeSingleUseToken).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it('refuses the bound tool against a DIFFERENT service (grant cannot be redirected)', async () => {
+    const { client } = await connect({ auth: { ...ONE_SHOT_AUTH, scopes: [...ONE_SHOT_AUTH.scopes] } });
+    const res = await client.callTool({ name: 'delete_service', arguments: { name: 'immich' } });
+    expect((res as { isError?: boolean }).isError).toBe(true);
+    expect((res.content as { text: string }[])[0].text).toMatch(/bound to "delete_service" on "honcho"/);
+    expect(deleteService).not.toHaveBeenCalled();
+    expect(consumeSingleUseToken).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it('does NOT burn when the bound op reports a logical error (caller can retry within TTL)', async () => {
+    deleteService.mockRejectedValueOnce(new Error('boom'));
+    const { client } = await connect({ auth: { ...ONE_SHOT_AUTH, scopes: [...ONE_SHOT_AUTH.scopes] } });
+    const res = await client.callTool({ name: 'delete_service', arguments: { name: 'honcho' } });
+    expect((res as { isError?: boolean }).isError).toBe(true);
+    expect(consumeSingleUseToken).not.toHaveBeenCalled();
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -35,11 +35,13 @@ import { submitApproval, registerMcpDispatcher } from '@/lib/approvals';
 import { dispatchWithServer } from './dispatchTool';
 import { redactLogText, redactServiceFiles } from './redact';
 import { type ApiScope, scopeSatisfiedBy, ALL_SCOPES } from '@/lib/auth/apiScope';
+import { consumeSingleUseToken } from '@/lib/auth/apiTokens';
 import {
   submitTokenRequest,
   pollTokenRequest,
   listTokenRequests,
   MAX_TTL_SECS,
+  ONE_SHOT_MAX_TTL_SECS,
   TokenRequestError,
   type TokenRequestStatus,
 } from '@/lib/auth/tokenRequests';
@@ -83,6 +85,12 @@ interface McpAuthContext {
   user: string;
   scopes: ApiScope[];
   tokenId?: string;
+  // One-shot owner-approved elevation (#2245). Present only for a token minted
+  // through the approved request_token one-shot flow: it holds an elevated
+  // scope BOUND to exactly one op, and burns after one use. The gate enforces
+  // the binding + burns the token; a normal token leaves these unset.
+  oneShotOp?: { toolName: string; service?: string };
+  singleUse?: boolean;
 }
 
 // Wire the approvals kernel's MCP-tool re-dispatch (#2234) to a no-auth
@@ -404,6 +412,26 @@ function safeHandler(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return async (...handlerArgs: any[]): Promise<ToolResult> => {
     const args = (handlerArgs[0] && typeof handlerArgs[0] === 'object') ? handlerArgs[0] : {};
+    // One-shot elevation binding (#2245): a token minted through the approved
+    // request_token one-shot flow carries an elevated scope but is BOUND to
+    // exactly one op. It may ONLY invoke its bound tool (and, when a target
+    // service was named, only against that service). Any other call — even a
+    // read — is refused, so the elevated grant can't be redirected. The token
+    // then burns after its one successful op (below). Checked before the scope
+    // check so an off-target call is refused up front.
+    if (auth?.oneShotOp) {
+      const bound = auth.oneShotOp;
+      if (toolName !== bound.toolName) {
+        const msg = `This is a one-shot token bound to "${bound.toolName}"${bound.service ? ` on ${bound.service}` : ''}; it cannot call ${toolName}.`;
+        void recordAudit({ ts: new Date().toISOString(), tool: toolName, caller: auth.user, outcome: 'blocked', durationMs: 0, args, errorMessage: msg });
+        return { content: [{ type: 'text' as const, text: msg }], isError: true as const };
+      }
+      if (bound.service && coerceApprovalService(args) !== bound.service) {
+        const msg = `This one-shot token is bound to "${bound.toolName}" on "${bound.service}"; the call targets a different service.`;
+        void recordAudit({ ts: new Date().toISOString(), tool: toolName, caller: auth.user, outcome: 'blocked', durationMs: 0, args, errorMessage: msg });
+        return { content: [{ type: 'text' as const, text: msg }], isError: true as const };
+      }
+    }
     // Scope check (token auth only — cookie has all scopes by design).
     const required = TOOL_SCOPES[toolName] ?? 'read';
     if (auth && !tokenHasScope(auth.scopes, required)) {
@@ -439,7 +467,10 @@ function safeHandler(
     // before: the human IS the operator. The gate lands here, AFTER the scope +
     // mutation/exec guards (so the agent still learns immediately if the call
     // would be refused) but BEFORE the snapshot/handler.
-    if (auth && isDestroyTierTool(toolName)) {
+    // A one-shot token (#2245) already went through owner approval when it was
+    // minted, so it must NOT park again — it runs its one bound op inline (then
+    // burns below). Only a NON-one-shot token proposing a destroy-tier op parks.
+    if (auth && !auth.oneShotOp && isDestroyTierTool(toolName)) {
       // Derive a service anchor from the tool args when it names one, else a
       // neutral "mcp" bucket. `submitApproval` re-validates it as a safe path
       // segment; fall back to "mcp" if the arg is not a usable service name.
@@ -466,7 +497,16 @@ function safeHandler(
       };
     }
 
-    return runToolWithSideEffects(toolName, args, handler, handlerArgs, auth);
+    const result = await runToolWithSideEffects(toolName, args, handler, handlerArgs, auth);
+    // Single-use burn (#2245): a one-shot elevated token is revoked after its
+    // one op RAN (isError = the tool reported a logical failure — then we do NOT
+    // burn, so the caller can retry the still-valid grant within its short TTL).
+    // Burn is fire-and-forget-safe but awaited so a follow-up call in the same
+    // tick can't slip through before the row is gone.
+    if (auth?.singleUse && auth.tokenId && !(result && typeof result === 'object' && (result as { isError?: boolean }).isError)) {
+      await consumeSingleUseToken(auth.tokenId).catch(() => undefined);
+    }
+    return result;
   };
 }
 
@@ -2033,25 +2073,46 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
 
   server.tool(
     'request_token',
-    'Request a scoped, short-lived sb_ API token that a ServiceBay admin must approve. Names the scopes you need, a human reason, and a TTL in seconds. Returns a pending request id — NO token yet. Poll it with poll_token_request; the admin may approve with NARROWED scopes (least privilege) or a shorter TTL, or deny. This tool itself needs only the read scope: a request grants nothing until a human signs off.',
+    'Request a scoped, short-lived sb_ API token that a ServiceBay admin must approve. Names the scopes you need, a human reason, and a TTL in seconds. Returns a pending request id — NO token yet. Poll it with poll_token_request; the admin may approve with NARROWED scopes (least privilege) or a shorter TTL, or deny. This tool itself needs only the read scope: a request grants nothing until a human signs off. Pass one_shot_op to instead request a ONE-SHOT, owner-approved ELEVATED (destroy/exec) token bound to exactly one op on one service — it parks as an approval card, mints only after the owner approves, authorizes that op ONCE, then burns.',
     {
-      scopes: z.array(SCOPE_ENUM).min(1).describe(`Scopes to request (least→most: ${ALL_SCOPES.join(', ')}). Ask for the minimum the task needs; the admin can only grant these or fewer.`),
+      scopes: z.array(SCOPE_ENUM).min(1).describe(`Scopes to request (least→most: ${ALL_SCOPES.join(', ')}). Ask for the minimum the task needs; the admin can only grant these or fewer. For a one-shot request pass exactly one elevated scope (destroy or exec) matching the tool's tier.`),
       reason: z.string().trim().min(1).max(1000).describe('Why the token is needed — the justification the admin weighs (e.g. "deploy one service, tor.dopp.cloud").'),
-      ttl_seconds: z.number().int().positive().max(MAX_TTL_SECS).describe(`Requested time-to-live in seconds (max ${MAX_TTL_SECS} = 30d). The admin can shorten it. The token auto-expires and is deleted from storage.`),
+      ttl_seconds: z.number().int().positive().max(MAX_TTL_SECS).describe(`Requested time-to-live in seconds (max ${MAX_TTL_SECS} = 30d). The admin can shorten it. A one-shot request is clamped to ${ONE_SHOT_MAX_TTL_SECS}s. The token auto-expires and is deleted from storage.`),
+      one_shot_op: z.object({
+        tool_name: z.string().trim().min(1).describe('The single MCP tool this one-shot token may invoke (e.g. "delete_service" or "exec_command"). Must be a destroy/exec-tier tool.'),
+        service: z.string().trim().optional().describe('Optional target service — when set, the token may only run the op against this service (e.g. delete_service on "honcho").'),
+      }).optional().describe('Request a ONE-SHOT owner-approved ELEVATED token bound to this op instead of a standing grant. The request parks as an approval card; the ambient token gains nothing. On owner Approve, poll_token_request returns a single-use, short-TTL token authorizing exactly this op once.'),
     },
-    async ({ scopes, reason, ttl_seconds }) => {
+    async ({ scopes, reason, ttl_seconds, one_shot_op }) => {
       try {
+        // For a one-shot request, validate the named tool is an elevated tier
+        // and that the requested scope matches its tier — server.ts owns
+        // TOOL_SCOPES, so the tier resolution lives here (keeps tokenRequests
+        // free of a cycle back to the tool map).
+        if (one_shot_op) {
+          const tier = TOOL_SCOPES[one_shot_op.tool_name];
+          if (tier !== 'destroy' && tier !== 'exec') {
+            return errorResult(`one_shot_op.tool_name "${one_shot_op.tool_name}" is not a destroy/exec-tier tool; a one-shot elevated token can only authorize an elevated op.`);
+          }
+          if (!(scopes.length === 1 && scopes[0] === tier)) {
+            return errorResult(`For a one-shot request, scopes must be exactly ["${tier}"] to match ${one_shot_op.tool_name}; got [${scopes.join(',')}].`);
+          }
+        }
         const view = await submitTokenRequest({
           requestedScopes: scopes,
           requestedTtlSecs: ttl_seconds,
           reason,
           requestedBy: opts?.auth?.user,
+          ...(one_shot_op ? { oneShotOp: { toolName: one_shot_op.tool_name, ...(one_shot_op.service ? { service: one_shot_op.service } : {}) } } : {}),
         });
         return textResult({
           ok: true,
           id: view.id,
           status: view.status,
-          message: `Token request filed. A ServiceBay admin must approve it (Settings → MCP). Poll with poll_token_request(id="${view.id}").`,
+          ...(view.approvalId ? { approvalId: view.approvalId } : {}),
+          message: one_shot_op
+            ? `One-shot ${scopes[0]} token request filed as approval ${view.approvalId}. The owner must approve it (Settings → Access → Approvals); it cannot self-approve. Poll with poll_token_request(id="${view.id}") — on approval you collect a single-use token authorizing "${one_shot_op.tool_name}" once.`
+            : `Token request filed. A ServiceBay admin must approve it (Settings → MCP). Poll with poll_token_request(id="${view.id}").`,
         });
       } catch (e) {
         return errorResult(e instanceof TokenRequestError ? e.message : e instanceof Error ? e.message : String(e));

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -217,11 +217,13 @@ app.prepare().then(() => {
         const { verifyBootstrapToken, clientIpForLanGate } = await import('./lib/mcp/bootstrapToken');
         const authHeader = req.headers.authorization || '';
         const bearerMatch = authHeader.match(/^Bearer\s+(\S+)$/i);
-        let auth: { user: string; scopes: import('./lib/auth/apiScope').ApiScope[]; tokenId?: string } | null = null;
+        let auth: { user: string; scopes: import('./lib/auth/apiScope').ApiScope[]; tokenId?: string; oneShotOp?: { toolName: string; service?: string }; singleUse?: boolean } | null = null;
         try {
           if (bearerMatch) {
             const t = await verifyToken(bearerMatch[1]);
-            if (t) auth = { user: `token:${t.name}`, scopes: t.scopes, tokenId: t.id };
+            // Thread the one-shot binding (#2245) into the auth context so the
+            // MCP gate can enforce "this token may run exactly this op, once".
+            if (t) auth = { user: `token:${t.name}`, scopes: t.scopes, tokenId: t.id, ...(t.oneShotOp ? { oneShotOp: t.oneShotOp } : {}), ...(t.singleUse ? { singleUse: true } : {}) };
             // Bootstrap token (#322): only valid bearer that doesn't
             // match the sb_<id>_<secret> shape. Always read-only, always
             // LAN-only, always TTL'd. The verifier handles all three


### PR DESCRIPTION
## What
Option (b) for #2245: `request_token` can ask for a ONE-SHOT token scoped to a SPECIFIC destructive op (destroy/exec on service X) instead of a standing grant. The request PARKS for owner approval (mints nothing, needs no destroy/exec to request); on owner Approve, `poll_token_request` returns a single-use, short-TTL token bound to exactly that op. The MCP gate runs the bound op once, then burns the token. The ambient token never gains standing destroy/exec. Generic / app-agnostic, same owner-approved one-shot model as #2246.

## Why
Closes #2245

## Risk
medium — touches the MCP/token/approval layer; guarded by owner approval + single-use + short-TTL + op-binding.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full — 3827 passed / 2 skipped)
- [ ] /verify on FCoS :dev box (MCP/token/approval path is path-mandated)