### PR TITLE
feat(napi): POST /napi/services/[name]/upgrade — companion-triggered service upgrade (#2313)

### DIFF
--- a/packages/frontend/src/app/napi/scopeGuards.test.ts
+++ b/packages/frontend/src/app/napi/scopeGuards.test.ts
@@ -67,12 +67,15 @@ describe('/napi/* read endpoints are read-scoped in the handler OPTIONS (#2252, 
  * higher scope in the withApiHandlerParams OPTIONS — a `read`-only device token
  * (the pairing default, #2251) must be unable to reach these:
  *   - operate (start/stop/restart) → 'lifecycle'
+ *   - upgrade (apply template/image re-deploy) → 'mutate' (#2313 — heavier than
+ *     operate's reversible verbs; a read OR a lifecycle token must be rejected)
  *   - approve / deny verdict       → 'mutate'
  * Pinning the exact scope here is what stops a future edit from silently
  * widening a read token's reach into service control or approval verdicts.
  */
 const MUTATE_ROUTES: Array<{ path: string; scope: string }> = [
   { path: 'services/[name]/operate/route.ts', scope: 'lifecycle' },
+  { path: 'services/[name]/upgrade/route.ts', scope: 'mutate' },
   { path: 'approvals/[id]/approve/route.ts', scope: 'mutate' },
   { path: 'approvals/[id]/deny/route.ts', scope: 'mutate' },
 ];

--- a/packages/frontend/src/app/napi/services/[name]/upgrade/route.test.ts
+++ b/packages/frontend/src/app/napi/services/[name]/upgrade/route.test.ts
@@ -1,0 +1,199 @@
+/**
+ * POST /napi/services/:name/upgrade — companion-app upgrade-apply (#2313).
+ *
+ * The scope machinery (accept a `mutate` Bearer, 401/403 a read/lifecycle/absent
+ * token) is proven in requireSession.test.ts, and the EXACT `mutate` scope baked
+ * into this route's OPTIONS is pinned in ../../../scopeGuards.test.ts. Here we
+ * exercise the route body: it reuses the SAME primitives the browser uses —
+ * `ServiceManager.updateAndRestartService` for an image update and
+ * `assembleManifest → applyVariableDefaults → createJob → startJob` for a
+ * template re-deploy — selecting by pending kind, with an invalid name 400 and a
+ * no-pending clean no-op (not a crash). `withApiHandlerParams` is stubbed to
+ * inject params the way the real gate would (same shape as the operate test).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  updateAndRestartService: vi.fn(),
+  getPendingTemplateUpgrades: vi.fn(),
+  getInstalledImageUpdates: vi.fn(),
+  assembleManifest: vi.fn(),
+  applyVariableDefaults: vi.fn(),
+  createJob: vi.fn(),
+  getCurrentJob: vi.fn(),
+  startJob: vi.fn(),
+}));
+
+vi.mock('@/lib/services/ServiceManager', () => ({
+  ServiceManager: { updateAndRestartService: mocks.updateAndRestartService },
+}));
+vi.mock('@/lib/templateUpgrades', () => ({
+  getPendingTemplateUpgrades: mocks.getPendingTemplateUpgrades,
+}));
+vi.mock('@/lib/imageDigest', () => ({
+  getInstalledImageUpdates: mocks.getInstalledImageUpdates,
+}));
+vi.mock('@/lib/install/manifestAssembler', () => ({
+  assembleManifest: mocks.assembleManifest,
+  applyVariableDefaults: mocks.applyVariableDefaults,
+}));
+vi.mock('@/lib/install/jobStore', () => ({
+  createJob: mocks.createJob,
+  getCurrentJob: mocks.getCurrentJob,
+  // Real subclass of Error so `instanceof` in the route works.
+  InstallInProgressError: class InstallInProgressError extends Error {
+    existingJobId: string;
+    constructor(id: string) {
+      super('install in progress');
+      this.name = 'InstallInProgressError';
+      this.existingJobId = id;
+    }
+  },
+}));
+vi.mock('@/lib/install/runner', () => ({ startJob: mocks.startJob }));
+
+vi.mock('@/lib/api/handler', () => ({
+  withApiHandlerParams:
+    (
+      _opts: unknown,
+      handler: (ctx: {
+        body: { kind?: string };
+        query: { node?: string };
+        params: { name: string };
+      }) => Promise<Response>,
+    ) =>
+    async (request: NextRequest, ctx: { params: Promise<{ name: string }> }) => {
+      const raw = await request.text();
+      const body = raw ? JSON.parse(raw) : {};
+      const node = new URL(request.url).searchParams.get('node') ?? undefined;
+      return handler({ body, query: { node }, params: await ctx.params });
+    },
+}));
+
+import { POST } from './route';
+
+function call(name: string, kind?: string, node?: string) {
+  const url = `http://localhost:5888/napi/services/${name}/upgrade${node ? `?node=${node}` : ''}`;
+  const req = new NextRequest(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(kind ? { kind } : {}),
+  });
+  return POST(req, { params: Promise.resolve({ name }) });
+}
+
+/** No template + no image pending for anyone, by default. Individual tests
+ *  override to make a specific kind pending for `immich`. */
+function pending(opts: { template?: boolean; image?: boolean } = {}) {
+  mocks.getPendingTemplateUpgrades.mockResolvedValue(
+    opts.template ? [{ name: 'immich', installedVersion: 1, currentVersion: 2 }] : [],
+  );
+  mocks.getInstalledImageUpdates.mockResolvedValue(
+    opts.image ? [{ service: 'immich', updateAvailable: true }] : [],
+  );
+}
+
+describe('POST /napi/services/:name/upgrade — apply a pending upgrade', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach(m => m.mockReset());
+    mocks.updateAndRestartService.mockResolvedValue({ logs: ['pulled'], status: 'active' });
+    mocks.assembleManifest.mockResolvedValue({ items: [{ name: 'immich', checked: true }], variables: [] });
+    mocks.applyVariableDefaults.mockImplementation(async (i: unknown) => i);
+    mocks.createJob.mockResolvedValue({ id: 'job-1', phase: 'running' });
+    mocks.getCurrentJob.mockResolvedValue(null);
+    pending();
+  });
+
+  it('kind=image with an image pending → calls updateAndRestartService(node, name) (acceptance: mutate token upgrades)', async () => {
+    pending({ image: true });
+    const res = await call('immich', 'image');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.kind).toBe('image');
+    expect(mocks.updateAndRestartService).toHaveBeenCalledWith('Local', 'immich');
+    expect(mocks.createJob).not.toHaveBeenCalled();
+  });
+
+  it('kind=template with a template pending → drives assemble→createJob→startJob for the service', async () => {
+    pending({ template: true });
+    const res = await call('immich', 'template');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.kind).toBe('template');
+    expect(body.jobId).toBe('job-1');
+    expect(mocks.assembleManifest).toHaveBeenCalledWith({ items: [{ name: 'immich', checked: true }] });
+    expect(mocks.createJob).toHaveBeenCalledWith({ source: 'napi', input: expect.objectContaining({ node: 'Local' }) });
+    expect(mocks.startJob).toHaveBeenCalledWith('job-1');
+    expect(mocks.updateAndRestartService).not.toHaveBeenCalled();
+  });
+
+  it('default (no kind) applies the image update when one is pending, image before template', async () => {
+    pending({ image: true, template: true });
+    const res = await call('immich');
+    expect(res.status).toBe(200);
+    expect((await res.json()).kind).toBe('image');
+    expect(mocks.updateAndRestartService).toHaveBeenCalledWith('Local', 'immich');
+    expect(mocks.createJob).not.toHaveBeenCalled();
+  });
+
+  it('default (no kind) falls through to the template re-deploy when only a template upgrade is pending', async () => {
+    pending({ template: true });
+    const res = await call('immich');
+    expect(res.status).toBe(200);
+    expect((await res.json()).kind).toBe('template');
+    expect(mocks.startJob).toHaveBeenCalledWith('job-1');
+  });
+
+  it('threads the node query through to the image upgrade primitive', async () => {
+    pending({ image: true });
+    await call('immich', 'image', 'box2');
+    expect(mocks.updateAndRestartService).toHaveBeenCalledWith('box2', 'immich');
+  });
+
+  it('no upgrade pending → clean no-op 200 (applied:false), not a crash', async () => {
+    pending(); // nothing pending
+    const res = await call('immich');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.applied).toBe(false);
+    expect(mocks.updateAndRestartService).not.toHaveBeenCalled();
+    expect(mocks.createJob).not.toHaveBeenCalled();
+  });
+
+  it('kind=image but nothing pending → clean no-op, no image pull', async () => {
+    pending({ template: true }); // template pending, but caller asked for image
+    const res = await call('immich', 'image');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.applied).toBe(false);
+    expect(mocks.updateAndRestartService).not.toHaveBeenCalled();
+  });
+
+  it('template re-deploy while an install job is already running → 409, no new job', async () => {
+    pending({ template: true });
+    mocks.getCurrentJob.mockResolvedValue({ id: 'busy-job' });
+    const res = await call('immich', 'template');
+    expect(res.status).toBe(409);
+    expect((await res.json()).jobId).toBe('busy-job');
+    expect(mocks.createJob).not.toHaveBeenCalled();
+  });
+
+  it('invalid service name → 400, nothing applied', async () => {
+    const res = await call('bad name!');
+    expect(res.status).toBe(400);
+    expect(mocks.updateAndRestartService).not.toHaveBeenCalled();
+    expect(mocks.getPendingTemplateUpgrades).not.toHaveBeenCalled();
+  });
+
+  it('an image-pull failure surfaces as 500, not a false-green ok', async () => {
+    pending({ image: true });
+    mocks.updateAndRestartService.mockRejectedValue(new Error('pull failed'));
+    const res = await call('immich', 'image');
+    expect(res.status).toBe(500);
+    expect((await res.json()).ok).not.toBe(true);
+  });
+});

--- a/packages/frontend/src/app/napi/services/[name]/upgrade/route.ts
+++ b/packages/frontend/src/app/napi/services/[name]/upgrade/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withApiHandlerParams } from '@/lib/api/handler';
+import { apiError } from '@/lib/api/errors';
+import { ServiceManager } from '@/lib/services/ServiceManager';
+import { ServiceName } from '@/lib/api/schemas';
+import { getPendingTemplateUpgrades } from '@/lib/templateUpgrades';
+import { getInstalledImageUpdates } from '@/lib/imageDigest';
+import { assembleManifest, applyVariableDefaults } from '@/lib/install/manifestAssembler';
+import {
+  createJob,
+  getCurrentJob,
+  InstallInProgressError,
+  type JobInput,
+} from '@/lib/install/jobStore';
+import { startJob } from '@/lib/install/runner';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /napi/services/:name/upgrade — apply a pending service upgrade from the
+ * companion app (#2313, consumer Solaris solarisbay#827).
+ *
+ * The token-only, proxy-bypassed mutating twin of the two browser upgrade-apply
+ * paths. The read side (`GET /napi/upgrades`, #2252) already tells the app that
+ * an upgrade is available for `<name>` in one of two kinds; this route APPLIES
+ * it, reusing the SAME primitives the browser uses — no second upgrade code
+ * path (mirrors how the operate route reuses ServiceManager):
+ *   - `image`    → `ServiceManager.updateAndRestartService(node, name)` — the
+ *                  exact primitive `POST /api/services/[name]/action`'s
+ *                  `update` action calls (pull newer image from the on-disk
+ *                  YAML, reload daemon, restart the unit).
+ *   - `template` → the wizard's server-side deploy flow
+ *                  `assembleManifest → applyVariableDefaults → createJob →
+ *                  startJob` for this ONE service (the same lib functions
+ *                  `POST /api/install/assemble` + `/api/install/start` and the
+ *                  `install_template` MCP tool #2141 drive) — the full template
+ *                  re-deploy (variable assembly, secret gen, proxy/Authelia
+ *                  wiring, dependency ordering, migrations), not a raw redeploy.
+ *
+ * TOKEN-GATED, `mutate`-scoped. An upgrade re-deploys the service — a spec/image
+ * mutation, heavier than operate's reversible start/stop/restart — so it sits at
+ * the `mutate` tier (create/update/add + config writes, per apiScope.ts; the
+ * same tier `install_template`/`deploy_service` carry). `tokenScope: 'mutate'`
+ * in the withApiHandlerParams OPTIONS (#2249 — the scope lives where the gate
+ * actually reads it, NOT an inner requireSession that would 401 a valid Bearer).
+ * A `read`-only device token (the pairing default, #2251) OR a `lifecycle` token
+ * (which can operate but not re-deploy) is REJECTED here.
+ *
+ * Body: optional `{ kind?: 'template' | 'image' }`. Omitted → apply whatever is
+ * pending for the service (image first — the cheaper in-place pull — else
+ * template). An explicit kind with nothing pending returns a clean no-op 200,
+ * never a crash (memory feedback_dont_mask_failures: honest, not a false green).
+ */
+const Body = z.object({
+  kind: z.enum(['template', 'image']).optional(),
+});
+const Query = z.object({ node: z.string().optional() });
+type BodyT = z.infer<typeof Body>;
+type QueryT = z.infer<typeof Query>;
+
+async function applyImageUpgrade(nodeName: string, name: string) {
+  const result = await ServiceManager.updateAndRestartService(nodeName, name);
+  return NextResponse.json({ ok: true, name, kind: 'image' as const, ...result });
+}
+
+/**
+ * Re-deploy the single service to its latest resolved template — the wizard
+ * flow, one item. Fire-and-forget (returns a jobId to poll), matching the
+ * browser install path. 409 if a deploy job is already running (single global
+ * install lock — the app should let the running job finish).
+ */
+async function applyTemplateUpgrade(nodeName: string, name: string) {
+  const active = await getCurrentJob();
+  if (active) {
+    return NextResponse.json(
+      { ok: false, error: 'install already in progress', jobId: active.id },
+      { status: 409 },
+    );
+  }
+  try {
+    const assembled = await assembleManifest({ items: [{ name, checked: true }] });
+    const input: JobInput = {
+      items: assembled.items,
+      variables: assembled.variables,
+      templateSource: 'Built-in',
+      host: 'localhost',
+      wipeMode: 'install',
+      ...(nodeName ? { node: nodeName } : {}),
+    };
+    const withDefaults = await applyVariableDefaults(input);
+    const job = await createJob({ source: 'napi', input: withDefaults });
+    startJob(job.id);
+    return NextResponse.json({ ok: true, name, kind: 'template' as const, jobId: job.id });
+  } catch (e) {
+    if (e instanceof InstallInProgressError) {
+      return NextResponse.json(
+        { ok: false, error: 'install already in progress', jobId: e.existingJobId },
+        { status: 409 },
+      );
+    }
+    throw e;
+  }
+}
+
+export const POST = withApiHandlerParams<BodyT, QueryT, { name: string }>(
+  { tokenScope: 'mutate', body: Body, query: Query },
+  async ({ body, query, params }) => {
+    const check = ServiceName.safeParse(decodeURIComponent(params.name));
+    if (!check.success) {
+      return NextResponse.json({ ok: false, error: 'invalid service name' }, { status: 400 });
+    }
+    const name = check.data;
+    const nodeName = query.node || 'Local';
+
+    try {
+      // Which upgrade kinds are actually pending for THIS service? Drives the
+      // default (no `kind`) selection and lets an explicit-kind request no-op
+      // cleanly when nothing of that kind is waiting.
+      const [templateUpgrades, imageUpdates] = await Promise.all([
+        getPendingTemplateUpgrades(),
+        getInstalledImageUpdates(),
+      ]);
+      const templatePending = templateUpgrades.some(t => t.name === name);
+      const imagePending = imageUpdates.some(u => u.service === name && u.updateAvailable);
+
+      if (body.kind === 'image') {
+        if (!imagePending) {
+          return NextResponse.json({ ok: true, name, kind: 'image', applied: false, reason: 'no image update pending' });
+        }
+        return await applyImageUpgrade(nodeName, name);
+      }
+
+      if (body.kind === 'template') {
+        if (!templatePending) {
+          return NextResponse.json({ ok: true, name, kind: 'template', applied: false, reason: 'no template upgrade pending' });
+        }
+        return await applyTemplateUpgrade(nodeName, name);
+      }
+
+      // Default: apply whatever is pending. Image first (cheap in-place pull),
+      // else the template re-deploy job.
+      if (imagePending) return await applyImageUpgrade(nodeName, name);
+      if (templatePending) return await applyTemplateUpgrade(nodeName, name);
+
+      return NextResponse.json({ ok: true, name, applied: false, reason: 'no upgrade pending' });
+    } catch (e) {
+      return apiError(e, { tag: 'napi:services:upgrade', status: 500 });
+    }
+  },
+);


### PR DESCRIPTION
## What
Adds `POST /napi/services/[name]/upgrade` so the Solaris companion BFF can trigger a service upgrade (it could already read `/napi/upgrades` + operate start/stop/restart, but not apply an upgrade).

## Why
Closes #2313

Mutate-scoped, token-only, proxy-bypassed sibling of `/napi/services/[name]/operate`. Reuses the browser upgrade-apply primitives (no second code path): image → `ServiceManager.updateAndRestartService`; template → the wizard deploy pipeline. Optional `{kind?}` body, default applies whatever's pending; no-pending → 200 no-op, busy install job → 409, invalid name → 400. Read/lifecycle tokens rejected.

## Risk / Rollback
low — new endpoint mirroring an established pattern, reuses existing primitives · git revert is enough
