### PR TITLE
feat(portal): generic pwa_install + apk_download setup-asset kinds

### DIFF
--- a/packages/backend/src/lib/portal/assets.test.ts
+++ b/packages/backend/src/lib/portal/assets.test.ts
@@ -167,4 +167,21 @@ describe('resolveSetupAsset', () => {
     const out = await resolveSetupAsset('basicsync_install_qr', 'file-share');
     expect(out).toBeNull();
   });
+
+  it('echoes the frontmatter url for pwa_install (service-agnostic, no server artifact)', async () => {
+    const out = await resolveSetupAsset('pwa_install', 'any-service', undefined, 'https://home.example.com');
+    expect(out).toEqual({ kind: 'pwa_install', data: 'https://home.example.com' });
+  });
+
+  it('echoes the release url for apk_download', async () => {
+    const url = 'https://github.com/owner/repo/releases/latest/download/app.apk';
+    const out = await resolveSetupAsset('apk_download', 'any-service', undefined, url);
+    expect(out).toEqual({ kind: 'apk_download', data: url });
+  });
+
+  it('returns null for a url-driven kind with a missing or unsafe url', async () => {
+    expect(await resolveSetupAsset('pwa_install', 'svc')).toBeNull();
+    expect(await resolveSetupAsset('apk_download', 'svc', undefined, 'javascript:alert(1)')).toBeNull();
+    expect(await resolveSetupAsset('pwa_install', 'svc', undefined, '//evil.example/x')).toBeNull();
+  });
 });

--- a/packages/backend/src/lib/portal/assets.ts
+++ b/packages/backend/src/lib/portal/assets.ts
@@ -198,11 +198,18 @@ export async function fetchSyncthingDeviceId(node: string = 'Local'): Promise<st
   }
 }
 
-/** Resolve any setup-asset kind into its concrete artifact. */
+/** Resolve any setup-asset kind into its concrete artifact.
+ *
+ *  `url` carries the frontmatter-declared target for the URL-driven
+ *  kinds (`pwa_install`, `apk_download`) — those have no server
+ *  artifact, so the resolver simply validates + echoes the URL back
+ *  (the portal renders the QR/CTA client-side from it). Ignored for
+ *  the other kinds. */
 export async function resolveSetupAsset(
   kind: SetupAssetKind,
   serviceName: string,
   subdomainVar?: string,
+  url?: string,
 ): Promise<{ kind: SetupAssetKind; data: string } | null> {
   switch (kind) {
     case 'ios_calendar_profile': {
@@ -222,6 +229,15 @@ export async function resolveSetupAsset(
       // static `/api/system/downloads/basicsync` URL, no server
       // artifact to resolve. Nothing to fetch here.
       return null;
+    case 'pwa_install':
+    case 'apk_download':
+      // URL-driven, service-agnostic: the target comes from the
+      // service's user-guide.md frontmatter (a PWA URL or an APK
+      // release URL). There's no server artifact to build — validate
+      // the URL is an absolute http(s) link and echo it back so the
+      // client can render the QR + download/Add-to-Home-Screen CTA.
+      // A missing/invalid URL resolves to null (route returns 404).
+      return url && /^https?:\/\//i.test(url) ? { kind, data: url } : null;
   }
 }
 

--- a/packages/backend/src/lib/portal/userGuide.test.ts
+++ b/packages/backend/src/lib/portal/userGuide.test.ts
@@ -164,6 +164,60 @@ setup_assets:
     });
   });
 
+  it('parses the pwa_install setup-asset kind with its url (service-agnostic)', () => {
+    const raw = `---
+setup_assets:
+  - kind: "pwa_install"
+    url: "https://home.example.com"
+    label: "Install to Home Screen"
+    description: "Add this to your phone."
+---
+`;
+    const result = parseUserGuide(raw, 'some-service');
+    expect(result!.frontmatter.setup_assets).toHaveLength(1);
+    expect(result!.frontmatter.setup_assets?.[0]).toEqual({
+      kind: 'pwa_install',
+      url: 'https://home.example.com',
+      label: 'Install to Home Screen',
+      description: 'Add this to your phone.',
+    });
+  });
+
+  it('parses the apk_download setup-asset kind with its release url', () => {
+    const raw = `---
+setup_assets:
+  - kind: "apk_download"
+    url: "https://github.com/owner/repo/releases/latest/download/app.apk"
+---
+`;
+    const result = parseUserGuide(raw, 'some-service');
+    expect(result!.frontmatter.setup_assets).toHaveLength(1);
+    expect(result!.frontmatter.setup_assets?.[0]).toEqual({
+      kind: 'apk_download',
+      url: 'https://github.com/owner/repo/releases/latest/download/app.apk',
+    });
+  });
+
+  it('drops a url-driven asset (pwa_install / apk_download) with a missing or unsafe url', () => {
+    const raw = `---
+setup_assets:
+  - kind: "pwa_install"
+  - kind: "apk_download"
+    url: "javascript:alert(1)"
+  - kind: "pwa_install"
+    url: "//evil.example/x"
+  - kind: "apk_download"
+    url: "https://ok.example/app.apk"
+---
+`;
+    const result = parseUserGuide(raw, 'x');
+    expect(result!.frontmatter.setup_assets).toHaveLength(1);
+    expect(result!.frontmatter.setup_assets?.[0]).toEqual({
+      kind: 'apk_download',
+      url: 'https://ok.example/app.apk',
+    });
+  });
+
   it('drops setup_assets entries with non-string kind', () => {
     const raw = `---
 setup_assets:

--- a/packages/backend/src/lib/portal/userGuide.ts
+++ b/packages/backend/src/lib/portal/userGuide.ts
@@ -68,18 +68,42 @@ export interface RecommendedApp {
  *      client straight onto the phone (point the phone camera at it
  *      → the APK download opens). Pure client-side render of the
  *      `/api/system/downloads/basicsync` URL — no server round-trip.
+ *    - `pwa_install` — a generic, service-agnostic "Add to Home
+ *      Screen" card. Renders a QR to the service `url` (from the
+ *      asset's `url` param) plus an "Add to Home Screen" CTA that
+ *      opens that URL. URL-driven — the portal builds the QR client-
+ *      side from the frontmatter `url`; no server artifact.
+ *    - `apk_download` — a generic APK-download card. Renders a
+ *      download button + a QR pointing at the release `url` (from the
+ *      asset's `url` param) so a phone can grab the APK directly.
+ *      URL-driven; the resolver just echoes the URL back (no server
+ *      artifact beyond the URL). NOT hard-coded to any one service —
+ *      the URL comes from the service's user-guide.md frontmatter.
  */
 export type SetupAssetKind =
   | 'ios_calendar_profile'
   | 'audiobookshelf_deeplink'
   | 'syncthing_qr'
-  | 'basicsync_install_qr';
+  | 'basicsync_install_qr'
+  | 'pwa_install'
+  | 'apk_download';
 
 const KNOWN_ASSET_KINDS: ReadonlySet<SetupAssetKind> = new Set([
   'ios_calendar_profile',
   'audiobookshelf_deeplink',
   'syncthing_qr',
   'basicsync_install_qr',
+  'pwa_install',
+  'apk_download',
+]);
+
+/** Kinds whose card is driven by an explicit `url` in the frontmatter
+ *  (a service PWA URL, an APK release URL). The parser keeps the URL;
+ *  the client builds the QR / CTA from it. Kept service-agnostic — the
+ *  URL is whatever the template author declares. */
+const URL_DRIVEN_ASSET_KINDS: ReadonlySet<SetupAssetKind> = new Set([
+  'pwa_install',
+  'apk_download',
 ]);
 
 export interface SetupAsset {
@@ -90,6 +114,11 @@ export interface SetupAsset {
   /** Optional one-line description rendered as a tooltip + below
    *  the button on the card. */
   description?: string;
+  /** URL the card points at, for URL-driven kinds (`pwa_install`,
+   *  `apk_download`). The QR encodes it and the CTA opens it. Only an
+   *  absolute http(s) URL is accepted — a URL-driven asset without a
+   *  valid `url` is dropped so a broken card never renders. */
+  url?: string;
 }
 
 /**
@@ -421,9 +450,19 @@ function parseSetupAssets(input: unknown): SetupAsset[] {
       if (!entry || typeof entry !== 'object') return null;
       const e = entry as Record<string, unknown>;
       if (typeof e.kind !== 'string' || !KNOWN_ASSET_KINDS.has(e.kind as SetupAssetKind)) return null;
-      const out: SetupAsset = { kind: e.kind as SetupAssetKind };
+      const kind = e.kind as SetupAssetKind;
+      const out: SetupAsset = { kind };
       if (typeof e.label === 'string' && e.label.trim()) out.label = e.label.trim();
       if (typeof e.description === 'string' && e.description.trim()) out.description = e.description.trim();
+      // URL-driven kinds (`pwa_install`, `apk_download`) require an
+      // absolute http(s) `url` from the frontmatter — the QR/CTA is
+      // built from it. Reject dangerous / protocol-relative schemes and
+      // drop the whole asset when the URL is missing/invalid so a broken
+      // card never renders. Non-URL-driven kinds ignore any stray `url`.
+      if (URL_DRIVEN_ASSET_KINDS.has(kind)) {
+        if (typeof e.url !== 'string' || !/^https?:\/\//i.test(e.url)) return null;
+        out.url = e.url;
+      }
       return out;
     })
     .filter((a): a is SetupAsset => a !== null);

--- a/packages/frontend/src/app/api/portal/asset/[service]/[kind]/route.ts
+++ b/packages/frontend/src/app/api/portal/asset/[service]/[kind]/route.ts
@@ -10,10 +10,18 @@ import { verifyAutheliaSession } from '@/lib/portal/auth';
 
 export const dynamic = 'force-dynamic';
 
-const KIND_VALUES: SetupAssetKind[] = ['ios_calendar_profile', 'audiobookshelf_deeplink', 'syncthing_qr'];
+const KIND_VALUES: SetupAssetKind[] = [
+  'ios_calendar_profile', 'audiobookshelf_deeplink', 'syncthing_qr',
+  'pwa_install', 'apk_download',
+];
 
 const Query = z.object({
   subdomain_var: z.string().regex(/^[A-Z][A-Z0-9_]*_SUBDOMAIN$/).optional(),
+  // URL-driven kinds (`pwa_install`, `apk_download`) pass their
+  // frontmatter target here so the resolver can validate + echo it.
+  // Only absolute http(s) URLs are accepted (defends the JSON echo
+  // against `javascript:` / `data:` smuggling).
+  url: z.string().url().regex(/^https?:\/\//i).optional(),
 });
 
 type Params = { service: string; kind: string };
@@ -32,6 +40,10 @@ type Params = { service: string; kind: string };
  *   - kind=`audiobookshelf_deeplink` → returns JSON `{ url: "abs://…" }`.
  *   - kind=`syncthing_qr` → returns JSON `{ deviceId }`; client
  *     renders the QR locally.
+ *   - kind=`pwa_install` / `apk_download` → returns JSON `{ url }`
+ *     echoing the frontmatter-declared `url` query param (service-
+ *     agnostic); client renders the QR + Add-to-Home-Screen / download
+ *     CTA locally.
  *
  * The service name and kind are validated against the templates that
  * actually ship the asset — random combos return 404.
@@ -83,9 +95,16 @@ export const GET = withApiHandlerParams<undefined, z.infer<typeof Query>, Params
       kind as SetupAssetKind,
       service,
       query.subdomain_var,
+      query.url,
     );
     if (!asset) {
       return new NextResponse('Asset not available — service may not be installed yet.', { status: 404 });
+    }
+
+    if (asset.kind === 'pwa_install' || asset.kind === 'apk_download') {
+      // URL-driven, service-agnostic — return the validated URL as JSON
+      // so the client renders the QR + Add-to-Home-Screen / download CTA.
+      return NextResponse.json({ url: asset.data });
     }
 
     if (asset.kind === 'ios_calendar_profile') {

--- a/packages/frontend/src/app/portal/PortalGrid.test.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.test.tsx
@@ -214,6 +214,60 @@ describe('Calendar one-tap iOS setup preserved behind disclosure (#2126)', () =>
   });
 });
 
+describe('generic URL-driven asset kinds — PWA install + APK download (#2295)', () => {
+  const pwaCard: PortalCard = {
+    ...baseCard,
+    id: 'some-app:APP_SUBDOMAIN',
+    name: 'some-app',
+    subdomainVar: 'APP_SUBDOMAIN',
+    label: 'Some App',
+    setupAssets: [
+      { kind: 'pwa_install', url: 'https://app.home.arpa', label: 'Install to Home Screen', description: 'Add it to your phone.' },
+    ],
+  };
+
+  const apkCard: PortalCard = {
+    ...baseCard,
+    id: 'some-app:APK_SUBDOMAIN',
+    name: 'some-app',
+    subdomainVar: 'APK_SUBDOMAIN',
+    label: 'Some APK App',
+    setupAssets: [
+      { kind: 'apk_download', url: 'https://github.com/owner/repo/releases/latest/download/app.apk', label: 'Download the app (Android)' },
+    ],
+  };
+
+  it('renders an "Install to Home Screen" card that opens a QR modal to the service url', () => {
+    render(<PortalGrid cards={[pwaCard]} />);
+    openDisclosure('Some App');
+    const btn = screen.getByRole('button', { name: /install to home screen/i });
+    expect(btn).toBeDefined();
+    // Modal QR + CTA to the service url appear only after clicking.
+    expect(screen.queryByRole('heading', { name: /add to home screen/i })).toBeNull();
+    fireEvent.click(btn);
+    expect(screen.getByRole('heading', { name: /add to home screen/i })).toBeDefined();
+    const cta = screen.getByRole('link', { name: /open to install/i });
+    expect(cta.getAttribute('href')).toBe('https://app.home.arpa');
+  });
+
+  it('renders an APK download card with a direct download link + a QR modal to the release url', () => {
+    render(<PortalGrid cards={[apkCard]} />);
+    openDisclosure('Some APK App');
+    const download = screen.getByRole('link', { name: /download the app \(android\)/i });
+    expect(download.getAttribute('href')).toBe('https://github.com/owner/repo/releases/latest/download/app.apk');
+    // The QR modal opens from the "Scan QR to phone" button.
+    fireEvent.click(screen.getByRole('button', { name: /scan qr to phone/i }));
+    expect(screen.getByRole('heading', { name: /download the app/i })).toBeDefined();
+    const link = screen.getByRole('link', { name: /open the download link directly/i });
+    expect(link.getAttribute('href')).toBe('https://github.com/owner/repo/releases/latest/download/app.apk');
+  });
+
+  it('is service-agnostic — neither card hard-codes Solaris', () => {
+    render(<PortalGrid cards={[pwaCard, apkCard]} />);
+    expect(screen.queryByText(/solaris/i)).toBeNull();
+  });
+});
+
 describe('per-service accent identity (#2126)', () => {
   const chipOf = (label: string): HTMLElement => {
     const chip = screen.getByRole('heading', { name: label })

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -18,6 +18,7 @@ import { Card } from '@/components/ui';
 import type { PortalCard } from '@/lib/portal/services';
 import type { AppPlatform, PortalAction, PortalIconName, SetupAssetKind } from '@/lib/portal/userGuide';
 import { ACCENT_CHIP_CLASS, serviceAccent, groupCardsBySection } from './portalAccent';
+import { PwaInstallButton, ApkDownloadButton } from './portalUrlAssets';
 
 type IconComponent = typeof Camera;
 
@@ -89,6 +90,8 @@ const ASSET_LABELS: Record<SetupAssetKind, { label: string; icon: IconComponent 
   audiobookshelf_deeplink: { label: 'Open in Audiobookshelf app', icon: Smartphone },
   syncthing_qr: { label: 'Pair Syncthing device', icon: QrCode },
   basicsync_install_qr: { label: 'Install BasicSync on your phone', icon: Download },
+  pwa_install: { label: 'Add to Home Screen', icon: Smartphone },
+  apk_download: { label: 'Download the app (Android)', icon: Download },
 };
 
 /** Coarse user-agent sniff for iOS devices — iPhone / iPad / iPod.
@@ -468,6 +471,12 @@ function SetupAssetButton({
   }
   if (asset.kind === 'basicsync_install_qr') {
     return <BasicSyncInstallQrButton label={label} description={asset.description} Icon={Icon} />;
+  }
+  if (asset.kind === 'pwa_install' && asset.url) {
+    return <PwaInstallButton url={asset.url} label={label} description={asset.description} Icon={Icon} />;
+  }
+  if (asset.kind === 'apk_download' && asset.url) {
+    return <ApkDownloadButton url={asset.url} label={label} description={asset.description} Icon={Icon} />;
   }
   return null;
 }

--- a/packages/frontend/src/app/portal/portalUrlAssets.tsx
+++ b/packages/frontend/src/app/portal/portalUrlAssets.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+/**
+ * Generic, service-agnostic URL-driven portal setup-asset cards (#2295).
+ *
+ * Split out of PortalGrid.tsx to keep that file under the max-lines
+ * budget. These two cards render entirely from a `url` declared in a
+ * service's `user-guide.md` `setup_assets` frontmatter — nothing here is
+ * hard-coded to any particular service:
+ *
+ *   - {@link PwaInstallButton} — an "Add to Home Screen" card: a QR to the
+ *     service URL + a CTA that opens it so the visitor can install the PWA
+ *     via their browser's own Add-to-Home-Screen.
+ *   - {@link ApkDownloadButton} — an APK-download card: a direct download
+ *     link + a QR to the release URL so a phone can grab the APK.
+ *
+ * Both mirror the BasicSync install-QR precedent (client-side QR from a
+ * static/declared URL, no server round-trip).
+ */
+
+import { useState } from 'react';
+import { QrCode } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Card } from '@/components/ui';
+
+type IconComponent = typeof QrCode;
+
+/** Compact full-width accent link — mirrors PortalGrid's PORTAL_LINK_BUTTON
+ *  so these cards read the same as the other setup-asset actions. */
+const LINK_BUTTON =
+  'flex items-center justify-center gap-space-2 w-full rounded-card text-sm font-medium py-2 ' +
+  'bg-accent text-on-accent hover:bg-accent-strong transition-colors';
+/** Neutral, bordered secondary action — mirrors PORTAL_SECONDARY_BUTTON. */
+const SECONDARY_BUTTON =
+  'flex items-center justify-center gap-space-2 w-full rounded-card text-sm font-medium py-2 ' +
+  'bg-surface-2 text-text border border-border hover:bg-surface-muted hover:border-border-strong transition-colors';
+
+/**
+ * Generic, service-agnostic "Add to Home Screen" card (#2295). Opens a
+ * modal with a QR to the service `url` (declared in the template's
+ * user-guide.md `setup_assets` frontmatter) plus a direct CTA that opens
+ * that URL. The visitor then uses the browser's own Add-to-Home-Screen to
+ * install the PWA. URL-driven — nothing here is tied to a specific service.
+ */
+export function PwaInstallButton({
+  url,
+  label,
+  description,
+  Icon,
+}: {
+  url: string;
+  label: string;
+  description?: string;
+  Icon: IconComponent;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <div>
+        <button onClick={() => setOpen(true)} className={LINK_BUTTON}>
+          <Icon size={14} /> {label}
+        </button>
+        {description && (
+          <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{description}</p>
+        )}
+      </div>
+      {open && (
+        <AssetQrModal
+          title="Add to Home Screen"
+          qrUrl={url}
+          onClose={() => setOpen(false)}
+          instructions="Open this on your phone, then use your browser's Share → Add to Home Screen to install the app."
+          ctaHref={url}
+          ctaLabel="Open to install"
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Generic, service-agnostic APK-download card (#2295). Offers a direct
+ * download button plus a modal with a QR pointing at the release `url`
+ * (from the template's user-guide.md `setup_assets` frontmatter) so a
+ * phone can grab the APK by scanning. URL-driven — not tied to any one
+ * service (the Solaris companion APK is just one caller once its release
+ * artifact exists, solarisbay#823).
+ */
+export function ApkDownloadButton({
+  url,
+  label,
+  description,
+  Icon,
+}: {
+  url: string;
+  label: string;
+  description?: string;
+  Icon: IconComponent;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <div className="space-y-1.5">
+        <a href={url} target="_blank" rel="noopener noreferrer" className={LINK_BUTTON}>
+          <Icon size={14} /> {label}
+        </a>
+        <button onClick={() => setOpen(true)} className={SECONDARY_BUTTON}>
+          <QrCode size={14} /> Scan QR to phone
+        </button>
+        {description && (
+          <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{description}</p>
+        )}
+      </div>
+      {open && (
+        <AssetQrModal
+          title="Download the app"
+          qrUrl={url}
+          onClose={() => setOpen(false)}
+          instructions="Point your phone camera at this QR to download the app directly."
+          ctaHref={url}
+          ctaLabel="Or open the download link directly"
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Shared QR modal for the URL-driven asset kinds (#2295). Renders a QR
+ * encoding an absolute `qrUrl` plus a short instruction line and a
+ * direct-link CTA. The QR sits on a literal white tile for scanner
+ * contrast regardless of theme (mirrors the BasicSync modal).
+ */
+function AssetQrModal({
+  title,
+  qrUrl,
+  instructions,
+  ctaHref,
+  ctaLabel,
+  onClose,
+}: {
+  title: string;
+  qrUrl: string;
+  instructions: string;
+  ctaHref: string;
+  ctaLabel: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-space-4 z-50" onClick={onClose}>
+      <Card className="shadow-xl max-w-sm w-full p-space-5 text-center" onClick={e => e.stopPropagation()}>
+        <h2 className="text-lg font-bold text-text">{title}</h2>
+        <p className="text-xs text-text-muted mt-space-1">{instructions}</p>
+        <div className="mt-space-4 flex justify-center">
+          <div className="bg-white p-space-3 rounded-card">
+            <QRCodeSVG value={qrUrl} size={192} level="M" />
+          </div>
+        </div>
+        <a
+          href={ctaHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-space-3 inline-block text-xs text-accent hover:underline break-all"
+        >
+          {ctaLabel}
+        </a>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds two generic, URL-driven portal setup-asset kinds — pwa_install (QR + Add-to-Home-Screen CTA) and apk_download (download button + QR) — with resolvers in assets.ts, a route wire-up in /api/portal/asset, and PortalGrid cards rendered from a service's user-guide.md setup_assets frontmatter. Both kinds are service-agnostic (URL/params come from the guide, no Solaris hard-coding).

## Why
Part (a) of #2295 — the generic asset-kind plumbing + the PWA-install card (self-sufficient now). This PR does NOT close #2295: part (b), the Solaris companion APK card resolving to a real signed artifact, is blocked on solarisbay#823 (APK build+publish). The apk_download kind/card/resolver ship here; the Solaris user-guide.md just needs a setup_assets entry once the artifact URL exists — no further servicebay code change.

Refs #2295

## Risk
Low — additive whitelisted kinds + new card renderers; no existing portal asset behavior changed.

## Rollback
git revert is enough.

## Verification
- [x] npm run lint (0 errors)
- [x] npm run typecheck
- [x] npm run check:arch
- [x] npm test (full, 3912 pass)
- [ ] /verify on FCoS :dev box — portal render on www.dopp.cloud (packages/frontend/src/app/portal/ is path-mandated; gate=verify)