### PR TITLE
feat(post-deploy): ServiceBay mints the durable read token as SB_READ_TOKEN (#2317)

### DIFF
--- a/packages/backend/src/lib/services/serviceLifecycle.postDeployReadToken.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.postDeployReadToken.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * #818 — ServiceBay mints the durable, read-scoped Bearer token itself and
+ * injects it into the post-deploy env as SB_READ_TOKEN, instead of leaving the
+ * external post-deploy.py to mint it (the failure mode: the read token was
+ * never minted, so the Solaris pollers fell back to a ~1h rotating admin token
+ * that went stale). These lock the injection contract.
+ */
+
+vi.mock('@/lib/logger', () => ({
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('@/lib/auth/internalToken', () => ({
+    getInternalApiToken: () => 'INTERNAL_HMAC',
+}));
+
+const createToken = vi.fn();
+const listTokens = vi.fn();
+const revokeToken = vi.fn();
+vi.mock('@/lib/auth/apiTokens', () => ({
+    createToken: (...a: unknown[]) => createToken(...a),
+    listTokens: (...a: unknown[]) => listTokens(...a),
+    revokeToken: (...a: unknown[]) => revokeToken(...a),
+}));
+
+// Imported after the mocks are registered.
+import { ServiceLifecycle } from './serviceLifecycle';
+
+// buildPostDeployEnvLines is a private static; call it through a typed hole
+// (TS `private` isn't runtime-enforced) — same spirit as the sibling tests
+// that exercise the delegated module functions directly.
+const buildEnvLines = (node: string, svc: string, env: Record<string, string>): Promise<string> =>
+    (ServiceLifecycle as unknown as {
+        buildPostDeployEnvLines(n: string, s: string, e: Record<string, string>): Promise<string>;
+    }).buildPostDeployEnvLines(node, svc, env);
+
+describe('buildPostDeployEnvLines → SB_READ_TOKEN injection (#818)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        listTokens.mockResolvedValue([]);
+        revokeToken.mockResolvedValue(true);
+        createToken.mockResolvedValue({ token: { id: 'aa11bb22', name: 'postdeploy-read:solaris' }, secret: 'sb_read_secret' });
+    });
+
+    it('mints a read-only, never-expiring token and injects it as SB_READ_TOKEN', async () => {
+        const out = await buildEnvLines('box', 'solaris', { FOO: 'bar' });
+        expect(createToken).toHaveBeenCalledWith(
+            expect.objectContaining({ name: 'postdeploy-read:solaris', scopes: ['read'], neverExpires: true }),
+        );
+        expect(out).toContain('SB_READ_TOKEN=sb_read_secret');
+        // still carries the existing contract
+        expect(out).toContain('SB_API_TOKEN=INTERNAL_HMAC');
+        expect(out).toContain('SB_NODE=box');
+        expect(out).toContain(`FOO='bar'`);
+    });
+
+    it('revokes any prior same-named token first (fresh each deploy, no accumulation)', async () => {
+        listTokens.mockResolvedValue([
+            { id: 'old11111', name: 'postdeploy-read:solaris' },
+            { id: 'keep2222', name: 'postdeploy-read:immich' }, // different service — untouched
+        ]);
+        await buildEnvLines('box', 'solaris', {});
+        expect(revokeToken).toHaveBeenCalledWith('old11111');
+        expect(revokeToken).not.toHaveBeenCalledWith('keep2222');
+    });
+
+    it('omits SB_READ_TOKEN (but still deploys) when the mint fails', async () => {
+        createToken.mockRejectedValue(new Error('token store unavailable'));
+        const out = await buildEnvLines('box', 'solaris', { FOO: 'bar' });
+        expect(out).not.toContain('SB_READ_TOKEN');
+        expect(out).toContain('SB_API_TOKEN=INTERNAL_HMAC');
+        expect(out).toContain(`FOO='bar'`);
+    });
+});

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -570,20 +570,63 @@ export class ServiceLifecycle {
     }
 
     /**
+     * Mint a durable, read-scoped Bearer token for a service's post-deploy to
+     * hand to its long-running consumers (#818). The token is minted HERE, in
+     * ServiceBay — NOT by the external post-deploy script — because minting a
+     * `neverExpires` credential idempotently is the platform's job, not a
+     * template's: the post-deploy can't recover a lost secret, can't dedupe
+     * without a round-trip, and lives in an external registry that may ship a
+     * stale copy (the #818 failure mode — the read token was never minted).
+     *
+     * Fresh each deploy (prior same-named tokens revoked → no accumulation, no
+     * plaintext-secret persistence). The token never expires, so it stays valid
+     * between deploys; the consumer just re-reads the injected value each deploy.
+     * Read scope only — the route-level `neverExpires ⇒ read-only` guard (#2299)
+     * is honoured here too (fail-closed to `read`). Best-effort: a mint failure
+     * returns null and the post-deploy simply runs without SB_READ_TOKEN.
+     */
+    private static async mintDurableReadToken(serviceName: string): Promise<string | null> {
+        try {
+            const { listTokens, createToken, revokeToken } = await import('@/lib/auth/apiTokens');
+            const tokenName = `postdeploy-read:${serviceName}`;
+            for (const t of (await listTokens()).filter(t => t.name === tokenName)) {
+                await revokeToken(t.id);
+            }
+            const { secret } = await createToken({
+                name: tokenName,
+                scopes: ['read'],
+                neverExpires: true,
+                createdBy: `internal:post-deploy:${serviceName}`,
+            });
+            return secret;
+        } catch (e) {
+            logger.warn('ServiceManager', `Could not mint durable read token for ${serviceName}:`, e);
+            return null;
+        }
+    }
+
+    /**
      * Build post-deploy script env file content with SB metadata.
      */
     private static async buildPostDeployEnvLines(
         nodeName: string,
+        serviceName: string,
         env: Record<string, string>,
     ): Promise<string> {
         const sbPort = process.env.PORT || '5888';
         const sbApiUrl = `http://localhost:${sbPort}`;
         const { getInternalApiToken } = await import('@/lib/auth/internalToken');
         const sbApiToken = getInternalApiToken();
+        // Durable, read-scoped Bearer for the service's long-running consumers
+        // (#818). Distinct from SB_API_TOKEN (the all-scopes internal HMAC, sent
+        // as X-SB-Internal-Token) — this is a real, least-privilege sb_ token the
+        // consumer presents as `Authorization: Bearer` and that never lapses.
+        const sbReadToken = await ServiceLifecycle.mintDurableReadToken(serviceName);
         const envLines = [
             `SB_NODE=${nodeName}`,
             `SB_API_URL=${sbApiUrl}`,
             `SB_API_TOKEN=${sbApiToken}`,
+            ...(sbReadToken ? [`SB_READ_TOKEN=${sbReadToken}`] : []),
             ...Object.entries(env).map(([k, v]) => {
                 if (typeof v !== 'string') return null;
                 const esc = v.replace(/'/g, `'\\''`);
@@ -687,7 +730,7 @@ export class ServiceLifecycle {
             return;
         }
 
-        const envLines = await ServiceLifecycle.buildPostDeployEnvLines(nodeName, env);
+        const envLines = await ServiceLifecycle.buildPostDeployEnvLines(nodeName, name, env);
         const envPath = `${scriptDir}/${name}.env`;
         const envWrite = await agent.sendCommand('write_file', { path: envPath, content: envLines + '\n' });
         if (envWrite !== 'ok') {


### PR DESCRIPTION
Closes #2317. Fixes the #818 token-staleness class at the platform layer.

## What
`ServiceLifecycle.buildPostDeployEnvLines` now mints the durable read token itself and injects it as `SB_READ_TOKEN`:
- `postdeploy-read:<service>`, `scopes:['read']`, `neverExpires:true` (fail-closed read-only per #2299)
- fresh each deploy; prior same-named tokens revoked (no accumulation, no plaintext-secret persistence)
- best-effort: mint failure omits the var, deploy still runs

`SB_READ_TOKEN` (real least-privilege `sb_` Bearer, never lapses) is distinct from `SB_API_TOKEN` (all-scopes internal HMAC via `X-SB-Internal-Token`).

## Why
On the box, `solaris-unattended-read` was never minted and the token file didn't exist — the Solaris pollers fell back to a ~1h rotating admin token that went stale (#818). Minting a non-expiring credential idempotently is the platform's job, not an external, stale-prone, untestable template post-deploy's.

## Tests
`serviceLifecycle.postDeployReadToken.test.ts` — injection contract, prior-token revocation, graceful mint-failure. tsc + eslint clean (0 errors).

## Follow-up (solarisbay)
Layer 2: Solaris post-deploy simplifies to `echo "$SB_READ_TOKEN" > $path`; all consumers use `read_sb_token`. The immediate #818 unblock (manual token in `/var/lib/solaris/sb-read-token`) is already live on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)