### PR TITLE
chore(deps): decline js-yaml v5 — ignore >=5 (breaks {{VAR}} template parsing)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,18 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # js-yaml v5 makes complex-key parsing strict: it THROWS on an unquoted
+      # `{{VAR}}` template placeholder that v4 tolerated (v4 → `{'[object
+      # Object]': null}`, v5 → "object-based map does not support complex keys").
+      # That breaks every `yaml.load`/`loadAll` of UN-rendered template YAML —
+      # the #1688 healthcheck parser, manifestAssembler, serviceListing,
+      # inferredEdges, contract, yamlExtractor. Declined (#2115/#2289): v4 works
+      # and there's no functional/security reason for v5; taking it needs a
+      # Mustache pre-substitution refactor across all those parse sites. Drop
+      # this ignore only when/if that refactor lands.
+      - dependency-name: "js-yaml"
+        versions: [">=5"]
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
Adds a dependabot `ignore` for `js-yaml >=5` so the recurring bump (#2115 → #2289 → …) stops resurrecting.

**Why declined:** verified live against js-yaml 5.2.1 — `yaml.load('port: {{VAR}}')` **throws** `object-based map does not support complex keys` (v4 tolerated it as `{'[object Object]': null}`). That breaks every `yaml.load`/`loadAll` of un-rendered template YAML: the #1688 healthcheck parser, manifestAssembler, serviceListing, inferredEdges, contract, yamlExtractor. Taking v5 needs a Mustache pre-substitution refactor across all those sites; v4 works and there's no functional/security reason for v5. Same decline pattern as the existing `jlaffaye/ftp` ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqUTDYDUbxStiSftPBXqPb