### PR TITLE
feat(auth): session-driven delegated-admin mint (no standing key in consumer)

### DIFF
--- a/packages/frontend/src/app/api/auth/delegated-admin-from-authelia-session/route.test.ts
+++ b/packages/frontend/src/app/api/auth/delegated-admin-from-authelia-session/route.test.ts
@@ -1,0 +1,192 @@
+/**
+ * POST /api/auth/delegated-admin-from-authelia-session — session-driven
+ * delegated-admin mint (#2275, SECURITY).
+ *
+ * The delegation analogue of #2246's token-from-authelia-session: a verified
+ * *browser* Authelia admin session (NPM forward-auth Remote-User /
+ * Remote-Groups) mints a SHORT-LIVED, SINGLE-USE `X-SB-Delegated-Admin`
+ * assertion — WITHOUT the consumer ever holding the standing AUTH_SECRET-derived
+ * delegationKey. ServiceBay holds the key server-side and only MINTS here.
+ *
+ * These tests drive the ACTUAL route module against the REAL delegatedAdmin /
+ * delegationKey codec (no HMAC mocking) so the round-trip is genuine: a minted
+ * assertion must be accepted by `verifyDelegatedAdmin` AND drive the approve
+ * route AS the named admin. Only LLDAP (`userIsInLldapGroup`) and the audit sink
+ * are stubbed — everything crypto is real. We assert the security invariants:
+ *   - valid admin session → mints an assertion verifyDelegatedAdmin accepts;
+ *   - non-admin session (Remote-Groups without admins) → 403, NO mint;
+ *   - missing forward-auth identity → 401; client Bearer (off-proxy) → 403;
+ *   - the assertion is short-TTL (expired → rejected) and single-use (reuse → 403);
+ *   - the response body leaks NEITHER the raw delegationKey NOR AUTH_SECRET.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// AUTH_SECRET must be set BEFORE delegationKey derives (module reads it lazily,
+// but set it here for determinism across the round-trip).
+process.env.AUTH_SECRET = 'test-auth-secret-for-2275-round-trip';
+
+const mocks = vi.hoisted(() => ({
+  userIsInLldapGroup: vi.fn(),
+  recordAudit: vi.fn(),
+}));
+
+// LLDAP admin re-derivation (the confused-deputy check inside verifyDelegatedAdmin)
+// is the only external dependency of the verify round-trip we stub.
+vi.mock('@/lib/lldap/client', () => ({
+  userIsInLldapGroup: mocks.userIsInLldapGroup,
+}));
+vi.mock('@/lib/mcp/audit', () => ({
+  recordAudit: mocks.recordAudit,
+}));
+
+import { POST } from './route';
+import {
+  verifyDelegatedAdmin,
+  createInMemoryReplayGuard,
+  MAX_ASSERTION_TTL_MS,
+} from '@/lib/auth/delegatedAdmin';
+import { resetDelegationKeyCache } from '@/lib/auth/delegationKey';
+
+function req(headers: Record<string, string>, body: unknown = { action: 'approvals.approve', target: 'r1' }): NextRequest {
+  return new NextRequest('http://localhost:5888/api/auth/delegated-admin-from-authelia-session', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  process.env.AUTH_SECRET = 'test-auth-secret-for-2275-round-trip';
+  resetDelegationKeyCache();
+  mocks.userIsInLldapGroup.mockReset();
+  mocks.recordAudit.mockReset();
+  mocks.userIsInLldapGroup.mockResolvedValue({ ok: true, inGroup: true });
+  mocks.recordAudit.mockResolvedValue(undefined);
+});
+
+describe('delegated-admin-from-authelia-session — session-driven mint (#2275)', () => {
+  it('mints an assertion that verifyDelegatedAdmin accepts AND runs AS the named admin', async () => {
+    const res = await POST(req({ 'remote-user': 'alice', 'remote-groups': 'admins,users' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.header).toBe('x-sb-delegated-admin');
+    expect(body.action).toBe('approvals.approve');
+    expect(body.target).toBe('r1');
+    expect(typeof body.assertion).toBe('string');
+
+    // The minted assertion is accepted by the verifier, bound to this action/
+    // target, and resolves to the admin from Remote-User.
+    const verdict = await verifyDelegatedAdmin({
+      rawAssertion: body.assertion,
+      expectedAction: 'approvals.approve',
+      expectedTarget: 'r1',
+      callerPrincipal: 'token:solaris',
+      replayGuard: createInMemoryReplayGuard(),
+    });
+    expect(verdict).toMatchObject({ ok: true, user: 'alice' });
+  });
+
+  it('binds to the requested action/target — a mint for deny is NOT accepted as approve', async () => {
+    const res = await POST(
+      req({ 'remote-user': 'alice', 'remote-groups': 'admins' }, { action: 'approvals.deny', target: 'r7' }),
+    );
+    const body = await res.json();
+    const verdict = await verifyDelegatedAdmin({
+      rawAssertion: body.assertion,
+      expectedAction: 'approvals.approve', // route is doing approve, assertion is for deny
+      expectedTarget: 'r7',
+      callerPrincipal: 'token:solaris',
+      replayGuard: createInMemoryReplayGuard(),
+    });
+    expect(verdict).toMatchObject({ ok: false, reason: 'binding_mismatch' });
+  });
+
+  it('non-admin session (Remote-Groups without admins) → 403, NO mint', async () => {
+    const res = await POST(req({ 'remote-user': 'bob', 'remote-groups': 'users' }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.assertion).toBeUndefined();
+  });
+
+  it('no forward-auth identity (off the proxy path) → 401, NO mint', async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.assertion).toBeUndefined();
+  });
+
+  it('REFUSES a client Bearer + spoofed Remote-Groups:admins (direct :5888 self-elevation) → 403, NO mint', async () => {
+    const res = await POST(
+      req({ authorization: 'Bearer sb_some_scoped_token', 'remote-user': 'evil', 'remote-groups': 'admins' }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.assertion).toBeUndefined();
+  });
+
+  it('rejects an unknown/too-broad action (narrow capability guard)', async () => {
+    const res = await POST(
+      req({ 'remote-user': 'alice', 'remote-groups': 'admins' }, { action: 'delete_service', target: 'honcho' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.assertion).toBeUndefined();
+  });
+
+  it('requires a target', async () => {
+    const res = await POST(
+      req({ 'remote-user': 'alice', 'remote-groups': 'admins' }, { action: 'approvals.approve' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('mints a SHORT-TTL assertion (<= MAX_ASSERTION_TTL_MS) — an expired one is rejected', async () => {
+    const res = await POST(req({ 'remote-user': 'alice', 'remote-groups': 'admins' }));
+    const body = await res.json();
+    const ttl = new Date(body.expiresAt).getTime() - Date.now();
+    expect(ttl).toBeLessThanOrEqual(MAX_ASSERTION_TTL_MS + 1000);
+    expect(ttl).toBeGreaterThan(0);
+
+    // Verify with a clock past the expiry → rejected as expired (never accepted).
+    const verdict = await verifyDelegatedAdmin({
+      rawAssertion: body.assertion,
+      expectedAction: 'approvals.approve',
+      expectedTarget: 'r1',
+      callerPrincipal: 'token:solaris',
+      replayGuard: createInMemoryReplayGuard(),
+      now: Date.now() + MAX_ASSERTION_TTL_MS + 1000,
+    });
+    expect(verdict).toMatchObject({ ok: false, reason: 'expired' });
+  });
+
+  it('mints a SINGLE-USE assertion — a second verify with the same nonce is a replay (403)', async () => {
+    const res = await POST(req({ 'remote-user': 'alice', 'remote-groups': 'admins' }));
+    const body = await res.json();
+    const guard = createInMemoryReplayGuard();
+    const input = {
+      rawAssertion: body.assertion,
+      expectedAction: 'approvals.approve',
+      expectedTarget: 'r1',
+      callerPrincipal: 'token:solaris',
+      replayGuard: guard,
+    };
+    const first = await verifyDelegatedAdmin(input);
+    expect(first).toMatchObject({ ok: true, user: 'alice' });
+    const second = await verifyDelegatedAdmin(input);
+    expect(second).toMatchObject({ ok: false, reason: 'replayed' });
+  });
+
+  it('does NOT leak the raw delegationKey or AUTH_SECRET in the response', async () => {
+    const res = await POST(req({ 'remote-user': 'alice', 'remote-groups': 'admins' }));
+    const raw = await res.text();
+    expect(raw).not.toContain(process.env.AUTH_SECRET as string);
+    // The delegationKey is HMAC(AUTH_SECRET, label) as base64/hex — neither the
+    // secret nor any key-material field name should appear.
+    expect(raw.toLowerCase()).not.toContain('delegationkey');
+    expect(raw.toLowerCase()).not.toContain('auth_secret');
+    // Only the encoded assertion (claims '.' hmac) and metadata are returned.
+    const body = JSON.parse(raw);
+    expect(Object.keys(body).sort()).toEqual(['action', 'assertion', 'expiresAt', 'header', 'target']);
+  });
+});

--- a/packages/frontend/src/app/api/auth/delegated-admin-from-authelia-session/route.ts
+++ b/packages/frontend/src/app/api/auth/delegated-admin-from-authelia-session/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'node:crypto';
+import { withApiHandler } from '@/lib/api/handler';
+import {
+  encodeAssertion,
+  DELEGATION_HEADER,
+  MAX_ASSERTION_TTL_MS,
+  ADMIN_GROUP,
+  type DelegatedAssertion,
+} from '@/lib/auth/delegatedAdmin';
+import { logger } from '@/lib/logger';
+
+/**
+ * Authelia-session → short-lived delegated-admin assertion (#2275).
+ *
+ * The DELEGATION analogue of `/api/auth/token-from-authelia-session` (#2246):
+ * a verified admin's *live* Authelia session mints a SHORT-LIVED, SINGLE-PURPOSE
+ * delegated-admin assertion (the `X-SB-Delegated-Admin` value) — WITHOUT the
+ * consumer (e.g. the Solaris BFF pod) ever holding the standing AUTH_SECRET-
+ * derived `delegationKey`. ServiceBay already holds that key server-side; here
+ * SB VERIFIES the admin session and MINTS the assertion with `encodeAssertion`,
+ * so the key never leaves the box. The consumer then presents the returned
+ * assertion to `POST /napi/approvals/:id/{approve,deny}`, where
+ * `verifyDelegatedAdmin` re-validates it (signature, window, replay, and the
+ * LLDAP admin re-derivation of the named user).
+ *
+ * WHY — #2272 shipped delegated-admin, but the ONLY way to mint the assertion
+ * was to HOLD the AUTH_SECRET-derived key in the consumer pod (a 24/7 root-of-
+ * trust admin credential — the exact anti-pattern #2246 avoided for the SB-MCP
+ * token). This endpoint moves the authority back to the live admin session:
+ * nothing standing in the consumer pod, the assertion expires in ≤2 minutes and
+ * is single-use.
+ *
+ * TRUST MODEL — read before touching the header check (identical to #2246):
+ *   The `Remote-User` / `Remote-Groups` headers are trustworthy ONLY because
+ *   NPM's forward-auth snippet (`stackInstall/forwardAuth.ts`) sets them via
+ *   `proxy_set_header Remote-User $user;` from the Authelia auth-request
+ *   subrequest, OVERWRITING any client-supplied copy (ADR 0009 §2 — Remote-*
+ *   trusted only on the LAN-gated proxy path). A request that actually carries
+ *   these headers has been through Authelia. A request WITHOUT them
+ *   (direct/loopback, or a public host not fronted by the forward-auth chain) is
+ *   NOT trusted — missing `Remote-User` → 401, never an assertion.
+ *
+ * PRIVILEGE-ESCALATION GUARD (#2246/#2249, SECURITY):
+ *   On a DIRECT `:5888` call (bypassing NPM) a Bearer holder passes proxy.ts's
+ *   `isValidBearerToken()` gate and could then supply its OWN `Remote-User: evil`
+ *   / `Remote-Groups: admins` headers (nothing upstream overwrote them) → mint an
+ *   admin assertion = self-elevation. So we REFUSE any request that presents a
+ *   client Bearer (403, mint nothing). Identity here may only come from the
+ *   proxy-injected forward-auth headers, never from a caller who is already a
+ *   token.
+ *
+ * `skipAuth: true`: the Authelia proxy headers ARE the credential (mirrors
+ * `/api/auth/token-from-authelia-session`). No cookie/admin session is required.
+ */
+
+/** The narrow, app-agnostic capability this endpoint mints for: the approvals
+ *  verdict actions `verifyDelegatedAdmin` binds to (`approvals.<verb>`). The
+ *  request names one; anything else is refused. Keeping the set explicit means a
+ *  minted assertion can only ever deliver an approve/deny verdict — never be
+ *  redirected to some other admin op. */
+const ALLOWED_ACTIONS = new Set(['approvals.approve', 'approvals.deny']);
+
+interface MintRequest {
+  /** The bound action, e.g. "approvals.approve" — must be in ALLOWED_ACTIONS. */
+  action?: unknown;
+  /** The bound target — the approval id the verdict operates on. */
+  target?: unknown;
+}
+
+function parseGroups(raw: string | null): string[] {
+  return (raw || '')
+    .split(',')
+    .map((g) => g.trim())
+    .filter(Boolean);
+}
+
+export const POST = withApiHandler({ skipAuth: true }, async ({ request }: { request: NextRequest }) => {
+  // PRIVILEGE-ESCALATION GUARD (#2249): refuse any caller presenting a client
+  // Bearer token — a token client reaching here on a direct :5888 call could set
+  // its OWN Remote-User/Remote-Groups and self-elevate to an admin assertion.
+  const authz = request.headers.get('authorization');
+  if (authz && authz.startsWith('Bearer ')) {
+    logger.warn(
+      'api:auth:delegated-admin-from-authelia-session',
+      'Refused mint: request carried a client Bearer token (not a browser Authelia session)',
+    );
+    return NextResponse.json(
+      { error: 'This endpoint is for a browser Authelia session; a token client may not mint an assertion here' },
+      { status: 403 },
+    );
+  }
+
+  // Only the proxy-injected identity is trusted (see TRUST MODEL above).
+  const user = request.headers.get('remote-user');
+  if (!user) {
+    return NextResponse.json(
+      { error: 'Authelia forward-auth identity required (no Remote-User header)' },
+      { status: 401 },
+    );
+  }
+
+  const groups = parseGroups(request.headers.get('remote-groups'));
+  if (!groups.includes(ADMIN_GROUP)) {
+    logger.warn(
+      'api:auth:delegated-admin-from-authelia-session',
+      `Denied mint for "${user}": not in "${ADMIN_GROUP}" (groups=[${groups.join(',')}])`,
+    );
+    return NextResponse.json(
+      { error: `User is not in the "${ADMIN_GROUP}" group` },
+      { status: 403 },
+    );
+  }
+
+  // The assertion is action+target-bound (the confused-deputy binding
+  // `verifyDelegatedAdmin` enforces). The caller names the exact verdict it is
+  // about to deliver; a minted assertion can only ever be used for THAT op.
+  let body: MintRequest;
+  try {
+    body = (await request.json()) as MintRequest;
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON { action, target }' }, { status: 400 });
+  }
+  const action = typeof body.action === 'string' ? body.action : '';
+  const target = typeof body.target === 'string' ? body.target : '';
+  if (!ALLOWED_ACTIONS.has(action)) {
+    return NextResponse.json(
+      { error: `action must be one of: ${[...ALLOWED_ACTIONS].join(', ')}` },
+      { status: 400 },
+    );
+  }
+  if (!target) {
+    return NextResponse.json({ error: 'target (the approval id) is required' }, { status: 400 });
+  }
+
+  // Mint the SHORT-LIVED, SINGLE-USE assertion server-side. TTL is the same
+  // MAX_ASSERTION_TTL_MS (≤2min) the verifier caps at (a longer window would be
+  // rejected as `bad_window`); the unique nonce makes it single-use via the
+  // verifier's replay guard. `user` comes from the verified Remote-User; the
+  // named user is re-checked against SB's own LLDAP at verify time.
+  const iat = Date.now();
+  const assertion: DelegatedAssertion = {
+    user,
+    action,
+    target,
+    nonce: crypto.randomUUID(),
+    iat,
+    exp: iat + MAX_ASSERTION_TTL_MS,
+  };
+  const encoded = encodeAssertion(assertion);
+
+  logger.info(
+    'api:auth:delegated-admin-from-authelia-session',
+    `Minted delegated-admin assertion for admin "${user}" action=${action} target=${target} exp=${new Date(assertion.exp).toISOString()}`,
+  );
+
+  // Return the assertion (the DELEGATION_HEADER value) and the header name so the
+  // consumer knows where to present it. The raw delegationKey / AUTH_SECRET is
+  // NEVER returned — only the HMAC output baked into the encoded assertion.
+  return NextResponse.json({
+    assertion: encoded,
+    header: DELEGATION_HEADER,
+    action,
+    target,
+    expiresAt: new Date(assertion.exp).toISOString(),
+  });
+});


### PR DESCRIPTION
## What
New `POST /api/auth/delegated-admin-from-authelia-session`: a verified Authelia **admin** session (NPM forward-auth injects `Remote-User` + `Remote-Groups: admins` on the LAN-gated proxy path) mints a short-lived (<=2min), single-use `X-SB-Delegated-Admin` assertion, action+target-bound to `approvals.approve|deny`. ServiceBay holds the AUTH_SECRET-derived `delegationKey` server-side and signs the assertion — the consumer (e.g. the Solaris BFF pod) never holds a standing key. The consumer presents the returned assertion to `POST /napi/approvals/:id/{approve,deny}`, where `verifyDelegatedAdmin` re-validates it (signature, window, replay, LLDAP admin re-derivation).

Delegation analogue of #2246 (token-from-authelia-session); builds on #2270/#2272 (delegatedAdmin + encodeAssertion), ADR 0009 §2 (Remote-* trust) + ADR 0010.

## Why
Closes #2275

## Risk
Medium — auth-surface mint endpoint. Mitigated: Bearer refused (no self-elevation on a direct :5888 call), admins-gated, action allowlist, <=2min single-use nonce, no raw key returned; 10 unit tests round-trip against the real delegatedAdmin/delegationKey codec.

## Rollback
`git revert` is enough (additive endpoint; nothing else changed).

## Verification
- [x] npm run lint (0 errors)
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full — 3875 passed, 2 skipped)
- [ ] /verify on FCoS :dev box (auth path — box_verify owed)