### PR TITLE
fix(security): gate /napi/pair against LAN Remote-User header forgery

### DIFF
--- a/packages/backend/src/lib/portal/provisioner.test.ts
+++ b/packages/backend/src/lib/portal/provisioner.test.ts
@@ -120,8 +120,10 @@ describe('provisionPortalRouting', () => {
       // stamped on the mint location — this is what lets the NPM-fronted call
       // pass proxy.ts:isInternalCall.
       expect(cfg).toContain(`proxy_set_header X-SB-Internal-Token ${expectedToken};`);
-      // Scoped to exactly the two mint routes (no over-broad token stamping).
-      expect(cfg).toContain('location ~ ^/api/auth/(?:delegated-admin|token)-from-authelia-session$ {');
+      // Scoped to exactly the mint routes + /napi/pair (#2281) — anchored, no
+      // over-broad token stamping (the PUBLIC /napi/pair/redeem is excluded).
+      expect(cfg).toContain('location ~ ^(?:/api/auth/(?:delegated-admin|token)-from-authelia-session|/napi/pair)$ {');
+      expect(cfg).not.toContain('/napi/pair/redeem');
       // Forward-auth injects the trusted identity the handler requires.
       expect(cfg).toContain('proxy_set_header Remote-Groups $groups;');
     }

--- a/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
@@ -170,22 +170,35 @@ describe('websocket sanitize — exactly one proxy_http_version reaches nginx (#
 describe('buildAutheliaSessionMintLocation (#2278)', () => {
   const TOKEN = 'deadbeef'.repeat(8); // AUTH_SECRET-derived HMAC shape
 
-  it('emits a location matching ONLY the two mint paths and injects the internal token', () => {
+  // The anchored alternation the location regex is built from (#2278 + #2281).
+  const MINT_RE = new RegExp('^(?:/api/auth/(?:delegated-admin|token)-from-authelia-session|/napi/pair)$');
+
+  it('emits a location matching the mint paths + /napi/pair and injects the internal token', () => {
     const out = buildAutheliaSessionMintLocation(TOKEN, 'www.dopp.cloud');
-    // The regex location anchors exactly the two mint routes.
-    expect(out).toContain('location ~ ^/api/auth/(?:delegated-admin|token)-from-authelia-session$ {');
+    // The regex location anchors exactly the two mint routes AND /napi/pair.
+    expect(out).toContain('location ~ ^(?:/api/auth/(?:delegated-admin|token)-from-authelia-session|/napi/pair)$ {');
     // The internal token is stamped so the request passes proxy.ts:isInternalCall.
     expect(out).toContain(`proxy_set_header X-SB-Internal-Token ${TOKEN};`);
-    // Both documented mint routes are covered by the anchored alternation.
+    // All three forward-auth-trust routes are covered by the anchored alternation.
     for (const p of AUTHELIA_SESSION_MINT_PATHS) {
-      const re = new RegExp('^/api/auth/(?:delegated-admin|token)-from-authelia-session$');
-      expect(re.test(p)).toBe(true);
+      expect(MINT_RE.test(p)).toBe(true);
     }
-    // Unrelated paths must NOT match — the token is scoped to the mint routes.
-    const re = new RegExp('^/api/auth/(?:delegated-admin|token)-from-authelia-session$');
-    expect(re.test('/api/system/update')).toBe(false);
-    expect(re.test('/api/auth/login')).toBe(false);
-    expect(re.test('/api/auth/token-from-authelia-session/extra')).toBe(false);
+    // #2281 — /napi/pair is included in the exported path set.
+    expect(AUTHELIA_SESSION_MINT_PATHS).toContain('/napi/pair');
+    // Unrelated paths must NOT match — the token is scoped to these routes only.
+    expect(MINT_RE.test('/api/system/update')).toBe(false);
+    expect(MINT_RE.test('/api/auth/login')).toBe(false);
+    expect(MINT_RE.test('/api/auth/token-from-authelia-session/extra')).toBe(false);
+  });
+
+  it('scopes /napi/pair TIGHTLY — the PUBLIC redeem path + other /napi twins do NOT get the token (#2281)', () => {
+    // Anchored `$` — the public /napi/pair/redeem (which must NOT be forward-auth
+    // gated NOR get the internal token) is excluded, and so are the other twins.
+    expect(MINT_RE.test('/napi/pair/redeem')).toBe(false);
+    expect(MINT_RE.test('/napi/pairXYZ')).toBe(false);
+    expect(MINT_RE.test('/napi/services')).toBe(false);
+    expect(MINT_RE.test('/napi/approvals')).toBe(false);
+    expect(MINT_RE.test('/napi/home')).toBe(false);
   });
 
   it('runs forward-auth so the trusted Remote-User/Remote-Groups are injected (not client-supplied)', () => {

--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -263,24 +263,27 @@ export function buildAuthSkipLocations(paths: string[] | undefined): string {
 }
 
 /**
- * #2278 — nginx `location` block that makes the ServiceBay session-mint routes
+ * #2278 / #2281 — nginx `location` block that makes ServiceBay's forward-auth
+ * header-trust routes reachable server-to-server through NPM, WITHOUT weakening
+ * the CSRF gate. Covers the two session-mint routes
  * (`/api/auth/delegated-admin-from-authelia-session` and
- * `/api/auth/token-from-authelia-session`) reachable server-to-server through
- * NPM, WITHOUT weakening the CSRF gate.
+ * `/api/auth/token-from-authelia-session`, #2278) AND the pairing-code mint
+ * `/napi/pair` (#2281) — all three `skipAuth:true` routes that trust
+ * NPM-injected `Remote-User`/`Remote-Groups` and must be gated the same way.
  *
- * THE PROBLEM (issue #2278): those two routes are `skipAuth:true` and expect a
+ * THE PROBLEM (issues #2278/#2281): these routes are `skipAuth:true` and expect a
  * forward-auth-header-only POST (NPM-injected `Remote-User`/`Remote-Groups`, NO
- * Bearer, NO Origin — the handler refuses a Bearer to block self-elevation). But
- * `proxy.ts`'s CSRF guard 403s that shape *before* the handler runs: it is not
- * `isInternalCall` (no `X-SB-Internal-Token`), not a valid Bearer, and not
- * same-origin (no Origin/Referer on a server-to-server call). There was no
- * working call path.
+ * Bearer, NO Origin — the handler refuses a Bearer to block self-elevation). Once
+ * `/napi/*` is routed through `proxy.ts` (#2281), `proxy.ts`'s CSRF guard 403s
+ * that shape *before* the handler runs: it is not `isInternalCall` (no
+ * `X-SB-Internal-Token`), not a valid Bearer, and not same-origin (no
+ * Origin/Referer on a server-to-server call). There was no working call path.
  *
  * THE FIX (operator decision): on the SB host's NPM route we add a location for
- * exactly these two paths that (a) runs Authelia forward-auth to inject the
- * trusted `Remote-User`/`Remote-Groups`, AND (b) injects
+ * exactly these paths that (a) runs Authelia forward-auth to inject the trusted
+ * `Remote-User`/`Remote-Groups`, AND (b) injects
  * `X-SB-Internal-Token: <internalToken>` — the AUTH_SECRET-derived token
- * `proxy.ts:isInternalCall` already accepts (proxy.ts:187 bypasses CSRF for it).
+ * `proxy.ts:isInternalCall` already accepts (proxy.ts bypasses CSRF for it).
  * So a request coming THROUGH NPM carries the token → passes the CSRF gate →
  * reaches the handler, which then applies its own no-Bearer / Remote-Groups∋admins
  * / LLDAP re-derive checks.
@@ -291,26 +294,32 @@ export function buildAuthSkipLocations(paths: string[] | undefined): string {
  * without an Origin) still hits `proxy.ts`'s CSRF 403 — it never reaches the
  * handler. Trust flows from NPM's network position, exactly like the existing
  * post-deploy internal callbacks; no standing AUTH_SECRET-derived credential
- * lives in any consumer pod.
+ * lives in any consumer pod. For `/napi/pair` this closes the LAN header-forgery
+ * hole: a direct `:5888` POST forging `Remote-User: mdopp` / `Remote-Groups:
+ * admins` can no longer mint a pairing code (#2281).
  *
  * The token is rendered into the config at DEPLOY time (`getInternalApiToken()`,
  * AUTH_SECRET-derived) — never a committed literal.
  *
  * The location uses `location ~ ^…$` (regex, exact set) so it wins over the
- * default `location /` and matches ONLY the two mint paths. It carries its OWN
- * `auth_request /authelia` (this host has no server-level forward-auth — the
- * portal apex is intentionally anonymous), and reuses the shared
- * `location = /authelia` internal subrequest emitted by
- * {@link AUTHELIA_FORWARD_AUTH_CORE}. The auth-request `X-Original-URL` is
- * pointed at `www.<domain>` (the `*.<domain>` `one_factor`-covered host), NOT
- * the apex — the apex is Authelia default-deny (ADR 0006), so probing it yields
- * no identity (mirrors `portal/auth.ts`). Pass `undefined`/'' for `wwwHost` on a
- * host that is already itself under the wildcard rule (probe the request's own
- * host).
+ * default `location /` and matches ONLY these three paths (anchored — nothing
+ * broader, e.g. `/napi/pair/redeem` (a PUBLIC route that must NOT get the token)
+ * or `/napi/services`, slips through). It carries its OWN `auth_request
+ * /authelia` (this host has no server-level forward-auth — the portal apex is
+ * intentionally anonymous), and reuses the shared `location = /authelia` internal
+ * subrequest emitted by {@link AUTHELIA_FORWARD_AUTH_CORE}. The auth-request
+ * `X-Original-URL` is pointed at `www.<domain>` (the `*.<domain>`
+ * `one_factor`-covered host), NOT the apex — the apex is Authelia default-deny
+ * (ADR 0006), so probing it yields no identity (mirrors `portal/auth.ts`). Pass
+ * `undefined`/'' for `wwwHost` on a host that is already itself under the
+ * wildcard rule (probe the request's own host).
  */
 export const AUTHELIA_SESSION_MINT_PATHS = [
   '/api/auth/delegated-admin-from-authelia-session',
   '/api/auth/token-from-authelia-session',
+  // #2281 — the pairing-code mint shares the exact same forward-auth header
+  // trust model; it is gated by the same token injection.
+  '/napi/pair',
 ] as const;
 
 export function buildAutheliaSessionMintLocation(
@@ -318,9 +327,10 @@ export function buildAutheliaSessionMintLocation(
   wwwHost: string | undefined,
   autheliaPort: string = DEFAULT_AUTHELIA_PORT,
 ): string {
-  // Anchored alternation matching EXACTLY the two mint paths (regex location so
-  // it beats `location /`; `$` anchors so nothing broader slips through).
-  const pathRegex = `^/api/auth/(?:delegated-admin|token)-from-authelia-session$`;
+  // Anchored alternation matching EXACTLY the three forward-auth-trust paths
+  // (regex location so it beats `location /`; `$` anchors so nothing broader —
+  // e.g. the PUBLIC `/napi/pair/redeem` — slips through and gets the token).
+  const pathRegex = `^(?:/api/auth/(?:delegated-admin|token)-from-authelia-session|/napi/pair)$`;
   // The auth-request subrequest target. On the anonymous portal apex the
   // request's own host is default-deny, so probe the wildcard-covered
   // `www.<domain>` instead (same rationale as portal/auth.ts). When wwwHost is

--- a/packages/frontend/src/app/napi/pair/redeem/route.ts
+++ b/packages/frontend/src/app/napi/pair/redeem/route.ts
@@ -24,10 +24,12 @@ import { logger } from '@/lib/logger';
  *     or destroy anything on the box.
  *
  * `skipAuth: true`: intentionally public — the pairing CODE is the credential.
- * This route lives under `/napi/*` (not `/api/*`), so proxy.ts's CSRF/session
- * gate never runs against it; the fail-closed checks here are the whole gate.
- * (When `/napi/*` moves behind proxy.ts, add a PUBLIC_API_RULES entry mirroring
- * this `skipAuth`.)
+ * `/napi/*` now runs through proxy.ts's gate (#2281), so this route has a
+ * `csrfExempt` PUBLIC_API_RULES entry there: its legitimate caller (the companion
+ * app) is cross-origin with no browser Origin, and the fail-closed checks here
+ * (single-use + constant-time + rate-limited code → read-only token) are the
+ * whole gate. `/napi/pair` (the mint) is deliberately NOT csrf-exempt — it stays
+ * CSRF-gated so a direct forgery 403s.
  */
 
 /** The minted token's scopes. READ ONLY — never widen this. The public redeem

--- a/packages/frontend/src/proxy.test.ts
+++ b/packages/frontend/src/proxy.test.ts
@@ -40,6 +40,10 @@ function post(headers: Record<string, string>): NextRequest {
   return new NextRequest(MINT_URL, { method: 'POST', headers });
 }
 
+function postTo(path: string, headers: Record<string, string>): NextRequest {
+  return new NextRequest(`http://localhost:5888${path}`, { method: 'POST', headers });
+}
+
 beforeEach(() => {
   process.env.AUTH_SECRET = 'test-auth-secret-for-2278-proxy';
 });
@@ -84,5 +88,78 @@ describe('proxy.ts — #2278 mint server-to-server gate', () => {
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toMatch(/cross-site/i);
+  });
+});
+
+// #2281 — /napi/pair (the pairing-code mint) shares the same forward-auth
+// header-trust model, and now runs through proxy.ts's gate (previously the
+// non-/api/ short-circuit let every /napi/* request straight through, CSRF-
+// unchecked). Acceptance criterion (1): a direct :5888 POST forging
+// Remote-User/Remote-Groups WITHOUT the internal token → 403.
+describe('proxy.ts — #2281 /napi/pair header-forgery gate', () => {
+  it('acceptance (1): a DIRECT :5888 POST forging Remote-User/Remote-Groups:admins WITHOUT the internal token and WITHOUT Origin → 403 CSRF (never reaches the pairing mint)', async () => {
+    const res = await proxy(
+      postTo('/napi/pair', {
+        // LAN attacker forges the forward-auth identity but has NO internal token
+        // (NPM never fronted this) and NO Origin (direct :5888 hit).
+        'remote-user': 'mdopp',
+        'remote-groups': 'admins',
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/cross-site/i);
+  });
+
+  it('the NPM-fronted shape (valid X-SB-Internal-Token + Remote-*, no Origin, no Bearer) crosses the gate to the handler', async () => {
+    // This is BOTH the Solaris server-to-server path AND the legit admin browser
+    // flow (NPM injects the token on the /napi/pair location for every request
+    // hitting that path). isInternalCall short-circuits before the cookie check.
+    const res = await proxy(
+      postTo('/napi/pair', {
+        'x-sb-internal-token': getInternalApiToken(),
+        'remote-user': 'mdopp',
+        'remote-groups': 'admins',
+      }),
+    );
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(401);
+    expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  it('a same-origin admin browser POST to /napi/pair (Origin matches Host) crosses the CSRF gate — no cookie 401 for the token/forward-auth route', async () => {
+    // Even without the injected token, a same-origin POST passes CSRF and the
+    // /napi/* branch reaches the handler rather than the admin cookie check.
+    const res = await proxy(
+      postTo('/napi/pair', {
+        host: 'localhost:5888',
+        origin: 'http://localhost:5888',
+      }),
+    );
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(401);
+    expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  it('the PUBLIC /napi/pair/redeem still accepts a cross-origin, no-Origin, no-Bearer POST (csrfExempt) — the companion app is not broken', async () => {
+    // The redeem route is the ONE public device-pairing surface; its caller has
+    // no browser Origin. It must NOT be 403'd by the newly-applied CSRF gate.
+    const res = await proxy(postTo('/napi/pair/redeem', {}));
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(401);
+    expect(res.headers.get('x-middleware-next')).toBe('1');
+  });
+
+  it('a token-gated /napi twin (Bearer, no Origin) is NOT 403 — bearer bypasses CSRF as before', async () => {
+    // /napi/services etc. are read-Bearer routes; a valid Bearer crosses the gate.
+    // (verifyToken is stubbed to null here, so simulate the internal-token path
+    //  which also represents "authenticated, no Origin" — asserts /napi/* GET is
+    //  not spuriously CSRF-403'd for a safe method.)
+    const res = await proxy(
+      new NextRequest('http://localhost:5888/napi/services', { method: 'GET' }),
+    );
+    // GET is a SAFE method → no CSRF check; the /napi branch passes to handler.
+    expect(res.status).not.toBe(403);
+    expect(res.headers.get('x-middleware-next')).toBe('1');
   });
 });

--- a/packages/frontend/src/proxy.ts
+++ b/packages/frontend/src/proxy.ts
@@ -25,6 +25,19 @@ type PublicApiRule = {
   /** Match by full-pathname regex. Mutually exclusive with prefix. */
   pattern?: RegExp;
   methods?: ReadonlySet<string>;
+  /**
+   * #2281 — also skip the same-origin CSRF check for this route. Normal public
+   * rules still enforce CSRF (they only skip the session cookie); set this ONLY
+   * for a route whose legitimate caller is a cross-origin, no-Origin client (a
+   * companion app / server-to-server POST) AND whose OWN handler is fail-closed
+   * on a self-supplied credential. `/napi/pair/redeem` qualifies: the pairing
+   * CODE is the credential, it is single-use + constant-time + rate-limited, and
+   * it mints only a READ-scoped token — so there is nothing for a forged
+   * cross-site POST to abuse. Do NOT set this on a header-trust route
+   * (`/napi/pair`): that one must stay CSRF-gated so a direct `:5888` forgery
+   * 403s (its trust flows only from the NPM-injected internal token, #2278).
+   */
+  csrfExempt?: boolean;
 };
 
 const PUBLIC_API_RULES: PublicApiRule[] = [
@@ -60,12 +73,20 @@ const PUBLIC_API_RULES: PublicApiRule[] = [
   // for the requested ABI and 302s to a public GitHub URL. Public because
   // the portal user guide that links it is family-facing — no secrets.
   { prefix: '/api/system/downloads/basicsync', methods: new Set(['GET']) },
+  // #2281 — the ONE public device-pairing redeem surface. A companion app
+  // POSTs `{ code }` here (cross-origin, no Origin, no Bearer) to trade a
+  // pairing code for a read-scoped token. It is `csrfExempt` because its
+  // legitimate caller has no browser Origin; the handler itself is fail-closed
+  // (single-use + constant-time + rate-limited code → read-only token), so the
+  // pairing CODE is the whole credential. This mirrors the route's own comment
+  // ("When `/napi/*` moves behind proxy.ts, add a PUBLIC_API_RULES entry").
+  { prefix: '/napi/pair/redeem', methods: new Set(['POST']), csrfExempt: true },
 ];
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
-function isPublicApi(pathname: string, method: string): boolean {
-  return PUBLIC_API_RULES.some(rule => {
+function matchPublicRule(pathname: string, method: string): PublicApiRule | undefined {
+  return PUBLIC_API_RULES.find(rule => {
     let matches = false;
     if (rule.prefix !== undefined) {
       matches = pathname === rule.prefix || pathname.startsWith(rule.prefix + '/');
@@ -75,6 +96,26 @@ function isPublicApi(pathname: string, method: string): boolean {
     if (!matches) return false;
     return !rule.methods || rule.methods.has(method);
   });
+}
+
+function isPublicApi(pathname: string, method: string): boolean {
+  return matchPublicRule(pathname, method) !== undefined;
+}
+
+/** #2281 — a public route flagged to also skip the same-origin CSRF check
+ *  (its legitimate caller has no browser Origin; see {@link PublicApiRule.csrfExempt}). */
+function isCsrfExempt(pathname: string, method: string): boolean {
+  return matchPublicRule(pathname, method)?.csrfExempt === true;
+}
+
+/** True when a state-changing request must be rejected as cross-site: an unsafe
+ *  method that is neither same-origin nor a {@link isCsrfExempt} public route. */
+function failsCsrf(request: NextRequest): boolean {
+  return (
+    !SAFE_METHODS.has(request.method) &&
+    !isSameOrigin(request) &&
+    !isCsrfExempt(request.nextUrl.pathname, request.method)
+  );
 }
 
 // Server-to-server calls from ServiceBay's own post-deploy scripts on
@@ -169,11 +210,22 @@ export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const host = request.headers.get('host') ?? '';
 
-  // Apex / www host → portal. Rewrite (not redirect) so the URL bar
-  // stays at home.arpa / www.home.arpa per the v2 design call.
-  // Apply to every path on these hosts so URL guessing (home.arpa/services
-  // etc.) can't escape into the admin surface.
-  if (!pathname.startsWith('/api/')) {
+  // #2281 — `/napi/*` (the native-companion API twins) run through the SAME
+  // internal-token / Bearer / CSRF gate as `/api/*`, because `/napi/pair` is a
+  // `skipAuth:true` forward-auth-header-trust route: a direct `:5888` POST forging
+  // `Remote-User`/`Remote-Groups:admins` without an Origin (and without the
+  // NPM-injected internal token, #2278) MUST be 403'd, or a LAN attacker mints a
+  // pairing code. Before this, the `!startsWith('/api/')` short-circuit let every
+  // `/napi/*` request straight through, CSRF-unchecked. These routes never rely on
+  // a session cookie (they are token- or forward-auth-gated at the handler via
+  // `skipAuth`/`tokenScope`), so we run the gate but fall through to the handler
+  // rather than the cookie check — see the isNapi branch below.
+  const isNapi = pathname.startsWith('/napi/');
+  if (!pathname.startsWith('/api/') && !isNapi) {
+    // Apex / www host → portal. Rewrite (not redirect) so the URL bar
+    // stays at home.arpa / www.home.arpa per the v2 design call.
+    // Apply to every path on these hosts so URL guessing (home.arpa/services
+    // etc.) can't escape into the admin surface.
     if (await isPortalApexHost(host) && !pathname.startsWith('/portal')) {
       const rewritten = request.nextUrl.clone();
       rewritten.pathname = '/portal';
@@ -196,9 +248,16 @@ export async function proxy(request: NextRequest) {
   // check. An invalid/absent Bearer just falls through to the normal checks.
   if (await isValidBearerToken(request)) return NextResponse.next();
 
-  if (!SAFE_METHODS.has(request.method) && !isSameOrigin(request)) {
+  if (failsCsrf(request)) {
     return NextResponse.json({ error: 'Forbidden: cross-site request' }, { status: 403 });
   }
+
+  // #2281 — `/napi/*` routes carry their own auth at the handler (`skipAuth` +
+  // forward-auth headers, or `tokenScope` Bearer) and never use a session
+  // cookie. Having passed the internal-token/Bearer/CSRF gate above, let them
+  // reach the handler — do NOT fall into the admin session-cookie check below
+  // (which would 401 every token/forward-auth companion request).
+  if (isNapi) return NextResponse.next();
 
   if (isPublicApi(pathname, request.method)) return NextResponse.next();
 
@@ -222,6 +281,11 @@ export const config = {
   // the middleware.
   matcher: [
     '/api/:path*',
+    // #2281 — the native-companion API twins must also pass through the gate so
+    // the CSRF/internal-token check applies to `/napi/pair` (was previously
+    // short-circuited by the non-`/api/` bypass, letting a LAN header-forgery
+    // POST straight through).
+    '/napi/:path*',
     '/((?!_next/static|_next/image|favicon|icon\\.svg|.*\\.(?:png|jpg|jpeg|svg|webp|gif|ico|woff2?|ttf)).*)',
   ],
 };


### PR DESCRIPTION
## What
Mirror the #2278 fix for /napi/pair: route /napi/* through proxy.ts's internal-token/Bearer/CSRF gate and inject X-SB-Internal-Token into the NPM proxy config's /napi/pair location. A direct :5888 POST without the token now hits the CSRF 403 and cannot forge Remote-User/Remote-Groups headers. /napi/pair/redeem stays reachable via a csrfExempt PUBLIC_API_RULES entry (cross-origin companion POST, code-is-credential).

## Why
Closes #2281

## Risk
medium — touches proxy CSRF gating + NPM forward-auth render for /napi/pair; the pairing-code-actually-minted end-to-end path needs a real NPM redeploy to confirm.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full)
- [ ] /verify on FCoS :dev box (proxy.ts + provisioner.ts path-mandated — box_verify owed)