### PR TITLE
feat(autoloop): deterministic seal script + scripts-for-mechanics rule (#2306 slice 1)

### DIFF
--- a/.claude/skills/autoloop-issues/stages/builder.md
+++ b/.claude/skills/autoloop-issues/stages/builder.md
@@ -72,66 +72,19 @@ Implement the one file/rule named in the unit. Size guard: **≤2 source files**
 
 ---
 
-## Mode: `seal` — ship the accumulated batch (expensive pipeline, once)
+## Mode: `seal` — ship the accumulated batch (once)
 
-Precondition (the orchestrator checked it, re-assert anyway): (`batch.count >= 8` **or** `queue[]` has no `planned` unit) **and** `box_verify.status` is clear (`green` or `null` — *not* `owed`/`verifying`/`red`). If you're mid-batch, do nothing, return "not ready to seal". If `box_verify` is `owed`/`verifying`/`red`, a prior batch is still in the release/verify critical section — **do not seal** (seal-ahead forbidden); return "blocked on box_verify, not sealing".
+Precondition (re-assert): (`batch.count >= 8` **or** no `planned` unit) **and** `box_verify.status` clear (`green`/`null`). Mid-batch → return "not ready to seal". `box_verify` owed/verifying/red → return "blocked on box_verify, not sealing" (seal-ahead forbidden).
 
-### 1. Full gate
-```bash
-git checkout <batch.branch>
-git rebase origin/main
-npm run lint && npm run typecheck && npm run check:arch && npm test    # + tsc --noEmit (CI parity, #2172); full suite — the safety net
-```
-A full-suite failure that the per-unit `--changed` runs missed → identify the culprit commit (atomic, `Closes #N` — cheap in-context bisect), fix on the branch, re-run. Push only when green:
-```bash
-git push --no-verify -u origin <batch.branch>
-```
-**Use `--no-verify`.** The step-1 full gate above already ran lint/typecheck/check:arch/`npm test` locally; the husky **pre-push hook re-runs `npm run test` + `next build`** (minutes, and trips on flakes like `logger_retention/vacuumLogsDb` or a pre-existing `knip` finding). CI re-runs every gate on the PR and **is** the authoritative gate, so bypassing the redundant local hook is correct — otherwise a plain `git push` silently fails (`husky - pre-push script failed`, ref unchanged) and you'll think you pushed when you didn't (memory `feedback_seal_builder_ci_watch_wedge`).
+1. **Local safety net.** `git checkout <batch.branch> && git rebase origin/main`, then `npm run lint && npm run typecheck && npm run check:arch && npm test`. A full-suite failure the per-unit `--changed` runs missed → bisect the culprit commit (atomic, `Closes #N`), fix on the branch, re-run.
 
-### 2. Seal via the deterministic script (push → CI → merge)
+2. **Seal — run the script, don't hand-roll the mechanics** (why: `CLAUDE.md` "deterministic → scripts"; the invariants — `--no-verify` push, hard-capped CI poll that returns, merge-on-green — live in `scripts/autoloop-seal.ts`, not here):
+   ```bash
+   npm run autoloop:seal -- <batch.branch> --title "<conventional subject>" --body-file /tmp/seal-body.md
+   ```
+   It emits `AUTOLOOP_SEAL_RESULT {json}`. **Exit 0** → fold the JSON (step 3). **Exit 3** = CI red → *your judgment*: a first fixable gate (e.g. diff-coverage) → fix forward on the branch (real tests, don't ratchet) + re-run; red twice same-SHA no-change → post the failing-job link (AI marker), leave the PR open, return (hard-exit #1). **Exit 2** = setup error (dirty tree / bad branch / conflict) → fix + re-run. (`--body-file` is a normal PR body: `## What` / `Closes #a` per issue / `## Risk·Rollback`.)
 
-The push/PR/CI-watch/merge/path-mandated mechanics are DETERMINISTIC — run the
-script, don't hand-roll them (that's what wedged past seals, memory
-`feedback_seal_builder_ci_watch_wedge`; principle in `CLAUDE.md`). Write the PR
-body to a temp file, then:
-
-```bash
-npm run autoloop:seal -- <batch.branch> --title "<conventional subject>" --body-file /tmp/seal-body.md
-```
-The script (`scripts/autoloop-seal.ts`) pushes `--no-verify`, creates the PR,
-**hard-capped-polls** CI (returns, never a Monitor / unbounded wait), merges on
-green, pulls `main`, and computes path-mandated files. It prints one last line:
-```
-AUTOLOOP_SEAL_RESULT {"ok":true,"pr":123,"sha":"abc1234","pathMandated":[...],"boxVerifyOwed":true,"detail":"…"}
-```
-Exit codes: **0** merged (parse the JSON for the fold-in below); **3** CI red —
-that's your JUDGMENT call: read the failing check, and on a first *fixable* gate
-red (e.g. diff-coverage) fix forward on the branch (add real tests — don't
-ratchet) and re-run the script; red twice on the same SHA with no change between
-→ post the failing-job link (AI marker), leave the PR open, return (orchestrator
-hard-exit #1). **2** setup error (dirty tree / bad branch / merge conflict) —
-fix and re-run.
-
-PR body template (write to the `--body-file`):
-```
-## What
-<1-2 sentences across the batch's themes>
-
-## Why
-Closes #<a>
-<one Closes line per issue in the batch>
-
-## Risk / Rollback
-<low|med|high — one sentence> · <git revert is enough | requires X>
-```
-
-### 3. Fold the result into the queue + hand off to Box-Verify
-
-From the script's `AUTOLOOP_SEAL_RESULT` JSON: set `box_verify = {sha:<sha>, status:"owed", detail:<detail>, since:<now>}` when **`boxVerifyOwed` is true OR any sealed unit's `gate` was `verify`** (the script only measures files; a user-facing/visual unit is `gate:verify` even if its files aren't path-mandated). Otherwise leave `box_verify` as-is. The orchestrator dispatches Box-Verify next; the release PR stays blocked until it's green.
-
-Then: move the batch's units → `completed[]` (`{issue|unit, pr, gate, merged_at}`), mark lint-sweep entries in `lint_sweep[]`, **reset `batch` to `null`**, and for every shipped `security:true` unit append `{issue, pr, flag:"security", merged_at}` to `review[]`. The release PR itself is merged later by the orchestrator preflight, *after* box-verify is green — not here.
-
-**Path-mandated list is canonical in the script** — `PATH_MANDATED_PATHS` in `scripts/autoloop-seal.ts` (kept broader than the old prose copy: it includes the NPM-render / proxy-gate / auth files — `stackInstall/`, `lib/portal/`, `proxy.ts`, `middleware.ts` — that this session proved need a box verify). Edit that array + its unit test to change the list, not this doc.
+3. **Fold the result.** Set `box_verify={sha,status:"owed",detail,since}` when the JSON's `boxVerifyOwed` is true **OR** any sealed unit's `gate` was `verify` (a user-facing unit is `gate:verify` even if its files aren't path-mandated). Move units → `completed[]`, lint-sweeps → `lint_sweep[]`, every `security:true` → `review[]`, and **reset `batch` to `null`**. (The release PR is merged later by orchestrator preflight, after box-verify is green.) The path-mandated list is canonical in the script's `PATH_MANDATED_PATHS` — edit it there.
 
 ## Return
 - build: `Builder: built fe-layout (#1420,#1424) onto batch/2026-06-01a, fast gate green, count 4/8.`

--- a/.claude/skills/autoloop-issues/stages/builder.md
+++ b/.claude/skills/autoloop-issues/stages/builder.md
@@ -88,57 +88,50 @@ git push --no-verify -u origin <batch.branch>
 ```
 **Use `--no-verify`.** The step-1 full gate above already ran lint/typecheck/check:arch/`npm test` locally; the husky **pre-push hook re-runs `npm run test` + `next build`** (minutes, and trips on flakes like `logger_retention/vacuumLogsDb` or a pre-existing `knip` finding). CI re-runs every gate on the PR and **is** the authoritative gate, so bypassing the redundant local hook is correct — otherwise a plain `git push` silently fails (`husky - pre-push script failed`, ref unchanged) and you'll think you pushed when you didn't (memory `feedback_seal_builder_ci_watch_wedge`).
 
-### 2. One PR for the whole batch
+### 2. Seal via the deterministic script (push → CI → merge)
+
+The push/PR/CI-watch/merge/path-mandated mechanics are DETERMINISTIC — run the
+script, don't hand-roll them (that's what wedged past seals, memory
+`feedback_seal_builder_ci_watch_wedge`; principle in `CLAUDE.md`). Write the PR
+body to a temp file, then:
+
 ```bash
-gh pr create --title "<conventional subject>" --body "$(cat <<'EOF'
+npm run autoloop:seal -- <batch.branch> --title "<conventional subject>" --body-file /tmp/seal-body.md
+```
+The script (`scripts/autoloop-seal.ts`) pushes `--no-verify`, creates the PR,
+**hard-capped-polls** CI (returns, never a Monitor / unbounded wait), merges on
+green, pulls `main`, and computes path-mandated files. It prints one last line:
+```
+AUTOLOOP_SEAL_RESULT {"ok":true,"pr":123,"sha":"abc1234","pathMandated":[...],"boxVerifyOwed":true,"detail":"…"}
+```
+Exit codes: **0** merged (parse the JSON for the fold-in below); **3** CI red —
+that's your JUDGMENT call: read the failing check, and on a first *fixable* gate
+red (e.g. diff-coverage) fix forward on the branch (add real tests — don't
+ratchet) and re-run the script; red twice on the same SHA with no change between
+→ post the failing-job link (AI marker), leave the PR open, return (orchestrator
+hard-exit #1). **2** setup error (dirty tree / bad branch / merge conflict) —
+fix and re-run.
+
+PR body template (write to the `--body-file`):
+```
 ## What
 <1-2 sentences across the batch's themes>
 
 ## Why
 Closes #<a>
-Closes #<b>
 <one Closes line per issue in the batch>
 
-## Risk
-<low | medium | high — one sentence>
-
-## Rollback
-<git revert is enough | requires X>
-
-## Verification
-- [ ] npm run lint
-- [ ] npm run check:arch
-- [ ] npm test (full)
-- [ ] /verify on FCoS :dev box (if any file is path-mandated — see below)
-EOF
-)"
+## Risk / Rollback
+<low|med|high — one sentence> · <git revert is enough | requires X>
 ```
 
-### 3. Merge gate (`main` is not branch-protected, so `--auto` no-ops — gate manually)
-```bash
-gh pr checks <PR#> --watch    # BLOCKING call with a built-in exit — it returns when CI resolves
-```
-- **Never wedge on the wait (memory `feedback_seal_builder_ci_watch_wedge`).** Use `gh pr checks --watch` directly — it is a foreground blocking call that RETURNS when CI finishes. Do **NOT** arm the Monitor tool for CI and yield, and do **NOT** enter an open-ended custom wait loop: a stage agent that yields waiting for a monitor event **never resumes** and dies mid-seal *after committing but before/without merging* — leaving the fix committed locally, unpushed, and the seal half-done. If you ever poll instead of `--watch`, **hard-cap it** (e.g. ≤18×30s) and act on the result; never `sleep` forever.
-- Green → `gh pr merge <PR#> --merge --delete-branch`, then `git checkout main && git pull --ff-only`.
-- Red on the **diff-coverage / a fixable gate** (first time) → fix forward on the branch (add the missing tests — don't ratchet), push (`--no-verify`), re-watch. Red **twice on the same SHA** with no change between → post the failing-job link (AI marker), leave the PR open, set a note, return (orchestrator hard-exit #1).
+### 3. Fold the result into the queue + hand off to Box-Verify
 
-### 4. Hand off to Box-Verify
-If **any** merged file is under a path-mandated path (list below), set `box_verify = {sha:"<merge SHA>", status:"owed", detail:"<which paths>", since:<now>}`. The orchestrator will dispatch Box-Verify next; the release PR stays blocked until it's green. Otherwise leave `box_verify` as-is.
+From the script's `AUTOLOOP_SEAL_RESULT` JSON: set `box_verify = {sha:<sha>, status:"owed", detail:<detail>, since:<now>}` when **`boxVerifyOwed` is true OR any sealed unit's `gate` was `verify`** (the script only measures files; a user-facing/visual unit is `gate:verify` even if its files aren't path-mandated). Otherwise leave `box_verify` as-is. The orchestrator dispatches Box-Verify next; the release PR stays blocked until it's green.
 
-Move the batch's units → `completed[]` (`{issue|unit, pr, gate, merged_at}`), mark lint-sweep entries in `lint_sweep[]`, and **reset `batch` to `null`**. For every shipped `security:true` unit, also append `{issue, pr, flag:"security", merged_at}` to `review[]` (the human's post-deploy review list). Note: the release PR itself is merged later by the orchestrator preflight, *after* box-verify is green — not here.
+Then: move the batch's units → `completed[]` (`{issue|unit, pr, gate, merged_at}`), mark lint-sweep entries in `lint_sweep[]`, **reset `batch` to `null`**, and for every shipped `security:true` unit append `{issue, pr, flag:"security", merged_at}` to `review[]`. The release PR itself is merged later by the orchestrator preflight, *after* box-verify is green — not here.
 
-### Path-mandated paths (trigger `box_verify=owed`)
-```
-packages/backend/src/lib/install/
-packages/backend/src/lib/config.ts
-packages/backend/src/lib/agent/
-packages/backend/src/lib/systemBackup.ts
-packages/backend/src/lib/mcp/
-packages/frontend/src/app/portal/
-packages/frontend/src/app/(dashboard)/
-packages/frontend/src/dashboards/
-packages/frontend/src/components/OnboardingWizard.tsx (or its decomposition)
-```
+**Path-mandated list is canonical in the script** — `PATH_MANDATED_PATHS` in `scripts/autoloop-seal.ts` (kept broader than the old prose copy: it includes the NPM-render / proxy-gate / auth files — `stackInstall/`, `lib/portal/`, `proxy.ts`, `middleware.ts` — that this session proved need a box verify). Edit that array + its unit test to change the list, not this doc.
 
 ## Return
 - build: `Builder: built fe-layout (#1420,#1424) onto batch/2026-06-01a, fast gate green, count 4/8.`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,22 +12,7 @@ Orientation:
 
 ## Deterministic execution → scripts; LLMs coordinate + evaluate
 
-**If a step is deterministic, make it a good script — don't leave it as prose an
-LLM re-interprets each run.** Prose invariants ("always push `--no-verify`",
-"never leave the box on `:dev`", "poll CI in a bounded loop") are *advisory* — an
-LLM can skip them, and did (that's what wedged the seal builders and stranded
-box-verify this session). In a script the same invariant is *structural*: a
-`finally` that flips back to `:latest`, a hard-capped poll that returns, a fixed
-`--no-verify` flag. Scripts are also cheaper (no tokens) and have zero variance.
-
-Reserve the LLM for **judgment**: *what* to verify (interpret acceptance), *why*
-a red happened (flake vs real) and how to fix it, triage/clustering/planning, and
-writing the actual code. So the split is: **scripts run the mechanics; LLMs
-coordinate them and evaluate the results.** When you find yourself writing a long
-procedural playbook, ask whether the deterministic core belongs in
-`scripts/*.ts` (house pattern: `tsx`, `node:` only, no new dep — see
-`scripts/check-diff-coverage.ts`) with the playbook shrunk to "call this script,
-then make *these* judgments."
+**Deterministic steps belong in a good script, not in prose an LLM re-interprets each run.** Prose invariants are advisory (an LLM skips them — that wedged the seal builders + stranded box-verify); in a script they're structural (a `finally` that flips back to `:latest`, a hard-capped poll that returns, a fixed `--no-verify`) — and cheaper, zero-variance. Reserve the LLM for **judgment**: what to verify, why a red happened + how to fix, triage/planning, writing the code. So: **scripts run the mechanics; LLMs coordinate + evaluate.** House pattern: `tsx scripts/*.ts`, `node:` only, no new dep (e.g. `scripts/check-diff-coverage.ts`, `autoloop-seal.ts`); shrink the playbook to "call the script, then judge X."
 
 ## Workflow: issues first, then the autoloop
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,25 @@ Orientation:
 - `docs/TEMPLATE_AUTHORING.md` + `templates/CLAUDE.md` — the template contract (auto-loads under `templates/`).
 - `docs/UX_DECISIONS.md` — locked UX decisions; don't re-litigate.
 
+## Deterministic execution → scripts; LLMs coordinate + evaluate
+
+**If a step is deterministic, make it a good script — don't leave it as prose an
+LLM re-interprets each run.** Prose invariants ("always push `--no-verify`",
+"never leave the box on `:dev`", "poll CI in a bounded loop") are *advisory* — an
+LLM can skip them, and did (that's what wedged the seal builders and stranded
+box-verify this session). In a script the same invariant is *structural*: a
+`finally` that flips back to `:latest`, a hard-capped poll that returns, a fixed
+`--no-verify` flag. Scripts are also cheaper (no tokens) and have zero variance.
+
+Reserve the LLM for **judgment**: *what* to verify (interpret acceptance), *why*
+a red happened (flake vs real) and how to fix it, triage/clustering/planning, and
+writing the actual code. So the split is: **scripts run the mechanics; LLMs
+coordinate them and evaluate the results.** When you find yourself writing a long
+procedural playbook, ask whether the deterministic core belongs in
+`scripts/*.ts` (house pattern: `tsx`, `node:` only, no new dep — see
+`scripts/check-diff-coverage.ts`) with the playbook shrunk to "call this script,
+then make *these* judgments."
+
 ## Workflow: issues first, then the autoloop
 
 Capture work as **GitHub issues first**, then let the **autoloop-issues** pipeline

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "check:backup-coverage": "tsx scripts/check-backup-coverage.ts",
     "check:deps": "depcruise --config .dependency-cruiser.cjs packages/frontend/src packages/backend/src",
     "check:arch": "npm run check:invariants && npm run check:backup-coverage && npm run check:deps",
-    "prepare": "husky || true"
+    "prepare": "husky || true",
+    "autoloop:seal": "tsx scripts/autoloop-seal.ts"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/autoloop-seal.test.ts
+++ b/scripts/autoloop-seal.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { isPathMandated, PATH_MANDATED_PATHS } from './autoloop-seal';
+
+describe('isPathMandated', () => {
+  it('matches install/deploy path files (this session: #2296 runner.ts)', () => {
+    expect(isPathMandated('packages/backend/src/lib/install/runner.ts')).toBe(true);
+    expect(isPathMandated('packages/backend/src/lib/config.ts')).toBe(true);
+    expect(isPathMandated('packages/backend/src/lib/systemBackup.ts')).toBe(true);
+  });
+
+  it('matches the NPM-render + proxy-gate files this session proved need verify', () => {
+    // #2278/#2281 forward-auth render + proxy gate — absent from the old builder.md list.
+    expect(isPathMandated('packages/backend/src/lib/stackInstall/forwardAuth.ts')).toBe(true);
+    expect(isPathMandated('packages/backend/src/lib/portal/provisioner.ts')).toBe(true);
+    expect(isPathMandated('packages/frontend/src/proxy.ts')).toBe(true);
+  });
+
+  it('matches user-facing surfaces (portal / dashboard / the wizard file)', () => {
+    expect(isPathMandated('packages/frontend/src/app/portal/PortalGrid.tsx')).toBe(true);
+    expect(isPathMandated('packages/frontend/src/app/(dashboard)/settings/page.tsx')).toBe(true);
+    expect(isPathMandated('packages/frontend/src/components/OnboardingWizard.tsx')).toBe(true);
+  });
+
+  it('does NOT match unrelated / pure-logic files', () => {
+    expect(isPathMandated('packages/backend/src/lib/auth/apiTokens.ts')).toBe(false);
+    expect(isPathMandated('packages/backend/src/lib/stackInstall/nginxScratchValidate.ts')).toBe(true); // stackInstall/ IS mandated
+    expect(isPathMandated('scripts/autoloop-seal.ts')).toBe(false);
+    expect(isPathMandated('docs/ARCHITECTURE_INVARIANTS.md')).toBe(false);
+    expect(isPathMandated('packages/frontend/src/hooks/useServiceActions.tsx')).toBe(false);
+  });
+
+  it('exact-matches file entries, prefix-matches directory entries', () => {
+    // proxy.ts is an exact file entry — a sibling must NOT match.
+    expect(isPathMandated('packages/frontend/src/proxyOther.ts')).toBe(false);
+    // config.ts exact — config.helper.ts must NOT match.
+    expect(isPathMandated('packages/backend/src/lib/configLoader.ts')).toBe(false);
+  });
+
+  it('every directory entry ends with a slash and every list entry is under packages/', () => {
+    for (const p of PATH_MANDATED_PATHS) {
+      expect(p.startsWith('packages/')).toBe(true);
+      // a heuristic guard: entries without an extension must be directories (trailing /)
+      const last = p.split('/').pop() ?? '';
+      if (!last.includes('.')) expect(p.endsWith('/')).toBe(true);
+    }
+  });
+});

--- a/scripts/autoloop-seal.ts
+++ b/scripts/autoloop-seal.ts
@@ -1,0 +1,182 @@
+/**
+ * Autoloop SEAL mechanics as a deterministic script (#2306).
+ *
+ * The seal step — push the batch, watch CI, merge on green, decide whether the
+ * merge is path-mandated (→ box-verify owed) — is 100% deterministic, yet it
+ * lived as free-text in stages/builder.md that a fresh sub-agent re-ran each
+ * time. That's what wedged the seal builders this session: an LLM interpreting
+ * "watch CI" armed a Monitor and yielded, dying mid-seal after committing but
+ * before pushing (memory feedback_seal_builder_ci_watch_wedge). As a script the
+ * invariants are STRUCTURAL, not advisory:
+ *   - push always uses `--no-verify` (the husky pre-push hook re-runs the full
+ *     vitest+build — slow, flaky, and silently fails a plain push; CI is the
+ *     authoritative gate);
+ *   - CI is watched by a HARD-CAPPED poll loop that RETURNS (never an unbounded
+ *     wait / Monitor);
+ *   - merge happens ONLY on all-green.
+ * The orchestrator (deterministic dispatch) calls this instead of spawning a
+ * wedge-prone seal sub-agent. LLMs stay for JUDGMENT: diagnosing a red,
+ * fixing forward. (CLAUDE.md: "Deterministic execution → scripts; LLMs
+ * coordinate + evaluate.")
+ *
+ * House pattern: tsx, node: only, no new runtime dep (sibling to
+ * scripts/check-diff-coverage.ts).
+ *
+ *   tsx scripts/autoloop-seal.ts <batchBranch> [--title "<PR title>"] [--body-file <path>]
+ *
+ * Emits a single machine-readable last line for the orchestrator to fold into
+ * work-queue.json (this script never writes the queue — single-writer is the
+ * orchestrator):
+ *   AUTOLOOP_SEAL_RESULT {"ok":true,"pr":123,"sha":"abc1234","pathMandated":[...],"boxVerifyOwed":true,"detail":"..."}
+ *
+ * Exit codes: 0 merged; 3 CI red (result carries the failing checks — LLM
+ * decides fix-forward); 2 setup error (dirty tree, bad branch, merge conflict).
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Path prefixes/files whose change means the release must run a real on-box
+ * `:dev` verify before shipping to `:latest`. This is the CANONICAL list
+ * (stages/builder.md should reference it). Broader than the old builder.md
+ * copy: this session proved the NPM-render + proxy-gate + auth files
+ * (forwardAuth/provisioner/proxy) also warrant box-verify. Matching is
+ * prefix-based (a trailing `/` marks a directory; otherwise an exact file).
+ */
+export const PATH_MANDATED_PATHS: readonly string[] = [
+  // install / deploy path
+  'packages/backend/src/lib/install/',
+  'packages/backend/src/lib/config.ts',
+  'packages/backend/src/lib/agent/',
+  'packages/backend/src/lib/systemBackup.ts',
+  'packages/backend/src/lib/mcp/',
+  // NPM reverse-proxy / forward-auth render (forwardAuth.ts, provisioner.ts)
+  'packages/backend/src/lib/stackInstall/',
+  'packages/backend/src/lib/portal/',
+  // request-path gate + middleware (proxy.ts CSRF/internal-token gate)
+  'packages/frontend/src/proxy.ts',
+  'packages/frontend/src/middleware.ts',
+  // user-facing surfaces that gate=verify covers
+  'packages/frontend/src/app/portal/',
+  'packages/frontend/src/app/(dashboard)/',
+  'packages/frontend/src/dashboards/',
+  'packages/frontend/src/components/OnboardingWizard.tsx',
+];
+
+/** Pure: does a repo-relative path trigger box_verify=owed? Prefix match for
+ *  directory entries (trailing `/`), exact match for file entries. Exported so
+ *  the matching is unit-tested without git. */
+export function isPathMandated(file: string): boolean {
+  return PATH_MANDATED_PATHS.some(p => (p.endsWith('/') ? file.startsWith(p) : file === p));
+}
+
+// ---- everything below runs only when invoked as a script ----
+
+function sh(cmd: string, args: string[]): string {
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+function shSafe(cmd: string, args: string[]): { ok: boolean; out: string } {
+  try {
+    return { ok: true, out: sh(cmd, args) };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; message?: string };
+    return { ok: false, out: `${err.stdout ?? ''}${err.stderr ?? ''}${err.message ?? ''}`.trim() };
+  }
+}
+function emit(result: Record<string, unknown>): void {
+  console.log(`AUTOLOOP_SEAL_RESULT ${JSON.stringify(result)}`);
+}
+function fail(code: number, result: Record<string, unknown>): never {
+  emit({ ok: false, ...result });
+  process.exit(code);
+}
+
+/** Poll CI for the PR in a HARD-CAPPED loop that always returns.
+ *  → 'green' (all non-pending, none failed), 'red' (a check failed), or
+ *  'timeout'. Never an unbounded wait — this is the anti-wedge core. */
+function watchCi(pr: number, maxPolls = 20, intervalSec = 30): { verdict: 'green' | 'red' | 'timeout'; failing: string[] } {
+  for (let i = 0; i < maxPolls; i++) {
+    sh('sleep', [String(intervalSec)]);
+    const res = shSafe('gh', ['pr', 'checks', String(pr), '--json', 'name,state,bucket']);
+    if (!res.ok) continue; // transient gh/API hiccup — keep polling within the cap
+    let checks: Array<{ name: string; state?: string; bucket?: string }>;
+    try {
+      checks = JSON.parse(res.out);
+    } catch {
+      continue;
+    }
+    const failing = checks.filter(c => c.bucket === 'fail' || ['FAILURE', 'ERROR'].includes(c.state ?? '')).map(c => c.name);
+    if (failing.length) return { verdict: 'red', failing };
+    const pending = checks.filter(c => c.bucket === 'pending' || ['PENDING', 'IN_PROGRESS', 'QUEUED'].includes(c.state ?? ''));
+    if (!pending.length) return { verdict: 'green', failing: [] };
+  }
+  return { verdict: 'timeout', failing: [] };
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const branch = argv.find(a => !a.startsWith('--'));
+  const titleIdx = argv.indexOf('--title');
+  const bodyIdx = argv.indexOf('--body-file');
+  const title = titleIdx >= 0 ? argv[titleIdx + 1] : undefined;
+  const bodyFile = bodyIdx >= 0 ? argv[bodyIdx + 1] : undefined;
+  if (!branch) fail(2, { detail: 'usage: autoloop-seal.ts <batchBranch> [--title T] [--body-file F]' });
+
+  // Preconditions: clean tree, batch branch exists.
+  if (sh('git', ['status', '--porcelain'])) fail(2, { detail: 'working tree is dirty — refusing to seal' });
+  if (!shSafe('git', ['rev-parse', '--verify', branch!]).ok) fail(2, { detail: `batch branch not found: ${branch}` });
+
+  sh('git', ['fetch', 'origin', '--quiet']);
+  const oldMain = sh('git', ['rev-parse', 'origin/main']);
+
+  // Push with --no-verify (structural: skip the slow/flaky local pre-push hook; CI is the gate).
+  sh('git', ['checkout', branch!]);
+  const push = shSafe('git', ['push', '--no-verify', '-u', 'origin', branch!]);
+  if (!push.ok) fail(2, { detail: `push failed: ${push.out.slice(0, 500)}` });
+
+  // Find or create the PR.
+  let pr = Number(shSafe('gh', ['pr', 'list', '--head', branch!, '--state', 'open', '--json', 'number', '--jq', '.[0].number']).out || 0);
+  if (!pr) {
+    const prTitle = title ?? sh('git', ['log', '-1', '--format=%s', branch!]);
+    const args = ['pr', 'create', '--base', 'main', '--head', branch!, '--title', prTitle];
+    if (bodyFile) args.push('--body-file', bodyFile);
+    else args.push('--body', `Autoloop batch seal for \`${branch}\`.`);
+    const created = shSafe('gh', args);
+    if (!created.ok) fail(2, { detail: `pr create failed: ${created.out.slice(0, 500)}` });
+    pr = Number(shSafe('gh', ['pr', 'list', '--head', branch!, '--state', 'open', '--json', 'number', '--jq', '.[0].number']).out || 0);
+    if (!pr) fail(2, { detail: 'PR created but could not resolve its number' });
+  }
+
+  // Watch CI — hard-capped poll, always returns.
+  const ci = watchCi(pr);
+  if (ci.verdict === 'red') fail(3, { pr, detail: `CI red: ${ci.failing.join(', ')}`, failing: ci.failing });
+  if (ci.verdict === 'timeout') fail(3, { pr, detail: 'CI did not resolve within the poll cap', failing: [] });
+
+  // Merge on green.
+  const merge = shSafe('gh', ['pr', 'merge', String(pr), '--merge', '--delete-branch']);
+  if (!merge.ok) fail(2, { pr, detail: `merge failed (conflict?): ${merge.out.slice(0, 500)}` });
+  sh('git', ['checkout', 'main']);
+  sh('git', ['pull', '--ff-only', '--quiet']);
+  const newSha = sh('git', ['rev-parse', '--short', 'HEAD']);
+
+  // Compute path-mandated files from the merged diff.
+  const changed = sh('git', ['diff', '--name-only', `${oldMain}..HEAD`]).split('\n').filter(Boolean);
+  const pathMandated = changed.filter(isPathMandated);
+
+  emit({
+    ok: true,
+    pr,
+    sha: newSha,
+    pathMandated,
+    boxVerifyOwed: pathMandated.length > 0,
+    detail: pathMandated.length
+      ? `Merged PR #${pr} → ${newSha}; box_verify=owed (path-mandated: ${pathMandated.join(', ')})`
+      : `Merged PR #${pr} → ${newSha}; nothing path-mandated (box_verify stays clear unless a unit's gate=verify)`,
+  });
+}
+
+// Only run when invoked directly (so tests can import isPathMandated purely).
+const invokedPath = process.argv[1] ?? '';
+if (invokedPath.endsWith('autoloop-seal.ts') || invokedPath.endsWith('autoloop-seal.js')) {
+  main();
+}


### PR DESCRIPTION
First slice of #2306 — move the **deterministic** autoloop seal mechanics out of free-text playbook prose (which an LLM re-interprets and can skip) into a script where the invariants are **structural**.

## Why
This session the prose seal flow wedged twice: a stage agent interpreting "watch CI" armed a Monitor and yielded, never resumed, dying mid-seal after committing but **unpushed**. Plus `git push` silently failed on the slow pre-push hook (no `--no-verify`). In a script none of that can happen.

## What
- **`CLAUDE.md`** — the rule: *deterministic execution → good scripts (invariants become structural); reserve LLMs to coordinate + evaluate (judgment)*.
- **`scripts/autoloop-seal.ts`** (+ test, `npm run autoloop:seal -- <batch>`): push `--no-verify` → create/find PR → **hard-capped CI poll that returns** (never a Monitor/unbounded wait) → merge on green → pull main → compute path-mandated files → emit `AUTOLOOP_SEAL_RESULT` JSON. Exit 0 merged / 3 CI-red (LLM judgment: fix forward) / 2 setup error.
  - `isPathMandated()` is pure + unit-tested (6 tests). `PATH_MANDATED_PATHS` is now the **canonical** list — broader than the old builder.md copy: it adds `stackInstall/`, `lib/portal/`, `proxy.ts`, `middleware.ts`, which this session proved need a box verify (#2278/#2281/#2296).
- **`stages/builder.md`** seal mode: call the script, then the LLM only judges a red / folds the JSON into the queue.

## Follow-ups (epic #2306)
- `scripts/autoloop-box.ts` — box-access helper (`/mcp` Bearer, no SSH) → kills the "unreachable" class.
- `scripts/autoloop-dev-verify.ts` — `:dev` flip-verify-flipback harness with the flip-back guaranteed in a `finally` (the "never strand on :dev" invariant, structural).

## Verify
`npm run autoloop:seal` (usage → exit 2), `vitest scripts/autoloop-seal.test.ts` (6/6), lint + check:arch clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqUTDYDUbxStiSftPBXqPb