### PR TITLE
chore(knip): ignore tailwindcss + @tailwindcss/typography (used via CSS pipeline) — closes #2305

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,10 +115,12 @@
           "tests/e2e/**/*.e2e.ts"
         ],
         "ignoreDependencies": [
+          "@tailwindcss/typography",
           "better-sqlite3",
           "lucide-react",
           "react-markdown",
-          "socket.io-client"
+          "socket.io-client",
+          "tailwindcss"
         ]
       },
       "packages/frontend": {


### PR DESCRIPTION
Closes #2305 — the knip pre-commit failure that forced `--no-verify` on **every** commit this session.

Both deps are **genuinely used**, just not via TS `import` (Tailwind v4 is CSS-first):
- `tailwindcss` → `postcss.config.mjs` loads `@tailwindcss/postcss`; `globals.css` has `@tailwind` directives.
- `@tailwindcss/typography` → `@plugin "@tailwindcss/typography"` in `globals.css`; `prose` used across 7 components.

So this **ignores** them in the root workspace `ignoreDependencies` (removing would break the CSS build). `npx knip` exits 0; this commit was made **without** `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqUTDYDUbxStiSftPBXqPb