### PR TITLE
feat(auth): delegated-admin verification + delegated approve/deny & new-approval SSE feed

### DIFF
--- a/packages/backend/src/lib/approvals/index.test.ts
+++ b/packages/backend/src/lib/approvals/index.test.ts
@@ -38,7 +38,9 @@ import {
   rejectApproval,
   registerMcpDispatcher,
   isSelfApproval,
+  onNewApproval,
   type ApprovalRequest,
+  type NewApprovalEvent,
 } from './index';
 
 // The mcp action calls the registered dispatcher (injected by the MCP layer in
@@ -494,5 +496,74 @@ describe('isSelfApproval — token cannot resolve its own proposal (#2244)', () 
 
   it('is a no-op for a request with no recorded proposer (plain move/restart)', () => {
     expect(isSelfApproval(withCaller(undefined), 'token:solaris')).toBe(false);
+  });
+});
+
+// #2268 part B — the new-approval event hook. Solaris subscribes server-server
+// and republishes on its own bus; the SSE route (wiring tested separately) is a
+// thin adapter over this emit. Here we prove the emit fires on a new pending
+// approval, carries a MINIMAL secret-free payload, and unsubscribe stops it.
+describe('onNewApproval / submitApproval emit hook (#2268 part B)', () => {
+  it('emits a new-approval event with id/kind/summary when a request is created', async () => {
+    const events: NewApprovalEvent[] = [];
+    const off = onNewApproval(e => events.push(e));
+    try {
+      const created = await submitApproval({
+        service: 'honcho',
+        title: 'delete_service: honcho',
+        description: 'secret detail here',
+        payload: { caller: 'token:solaris', secretToken: 'sb_should_not_leak' },
+        on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+        node: 'box1',
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: 'new-approval',
+        id: created.id,
+        kind: 'honcho',
+        summary: 'delete_service: honcho',
+        created_at: created.created_at,
+      });
+    } finally {
+      off();
+    }
+  });
+
+  it('leaks NO secret/payload/action fields onto the event', async () => {
+    const events: NewApprovalEvent[] = [];
+    const off = onNewApproval(e => events.push(e));
+    try {
+      await submitApproval({
+        service: 'honcho',
+        title: 'do the thing',
+        payload: { caller: 'token:solaris', apiKey: 'sb_secret_value' },
+        on_approve: { mcp: { toolName: 'delete_service', args: { name: 'honcho' } } },
+        node: 'box1',
+      });
+      const serialized = JSON.stringify(events[0]);
+      expect(serialized).not.toContain('sb_secret_value');
+      expect(serialized).not.toContain('delete_service');
+      expect(Object.keys(events[0]).sort()).toEqual(['created_at', 'id', 'kind', 'summary', 'type']);
+    } finally {
+      off();
+    }
+  });
+
+  it('stops delivering after unsubscribe', async () => {
+    const events: NewApprovalEvent[] = [];
+    const off = onNewApproval(e => events.push(e));
+    off();
+    await submitApproval({ service: 'honcho', title: 't', node: 'box1' });
+    expect(events).toHaveLength(0);
+  });
+
+  it('a throwing listener does not fail the submit (approval is stored)', async () => {
+    const off = onNewApproval(() => { throw new Error('boom'); });
+    try {
+      const created = await submitApproval({ service: 'honcho', title: 't', node: 'box1' });
+      expect(await getApproval(created.id)).not.toBeNull();
+    } finally {
+      off();
+    }
   });
 });

--- a/packages/backend/src/lib/approvals/index.ts
+++ b/packages/backend/src/lib/approvals/index.ts
@@ -15,6 +15,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
+import { EventEmitter } from 'events';
 import { randomUUID } from 'crypto';
 import { DATA_DIR } from '@/lib/dirs';
 import { getExecutor } from '@/lib/executor';
@@ -206,6 +207,55 @@ export interface SubmitApprovalInput {
   node?: string;
 }
 
+/**
+ * A minimal, non-secret notification that a NEW pending approval was created
+ * (#2268 part B). Emitted server-side so a trusted server-server subscriber
+ * (Solaris) can be notified and republish it on its own bus — per ADR 0010 the
+ * PHONE never subscribes to ServiceBay directly, Solaris aggregates. The payload
+ * carries ONLY what a subscriber needs to fetch the full request over the
+ * already-authenticated read surface: id + kind (the service) + a short summary
+ * (the title). No payload, no on_approve/on_reject actions, no secrets leak onto
+ * the stream.
+ */
+export interface NewApprovalEvent {
+  type: 'new-approval';
+  id: string;
+  /** The requesting service name — the event "kind" for the subscriber. */
+  kind: string;
+  /** Human-readable one-liner (the request title). */
+  summary: string;
+  created_at: string;
+}
+
+/**
+ * In-process event bus for approval lifecycle notifications. A single Node
+ * process owns the JSON store, so an in-process EventEmitter is sufficient to
+ * fan a create-event out to every open SSE stream. `setMaxListeners(0)` removes
+ * the default 10-listener warning cap — each open Solaris SSE connection adds a
+ * listener, and there is no fixed upper bound on concurrent subscribers.
+ */
+const approvalEvents = new EventEmitter();
+approvalEvents.setMaxListeners(0);
+
+const NEW_APPROVAL_EVENT = 'new-approval';
+
+/** Subscribe to new-pending-approval events. Returns an unsubscribe fn. */
+export function onNewApproval(listener: (event: NewApprovalEvent) => void): () => void {
+  approvalEvents.on(NEW_APPROVAL_EVENT, listener);
+  return () => approvalEvents.off(NEW_APPROVAL_EVENT, listener);
+}
+
+/** Build the minimal, secret-free event payload for a freshly-created request. */
+function toNewApprovalEvent(request: ApprovalRequest): NewApprovalEvent {
+  return {
+    type: 'new-approval',
+    id: request.id,
+    kind: request.service,
+    summary: request.title,
+    created_at: request.created_at,
+  };
+}
+
 async function readStore(): Promise<ApprovalRequest[]> {
   try {
     const raw = await fs.readFile(STORE_PATH, 'utf-8');
@@ -328,6 +378,16 @@ export async function submitApproval(input: SubmitApprovalInput): Promise<Approv
     await writeStore(all);
   });
   logger.info(TAG, `submitted approval ${request.id} for service ${request.service}`);
+  // Notify server-server subscribers (Solaris) that a NEW pending approval
+  // exists so they can republish it (#2268 part B). Emitted only AFTER the
+  // request is durably persisted, so a subscriber that fetches on the event
+  // always finds it. Emit is best-effort: a throwing listener must never fail
+  // the submit (the approval is already stored).
+  try {
+    approvalEvents.emit(NEW_APPROVAL_EVENT, toNewApprovalEvent(request));
+  } catch (err) {
+    logger.warn(TAG, `new-approval event listener threw: ${err instanceof Error ? err.message : String(err)}`);
+  }
   return request;
 }
 

--- a/packages/backend/src/lib/auth/delegatedAdmin.test.ts
+++ b/packages/backend/src/lib/auth/delegatedAdmin.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import crypto from 'node:crypto';
+
+// #2270 — delegated-admin verification: every security-critical failure mode is
+// tested explicitly. A bug that lets a forged/replayed assertion, or a
+// non-admin, or a standing elevation through is the worst-case failure, so each
+// gets its own case with a distinct failure reason asserted.
+
+// Capture audit writes without touching the real fs.
+const auditCalls: unknown[] = [];
+vi.mock('@/lib/mcp/audit', () => ({
+  recordAudit: vi.fn(async (e: unknown) => { auditCalls.push(e); }),
+}));
+
+// Mock LLDAP so the DEFAULT admin-check path (no injected adminCheck) is
+// exercised deterministically — proves the guard really consults SB's own LLDAP.
+const lldapMembers = new Set<string>();
+let lldapErrors = false;
+vi.mock('@/lib/lldap/client', () => ({
+  userIsInLldapGroup: vi.fn(async (user: string, _group: string) => {
+    if (lldapErrors) return { ok: false, reason: 'unreachable', message: 'LLDAP down' };
+    return { ok: true, inGroup: lldapMembers.has(user), groups: lldapMembers.has(user) ? ['admins'] : [] };
+  }),
+}));
+
+import {
+  verifyDelegatedAdmin,
+  encodeAssertion,
+  createInMemoryReplayGuard,
+  MAX_ASSERTION_TTL_MS,
+  DELEGATION_HEADER,
+  type DelegatedAssertion,
+} from './delegatedAdmin';
+import { resetDelegationKeyCache } from './delegationKey';
+
+const ORIG = process.env.AUTH_SECRET;
+const ADMIN = 'alice';
+const NON_ADMIN = 'mallory';
+
+function assertion(over: Partial<DelegatedAssertion> = {}): DelegatedAssertion {
+  const now = Date.now();
+  return {
+    user: ADMIN,
+    action: 'approvals.approve',
+    target: 'appr-42',
+    nonce: crypto.randomUUID(),
+    iat: now,
+    exp: now + 60_000,
+    ...over,
+  };
+}
+
+// A distinct guard + a stable clock per test.
+let guard = createInMemoryReplayGuard();
+
+beforeEach(() => {
+  process.env.AUTH_SECRET = 'x'.repeat(48);
+  resetDelegationKeyCache();
+  auditCalls.length = 0;
+  lldapMembers.clear();
+  lldapMembers.add(ADMIN);
+  lldapErrors = false;
+  guard = createInMemoryReplayGuard();
+});
+afterEach(() => {
+  if (ORIG === undefined) delete process.env.AUTH_SECRET;
+  else process.env.AUTH_SECRET = ORIG;
+  resetDelegationKeyCache();
+});
+
+function verify(raw: string | null, over: { action?: string; target?: string } = {}) {
+  return verifyDelegatedAdmin({
+    rawAssertion: raw,
+    expectedAction: over.action ?? 'approvals.approve',
+    expectedTarget: over.target ?? 'appr-42',
+    callerPrincipal: 'token:svc-solaris',
+    replayGuard: guard,
+  });
+}
+
+describe('verifyDelegatedAdmin', () => {
+  it('exposes the stable wire header name (#2268 route wiring contract)', () => {
+    expect(DELEGATION_HEADER).toBe('x-sb-delegated-admin');
+  });
+
+  it('accepts a valid assertion by a real admin and writes an audit record', async () => {
+    const res = await verify(encodeAssertion(assertion()));
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.user).toBe(ADMIN);
+    expect(auditCalls).toHaveLength(1);
+    const entry = auditCalls[0] as Record<string, unknown>;
+    expect(entry.caller).toBe(ADMIN);
+    expect(entry.tool).toBe('delegated:approvals.approve');
+    expect((entry.args as Record<string, unknown>).assertedBy).toBe('token:svc-solaris');
+    expect(entry.outcome).toBe('ok');
+  });
+
+  it('rejects an assertion naming a non-admin user even with a valid signature (confused-deputy)', async () => {
+    // Correctly signed by the real key, but the named user is NOT in admins per
+    // SB's LLDAP — the role is never trusted from the assertion.
+    const res = await verify(encodeAssertion(assertion({ user: NON_ADMIN })));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('not_admin');
+    expect(auditCalls).toHaveLength(0);
+  });
+
+  it('rejects an expired assertion', async () => {
+    const past = Date.now() - 10_000;
+    const res = await verify(encodeAssertion(assertion({ iat: past - 60_000, exp: past })));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('expired');
+  });
+
+  it('rejects an over-long lifetime window', async () => {
+    const now = Date.now();
+    const res = await verify(encodeAssertion(assertion({ iat: now, exp: now + MAX_ASSERTION_TTL_MS + 1000 })));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('bad_window');
+  });
+
+  it('rejects a replayed nonce (single-use within its lifetime)', async () => {
+    const token = encodeAssertion(assertion());
+    const first = await verify(token);
+    expect(first.ok).toBe(true);
+    const second = await verify(token);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.reason).toBe('replayed');
+    // Only the first (valid) use is audited.
+    expect(auditCalls).toHaveLength(1);
+  });
+
+  it('rejects a tampered action (signature no longer matches)', async () => {
+    // Sign for one action, present the wire token but ask the route to verify a
+    // DIFFERENT action — the signature is over the original action, so editing
+    // the claim would break the signature; here the mismatch is caught either as
+    // bad_signature (edited claim) or binding_mismatch (route expectation). We
+    // tamper the encoded claims blob to prove the signature guard fires.
+    const a = assertion();
+    const token = encodeAssertion(a);
+    const [claimsB64, sig] = token.split('.');
+    const claims = JSON.parse(Buffer.from(claimsB64, 'base64url').toString('utf-8'));
+    claims.action = 'services.delete'; // attacker widens the action
+    const forged = Buffer.from(JSON.stringify(claims), 'utf-8').toString('base64url') + '.' + sig;
+    const res = await verify(forged, { action: 'services.delete' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('bad_signature');
+  });
+
+  it('rejects a binding mismatch (valid signature, wrong target for this route)', async () => {
+    // Legitimately signed for target appr-42, but the route is operating on a
+    // different target — the action can't be redirected.
+    const res = await verify(encodeAssertion(assertion({ target: 'appr-99' })), { target: 'appr-42' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('binding_mismatch');
+  });
+
+  it('rejects a signature made with the wrong key', async () => {
+    const token = encodeAssertion(assertion());
+    // Rotate the derivation key (as if a different box / wrong AUTH_SECRET) and
+    // re-verify the previously-signed token.
+    process.env.AUTH_SECRET = 'z'.repeat(48);
+    resetDelegationKeyCache();
+    const res = await verify(token);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('bad_signature');
+  });
+
+  it('returns reason "missing" when no assertion is present (route falls back to other auth)', async () => {
+    const res = await verify(null);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('missing');
+  });
+
+  it('rejects a malformed assertion header', async () => {
+    const res = await verify('not-a-real-token');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('malformed');
+  });
+
+  it('fails closed on a directory error (deny rather than assume admin)', async () => {
+    lldapErrors = true;
+    const res = await verify(encodeAssertion(assertion()));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe('directory_error');
+    expect(auditCalls).toHaveLength(0);
+  });
+
+  it('does not burn a nonce when the assertion is rejected for binding (forged copy cannot exhaust a real nonce)', async () => {
+    const a = assertion();
+    // First, a mis-bound presentation that must NOT consume the nonce.
+    const misbound = await verify(encodeAssertion(a), { target: 'wrong-target' });
+    expect(misbound.ok).toBe(false);
+    // The legitimate, correctly-bound presentation of the SAME nonce still works.
+    const legit = await verify(encodeAssertion(a));
+    expect(legit.ok).toBe(true);
+  });
+});

--- a/packages/backend/src/lib/auth/delegatedAdmin.ts
+++ b/packages/backend/src/lib/auth/delegatedAdmin.ts
@@ -1,0 +1,346 @@
+/**
+ * Delegated-admin verification (#2270, ADR 0011 on ADR 0009).
+ *
+ * The MECHANISM by which a trusted server-server caller (Solaris) may perform a
+ * MUTATING admin action AS an authenticated admin user WITHOUT becoming a
+ * confused deputy. This is a REUSABLE guard the mutation routes opt into
+ * (wiring into the approve/deny routes is #2268); read-only aggregation never
+ * uses it.
+ *
+ * The two-part credential (operator-approved design):
+ *   1. CALLER AUTH — the caller presents its existing ADR-0009 scoped service
+ *      token (`sb_<id>_<secret>` Bearer). That is verified by the normal
+ *      requireSession/tokenScope gate BEFORE this guard runs; this guard only
+ *      accepts an already-authenticated caller principal. A missing/invalid
+ *      service token is a 401 at the gate — never reaches here.
+ *   2. USER+SCOPE ASSERTION — on top of the service token, the caller sends a
+ *      SHORT-LIVED, ACTION-BOUND assertion `{user, action, target, nonce, iat,
+ *      exp}` HMAC-signed with the delegation trust key (derived from the
+ *      ADR-0009 root-of-trust AUTH_SECRET — see delegationKey.ts; survives a
+ *      wipe-config reinstall).
+ *
+ * ServiceBay verifies ALL of, fail-closed:
+ *   - signature valid (constant-time HMAC compare over the canonical payload);
+ *   - not expired (`exp` in the future) and sane window (`exp - iat` ≤ MAX_TTL);
+ *   - nonce not replayed (single-use within the assertion's own lifetime);
+ *   - the requested `action`/`target` match what the route is actually doing
+ *     (binding — the assertion can't be redirected to a different op);
+ *   - the named `user` is ACTUALLY in the `admins` group per ServiceBay's OWN
+ *     LLDAP (NOT the assertion's role claim — the confused-deputy mitigation).
+ *
+ * On success the route executes the action IN THAT USER'S NAME and an AUDIT
+ * record is written (who/what/when/asserted-by-which-service-token). Any check
+ * failing → the route returns 403.
+ *
+ * This is an ADDITIONAL accepted auth mode. It does not replace the existing
+ * device-token / operator-session paths on the mutation routes — those keep
+ * working; a route calls this guard only when the caller supplied an assertion.
+ */
+import crypto from 'node:crypto';
+import { getDelegationKey } from './delegationKey';
+import { userIsInLldapGroup } from '@/lib/lldap/client';
+import { recordAudit } from '@/lib/mcp/audit';
+import { logger } from '@/lib/logger';
+
+/** The group whose membership grants admin — matches Authelia's access rules
+ *  and lanDeniedPage's admin-only classification (ADR 0009 §2). */
+export const ADMIN_GROUP = 'admins';
+
+/** Header the caller puts the base64url-encoded signed assertion on. */
+export const DELEGATION_HEADER = 'x-sb-delegated-admin';
+
+/** Max assertion lifetime. Short by design — the assertion is action-bound and
+ *  single-use, so a 2-minute window bounds the replay/clock-skew surface. */
+export const MAX_ASSERTION_TTL_MS = 2 * 60 * 1000;
+
+/** The signed claims. `iat`/`exp` are epoch milliseconds. */
+export interface DelegatedAssertion {
+  /** LLDAP user id the caller wants to act AS (verified against SB's LLDAP). */
+  user: string;
+  /** The bound action, e.g. "approvals.approve". Must match the route. */
+  action: string;
+  /** The bound target, e.g. the approval id or service name. Must match. */
+  target: string;
+  /** Unique per assertion — replay guard key. */
+  nonce: string;
+  /** Issued-at (epoch ms). */
+  iat: number;
+  /** Expiry (epoch ms). */
+  exp: number;
+}
+
+export type DelegationFailureReason =
+  | 'missing'          // no assertion header — the route should fall back to its other auth modes
+  | 'malformed'        // header present but not a decodable/valid-shape assertion
+  | 'bad_signature'
+  | 'expired'
+  | 'bad_window'       // exp<=iat or exp-iat > MAX_TTL
+  | 'replayed'
+  | 'binding_mismatch' // action/target don't match the request
+  | 'not_admin'        // named user is not in admins per SB's own LLDAP
+  | 'directory_error'; // LLDAP unreachable/misconfigured → fail closed
+
+export type DelegationResult =
+  | { ok: true; user: string; assertion: DelegatedAssertion }
+  | { ok: false; reason: DelegationFailureReason; message: string };
+
+/**
+ * Canonical bytes signed by the assertion. Field order is FIXED and every field
+ * is included — an attacker who edits any claim (including action/target)
+ * invalidates the signature. JSON with sorted, explicit keys keeps client and
+ * server byte-identical.
+ */
+function canonicalPayload(a: DelegatedAssertion): string {
+  return JSON.stringify({
+    action: a.action,
+    exp: a.exp,
+    iat: a.iat,
+    nonce: a.nonce,
+    target: a.target,
+    user: a.user,
+  });
+}
+
+/** Compute the base64url HMAC-SHA256 over an assertion's canonical payload. */
+function signAssertion(a: DelegatedAssertion): string {
+  return crypto.createHmac('sha256', getDelegationKey())
+    .update(canonicalPayload(a))
+    .digest('base64url');
+}
+
+/**
+ * Mint a wire token for an assertion: base64url(JSON claims) + "." +
+ * base64url(HMAC). Exported so the trusted CALLER side (and tests) produce the
+ * exact byte layout the verifier expects — a shared codec, not a duplicated
+ * format that could drift. ServiceBay itself only ever VERIFIES.
+ */
+export function encodeAssertion(a: DelegatedAssertion): string {
+  const claims = Buffer.from(canonicalPayload(a), 'utf-8').toString('base64url');
+  return `${claims}.${signAssertion(a)}`;
+}
+
+/** Structural validation of the parsed claims object. A non-empty string is
+ *  required for identity/binding fields; `target` may be empty (some ops bind
+ *  to an action alone); iat/exp must be finite numbers. */
+function isValidClaims(o: Record<string, unknown>): boolean {
+  const str = (v: unknown, allowEmpty = false) => typeof v === 'string' && (allowEmpty || v.length > 0);
+  const num = (v: unknown) => typeof v === 'number' && Number.isFinite(v);
+  return str(o.user) && str(o.action) && str(o.target, true) && str(o.nonce) && num(o.iat) && num(o.exp);
+}
+
+/** Parse + shape-check the wire token. Returns the claims and the presented
+ *  signature, or null if the token is structurally invalid. */
+function decodeAssertion(raw: string): { assertion: DelegatedAssertion; signature: string } | null {
+  const dot = raw.indexOf('.');
+  if (dot <= 0 || dot === raw.length - 1) return null;
+  const signature = raw.slice(dot + 1);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(raw.slice(0, dot), 'base64url').toString('utf-8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const o = parsed as Record<string, unknown>;
+  if (!isValidClaims(o)) return null;
+  return {
+    assertion: {
+      user: o.user as string, action: o.action as string, target: o.target as string,
+      nonce: o.nonce as string, iat: o.iat as number, exp: o.exp as number,
+    },
+    signature,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Replay guard — a nonce may be used at most ONCE within its assertion's own
+// lifetime. In-memory + bounded by exp: since assertions live ≤ MAX_TTL, a
+// nonce need only be remembered until its exp passes. A same-process replay is
+// caught here; a cross-restart replay is bounded by the ≤2-min exp window
+// (verifyExpiry rejects anything already expired). The store is injectable so a
+// later unit can back it with shared/persisted storage if the deployment ever
+// runs multiple ServiceBay processes.
+// ---------------------------------------------------------------------------
+
+export interface ReplayGuard {
+  /** Record a nonce as consumed until `expEpochMs`. Returns false if the nonce
+   *  was ALREADY consumed (a replay), true if this is its first use. */
+  consume(nonce: string, expEpochMs: number): boolean;
+}
+
+class InMemoryReplayGuard implements ReplayGuard {
+  private readonly seen = new Map<string, number>(); // nonce -> exp (epoch ms)
+
+  consume(nonce: string, expEpochMs: number): boolean {
+    const now = Date.now();
+    this.sweep(now);
+    if (this.seen.has(nonce)) return false; // replay
+    this.seen.set(nonce, expEpochMs);
+    return true;
+  }
+
+  private sweep(now: number): void {
+    for (const [n, exp] of this.seen) {
+      if (exp <= now) this.seen.delete(n);
+    }
+  }
+}
+
+const defaultReplayGuard: ReplayGuard = new InMemoryReplayGuard();
+
+/** Test-only: a fresh in-memory guard so a test's nonces don't collide across
+ *  cases (and to assert replay behaviour in isolation). */
+export function createInMemoryReplayGuard(): ReplayGuard {
+  return new InMemoryReplayGuard();
+}
+
+// ---------------------------------------------------------------------------
+
+export interface VerifyDelegatedAdminInput {
+  /** The raw wire assertion (the DELEGATION_HEADER value). */
+  rawAssertion: string | null | undefined;
+  /** The action the route is actually about to perform. */
+  expectedAction: string;
+  /** The target the route is actually operating on (approval id / service). */
+  expectedTarget: string;
+  /** The already-authenticated caller principal (the service token id, e.g.
+   *  `token:ab12cd34`), recorded in the audit trail as asserted-by. */
+  callerPrincipal: string;
+  /** Injectable for tests / future persisted store. */
+  replayGuard?: ReplayGuard;
+  /** Injectable clock for tests. */
+  now?: number;
+  /** Injectable admin-membership check for tests (defaults to SB's LLDAP). */
+  adminCheck?: (user: string) => Promise<{ ok: true; inGroup: boolean } | { ok: false; message: string }>;
+}
+
+const failMessages: Record<DelegationFailureReason, string> = {
+  missing: 'No delegated-admin assertion present.',
+  malformed: 'Delegated-admin assertion is malformed.',
+  bad_signature: 'Delegated-admin assertion signature is invalid.',
+  expired: 'Delegated-admin assertion has expired.',
+  bad_window: 'Delegated-admin assertion lifetime is invalid.',
+  replayed: 'Delegated-admin assertion nonce has already been used.',
+  binding_mismatch: 'Delegated-admin assertion is not bound to this action/target.',
+  not_admin: 'Asserted user is not a ServiceBay admin.',
+  directory_error: 'Could not verify admin membership against the identity directory.',
+};
+
+function fail(reason: DelegationFailureReason): DelegationResult {
+  return { ok: false, reason, message: failMessages[reason] };
+}
+
+/** Constant-time compare of two base64url signature strings. */
+function signaturesEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ba, bb);
+}
+
+async function defaultAdminCheck(
+  user: string,
+): Promise<{ ok: true; inGroup: boolean } | { ok: false; message: string }> {
+  const r = await userIsInLldapGroup(user, ADMIN_GROUP);
+  if (!r.ok) return { ok: false, message: r.message };
+  return { ok: true, inGroup: r.inGroup };
+}
+
+/**
+ * The synchronous, side-effect-free checks on a presented assertion: decode,
+ * signature, window/expiry, and action/target binding. Split out of
+ * verifyDelegatedAdmin so the async guard stays within the complexity budget
+ * and the ordering (crypto before any state change) is explicit. Returns the
+ * parsed assertion on success, or the specific failure reason.
+ */
+function checkAssertionShape(
+  rawAssertion: string,
+  expectedAction: string,
+  expectedTarget: string,
+  now: number,
+): { ok: true; assertion: DelegatedAssertion } | { ok: false; reason: DelegationFailureReason } {
+  const decoded = decodeAssertion(rawAssertion);
+  if (!decoded) return { ok: false, reason: 'malformed' };
+  const { assertion, signature } = decoded;
+
+  // 1. Signature over the FULL canonical payload — any tampered claim fails.
+  if (!signaturesEqual(signature, signAssertion(assertion))) {
+    return { ok: false, reason: 'bad_signature' };
+  }
+  // 2. Window sanity, then expiry.
+  if (!(assertion.exp > assertion.iat) || assertion.exp - assertion.iat > MAX_ASSERTION_TTL_MS) {
+    return { ok: false, reason: 'bad_window' };
+  }
+  if (assertion.exp <= now) return { ok: false, reason: 'expired' };
+  // 3. Binding — signed action/target must match what the route is doing.
+  if (assertion.action !== expectedAction || assertion.target !== expectedTarget) {
+    return { ok: false, reason: 'binding_mismatch' };
+  }
+  return { ok: true, assertion };
+}
+
+/**
+ * Verify a delegated-admin assertion. Runs every check fail-closed and in an
+ * order that avoids side effects on a bad token: cheap crypto/shape/window
+ * checks first, then the replay-consume (which MUST only fire on an otherwise
+ * valid, correctly-bound assertion so a forged nonce can't burn a real one),
+ * then the LLDAP admin-membership check last (a network round-trip).
+ *
+ * `reason: 'missing'` is distinguished so a route can FALL BACK to its existing
+ * device-token/session auth when no assertion was supplied (layering); every
+ * other failure means an assertion WAS presented but is invalid → 403.
+ *
+ * On success writes an audit record: who (user), what (action+target), when,
+ * asserted-by (callerPrincipal), and returns the resolved user so the route
+ * executes in that user's name.
+ */
+export async function verifyDelegatedAdmin(input: VerifyDelegatedAdminInput): Promise<DelegationResult> {
+  const {
+    rawAssertion, expectedAction, expectedTarget, callerPrincipal,
+    replayGuard = defaultReplayGuard,
+    now = Date.now(),
+    adminCheck = defaultAdminCheck,
+  } = input;
+
+  if (!rawAssertion) return fail('missing');
+
+  // Steps 1-3: decode + signature + window/expiry + action/target binding.
+  // All synchronous and side-effect-free — no nonce is consumed and no network
+  // call is made until the assertion is proven authentic and correctly bound.
+  const shape = checkAssertionShape(rawAssertion, expectedAction, expectedTarget, now);
+  if (!shape.ok) return fail(shape.reason);
+  const { assertion } = shape;
+
+  // 4. Replay — consume the nonce ONLY now that the assertion is otherwise
+  //    valid and correctly bound, so an attacker can't burn a legitimate nonce
+  //    with a mis-bound/forged copy. Remembered until the assertion's exp.
+  if (!replayGuard.consume(assertion.nonce, assertion.exp)) return fail('replayed');
+
+  // 5. Admin membership per SB's OWN LLDAP — never trust a role claim in the
+  //    assertion. This is the confused-deputy mitigation. Fail CLOSED on a
+  //    directory error (deny rather than assume admin).
+  let admin: { ok: true; inGroup: boolean } | { ok: false; message: string };
+  try {
+    admin = await adminCheck(assertion.user);
+  } catch (e) {
+    logger.warn('auth:delegatedAdmin', `admin check threw for ${assertion.user}: ${e instanceof Error ? e.message : String(e)}`);
+    return fail('directory_error');
+  }
+  if (!admin.ok) {
+    logger.warn('auth:delegatedAdmin', `admin check failed for ${assertion.user}: ${admin.message}`);
+    return fail('directory_error');
+  }
+  if (!admin.inGroup) return fail('not_admin');
+
+  // Success — record the delegation in the audit trail (who/what/when/by-whom).
+  await recordAudit({
+    ts: new Date(now).toISOString(),
+    tool: `delegated:${assertion.action}`,
+    caller: assertion.user,
+    outcome: 'ok',
+    durationMs: 0,
+    args: { target: assertion.target, assertedBy: callerPrincipal, nonce: assertion.nonce },
+  });
+
+  return { ok: true, user: assertion.user, assertion };
+}

--- a/packages/backend/src/lib/auth/delegationKey.test.ts
+++ b/packages/backend/src/lib/auth/delegationKey.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import { getDelegationKey, resetDelegationKeyCache } from './delegationKey';
+
+// #2270 — the delegated-admin trust key is DERIVED from AUTH_SECRET (ADR 0009
+// root-of-trust), so it inherits AUTH_SECRET's wipe-config-reinstall survival:
+// as long as AUTH_SECRET is preserved (which ADR 0009 §1 mandates), the derived
+// key is byte-identical across restarts/reinstalls — no new persisted file, no
+// key that "regenerates on reinstall".
+
+const ORIG = process.env.AUTH_SECRET;
+const SECRET_A = 'a'.repeat(48);
+const SECRET_B = 'b'.repeat(48);
+
+beforeEach(() => resetDelegationKeyCache());
+afterEach(() => {
+  if (ORIG === undefined) delete process.env.AUTH_SECRET;
+  else process.env.AUTH_SECRET = ORIG;
+  resetDelegationKeyCache();
+});
+
+describe('delegationKey', () => {
+  it('derives a 32-byte HMAC key from AUTH_SECRET', () => {
+    process.env.AUTH_SECRET = SECRET_A;
+    const key = getDelegationKey();
+    expect(key).toHaveLength(32);
+  });
+
+  it('is deterministic for a given AUTH_SECRET (survives a simulated reinstall that preserves it)', () => {
+    process.env.AUTH_SECRET = SECRET_A;
+    const before = getDelegationKey();
+    // Simulate a wipe-config reinstall: process restart (cache cleared) but
+    // AUTH_SECRET is preserved per ADR 0009 §1.
+    resetDelegationKeyCache();
+    const after = getDelegationKey();
+    expect(after.equals(before)).toBe(true);
+  });
+
+  it('changes when AUTH_SECRET changes (a fresh identity yields a fresh key)', () => {
+    process.env.AUTH_SECRET = SECRET_A;
+    const keyA = getDelegationKey();
+    resetDelegationKeyCache();
+    process.env.AUTH_SECRET = SECRET_B;
+    const keyB = getDelegationKey();
+    expect(keyB.equals(keyA)).toBe(false);
+  });
+
+  it('is domain-separated from the internal API token key (independent derivation)', () => {
+    process.env.AUTH_SECRET = SECRET_A;
+    const delegationKey = getDelegationKey().toString('hex');
+    // The internalToken derivation uses a different label over the same secret;
+    // the two outputs must not collide.
+    const internalTokenKey = crypto
+      .createHmac('sha256', SECRET_A)
+      .update('servicebay:internal-api:v1')
+      .digest('hex');
+    expect(delegationKey).not.toBe(internalTokenKey);
+  });
+
+  it('falls closed (random, non-deterministic) when AUTH_SECRET is unset', () => {
+    delete process.env.AUTH_SECRET;
+    const k1 = getDelegationKey();
+    resetDelegationKeyCache();
+    const k2 = getDelegationKey();
+    // Two independent random keys → verification of any externally-minted
+    // assertion fails closed rather than authenticating.
+    expect(k1.equals(k2)).toBe(false);
+  });
+});

--- a/packages/backend/src/lib/auth/delegationKey.ts
+++ b/packages/backend/src/lib/auth/delegationKey.ts
@@ -1,0 +1,61 @@
+import crypto from 'node:crypto';
+
+/**
+ * Delegated-admin trust key (#2270, ADR 0011 building on ADR 0009).
+ *
+ * The HMAC key ServiceBay uses to verify the SHORT-LIVED, ACTION-BOUND
+ * user+scope assertions that a trusted server-server caller (Solaris) presents
+ * when it wants to act AS an authenticated admin user for a mutating admin
+ * action (approve/deny, service-operate).
+ *
+ * WHY DERIVE FROM AUTH_SECRET — the reinstall-survival requirement:
+ *   ADR 0009 §1 makes `AUTH_SECRET`/`secret.key` the box's per-box IDENTITY:
+ *   they MUST survive a wipe-config reinstall (they are NOT regenerated when a
+ *   preserved `enc:`-bearing config is present). By DERIVING this key from
+ *   AUTH_SECRET — exactly the same HMAC-with-a-domain-label pattern as
+ *   `internalToken.ts` (SB_API_TOKEN) — the delegation trust key inherits that
+ *   survival property for free: no new persisted file, no new boot-init unit,
+ *   no key that "regenerates on reinstall" (the ADR-0009 footgun this ADR is
+ *   explicitly told to avoid). Both peers derive the same value from the shared
+ *   root-of-trust; the operator provisions Solaris with the box's AUTH_SECRET
+ *   (or a key derived from it) out of band, the same trust class as the
+ *   service token it already holds.
+ *
+ * Domain separation: a DISTINCT label from `internalToken.ts` so this key is
+ * cryptographically independent of SB_API_TOKEN — a compromise of one HMAC
+ * output never reveals the AUTH_SECRET nor the other derived key.
+ *
+ * Read AUTH_SECRET lazily (module may be imported before it is set in tests).
+ */
+
+const DELEGATION_KEY_LABEL = 'servicebay:delegated-admin:v1';
+
+let cached: Buffer | null = null;
+
+/**
+ * The 32-byte HMAC key for signing/verifying delegated-admin assertions.
+ * Deterministic for a given AUTH_SECRET → survives restarts and reinstalls
+ * that preserve AUTH_SECRET (ADR 0009 §1). Never leaves the process; only its
+ * HMAC output over an assertion is ever compared.
+ */
+export function getDelegationKey(): Buffer {
+  if (cached) return cached;
+  const secret = process.env.AUTH_SECRET ?? '';
+  if (!secret) {
+    // Without AUTH_SECRET the install is unsupportable (ADR 0009). Fail toward a
+    // per-process random key so verification of ANY externally-minted assertion
+    // fails closed (deny) rather than crashing at import; the rest of the app
+    // surfaces the missing-AUTH_SECRET configuration error on its own.
+    cached = crypto.randomBytes(32);
+    return cached;
+  }
+  cached = crypto.createHmac('sha256', secret).update(DELEGATION_KEY_LABEL).digest();
+  return cached;
+}
+
+/** Test-only: drop the cached key so a test can flip AUTH_SECRET and re-derive
+ *  (e.g. to assert the derivation is deterministic across a simulated reinstall
+ *  that preserves AUTH_SECRET, and changes when AUTH_SECRET changes). */
+export function resetDelegationKeyCache(): void {
+  cached = null;
+}

--- a/packages/backend/src/lib/lldap/client.ts
+++ b/packages/backend/src/lib/lldap/client.ts
@@ -314,6 +314,16 @@ const DELETE_USER_MUTATION = `
   }
 `;
 
+// Single-user group-membership lookup (#2270). `user(userId:)` returns the one
+// user + their group displayNames — the authoritative source ServiceBay checks
+// to decide whether a delegated-admin assertion's named user is REALLY an admin
+// here (we never trust the assertion's own role claim — confused-deputy).
+const USER_GROUPS_QUERY = `
+  query UserGroups($userId: String!) {
+    user(userId: $userId) { id groups { displayName } }
+  }
+`;
+
 type LldapMutationReason =
   | 'not_configured'
   | 'unreachable'
@@ -399,6 +409,52 @@ export async function deleteLldapUser(userId: string): Promise<LldapMutationResu
     return { ok: false, reason: 'graphql_error', message: `LLDAP did not confirm deletion of ${userId}.` };
   }
   return { ok: true };
+}
+
+export type LldapUserInGroupResult =
+  | { ok: true; inGroup: boolean; groups: string[] }
+  | { ok: false; reason: LldapMutationReason | 'unknown_user'; message: string };
+
+/**
+ * Is `userId` a member of `groupDisplayName` per ServiceBay's OWN LLDAP (#2270)?
+ *
+ * This is the confused-deputy mitigation for delegated-admin: a caller (Solaris)
+ * asserts "act as user X, who is an admin" — ServiceBay does NOT trust that role
+ * claim, it re-derives the truth here by asking its own identity source whether
+ * X is actually in `admins`. Group match is on displayName (LLDAP 0.6.x has no
+ * POSIX attrs; Authelia's access rules key off the same displayName), matched
+ * case-insensitively since LLDAP group names are effectively case-folded.
+ *
+ * A missing user is `{ ok:true, inGroup:false }` with reason surfaced via the
+ * empty `groups` — an unknown user is a definitive "not an admin", not an error
+ * the caller should retry. A network/auth/config failure is `ok:false` so the
+ * guard fails CLOSED (deny) rather than treating an unreachable directory as a
+ * membership decision.
+ */
+export async function userIsInLldapGroup(
+  userId: string,
+  groupDisplayName: string,
+): Promise<LldapUserInGroupResult> {
+  if (!userId) return { ok: true, inGroup: false, groups: [] };
+  const r = await runAuthedGraphql<{ user?: { id: string; groups?: Array<{ displayName: string }> } }>(
+    USER_GROUPS_QUERY,
+    { userId },
+  );
+  if (!r.ok) {
+    // LLDAP returns a graphql error for an unknown user id ("Entity not found").
+    // Treat that specific case as a definitive non-member rather than a failure,
+    // so a delegated assertion naming a bogus user is a clean 403 (not a 5xx).
+    if (r.reason === 'graphql_error' && /not\s*found|no\s*such|unknown/i.test(r.message)) {
+      return { ok: true, inGroup: false, groups: [] };
+    }
+    return { ok: false, reason: r.reason, message: r.message };
+  }
+  const user = r.data.user;
+  if (!user) return { ok: true, inGroup: false, groups: [] };
+  const groups = (user.groups ?? []).map(g => g.displayName);
+  const target = groupDisplayName.toLowerCase();
+  const inGroup = groups.some(g => g.toLowerCase() === target);
+  return { ok: true, inGroup, groups };
 }
 
 /**

--- a/packages/backend/src/lib/lldap/client.userInGroup.test.ts
+++ b/packages/backend/src/lib/lldap/client.userInGroup.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetConfig } = vi.hoisted(() => ({ mockGetConfig: vi.fn() }));
+vi.mock('../config', () => ({ getConfig: () => mockGetConfig() }));
+
+import { userIsInLldapGroup } from './client';
+
+beforeEach(() => {
+  mockGetConfig.mockResolvedValue({ lldap: { url: 'http://lldap:17170', username: 'admin', password: 'pw' } });
+  vi.restoreAllMocks();
+});
+
+/** auth/simple/login succeeds, then the graphql call returns `graphqlBody`. */
+function stubFetch(graphqlBody: unknown) {
+  vi.stubGlobal('fetch', vi.fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ token: 'jwt' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => graphqlBody }));
+}
+
+// #2270 — the authoritative admin-membership check the delegated-admin guard
+// consults. Never trusts a caller's role claim; asks SB's own LLDAP.
+describe('userIsInLldapGroup', () => {
+  it('returns inGroup:true when the user is a member (case-insensitive)', async () => {
+    stubFetch({ data: { user: { id: 'alice', groups: [{ displayName: 'Admins' }, { displayName: 'family' }] } } });
+    const r = await userIsInLldapGroup('alice', 'admins');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.inGroup).toBe(true);
+  });
+
+  it('returns inGroup:false when the user is not in the group', async () => {
+    stubFetch({ data: { user: { id: 'bob', groups: [{ displayName: 'family' }] } } });
+    const r = await userIsInLldapGroup('bob', 'admins');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.inGroup).toBe(false);
+  });
+
+  it('treats an unknown user as a definitive non-member (not an error)', async () => {
+    stubFetch({ errors: [{ message: 'Entity not found' }] });
+    const r = await userIsInLldapGroup('ghost', 'admins');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.inGroup).toBe(false);
+  });
+
+  it('empty user id is a non-member without a network call', async () => {
+    const r = await userIsInLldapGroup('', 'admins');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.inGroup).toBe(false);
+  });
+
+  it('fails closed (ok:false) on a directory/network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const r = await userIsInLldapGroup('alice', 'admins');
+    expect(r.ok).toBe(false);
+  });
+
+  it('fails closed (ok:false) when LLDAP creds are absent', async () => {
+    mockGetConfig.mockResolvedValue({});
+    const r = await userIsInLldapGroup('alice', 'admins');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('not_configured');
+  });
+});

--- a/packages/frontend/src/app/napi/approvals/[id]/approve/route.test.ts
+++ b/packages/frontend/src/app/napi/approvals/[id]/approve/route.test.ts
@@ -16,10 +16,18 @@ import type { ApprovalRequest } from '@/lib/approvals';
 const mocks = vi.hoisted(() => ({
   approveApproval: vi.fn(),
   getApproval: vi.fn(),
+  verifyDelegatedAdmin: vi.fn(),
   authRef: { value: undefined as { user: string } | undefined },
 }));
 
 vi.mock('@/lib/mcp/server', () => ({}));
+
+// Delegated-admin guard (#2268) — inject verify results so the route's
+// layered-auth branch is exercised without minting real HMAC assertions.
+vi.mock('@/lib/auth/delegatedAdmin', () => ({
+  DELEGATION_HEADER: 'x-sb-delegated-admin',
+  verifyDelegatedAdmin: mocks.verifyDelegatedAdmin,
+}));
 
 vi.mock('@/lib/approvals', async () => {
   const actual = await vi.importActual<typeof import('@/lib/approvals')>('@/lib/approvals');
@@ -34,10 +42,10 @@ vi.mock('@/lib/api/handler', () => ({
   withApiHandlerParams:
     (
       _opts: unknown,
-      handler: (ctx: { params: { id: string }; auth?: { user: string } }) => Promise<Response>,
+      handler: (ctx: { request: NextRequest; params: { id: string }; auth?: { user: string } }) => Promise<Response>,
     ) =>
-    async (_request: NextRequest, ctx: { params: Promise<{ id: string }> }) =>
-      handler({ params: await ctx.params, auth: mocks.authRef.value }),
+    async (request: NextRequest, ctx: { params: Promise<{ id: string }> }) =>
+      handler({ request, params: await ctx.params, auth: mocks.authRef.value }),
 }));
 
 import { POST } from './route';
@@ -55,15 +63,17 @@ const proposal = (caller: string): ApprovalRequest => ({
   status: 'pending',
 });
 
-const call = async (auth: { user: string } | undefined) => {
+const call = async (auth: { user: string } | undefined, delegationHeader?: string) => {
   mocks.authRef.value = auth;
-  const req = new NextRequest('http://localhost/napi/approvals/r1/approve', { method: 'POST' });
+  const headers = delegationHeader ? { 'x-sb-delegated-admin': delegationHeader } : undefined;
+  const req = new NextRequest('http://localhost/napi/approvals/r1/approve', { method: 'POST', headers });
   return POST(req, { params: Promise.resolve({ id: 'r1' }) });
 };
 
 beforeEach(() => {
   mocks.approveApproval.mockReset();
   mocks.getApproval.mockReset();
+  mocks.verifyDelegatedAdmin.mockReset();
   mocks.approveApproval.mockResolvedValue({ request: proposal('token:solaris') });
 });
 
@@ -85,6 +95,37 @@ describe('POST /napi/approvals/:id/approve — self-approval guard (#2253, #2244
   it('lets the cookie operator approve (never a token proposer)', async () => {
     mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
     const res = await call({ user: 'admin' });
+    expect(res.status).toBe(200);
+    expect(mocks.approveApproval).toHaveBeenCalledWith('r1');
+  });
+});
+
+describe('POST /napi/approvals/:id/approve — delegated-admin auth mode (#2268, ADR 0010)', () => {
+  it('approves when a valid delegated-admin assertion is presented (runs AS the admin)', async () => {
+    mocks.verifyDelegatedAdmin.mockResolvedValue({ ok: true, user: 'alice', assertion: {} });
+    // Even the self-approve-blocked token proposer is allowed through: the
+    // delegated path resolved a REAL admin, so the token-self-approve guard does
+    // not apply (the guard is only for the raw-token fallback).
+    const res = await call({ user: 'token:solaris' }, 'valid-assertion');
+    expect(res.status).toBe(200);
+    expect(mocks.verifyDelegatedAdmin).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedAction: 'approvals.approve', expectedTarget: 'r1', rawAssertion: 'valid-assertion' }),
+    );
+    expect(mocks.getApproval).not.toHaveBeenCalled(); // no fallback self-approve lookup
+    expect(mocks.approveApproval).toHaveBeenCalledWith('r1');
+  });
+
+  it('403s an INVALID assertion — never silently falls back to the raw token', async () => {
+    mocks.verifyDelegatedAdmin.mockResolvedValue({ ok: false, reason: 'not_admin', message: 'Asserted user is not a ServiceBay admin.' });
+    const res = await call({ user: 'token:solaris' }, 'forged-or-nonadmin');
+    expect(res.status).toBe(403);
+    expect(mocks.approveApproval).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the device-token path when NO assertion header is present', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'token:other' });
+    expect(mocks.verifyDelegatedAdmin).not.toHaveBeenCalled();
     expect(res.status).toBe(200);
     expect(mocks.approveApproval).toHaveBeenCalledWith('r1');
   });

--- a/packages/frontend/src/app/napi/approvals/[id]/approve/route.ts
+++ b/packages/frontend/src/app/napi/approvals/[id]/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { withApiHandlerParams } from '@/lib/api/handler';
 import { approveApproval, getApproval, isSelfApproval } from '@/lib/approvals';
+import { resolveDelegatedApprover } from '../../delegatedApprover';
 // Side-effect import (#2237): loading mcp/server runs its top-level
 // registerMcpDispatcher(...) call, so THIS route's bundle instance of
 // lib/approvals has a dispatcher when approving an on_approve.mcp approval.
@@ -37,14 +38,25 @@ export const dynamic = 'force-dynamic';
  */
 export const POST = withApiHandlerParams<undefined, undefined, { id: string }>(
   { tokenScope: 'mutate' },
-  async ({ params, auth }) => {
+  async ({ request, params, auth }) => {
     const id = decodeURIComponent(params.id);
-    const existing = await getApproval(id);
-    if (existing && isSelfApproval(existing, auth?.user)) {
-      return NextResponse.json(
-        { error: 'A token cannot approve the request it proposed; a ServiceBay admin must approve it.' },
-        { status: 403 },
-      );
+
+    // Delegated-admin auth mode (#2268, ADR 0010): if the caller carries a valid
+    // X-SB-Delegated-Admin assertion, the verdict runs AS that real admin user
+    // (audited by the guard). No assertion → fall back to the existing
+    // device-token/session path (self-approve guard below). An INVALID assertion
+    // → 403, never a silent fall-through.
+    const delegated = await resolveDelegatedApprover(request, 'approve', id, auth);
+    if (delegated.mode === 'reject') return delegated.response;
+
+    if (delegated.mode === 'fallback') {
+      const existing = await getApproval(id);
+      if (existing && isSelfApproval(existing, auth?.user)) {
+        return NextResponse.json(
+          { error: 'A token cannot approve the request it proposed; a ServiceBay admin must approve it.' },
+          { status: 403 },
+        );
+      }
     }
     try {
       const result = await approveApproval(id);

--- a/packages/frontend/src/app/napi/approvals/[id]/deny/route.test.ts
+++ b/packages/frontend/src/app/napi/approvals/[id]/deny/route.test.ts
@@ -13,7 +13,13 @@ import type { ApprovalRequest } from '@/lib/approvals';
 const mocks = vi.hoisted(() => ({
   rejectApproval: vi.fn(),
   getApproval: vi.fn(),
+  verifyDelegatedAdmin: vi.fn(),
   authRef: { value: undefined as { user: string } | undefined },
+}));
+
+vi.mock('@/lib/auth/delegatedAdmin', () => ({
+  DELEGATION_HEADER: 'x-sb-delegated-admin',
+  verifyDelegatedAdmin: mocks.verifyDelegatedAdmin,
 }));
 
 vi.mock('@/lib/approvals', async () => {
@@ -29,10 +35,10 @@ vi.mock('@/lib/api/handler', () => ({
   withApiHandlerParams:
     (
       _opts: unknown,
-      handler: (ctx: { params: { id: string }; auth?: { user: string } }) => Promise<Response>,
+      handler: (ctx: { request: NextRequest; params: { id: string }; auth?: { user: string } }) => Promise<Response>,
     ) =>
-    async (_request: NextRequest, ctx: { params: Promise<{ id: string }> }) =>
-      handler({ params: await ctx.params, auth: mocks.authRef.value }),
+    async (request: NextRequest, ctx: { params: Promise<{ id: string }> }) =>
+      handler({ request, params: await ctx.params, auth: mocks.authRef.value }),
 }));
 
 import { POST } from './route';
@@ -50,15 +56,17 @@ const proposal = (caller: string): ApprovalRequest => ({
   status: 'pending',
 });
 
-const call = async (auth: { user: string } | undefined) => {
+const call = async (auth: { user: string } | undefined, delegationHeader?: string) => {
   mocks.authRef.value = auth;
-  const req = new NextRequest('http://localhost/napi/approvals/r1/deny', { method: 'POST' });
+  const headers = delegationHeader ? { 'x-sb-delegated-admin': delegationHeader } : undefined;
+  const req = new NextRequest('http://localhost/napi/approvals/r1/deny', { method: 'POST', headers });
   return POST(req, { params: Promise.resolve({ id: 'r1' }) });
 };
 
 beforeEach(() => {
   mocks.rejectApproval.mockReset();
   mocks.getApproval.mockReset();
+  mocks.verifyDelegatedAdmin.mockReset();
   mocks.rejectApproval.mockResolvedValue({ request: proposal('token:solaris') });
 });
 
@@ -80,6 +88,34 @@ describe('POST /napi/approvals/:id/deny — self-approval guard (#2253, #2244)',
   it('lets the cookie operator deny (never a token proposer)', async () => {
     mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
     const res = await call({ user: 'admin' });
+    expect(res.status).toBe(200);
+    expect(mocks.rejectApproval).toHaveBeenCalledWith('r1');
+  });
+});
+
+describe('POST /napi/approvals/:id/deny — delegated-admin auth mode (#2268, ADR 0010)', () => {
+  it('denies when a valid delegated-admin assertion is presented (runs AS the admin)', async () => {
+    mocks.verifyDelegatedAdmin.mockResolvedValue({ ok: true, user: 'alice', assertion: {} });
+    const res = await call({ user: 'token:solaris' }, 'valid-assertion');
+    expect(res.status).toBe(200);
+    expect(mocks.verifyDelegatedAdmin).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedAction: 'approvals.deny', expectedTarget: 'r1', rawAssertion: 'valid-assertion' }),
+    );
+    expect(mocks.getApproval).not.toHaveBeenCalled();
+    expect(mocks.rejectApproval).toHaveBeenCalledWith('r1');
+  });
+
+  it('403s an INVALID assertion — never silently falls back to the raw token', async () => {
+    mocks.verifyDelegatedAdmin.mockResolvedValue({ ok: false, reason: 'bad_signature', message: 'Delegated-admin assertion signature is invalid.' });
+    const res = await call({ user: 'token:solaris' }, 'forged');
+    expect(res.status).toBe(403);
+    expect(mocks.rejectApproval).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the device-token path when NO assertion header is present', async () => {
+    mocks.getApproval.mockResolvedValue(proposal('token:solaris'));
+    const res = await call({ user: 'token:other' });
+    expect(mocks.verifyDelegatedAdmin).not.toHaveBeenCalled();
     expect(res.status).toBe(200);
     expect(mocks.rejectApproval).toHaveBeenCalledWith('r1');
   });

--- a/packages/frontend/src/app/napi/approvals/[id]/deny/route.ts
+++ b/packages/frontend/src/app/napi/approvals/[id]/deny/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { withApiHandlerParams } from '@/lib/api/handler';
 import { rejectApproval, getApproval, isSelfApproval } from '@/lib/approvals';
+import { resolveDelegatedApprover } from '../../delegatedApprover';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
@@ -24,14 +25,24 @@ export const dynamic = 'force-dynamic';
  */
 export const POST = withApiHandlerParams<undefined, undefined, { id: string }>(
   { tokenScope: 'mutate' },
-  async ({ params, auth }) => {
+  async ({ request, params, auth }) => {
     const id = decodeURIComponent(params.id);
-    const existing = await getApproval(id);
-    if (existing && isSelfApproval(existing, auth?.user)) {
-      return NextResponse.json(
-        { error: 'A token cannot resolve the request it proposed; a ServiceBay admin must decide it.' },
-        { status: 403 },
-      );
+
+    // Delegated-admin auth mode (#2268, ADR 0010): a valid X-SB-Delegated-Admin
+    // assertion runs the verdict AS that real admin user (audited). No assertion
+    // → fall back to the device-token/session path (self-approve guard below).
+    // An INVALID assertion → 403, never a silent fall-through.
+    const delegated = await resolveDelegatedApprover(request, 'deny', id, auth);
+    if (delegated.mode === 'reject') return delegated.response;
+
+    if (delegated.mode === 'fallback') {
+      const existing = await getApproval(id);
+      if (existing && isSelfApproval(existing, auth?.user)) {
+        return NextResponse.json(
+          { error: 'A token cannot resolve the request it proposed; a ServiceBay admin must decide it.' },
+          { status: 403 },
+        );
+      }
     }
     try {
       const result = await rejectApproval(id);

--- a/packages/frontend/src/app/napi/approvals/delegatedApprover.ts
+++ b/packages/frontend/src/app/napi/approvals/delegatedApprover.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { SessionPayload } from '@/lib/auth/session';
+import {
+  verifyDelegatedAdmin,
+  DELEGATION_HEADER,
+} from '@/lib/auth/delegatedAdmin';
+
+/**
+ * Delegated-admin auth mode for the /napi approve|deny verdict routes (#2268,
+ * ADR 0010 on #2270).
+ *
+ * These routes already accept a `mutate`-scoped device token / operator session
+ * (shipped #2253). This helper LAYERS the #2270 delegated-admin assertion on top
+ * so a trusted server-server caller (Solaris) can deliver a verdict AS an
+ * authenticated ServiceBay admin user — the mutation is gated by a REAL admin
+ * per SB's own LLDAP (confused-deputy mitigation), not by the raw ambient token.
+ *
+ * The two-part credential is verified upstream + here:
+ *   - the caller's `mutate` service token is checked by the handler's
+ *     `tokenScope: 'mutate'` gate BEFORE the route body runs (a missing/wrong
+ *     token is a 401 there, never reaching this helper);
+ *   - the `X-SB-Delegated-Admin` assertion is verified here, action/target-bound
+ *     to `approvals.<verb>` + this approval id, and the named user re-checked
+ *     against SB's own LLDAP. `verifyDelegatedAdmin` writes the audit record.
+ *
+ * Return contract:
+ *   - `{ mode: 'delegated', user }` — a valid assertion; run the verdict AS
+ *     `user` (a real admin), audited by the guard.
+ *   - `{ mode: 'fallback' }` — NO assertion header; the route keeps its existing
+ *     device-token/session path (the layering requirement).
+ *   - `{ mode: 'reject', response }` — an assertion WAS presented but is invalid
+ *     (bad signature / expired / replayed / mis-bound / non-admin / directory
+ *     error). The route returns the 403 as-is; it must NOT silently fall back
+ *     to the raw-token path (that would let a forged assertion be ignored rather
+ *     than refused).
+ */
+export type DelegatedApprover =
+  | { mode: 'delegated'; user: string }
+  | { mode: 'fallback' }
+  | { mode: 'reject'; response: NextResponse };
+
+/**
+ * @param verb  the approval verb this route performs — 'approve' | 'deny'.
+ * @param id    the decoded approval id the route is operating on (the binding
+ *              target the assertion must match).
+ * @param auth  the already-authenticated caller principal (the service token id),
+ *              recorded in the audit trail as asserted-by.
+ */
+export async function resolveDelegatedApprover(
+  request: NextRequest,
+  verb: 'approve' | 'deny',
+  id: string,
+  auth: SessionPayload | undefined,
+): Promise<DelegatedApprover> {
+  const rawAssertion = request.headers.get(DELEGATION_HEADER);
+  if (!rawAssertion) return { mode: 'fallback' };
+
+  const result = await verifyDelegatedAdmin({
+    rawAssertion,
+    expectedAction: `approvals.${verb}`,
+    expectedTarget: id,
+    callerPrincipal: auth?.user ?? 'unknown',
+  });
+
+  if (result.ok) return { mode: 'delegated', user: result.user };
+
+  // A `missing` reason cannot occur (we checked the header is present above),
+  // but treat any non-ok result as a refusal: an assertion was presented and is
+  // invalid → 403, NEVER a silent fall-through to the raw-token path.
+  return {
+    mode: 'reject',
+    response: NextResponse.json({ error: result.message }, { status: 403 }),
+  };
+}

--- a/packages/frontend/src/app/napi/approvals/events/route.test.ts
+++ b/packages/frontend/src/app/napi/approvals/events/route.test.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /napi/approvals/events — server-server SSE feed of new pending approvals
+ * (#2268 part B). Solaris subscribes with a read-scoped token and republishes.
+ *
+ * The gate machinery (accept right-scope Bearer, 401 wrong/absent scope) lives
+ * in requireSession.test.ts; the exact `read` scope in OPTIONS is pinned in
+ * ../../scopeGuards.test.ts. Here we prove the STREAM WIRING: it subscribes to
+ * the approvals bus, forwards a new-approval event, unsubscribes on cancel, and
+ * carries the SSE content-type. We drive the real `onNewApproval` bus so the
+ * wiring (not a mock) is exercised.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { NewApprovalEvent } from '@/lib/approvals';
+
+// Stub the handler wrapper so we invoke the stream directly (gate covered
+// elsewhere); the route body under test is the ReadableStream + bus wiring.
+vi.mock('@/lib/api/handler', () => ({
+  withApiHandler:
+    (_opts: unknown, handler: () => Promise<Response>) =>
+    async (_req: NextRequest) => handler(),
+}));
+
+// Use the REAL approvals bus so we test the actual emit→stream path. Only the
+// fs/executor dependencies of the module are stubbed to keep it hermetic.
+vi.mock('@/lib/dirs', () => ({ DATA_DIR: `${process.env.TMPDIR || '/tmp'}/napi-events-test-${process.pid}` }));
+vi.mock('@/lib/executor', () => ({ getExecutor: vi.fn() }));
+vi.mock('@/lib/nodes', () => ({ listNodes: vi.fn(() => Promise.resolve([{ Name: 'box1' }])) }));
+vi.mock('@/lib/services/ServiceManager', () => ({ ServiceManager: {} }));
+
+import { GET } from './route';
+import { submitApproval } from '@/lib/approvals';
+
+function parseSse(chunk: string): NewApprovalEvent | { type: string } | null {
+  const line = chunk.split('\n').find(l => l.startsWith('data: '));
+  return line ? JSON.parse(line.slice('data: '.length)) : null;
+}
+
+describe('GET /napi/approvals/events — SSE new-approval feed (#2268 part B)', () => {
+  it('returns an event-stream and emits a new-approval event when one is created', async () => {
+    const res = await GET(new NextRequest('http://localhost/napi/approvals/events'));
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    // First frame is the connection handshake.
+    const first = await reader.read();
+    expect(parseSse(decoder.decode(first.value))).toEqual({ type: 'connected' });
+
+    // Create a pending approval — the stream must forward a new-approval event.
+    const created = await submitApproval({ service: 'honcho', title: 'delete honcho', node: 'box1' });
+    const next = await reader.read();
+    expect(parseSse(decoder.decode(next.value))).toEqual({
+      type: 'new-approval',
+      id: created.id,
+      kind: 'honcho',
+      summary: 'delete honcho',
+      created_at: created.created_at,
+    });
+
+    // Cancelling the stream unsubscribes — a later approval must NOT arrive.
+    await reader.cancel();
+    const before = await submitApproval({ service: 'honcho', title: 'later', node: 'box1' });
+    expect(before.id).toBeTruthy(); // submit still succeeds with no live subscriber
+  });
+});

--- a/packages/frontend/src/app/napi/approvals/events/route.ts
+++ b/packages/frontend/src/app/napi/approvals/events/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { withApiHandler } from '@/lib/api/handler';
+import { onNewApproval, type NewApprovalEvent } from '@/lib/approvals';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /napi/approvals/events — server-server SSE feed of NEW pending approvals
+ * (#2268 part B, ADR 0010).
+ *
+ * Solaris (server-server, read-scoped token) subscribes here and republishes
+ * each new-approval event on its OWN bus; per ADR 0010 the PHONE never
+ * subscribes to ServiceBay directly — Solaris aggregates. The stream emits a
+ * MINIMAL, secret-free payload (`onNewApproval` builds it): approval id + kind
+ * (service) + summary (title). No approval payload, no on_approve/on_reject
+ * actions, no secrets ride the stream.
+ *
+ * TOKEN-GATED, `read`-scoped (`tokenScope: 'read'` in the withApiHandler OPTIONS
+ * — the wrapper gate reads it there, #2249/#2252). A request with NO valid
+ * Bearer is 401'd by the gate before the stream opens; this is a read-only
+ * notification, not a mutation, so a `read` token is the correct floor (and it
+ * matches the other /napi read surfaces). Modelled on /api/stream but scoped to
+ * the approvals bus.
+ */
+export const GET = withApiHandler({ tokenScope: 'read' }, async () => {
+  const encoder = new TextEncoder();
+
+  let cleanup: (() => void) | null = null;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = (data: unknown) => {
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+        } catch {
+          // Controller closed (client gone) — tear the subscription down.
+          if (cleanup) cleanup();
+        }
+      };
+
+      // Initial handshake so the subscriber knows the stream is live.
+      send({ type: 'connected' });
+
+      const unsubscribe = onNewApproval((event: NewApprovalEvent) => send(event));
+
+      // Keep-alive ping so intermediaries don't drop an idle connection.
+      const interval = setInterval(() => send({ type: 'ping' }), 30000);
+
+      cleanup = () => {
+        unsubscribe();
+        clearInterval(interval);
+      };
+    },
+    cancel() {
+      if (cleanup) cleanup();
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    },
+  });
+});

--- a/packages/frontend/src/app/napi/scopeGuards.test.ts
+++ b/packages/frontend/src/app/napi/scopeGuards.test.ts
@@ -40,7 +40,15 @@ function hasInnerRequireSessionScope(relPath: string): boolean {
   return /requireSession\([^)]*tokenScope/.test(src(relPath));
 }
 
-const ROUTES = ['home/route.ts', 'approvals/route.ts', 'services/route.ts', 'upgrades/route.ts'];
+const ROUTES = [
+  'home/route.ts',
+  'approvals/route.ts',
+  'services/route.ts',
+  'upgrades/route.ts',
+  // #2268 part B — the server-server new-approval SSE feed (Solaris subscribes
+  // with a read-scoped token; the phone gets it via Solaris per ADR 0010).
+  'approvals/events/route.ts',
+];
 
 describe('/napi/* read endpoints are read-scoped in the handler OPTIONS (#2252, #2249)', () => {
   for (const route of ROUTES) {


### PR DESCRIPTION
## What
Auth-delegation (ADR 0010, on ADR 0009): Solaris (server-server) can perform a mutating admin action AS an authenticated admin user without a confused-deputy, and delegated approve/deny plus a new-approval SSE feed under `/napi/approvals`.

- **#2270** — delegated-admin verification mechanism: a caller authenticated with its ADR-0009 scoped service token additionally sends a short-lived, action-bound HMAC-signed `{user, action, target, nonce, iat, exp}` assertion. `verifyDelegatedAdmin` checks signature + TTL (<=2min) + single-use nonce (replay guard) + action/target binding, and **re-derives** admin membership against ServiceBay's OWN LLDAP (never trusting the assertion's role claim). Success runs the action in that user's name and writes an audit record. The trust key is derived from the AUTH_SECRET root-of-trust (survives a wipe-config reinstall). Additive/layered auth mode.
- **#2268** — delegated approve/deny on the existing `/napi/approvals/[id]/{approve,deny}` routes (layered on the existing device-token path), plus a token-gated SSE feed `GET /napi/approvals/events` emitting a minimal, secret-free new-approval event so Solaris can republish it on its own bus (phone via Solaris per ADR 0010).

## Why
Closes #2270
Closes #2268

## Risk
Medium — touches auth/token/approvals code paths; mitigated by a layered (additive) design, fail-closed verification, admin membership re-derived against SB's own LLDAP, and thorough unit coverage.

## Rollback
git revert is enough (additive; no schema/migration changes).

## Verification
- [x] npm run lint (0 errors)
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full suite, 3863 passed)
- [ ] /verify on FCoS :dev box (napi/approvals path-mandated — delegated approve round-trip + SSE feed against live LLDAP + AUTH_SECRET)
