### PR TITLE
fix(approvals): share approvalEvents bus via globalThis across bundles

### DIFF
--- a/packages/backend/src/lib/approvals/globalEventBus.test.ts
+++ b/packages/backend/src/lib/approvals/globalEventBus.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression for #2268 part B: the approvals event bus (`approvalEvents`) must
+ * be a `globalThis`-shared singleton so it survives across the Next.js
+ * per-route module-cache boundary.
+ *
+ * WHY THIS IS ITS OWN FILE + WHAT IT CAN AND CANNOT PROVE:
+ * The real bug is cross-BUNDLE — in the Next.js standalone build the SSE route
+ * bundle and the MCP-server bundle each get their OWN module-cache copy of
+ * approvals/index.ts, so a bare `new EventEmitter()` gave them DIFFERENT
+ * instances (emit on one, listen on the other → nothing arrives). A vitest/jsdom
+ * unit test shares ONE module cache, so it CANNOT reproduce two bundle copies —
+ * the real end-to-end check is box-verify (BOUNDED SSE: subscribe-then-create,
+ * `timeout N curl -N --max-time N`). What this test CAN pin is the SHARING
+ * MECHANISM that makes cross-bundle work: the emitter is anchored on
+ * `globalThis` (the one object every bundle in the process shares), and a
+ * pre-existing global emitter is REUSED, not replaced. If someone reverts to a
+ * bare module-level `new EventEmitter()`, `globalThis.__sbApprovalEvents` goes
+ * undefined and this test fails — a cheap tripwire for the box-verified bug.
+ *
+ * The fs/executor deps are stubbed only to keep the import hermetic; the assert
+ * is purely on the global anchor, so no store I/O happens.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('@/lib/dirs', () => ({ DATA_DIR: `${process.env.TMPDIR || '/tmp'}/approvals-globalbus-test-${process.pid}` }));
+vi.mock('@/lib/executor', () => ({ getExecutor: vi.fn() }));
+vi.mock('@/lib/nodes', () => ({ listNodes: vi.fn(() => Promise.resolve([{ Name: 'box1' }])) }));
+vi.mock('@/lib/services/ServiceManager', () => ({ ServiceManager: {} }));
+
+const g = globalThis as unknown as { __sbApprovalEvents?: EventEmitter };
+
+describe('#2268-B approvals event bus is a globalThis-shared singleton', () => {
+  it('importing the module anchors the emitter on globalThis (cross-bundle sharing mechanism)', async () => {
+    // Importing the module runs its top-level singleton setup.
+    await import('./index');
+    expect(g.__sbApprovalEvents).toBeInstanceOf(EventEmitter);
+    // The listener cap is lifted (unbounded concurrent SSE subscribers).
+    expect(g.__sbApprovalEvents!.getMaxListeners()).toBe(0);
+  });
+
+  it('the onNewApproval subscription binds to the SAME global emitter the module emits on', async () => {
+    const { onNewApproval } = await import('./index');
+    const listener = vi.fn();
+    const off = onNewApproval(listener);
+    // A subscriber registered via the public API must land on the shared global
+    // emitter — this is exactly what breaks cross-bundle when they diverge.
+    g.__sbApprovalEvents!.emit('new-approval', { type: 'new-approval', id: 'x', kind: 'k', summary: 's', created_at: 't' });
+    expect(listener).toHaveBeenCalledTimes(1);
+    off();
+  });
+});

--- a/packages/backend/src/lib/approvals/index.ts
+++ b/packages/backend/src/lib/approvals/index.ts
@@ -228,13 +228,34 @@ export interface NewApprovalEvent {
 }
 
 /**
- * In-process event bus for approval lifecycle notifications. A single Node
- * process owns the JSON store, so an in-process EventEmitter is sufficient to
- * fan a create-event out to every open SSE stream. `setMaxListeners(0)` removes
- * the default 10-listener warning cap — each open Solaris SSE connection adds a
- * listener, and there is no fixed upper bound on concurrent subscribers.
+ * In-process event bus for approval lifecycle notifications, backed by a
+ * `globalThis`-shared singleton so EVERY webpack/Turbopack bundle in the process
+ * shares ONE emitter (#2268 part B).
+ *
+ * CROSS-BUNDLE HAZARD — the reason this is not a bare `new EventEmitter()`:
+ * a single Node process owns the JSON store, but in the Next.js standalone
+ * build EACH App-Router route is bundled with its OWN module-cache copy of this
+ * file. A module-level `const approvalEvents = new EventEmitter()` therefore
+ * gives DIFFERENT emitter instances to different route bundles. The event is
+ * EMITTED from the MCP-server bundle (mcp/server → submitApproval → emit) but
+ * the SSE feed SUBSCRIBES in the /napi/approvals/events route bundle
+ * (onNewApproval) — two different emitters → the event was fired on one and
+ * listened for on the other, so nothing ever arrived on the box (box-verified
+ * RED 2026-07-13). This is the SAME cross-bundle-singleton class as #2237
+ * (mcpDispatcher was null in the Next.js route bundle vs the MCP-server bundle).
+ *
+ * A side-effect import can co-locate a per-bundle *registration* (that is how
+ * #2237 fixed the dispatcher), but an EventEmitter is a shared STATEFUL object:
+ * a side-effect import cannot make two separately-constructed emitters be the
+ * same instance. Since all bundles run in ONE process, `globalThis` IS shared
+ * across them, so stashing the emitter on `globalThis` gives every bundle the
+ * one-and-only emitter. `setMaxListeners(0)` removes the default 10-listener
+ * warning cap — each open Solaris SSE connection adds a listener, and there is
+ * no fixed upper bound on concurrent subscribers.
  */
-const approvalEvents = new EventEmitter();
+const globalForApprovals = globalThis as unknown as { __sbApprovalEvents?: EventEmitter };
+const approvalEvents =
+  globalForApprovals.__sbApprovalEvents ?? (globalForApprovals.__sbApprovalEvents = new EventEmitter());
 approvalEvents.setMaxListeners(0);
 
 const NEW_APPROVAL_EVENT = 'new-approval';


### PR DESCRIPTION
## What
Fixes the #2268-B SSE new-approval feed (`GET /napi/approvals/events`) that never emitted on the box despite green unit tests. `approvalEvents` was a bare module-level `new EventEmitter()`; in the Next.js standalone build each App-Router route bundle has its own module cache, so the SSE-route bundle (subscribes) and the MCP-server bundle (`submitApproval` -> `emit`) held different emitter instances. Anchoring the emitter on `globalThis` (`__sbApprovalEvents`) — one process, shared global — gives every bundle the one-and-only emitter. Same cross-bundle-singleton class as #2237. Payload and route API unchanged.

## Why
Closes #2268

## Risk
Low — single-file behavior change to a shared bus + one new test; API surface unchanged.

## Rollback
`git revert` is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full, 3865 passed)
- [ ] /verify on FCoS :dev box — RE-VERIFY the full #2270+#2268 companion-delegation feature now the SSE cross-bundle bug is fixed (bounded SSE: subscribe-then-create, `timeout N curl -N --max-time N`)

AI-generated
<!-- sb-ai-comment -->