### PR TITLE
feat(auth): non-expiring read-only machine token for unattended consumers (#2299)

### DIFF
--- a/assists/recipe-unattended-read-only-machine-token.md
+++ b/assists/recipe-unattended-read-only-machine-token.md
@@ -1,0 +1,86 @@
+---
+title: Give an unattended consumer a long-lived read-only ServiceBay token (never-expires)
+whenToUse: A headless/background client (a script, a companion service, a cron job) needs to call ServiceBay's read-only API or MCP tools with no human to re-mint an expiring credential. Use this to mint a read-only + never-expiring token, place it in a deploy-time file, and recover from a 401.
+kind: recipe
+tags: [auth, api-token, machine-token, unattended, read-only, never-expires, mcp, headless, automation, 2299]
+---
+
+# The unattended-consumer token: read-only + never-expires
+
+An interactive operator can re-mint a lapsed token from the UI. A **headless
+consumer** can't — a token that expires silently breaks the integration at 3am
+with nobody to notice. ServiceBay (#2299) makes the *safe* long-lived path
+first-class: a token that **never expires**, hard-limited to the **read** scope.
+
+The guard is deliberate and fail-closed: a never-expiring credential that could
+`mutate`/`destroy`/`exec` is a standing liability, so the mint refuses it. If
+your consumer genuinely needs to change state, don't reach for never-expires —
+use a scoped, *expiring* token (and rotate it), or the delegated/one-shot flows.
+
+## 1. Mint the token (once)
+
+### From the UI
+Settings → Access → **API Tokens** → *New token*:
+1. Name it for the consumer (e.g. the service or host it runs on).
+2. Leave **only `read`** selected. Any other scope disables the checkbox.
+3. Tick **Never Expires**.
+4. Create, and **copy the secret now** — it is shown exactly once.
+
+The token appears in the list marked **Expires: Never**.
+
+### From the API (for a scripted/first-boot provision)
+`POST /api/system/api-tokens` with an admin session:
+
+```
+POST /api/system/api-tokens
+Content-Type: application/json
+{ "name": "<consumer-name>", "scopes": ["read"], "neverExpires": true }
+```
+
+Response returns the clear-text secret **once** as `secret`
+(shape `sb_<id>_<secret>`). A `403` means you asked for a non-`read` scope
+alongside `neverExpires` — drop the extra scopes or give the token an expiry.
+
+## 2. Place it in a deploy-time token file
+
+Write the secret to a file the consumer reads at startup — **not** an
+environment literal baked into an image, and **never** committed to a repo:
+
+```
+# owned by the consumer's runtime user, 0600
+printf '%s' "$SECRET" > "$TOKEN_FILE"
+chmod 600 "$TOKEN_FILE"
+```
+
+The consumer loads it at boot and sends it as a Bearer credential on every call:
+
+```
+Authorization: Bearer <contents of $TOKEN_FILE>
+```
+
+Because the token never expires, there is **no refresh loop** to build — read
+the file once and reuse it.
+
+## 3. Trivial 401-recovery: re-read the file
+
+A never-expiring token doesn't lapse, but it *can* be **revoked** by the operator
+(rotation, off-boarding a host). Handle that with the simplest possible recovery:
+**on a 401/403, re-read the token file** (the operator may have dropped a fresh
+secret in place) and retry once. No token-refresh protocol, no cached-in-memory
+staleness:
+
+```
+1. call ServiceBay with the in-memory token
+2. on 401/403 → re-read $TOKEN_FILE, replace the in-memory token, retry once
+3. still 401/403 → the credential is gone; log + alert the operator to re-mint
+```
+
+This keeps an unattended consumer self-healing across a routine rotation without
+any coordination beyond "the operator overwrote the file."
+
+## Hygiene
+- The secret is shown **once**. If it's lost, revoke the token and mint a new one.
+- Never commit the secret. Never log its value. Keep the file `0600`.
+- Read-only is the ceiling for a never-expiring token by design — if the
+  consumer's job grows to need writes, that's a *different* credential (expiring +
+  scoped), reviewed as such.

--- a/packages/backend/src/lib/api/apiTokenRoutes.neverExpires.test.ts
+++ b/packages/backend/src/lib/api/apiTokenRoutes.neverExpires.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #2299 — the createTokenHandler must fail-closed 403 when a `neverExpires`
+// token requests any non-read scope, and pass `neverExpires` through otherwise.
+// requireSession + the mint + the bootstrap-revoke are mocked so this exercises
+// only the guard + wiring.
+vi.mock('@/lib/api/requireSession', () => ({
+  requireSession: vi.fn(async () => ({ user: 'admin' })),
+}));
+vi.mock('@/lib/auth/apiTokens', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/apiTokens')>();
+  return {
+    ...actual,
+    createToken: vi.fn(async () => ({ token: { id: 'aabbccdd' }, secret: 'sb_aabbccdd_SECRET' })),
+    createDelegatedToken: vi.fn(),
+    revokeToken: vi.fn(),
+    listTokens: vi.fn(),
+  };
+});
+vi.mock('@/lib/mcp/bootstrapToken', () => ({
+  revokeBootstrapToken: vi.fn(async () => {}),
+}));
+
+import { createTokenHandler } from './apiTokenRoutes';
+import { createToken } from '@/lib/auth/apiTokens';
+
+const mkRequest = (body: unknown) =>
+  new Request('http://test/api/system/api-tokens', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createTokenHandler neverExpires guard (#2299)', () => {
+  it('mints a read-only + neverExpires token and passes neverExpires through', async () => {
+    const res = await createTokenHandler({ request: mkRequest({ name: 'machine', scopes: ['read'], neverExpires: true }) });
+    expect(res.status).toBe(200);
+    expect(createToken).toHaveBeenCalledWith(expect.objectContaining({ neverExpires: true, scopes: ['read'] }));
+  });
+
+  it('rejects neverExpires + a non-read scope with 403 and does NOT mint', async () => {
+    const res = await createTokenHandler({ request: mkRequest({ name: 'machine', scopes: ['read', 'mutate'], neverExpires: true }) });
+    expect(res.status).toBe(403);
+    expect(createToken).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.error).toMatch(/never-expiring/i);
+  });
+
+  it('rejects neverExpires with a lone non-read scope (403)', async () => {
+    const res = await createTokenHandler({ request: mkRequest({ name: 'machine', scopes: ['destroy'], neverExpires: true }) });
+    expect(res.status).toBe(403);
+    expect(createToken).not.toHaveBeenCalled();
+  });
+
+  it('allows a non-read scope when neverExpires is absent (default false)', async () => {
+    const res = await createTokenHandler({ request: mkRequest({ name: 'ops', scopes: ['read', 'mutate'] }) });
+    expect(res.status).toBe(200);
+    expect(createToken).toHaveBeenCalledWith(expect.objectContaining({ neverExpires: false }));
+  });
+});

--- a/packages/backend/src/lib/api/apiTokenRoutes.ts
+++ b/packages/backend/src/lib/api/apiTokenRoutes.ts
@@ -24,7 +24,19 @@ const CreateBody = z.object({
   name: z.string().min(1).max(100),
   scopes: z.array(z.enum(ALL_SCOPES as [ApiScope, ...ApiScope[]])).min(1),
   expiresAt: z.string().datetime().optional(),
+  // Non-expiring machine token (#2299). Opt-in; defaults false. HARD-guarded
+  // below to read-only scopes — a never-expiring credential that could mutate
+  // or destroy is a standing liability, so it's fail-closed to `read`.
+  neverExpires: z.boolean().optional().default(false),
 });
+
+/** A never-expiring token may only carry the read scope (#2299). Any other
+ *  requested scope is refused so an unattended, non-lapsing credential can
+ *  never mutate/destroy/exec. Read is the single allowed scope (no implication
+ *  path widens `read`, so an exact-equality check is correct and fail-closed). */
+function neverExpiresScopesAreReadOnly(scopes: ApiScope[]): boolean {
+  return scopes.every(s => s === 'read');
+}
 
 export async function createTokenHandler({ request }: { request: Request }) {
   // requireSession is re-run here (the wrapper already gated POST) to
@@ -33,10 +45,21 @@ export async function createTokenHandler({ request }: { request: Request }) {
   if (auth instanceof NextResponse) return auth;
   try {
     const body = CreateBody.parse(await request.json());
+
+    // Fail-closed guard (#2299): a never-expiring token is restricted to the
+    // read scope. Reject (403) before minting if it asks for anything more.
+    if (body.neverExpires && !neverExpiresScopesAreReadOnly(body.scopes)) {
+      return NextResponse.json(
+        { error: 'A never-expiring token may only carry the read scope. Remove the extra scopes or give the token an expiry.' },
+        { status: 403 },
+      );
+    }
+
     const result = await createToken({
       name: body.name,
       scopes: body.scopes,
       expiresAt: body.expiresAt,
+      neverExpires: body.neverExpires,
       createdBy: auth.user,
     });
 

--- a/packages/backend/src/lib/auth/apiTokens.neverExpires.test.ts
+++ b/packages/backend/src/lib/auth/apiTokens.neverExpires.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsp from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+// #2299 — non-expiring machine token: createToken accepts `neverExpires`, which
+// omits `expiresAt` entirely so the token never lapses. Real-fs DATA_DIR per
+// test, mirroring apiTokens.delegate.test.ts.
+let dataDir = '';
+vi.mock('@/lib/dirs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/dirs')>();
+  return { ...actual, get DATA_DIR() { return dataDir; } };
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+  dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sb-neverexpires-'));
+});
+afterEach(async () => {
+  await (await load()).flushPendingStamps();
+  await fsp.rm(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+});
+
+const load = () => import('@/lib/auth/apiTokens');
+
+describe('createToken neverExpires (#2299)', () => {
+  it('mints a read-only + neverExpires token with NO expiresAt', async () => {
+    const { createToken } = await load();
+    const { token } = await createToken({
+      name: 'machine', scopes: ['read'], neverExpires: true, createdBy: 'admin',
+    });
+    expect(token.expiresAt).toBeUndefined();
+    expect(token.scopes).toEqual(['read']);
+  });
+
+  it('the never-expiring token validates and never rejects on expiry', async () => {
+    const { createToken, verifyToken } = await load();
+    const { secret } = await createToken({
+      name: 'machine', scopes: ['read'], neverExpires: true, createdBy: 'admin',
+    });
+    // No amount of time makes it lapse — verifyToken never sees an expiresAt.
+    const verified = await verifyToken(secret);
+    expect(verified).not.toBeNull();
+    expect(verified?.expiresAt).toBeUndefined();
+  });
+
+  it('neverExpires wins over an explicitly passed expiresAt (still no expiry)', async () => {
+    const { createToken } = await load();
+    const soon = new Date(Date.now() + 60 * 1000).toISOString();
+    const { token } = await createToken({
+      name: 'machine', scopes: ['read'], expiresAt: soon, neverExpires: true, createdBy: 'admin',
+    });
+    expect(token.expiresAt).toBeUndefined();
+  });
+
+  it('neverExpires=false still respects expiresAt (no regression)', async () => {
+    const { createToken } = await load();
+    const exp = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const { token } = await createToken({
+      name: 'expiring', scopes: ['read'], expiresAt: exp, neverExpires: false, createdBy: 'admin',
+    });
+    expect(token.expiresAt).toBe(exp);
+  });
+
+  it('neverExpires absent still respects expiresAt (no regression)', async () => {
+    const { createToken } = await load();
+    const exp = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const { token } = await createToken({
+      name: 'expiring', scopes: ['read'], expiresAt: exp, createdBy: 'admin',
+    });
+    expect(token.expiresAt).toBe(exp);
+  });
+
+  it('an expiring token past its expiry is rejected (baseline unchanged)', async () => {
+    const { createToken, verifyToken } = await load();
+    const past = new Date(Date.now() - 1000).toISOString();
+    const { secret } = await createToken({
+      name: 'stale', scopes: ['read'], expiresAt: past, createdBy: 'admin',
+    });
+    expect(await verifyToken(secret)).toBeNull();
+  });
+});

--- a/packages/backend/src/lib/auth/apiTokens.ts
+++ b/packages/backend/src/lib/auth/apiTokens.ts
@@ -189,6 +189,12 @@ export async function createToken(input: {
   name: string;
   scopes: ApiScope[];
   expiresAt?: string;
+  // Non-expiring machine token (#2299). When true, the token is minted with NO
+  // `expiresAt` at all, so it never lapses — the safe path for an unattended
+  // consumer. The *route* fail-closed-guards this to read-only scopes; the
+  // model-level primitive itself just omits the expiry when asked. Mutually
+  // exclusive with `expiresAt` (a never-expiring token can't also carry one).
+  neverExpires?: boolean;
   createdBy: string;
   // Lineage marker (#2048). Set only by the delegated-mint path — the public
   // mint route never passes it, so an external caller can't forge a parent.
@@ -216,7 +222,9 @@ export async function createToken(input: {
     hash: sha256(secret),
     prefix: secret.slice(0, 4),
     createdAt: new Date().toISOString(),
-    expiresAt: input.expiresAt,
+    // `neverExpires` wins: a non-expiring token is minted with no expiresAt,
+    // regardless of any expiresAt passed alongside it (#2299).
+    expiresAt: input.neverExpires ? undefined : input.expiresAt,
     createdBy: input.createdBy,
     ...(input.parentId ? { parentId: input.parentId } : {}),
     ...(input.oneShotOp ? { oneShotOp: input.oneShotOp } : {}),

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.test.tsx
@@ -52,6 +52,37 @@ describe('ApiTokensSection (#2100 settings migration)', () => {
     expect(screen.getByRole('button', { name: /^create$/i })).toBeDefined();
   });
 
+  // #2299: the "Never Expires" checkbox is offered only for a read-only scope
+  // set; selecting any broader scope disables it (fail-closed, mirroring the
+  // server's 403 guard).
+  it('Never Expires checkbox is enabled for read-only scopes and disabled once a broader scope is selected', async () => {
+    mockFetch([]);
+    render(<ApiTokensSection />);
+    await waitFor(() => expect(screen.getByText(/No tokens yet/)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /new token/i }));
+
+    const neverExpires = screen.getByRole('checkbox', { name: /never expires/i }) as HTMLInputElement;
+    // Default scope set is ['read'] → enabled.
+    expect(neverExpires.disabled).toBe(false);
+
+    // Selecting `mutate` (a non-read scope) disables it.
+    fireEvent.click(screen.getByRole('checkbox', { name: /^mutate$/i }));
+    expect(neverExpires.disabled).toBe(true);
+    // …and it can't stay checked.
+    expect(neverExpires.checked).toBe(false);
+
+    // Removing `mutate` again re-enables it.
+    fireEvent.click(screen.getByRole('checkbox', { name: /^mutate$/i }));
+    expect(neverExpires.disabled).toBe(false);
+  });
+
+  it('shows "Expires: Never" for a token with no expiresAt', async () => {
+    mockFetch([{ ...TOKEN, scopes: ['read'], expiresAt: undefined }]);
+    render(<ApiTokensSection />);
+    await waitFor(() => expect(screen.getByText('workstation')).toBeDefined());
+    expect(screen.getByText(/Expires: Never/i)).toBeDefined();
+  });
+
   // #2164: revoke is guarded by the typed-confirmation ConfirmModal, not a bare
   // browser confirm() — consistent with stack-wipe / service-delete / factory-reset.
   it('revoke opens a typed-confirmation modal that blocks until the token name is typed', async () => {

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
@@ -108,6 +108,12 @@ function TokenRow({ token, onRevoke }: { token: TokenView; onRevoke: (id: string
           {token.scopes.map(s => (
             <span key={s} className={`text-[10px] uppercase font-bold px-1.5 py-0.5 rounded-chip ${SCOPE_BADGE[s]}`}>{s}</span>
           ))}
+          {/* A token minted with "Never Expires" carries no expiresAt (#2299) —
+              surface it so the operator can tell a long-lived machine token from
+              an expiring one at a glance. */}
+          <span className="text-[10px] text-text-subtle">
+            {token.expiresAt ? `expires ${new Date(token.expiresAt).toLocaleString()}` : 'Expires: Never'}
+          </span>
           <span className="text-[10px] text-text-subtle">
             {token.lastUsedAt ? `last used ${new Date(token.lastUsedAt).toLocaleString()}` : 'never used'}
           </span>
@@ -131,15 +137,49 @@ function TokenRow({ token, onRevoke }: { token: TokenView; onRevoke: (id: string
 interface CreateTokenFormProps {
   name: string;
   scopes: ApiScope[];
+  neverExpires: boolean;
   creating: boolean;
   error: string | null;
   onName: (v: string) => void;
   onToggleScope: (s: ApiScope) => void;
+  onToggleNeverExpires: () => void;
   onCreate: () => void;
   onCancel: () => void;
 }
 
+/** A "Never Expires" token is fail-closed to the read scope only (#2299) — the
+ *  server refuses any other scope with a 403, so the checkbox is only offered
+ *  when the selected scope set is exactly read-only. */
+function isReadOnlyScopeSet(scopes: ApiScope[]): boolean {
+  return scopes.length > 0 && scopes.every(s => s === 'read');
+}
+
+/** The "Never Expires" checkbox (#2299): enabled only for a read-only scope
+ *  set, mirroring the server's fail-closed 403 guard. */
+function NeverExpiresField({ readOnly, checked, onToggle }: { readOnly: boolean; checked: boolean; onToggle: () => void }) {
+  return (
+    <div>
+      <label
+        className={`flex items-center gap-1.5 text-xs ${readOnly ? 'cursor-pointer text-text-muted' : 'cursor-not-allowed text-text-subtle opacity-60'}`}
+        title={readOnly ? 'Mint a non-expiring token — safe only for a read-only, unattended consumer.' : 'Never-expiring tokens are limited to the read scope. Select only "read" to enable this.'}
+      >
+        <input
+          type="checkbox"
+          checked={readOnly && checked}
+          disabled={!readOnly}
+          onChange={onToggle}
+          className="rounded accent-accent"
+          aria-label="Never Expires"
+        />
+        <span>Never Expires</span>
+      </label>
+      <p className="text-[10px] text-text-subtle mt-1">For an unattended machine consumer. Only available when the scope set is read-only.</p>
+    </div>
+  );
+}
+
 function CreateTokenForm(props: CreateTokenFormProps) {
+  const readOnly = isReadOnlyScopeSet(props.scopes);
   return (
     <div className="space-y-2 p-3 rounded-card border border-border bg-surface-2">
       <div>
@@ -164,6 +204,7 @@ function CreateTokenForm(props: CreateTokenFormProps) {
         </div>
         <p className="text-[10px] text-text-subtle mt-1">read = list/get only. lifecycle = start/stop/restart. mutate = create/update/config-edit. reboot = reboot the node (transient, recoverable). destroy = delete/restore/purge/factory-reset. exec = exec_command (shell). Tokens with destroy also implicitly grant reboot and exec for back-compat.</p>
       </div>
+      <NeverExpiresField readOnly={readOnly} checked={props.neverExpires} onToggle={props.onToggleNeverExpires} />
       {props.error && <p className="text-xs text-status-fail">{props.error}</p>}
       <div className="flex gap-2">
         <Button
@@ -197,6 +238,9 @@ export default function ApiTokensSection() {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState('');
   const [newScopes, setNewScopes] = useState<ApiScope[]>(['read']);
+  // Non-expiring machine token (#2299) — only honored when the scope set is
+  // read-only (the server 403s otherwise).
+  const [newNeverExpires, setNewNeverExpires] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
@@ -256,16 +300,20 @@ export default function ApiTokensSection() {
     setCreating(true);
     setCreateError(null);
     try {
+      // Only a read-only scope set may carry neverExpires (the server enforces
+      // this too, fail-closed) — never send it alongside a broader scope.
+      const readOnly = newScopes.length > 0 && newScopes.every(s => s === 'read');
       const res = await fetch('/api/system/api-tokens', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: newName.trim(), scopes: newScopes }),
+        body: JSON.stringify({ name: newName.trim(), scopes: newScopes, neverExpires: readOnly && newNeverExpires }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
       setRevealedSecret(data.secret);
       setNewName('');
       setNewScopes(['read']);
+      setNewNeverExpires(false);
       setShowCreate(false);
       loadTokens();
       // Server-side createToken auto-revokes the bootstrap token —
@@ -303,8 +351,16 @@ export default function ApiTokensSection() {
   };
 
   const toggleScope = (scope: ApiScope) => {
-    setNewScopes(prev => prev.includes(scope) ? prev.filter(s => s !== scope) : [...prev, scope]);
+    setNewScopes(prev => {
+      const next = prev.includes(scope) ? prev.filter(s => s !== scope) : [...prev, scope];
+      // Leaving a read-only scope set disables "Never Expires" — clear it so a
+      // stale checked state can't ride along to a broader-scope mint (#2299).
+      if (!(next.length > 0 && next.every(s => s === 'read'))) setNewNeverExpires(false);
+      return next;
+    });
   };
+
+  const toggleNeverExpires = () => setNewNeverExpires(prev => !prev);
 
   return (
     <>
@@ -332,10 +388,12 @@ export default function ApiTokensSection() {
           <CreateTokenForm
             name={newName}
             scopes={newScopes}
+            neverExpires={newNeverExpires}
             creating={creating}
             error={createError}
             onName={setNewName}
             onToggleScope={toggleScope}
+            onToggleNeverExpires={toggleNeverExpires}
             onCreate={createNewToken}
             onCancel={() => { setShowCreate(false); setCreateError(null); }}
           />


### PR DESCRIPTION
Refs #2299. Adds a first-class, guarded long-lived read-only token so unattended machine consumers (e.g. Solaris background pollers) stop 401'ing when the rotating deploy-time token expires.

- `createToken` (`apiTokens.ts`): optional `neverExpires` → omits `expiresAt`.
- `apiTokenRoutes.ts`: `CreateBody` gains `neverExpires`; **fail-closed guard** — `neverExpires` + any non-`read` scope → 403.
- Settings → API Tokens: "Never Expires" checkbox (disabled unless read-only) + "Expires: Never" list label.
- Reuses the existing `read` scope (#2252) — no new scope.
- Client assist `recipe-unattended-read-only-machine-token.md` (how an unattended consumer mints + uses it + 401-recovery).
- 18 tests across 3 files; assist passes secret-scan.

box-verify (gate=verify): mint a read-only+neverExpires token on :dev → no `expiresAt`, authenticates a `/napi` read; `neverExpires`+non-read → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqUTDYDUbxStiSftPBXqPb