### PR TITLE
fix(auth): mint reachable server-to-server via NPM-injected internal token

### DIFF
--- a/packages/backend/src/lib/portal/provisioner.test.ts
+++ b/packages/backend/src/lib/portal/provisioner.test.ts
@@ -88,4 +88,42 @@ describe('provisionPortalRouting', () => {
     );
     expect(res.rewrites).toEqual({ 'dopp.cloud': 'added', 'www.dopp.cloud': 'added', '*.dopp.cloud': 'added' });
   });
+
+  // #2278 — the SB proxy host must inject X-SB-Internal-Token on the two
+  // *-from-authelia-session mint routes so a server-to-server caller through NPM
+  // crosses proxy.ts's CSRF gate and reaches the mint handler.
+  it('POSTs the SB proxy host with the internal-token mint location for BOTH apex and www', async () => {
+    process.env.AUTH_SECRET = 'test-secret-for-2278-provisioner';
+    const { getInternalApiToken } = await import('@/lib/auth/internalToken');
+    const expectedToken = getInternalApiToken();
+
+    // nginx active so provisionNpmProxyHost proceeds to the POST.
+    state.services = [{ name: 'nginx', active: true, ports: [{ containerPort: 81, hostPort: 81 }] }];
+
+    let postBody: any = null;
+    mockFetch.mockImplementation((url: string, init?: any) => {
+      if (typeof url === 'string' && url.includes('/api/system/nginx/proxy-hosts') && init?.method === 'POST') {
+        postBody = JSON.parse(init.body);
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ created: ['dopp.cloud', 'www.dopp.cloud'] }) });
+      }
+      // AdGuard rewrites etc. — irrelevant to this assertion.
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    await provisionPortalRouting();
+
+    expect(postBody).not.toBeNull();
+    expect(postBody.hosts).toHaveLength(2);
+    for (const host of postBody.hosts) {
+      const cfg = host.proxyConfig?.advanced_config ?? '';
+      // The internal token (AUTH_SECRET-derived, rendered at deploy time) is
+      // stamped on the mint location — this is what lets the NPM-fronted call
+      // pass proxy.ts:isInternalCall.
+      expect(cfg).toContain(`proxy_set_header X-SB-Internal-Token ${expectedToken};`);
+      // Scoped to exactly the two mint routes (no over-broad token stamping).
+      expect(cfg).toContain('location ~ ^/api/auth/(?:delegated-admin|token)-from-authelia-session$ {');
+      // Forward-auth injects the trusted identity the handler requires.
+      expect(cfg).toContain('proxy_set_header Remote-Groups $groups;');
+    }
+  });
 });

--- a/packages/backend/src/lib/portal/provisioner.ts
+++ b/packages/backend/src/lib/portal/provisioner.ts
@@ -28,6 +28,8 @@ import { getConfig } from '@/lib/config';
 import { getActiveDomain } from '@/lib/mode';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { ensureWildcardRewrite } from '@/lib/adguard/rewrites';
+import { buildAutheliaSessionMintLocation } from '@/lib/stackInstall/forwardAuth';
+import { getInternalApiToken } from '@/lib/auth/internalToken';
 import { logger } from '@/lib/logger';
 
 const LOG = 'portal:provisioner';
@@ -86,9 +88,18 @@ function buildPortalProxyHost(domain: string, lanIp: string): {
     forwardScheme: string;
     service: string;
     exposure: 'public' | 'lan';
+    proxyConfig?: { advanced_config?: string };
   }>;
 } {
   const port = parseInt(process.env.PORT ?? '5888', 10);
+  // #2278 — the SB host must inject the internal token on the two
+  // *-from-authelia-session mint routes so a server-to-server caller (Solaris)
+  // coming THROUGH NPM with Authelia-injected Remote-*/no-Bearer/no-Origin can
+  // cross proxy.ts's CSRF gate and reach the mint handler. Token is
+  // AUTH_SECRET-derived and rendered here at deploy time — never a literal. The
+  // auth-request probes `www.<domain>` (the `*.<domain>` one_factor host), since
+  // the apex is Authelia default-deny (ADR 0006) and yields no identity.
+  const mintConfig = { advanced_config: buildAutheliaSessionMintLocation(getInternalApiToken(), `www.${domain}`) };
   // The portal apex is reachable from outside (operator sees it at
   // the public domain), so exposure is `public`. Without this the
   // letsdebug check and the domain-health dot defaulted via the
@@ -96,8 +107,8 @@ function buildPortalProxyHost(domain: string, lanIp: string): {
   // domain, the heuristic isn't safe and we set the value explicitly.
   return {
     hosts: [
-      { domain, forwardPort: port, forwardHost: lanIp, forwardScheme: 'http', service: 'servicebay-portal', exposure: 'public' },
-      { domain: `www.${domain}`, forwardPort: port, forwardHost: lanIp, forwardScheme: 'http', service: 'servicebay-portal', exposure: 'public' },
+      { domain, forwardPort: port, forwardHost: lanIp, forwardScheme: 'http', service: 'servicebay-portal', exposure: 'public', proxyConfig: mintConfig },
+      { domain: `www.${domain}`, forwardPort: port, forwardHost: lanIp, forwardScheme: 'http', service: 'servicebay-portal', exposure: 'public', proxyConfig: mintConfig },
     ],
   };
 }

--- a/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
@@ -4,6 +4,8 @@ import {
   expandForwardAuthSentinel,
   renderForwardAuthAdvancedConfig,
   stripDuplicateProxyHttpVersion,
+  buildAutheliaSessionMintLocation,
+  AUTHELIA_SESSION_MINT_PATHS,
   DEFAULT_AUTHELIA_PORT,
 } from './forwardAuth';
 
@@ -159,5 +161,63 @@ describe('websocket sanitize — exactly one proxy_http_version reaches nginx (#
     })!;
     expect(countHttpVersion(out)).toBe(0);
     expect(out).toContain('auth_request /authelia;');
+  });
+});
+
+// #2278 — the SB host injects the internal token on the *-from-authelia-session
+// mint routes so a server-to-server caller through NPM crosses proxy.ts's CSRF
+// gate (isInternalCall) and reaches the mint handler.
+describe('buildAutheliaSessionMintLocation (#2278)', () => {
+  const TOKEN = 'deadbeef'.repeat(8); // AUTH_SECRET-derived HMAC shape
+
+  it('emits a location matching ONLY the two mint paths and injects the internal token', () => {
+    const out = buildAutheliaSessionMintLocation(TOKEN, 'www.dopp.cloud');
+    // The regex location anchors exactly the two mint routes.
+    expect(out).toContain('location ~ ^/api/auth/(?:delegated-admin|token)-from-authelia-session$ {');
+    // The internal token is stamped so the request passes proxy.ts:isInternalCall.
+    expect(out).toContain(`proxy_set_header X-SB-Internal-Token ${TOKEN};`);
+    // Both documented mint routes are covered by the anchored alternation.
+    for (const p of AUTHELIA_SESSION_MINT_PATHS) {
+      const re = new RegExp('^/api/auth/(?:delegated-admin|token)-from-authelia-session$');
+      expect(re.test(p)).toBe(true);
+    }
+    // Unrelated paths must NOT match — the token is scoped to the mint routes.
+    const re = new RegExp('^/api/auth/(?:delegated-admin|token)-from-authelia-session$');
+    expect(re.test('/api/system/update')).toBe(false);
+    expect(re.test('/api/auth/login')).toBe(false);
+    expect(re.test('/api/auth/token-from-authelia-session/extra')).toBe(false);
+  });
+
+  it('runs forward-auth so the trusted Remote-User/Remote-Groups are injected (not client-supplied)', () => {
+    const out = buildAutheliaSessionMintLocation(TOKEN, 'www.dopp.cloud');
+    expect(out).toContain('auth_request /authelia;');
+    expect(out).toContain('auth_request_set $user $upstream_http_remote_user;');
+    expect(out).toContain('auth_request_set $groups $upstream_http_remote_groups;');
+    expect(out).toContain('proxy_set_header Remote-User $user;');
+    expect(out).toContain('proxy_set_header Remote-Groups $groups;');
+    // Reuses NPM's proxy.conf for the upstream proxy_pass — never a second one.
+    expect(out).toContain('include conf.d/include/proxy.conf;');
+    expect(out).not.toContain('proxy_pass $forward_scheme');
+  });
+
+  it('probes the wildcard-covered www host (apex is Authelia default-deny — no identity there)', () => {
+    const out = buildAutheliaSessionMintLocation(TOKEN, 'www.dopp.cloud');
+    expect(out).toContain('proxy_pass http://127.0.0.1:9091/api/authz/auth-request;');
+    // X-Original-URL points at the www host, NOT the request's own (apex) host.
+    expect(out).toContain('proxy_set_header X-Original-URL https://www.dopp.cloud$request_uri;');
+  });
+
+  it('falls back to the request host when no www host is given (host already under the wildcard rule)', () => {
+    const out = buildAutheliaSessionMintLocation(TOKEN, undefined);
+    expect(out).toContain('proxy_set_header X-Original-URL $scheme://$http_host$request_uri;');
+  });
+
+  it('substitutes the given Authelia port (defaults to DEFAULT_AUTHELIA_PORT)', () => {
+    expect(buildAutheliaSessionMintLocation(TOKEN, 'www.dopp.cloud', '9099')).toContain(
+      'proxy_pass http://127.0.0.1:9099/api/authz/auth-request;',
+    );
+    expect(buildAutheliaSessionMintLocation(TOKEN, 'www.dopp.cloud')).toContain(
+      `proxy_pass http://127.0.0.1:${DEFAULT_AUTHELIA_PORT}/api/authz/auth-request;`,
+    );
   });
 });

--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -262,6 +262,111 @@ export function buildAuthSkipLocations(paths: string[] | undefined): string {
   return blocks.join('\n\n');
 }
 
+/**
+ * #2278 — nginx `location` block that makes the ServiceBay session-mint routes
+ * (`/api/auth/delegated-admin-from-authelia-session` and
+ * `/api/auth/token-from-authelia-session`) reachable server-to-server through
+ * NPM, WITHOUT weakening the CSRF gate.
+ *
+ * THE PROBLEM (issue #2278): those two routes are `skipAuth:true` and expect a
+ * forward-auth-header-only POST (NPM-injected `Remote-User`/`Remote-Groups`, NO
+ * Bearer, NO Origin — the handler refuses a Bearer to block self-elevation). But
+ * `proxy.ts`'s CSRF guard 403s that shape *before* the handler runs: it is not
+ * `isInternalCall` (no `X-SB-Internal-Token`), not a valid Bearer, and not
+ * same-origin (no Origin/Referer on a server-to-server call). There was no
+ * working call path.
+ *
+ * THE FIX (operator decision): on the SB host's NPM route we add a location for
+ * exactly these two paths that (a) runs Authelia forward-auth to inject the
+ * trusted `Remote-User`/`Remote-Groups`, AND (b) injects
+ * `X-SB-Internal-Token: <internalToken>` — the AUTH_SECRET-derived token
+ * `proxy.ts:isInternalCall` already accepts (proxy.ts:187 bypasses CSRF for it).
+ * So a request coming THROUGH NPM carries the token → passes the CSRF gate →
+ * reaches the handler, which then applies its own no-Bearer / Remote-Groups∋admins
+ * / LLDAP re-derive checks.
+ *
+ * WHY THIS IS NOT A FORGERY HOLE: the token is injected by NPM (which holds the
+ * position of trust), not by the client. A DIRECT `:5888` POST forging
+ * `Remote-User`/`Remote-Groups:admins` but WITHOUT the internal token (and
+ * without an Origin) still hits `proxy.ts`'s CSRF 403 — it never reaches the
+ * handler. Trust flows from NPM's network position, exactly like the existing
+ * post-deploy internal callbacks; no standing AUTH_SECRET-derived credential
+ * lives in any consumer pod.
+ *
+ * The token is rendered into the config at DEPLOY time (`getInternalApiToken()`,
+ * AUTH_SECRET-derived) — never a committed literal.
+ *
+ * The location uses `location ~ ^…$` (regex, exact set) so it wins over the
+ * default `location /` and matches ONLY the two mint paths. It carries its OWN
+ * `auth_request /authelia` (this host has no server-level forward-auth — the
+ * portal apex is intentionally anonymous), and reuses the shared
+ * `location = /authelia` internal subrequest emitted by
+ * {@link AUTHELIA_FORWARD_AUTH_CORE}. The auth-request `X-Original-URL` is
+ * pointed at `www.<domain>` (the `*.<domain>` `one_factor`-covered host), NOT
+ * the apex — the apex is Authelia default-deny (ADR 0006), so probing it yields
+ * no identity (mirrors `portal/auth.ts`). Pass `undefined`/'' for `wwwHost` on a
+ * host that is already itself under the wildcard rule (probe the request's own
+ * host).
+ */
+export const AUTHELIA_SESSION_MINT_PATHS = [
+  '/api/auth/delegated-admin-from-authelia-session',
+  '/api/auth/token-from-authelia-session',
+] as const;
+
+export function buildAutheliaSessionMintLocation(
+  internalToken: string,
+  wwwHost: string | undefined,
+  autheliaPort: string = DEFAULT_AUTHELIA_PORT,
+): string {
+  // Anchored alternation matching EXACTLY the two mint paths (regex location so
+  // it beats `location /`; `$` anchors so nothing broader slips through).
+  const pathRegex = `^/api/auth/(?:delegated-admin|token)-from-authelia-session$`;
+  // The auth-request subrequest target. On the anonymous portal apex the
+  // request's own host is default-deny, so probe the wildcard-covered
+  // `www.<domain>` instead (same rationale as portal/auth.ts). When wwwHost is
+  // empty we fall back to the request's own scheme/host (a host that IS under
+  // the wildcard rule).
+  const originalUrl = wwwHost
+    ? `https://${wwwHost}$request_uri`
+    : `$scheme://$http_host$request_uri`;
+  const mintLocation = [
+    `location ~ ${pathRegex} {`,
+    '    auth_request /authelia;',
+    '    auth_request_set $user $upstream_http_remote_user;',
+    '    auth_request_set $groups $upstream_http_remote_groups;',
+    '    auth_request_set $name $upstream_http_remote_name;',
+    '    auth_request_set $email $upstream_http_remote_email;',
+    // Trusted identity, injected by NPM (overwrites any client-supplied copy).
+    '    proxy_set_header Remote-User $user;',
+    '    proxy_set_header Remote-Groups $groups;',
+    '    proxy_set_header Remote-Name $name;',
+    '    proxy_set_header Remote-Email $email;',
+    // #2278 — the internal token that lets this NPM-fronted request cross
+    // proxy.ts's CSRF gate (isInternalCall). Rendered at deploy time.
+    `    proxy_set_header X-SB-Internal-Token ${internalToken};`,
+    // proxy.conf supplies proxy_pass + Host/X-Forwarded-* — do NOT add our own
+    // proxy_pass (a second one is `nginx: [emerg] "proxy_pass" directive is
+    // duplicate`). The Remote-*/token set BEFORE the include so nginx's
+    // "location owns all proxy_set_header" rule picks them up.
+    '    include conf.d/include/proxy.conf;',
+    '}',
+  ].join('\n');
+  // The internal auth-request upstream, pointed at the wildcard-covered host.
+  const authRequest = [
+    'location = /authelia {',
+    '    internal;',
+    `    proxy_pass http://127.0.0.1:${autheliaPort}/api/authz/auth-request;`,
+    '    proxy_pass_request_body off;',
+    '    proxy_set_header Content-Length "";',
+    `    proxy_set_header X-Original-URL ${originalUrl};`,
+    '    proxy_set_header X-Original-Method $request_method;',
+    '    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;',
+    '    proxy_set_header X-Real-IP $remote_addr;',
+    '}',
+  ].join('\n');
+  return `${mintLocation}\n\n${authRequest}`;
+}
+
 function baseSnippet(opts?: ForwardAuthExpandOptions): string {
   const core = opts?.omitAcmeBypass
     ? AUTHELIA_FORWARD_AUTH_CORE

--- a/packages/frontend/src/proxy.test.ts
+++ b/packages/frontend/src/proxy.test.ts
@@ -1,0 +1,88 @@
+/**
+ * proxy.ts CSRF/auth gate — the #2278 server-to-server mint path.
+ *
+ * The two `*-from-authelia-session` mint routes (#2246/#2276) are `skipAuth:true`
+ * and expect a forward-auth-header-only POST (NPM-injected Remote-User/
+ * Remote-Groups, NO Bearer, NO Origin). Before #2278 that shape was 403'd by
+ * proxy.ts's CSRF guard BEFORE the handler ran: not isInternalCall, not a valid
+ * Bearer, not same-origin → 403 "cross-site request". The fix makes NPM inject
+ * `X-SB-Internal-Token` on the mint location, so a request through NPM carries
+ * the token and passes `isInternalCall` (proxy.ts:187) → reaches the handler.
+ *
+ * These tests assert the proxy-LAYER security invariants of that path:
+ *   (a) a POST with a VALID X-SB-Internal-Token (the NPM-fronted shape) crosses
+ *       the CSRF gate — no Origin, no Bearer needed;
+ *   (b) a DIRECT :5888 POST forging Remote-User/Remote-Groups:admins WITHOUT the
+ *       internal token and WITHOUT an Origin is REJECTED (403 CSRF) — a LAN
+ *       attacker forging Remote-* can NEVER reach the mint. Trust flows only
+ *       from NPM's position (the injected token), never from client headers.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+process.env.AUTH_SECRET = 'test-auth-secret-for-2278-proxy';
+
+// Config/domain reads must not touch disk; the mint paths are /api/* so the
+// apex-portal rewrite branch is never reached, but stub them defensively.
+vi.mock('@/lib/config', () => ({ getConfig: vi.fn(() => Promise.resolve({})) }));
+vi.mock('@/lib/mode', () => ({ getActiveDomain: vi.fn(() => '') }));
+vi.mock('@/lib/auth/session', () => ({ decrypt: vi.fn(() => Promise.resolve(null)) }));
+// No Bearer is valid in these tests (the forged/token-less shapes) — a real
+// token verify would hit the token store; stub it to "invalid".
+vi.mock('@/lib/auth/apiTokens', () => ({ verifyToken: vi.fn(() => Promise.resolve(null)) }));
+
+import { proxy } from './proxy';
+import { getInternalApiToken } from '@/lib/auth/internalToken';
+
+const MINT_URL = 'http://localhost:5888/api/auth/delegated-admin-from-authelia-session';
+
+function post(headers: Record<string, string>): NextRequest {
+  return new NextRequest(MINT_URL, { method: 'POST', headers });
+}
+
+beforeEach(() => {
+  process.env.AUTH_SECRET = 'test-auth-secret-for-2278-proxy';
+});
+
+describe('proxy.ts — #2278 mint server-to-server gate', () => {
+  it('(a) a POST with a valid X-SB-Internal-Token + Remote-* (NPM-fronted shape) crosses the CSRF gate — no Origin, no Bearer', async () => {
+    const res = await proxy(
+      post({
+        'x-sb-internal-token': getInternalApiToken(),
+        'remote-user': 'alice',
+        'remote-groups': 'admins',
+      }),
+    );
+    // NextResponse.next() carries the passthrough header and no 403 body.
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(401);
+    expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  it('(b) a DIRECT :5888 POST forging Remote-User/Remote-Groups:admins WITHOUT the internal token and WITHOUT Origin → 403 CSRF (never reaches the mint)', async () => {
+    const res = await proxy(
+      post({
+        // Attacker forges the forward-auth identity but has NO internal token
+        // (NPM never fronted this) and NO Origin (server-to-server).
+        'remote-user': 'evil',
+        'remote-groups': 'admins',
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/cross-site/i);
+  });
+
+  it('(b′) a wrong/garbage X-SB-Internal-Token does not cross the gate (constant-length compare) → 403', async () => {
+    const res = await proxy(
+      post({
+        'x-sb-internal-token': 'not-the-real-token',
+        'remote-user': 'evil',
+        'remote-groups': 'admins',
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/cross-site/i);
+  });
+});


### PR DESCRIPTION
## What
Make the `*-from-authelia-session` mint routes reachable server-to-server through NPM: NPM injects `X-SB-Internal-Token` on the forward-auth path for the scoped `/api/auth/*-from-authelia-session` routes so a request coming through NPM (with Authelia-injected `Remote-User`/`Remote-Groups`) passes the proxy CSRF guard (`isInternalCall`) and reaches the mint handler. Handlers accept the internal-token forward-auth shape (require `Remote-Groups: admins`, LLDAP re-derive) while still refusing a client Bearer. Trust flows from NPM position — no standing AUTH_SECRET-derived credential in the Solaris/consumer pod.

## Why
Closes #2278

## Risk
medium — touches NPM forward-auth/proxy config render (forwardAuth.ts, provisioner.ts) and mint auth shape; forgery guard (direct :5888 forged Remote-* without internal token/Origin -> 403) is the load-bearing invariant, covered by tests and box-verify.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full)
- [ ] /verify on FCoS :dev box (NPM forward-auth/proxy config render is path-mandated)