### PR TITLE
chore(autoloop): mark /napi companion routes path-mandated in autoloop-seal

### DIFF
--- a/scripts/autoloop-seal.test.ts
+++ b/scripts/autoloop-seal.test.ts
@@ -15,6 +15,12 @@ describe('isPathMandated', () => {
     expect(isPathMandated('packages/frontend/src/proxy.ts')).toBe(true);
   });
 
+  it('matches the /napi companion surface (mutating device routes — #2313)', () => {
+    expect(isPathMandated('packages/frontend/src/app/napi/services/[name]/upgrade/route.ts')).toBe(true);
+    expect(isPathMandated('packages/frontend/src/app/napi/services/[name]/operate/route.ts')).toBe(true);
+    expect(isPathMandated('packages/frontend/src/app/napi/upgrades/route.ts')).toBe(true);
+  });
+
   it('matches user-facing surfaces (portal / dashboard / the wizard file)', () => {
     expect(isPathMandated('packages/frontend/src/app/portal/PortalGrid.tsx')).toBe(true);
     expect(isPathMandated('packages/frontend/src/app/(dashboard)/settings/page.tsx')).toBe(true);

--- a/scripts/autoloop-seal.ts
+++ b/scripts/autoloop-seal.ts
@@ -56,6 +56,11 @@ export const PATH_MANDATED_PATHS: readonly string[] = [
   // request-path gate + middleware (proxy.ts CSRF/internal-token gate)
   'packages/frontend/src/proxy.ts',
   'packages/frontend/src/middleware.ts',
+  // the /napi companion surface — token-scoped, proxy-bypassed routes the
+  // Solaris app calls (read + mutating operate/upgrade/approvals). A change
+  // here must box-verify on the real device path (#2313 dogfood found this
+  // gap — it was only caught by gate=verify before).
+  'packages/frontend/src/app/napi/',
   // user-facing surfaces that gate=verify covers
   'packages/frontend/src/app/portal/',
   'packages/frontend/src/app/(dashboard)/',


### PR DESCRIPTION
Follow-up surfaced by the #2313 dogfood of `autoloop:seal`: a mutating `/napi` endpoint (the Solaris companion device surface) wasn't in `PATH_MANDATED_PATHS`, so the script reported `boxVerifyOwed:false` — only the unit's `gate=verify` OR-rule caught it. Adds `packages/frontend/src/app/napi/` so any /napi change auto-triggers box-verify regardless of the unit's gate (defense-in-depth against a mis-set gate). Test covers upgrade/operate/upgrades routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqUTDYDUbxStiSftPBXqPb