### PR TITLE
fix(registry): fall back to registries when a 'Built-in' source misses (#2320)

### DIFF
--- a/packages/backend/src/lib/registry.local.test.ts
+++ b/packages/backend/src/lib/registry.local.test.ts
@@ -43,6 +43,7 @@ import {
   getStackManifest,
   readTemplateFile,
   getTemplateUserGuide,
+  getTemplatePostDeployScript,
 } from './registry';
 
 const LOCAL_DIR = path.join(ROOTS.dataRoot, 'local-templates');
@@ -179,6 +180,32 @@ describe('local persistent source (#1919)', () => {
 
     // A file the template doesn't ship resolves to null, not a throw.
     expect(await readTemplateFile('solaris', 'does-not-exist.md')).toBeNull();
+  });
+
+  it('resolves a registry template through a stale "Built-in" source record (#818 fallback)', async () => {
+    // The solaris post-deploy that mints the /napi read token was silently
+    // skipped for weeks: its saved JobInput carried templateSource:'Built-in',
+    // and readTemplateFile('post-deploy.py', 'Built-in') looked ONLY in the
+    // bundled built-in dir (where solaris isn't) → returned null → the deploy
+    // shipped with no post-deploy. It's actually shipped by a registry, so a
+    // 'Built-in' miss must fall back to the registries.
+    // Manifest-less registry (no servicebay.json) → legacy layout
+    // REGISTRIES_DIR/<reg>/templates/<name>/. REGISTRIES_DIR lives under the
+    // config dir (CONTAINER_CONFIG_DIR), not the data mount.
+    const regDir = path.join(ROOTS.cfgRoot, 'registries', 'solbay', 'templates', 'solaris');
+    await fs.mkdir(regDir, { recursive: true });
+    await fs.writeFile(path.join(regDir, 'post-deploy.py'), '# mints SB_READ_TOKEN\nprint("solaris post-deploy")');
+    mockConfigState.registries.items = [{ name: 'solbay', url: 'https://github.com/mdopp/solbay' }];
+
+    // The stale/default 'Built-in' source still resolves it via the fallback.
+    const viaBuiltin = await getTemplatePostDeployScript('solaris', 'Built-in');
+    expect(viaBuiltin).toContain('mints SB_READ_TOKEN');
+    // …and no-source resolution finds it too.
+    expect(await getTemplatePostDeployScript('solaris')).toContain('mints SB_READ_TOKEN');
+    // A genuinely-absent template stays null (no false positive).
+    expect(await getTemplatePostDeployScript('nonesuch', 'Built-in')).toBeNull();
+
+    await fs.rm(path.join(ROOTS.cfgRoot, 'registries'), { recursive: true, force: true });
   });
 
   it('returns no local items when the local dir is absent', async () => {

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -1117,6 +1117,10 @@ export async function getTemplatePostDeployScript(name: string, source?: string)
  *   source (a registry name)  → only that registry
  *   no source                 → local → every configured registry →
  *                               bundled built-in templates
+ *   source === 'Built-in'     → built-in first, then fall back to the
+ *                               registries (a stale/default 'Built-in' source
+ *                               record for a registry-shipped template must
+ *                               still resolve — #818)
  *
  * Returns the raw file content, or `null` when the file isn't present in
  * the resolved location(s). This is the single primitive behind
@@ -1145,19 +1149,36 @@ export async function readTemplateFile(
     return tryRead(await resolveRegistryItemPath(source, 'template', name));
   }
 
+  const config = await getConfig();
+  const registries = getRegistries(config);
+
   if (!source) {
+    // No source → local → every registry → built-in (order unchanged).
     const local = await tryRead(localItemPath('template', name));
     if (local !== null) return local;
-    const config = await getConfig();
-    const registries = getRegistries(config);
     for (const reg of registries) {
       const found = await tryRead(await resolveRegistryItemPath(reg.name, 'template', name));
       if (found !== null) return found;
     }
+    // `name` is request-supplied → single-segment barrier.
+    return tryRead(safeJoin(TEMPLATES_PATH, name));
   }
 
-  // `name` is request-supplied → single-segment barrier.
-  return tryRead(safeJoin(TEMPLATES_PATH, name));
+  // source === 'Built-in': honour the explicit request (built-in first), but
+  // if it MISSES, fall back to the registries. A template recorded with the
+  // default/stale 'Built-in' source that is actually shipped by a registry
+  // (e.g. `solaris` from the solbay/oscar registry) must still resolve — else
+  // its post-deploy is silently skipped. This was the root of #818: the
+  // solaris post-deploy that mints the /napi read token never ran because the
+  // saved JobInput carried templateSource:'Built-in', so getTemplatePostDeploy
+  // Script returned null and the deploy quietly shipped with no post-deploy.
+  const builtIn = await tryRead(safeJoin(TEMPLATES_PATH, name));
+  if (builtIn !== null) return builtIn;
+  for (const reg of registries) {
+    const found = await tryRead(await resolveRegistryItemPath(reg.name, 'template', name));
+    if (found !== null) return found;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
Closes #2320. The **real root cause of #818**, found by testing the full deploy path on the box.

## What
`readTemplateFile(..., 'Built-in')` looked only in the bundled built-in dir. A registry template recorded with a stale/default `'Built-in'` source (the saved solaris JobInput) resolved to `null` → `getTemplatePostDeployScript` returned null → the runner's `catch {}` silently shipped the deploy with **no post-deploy**. Now a `'Built-in'` miss falls back to the registries (built-in checked first; no-source order unchanged).

## Why it matters
The solaris post-deploy mints the durable `/napi` read token. It never ran for weeks because of this — that's #818. `deploy_service`/auto-update don't run post-deploys either, so nothing else caught it.

## Verified live on the box
Replaying the saved solaris JobInput with `templateSource:'Built-in'` → `solaris.env` untouched, no token. Forcing all-source resolution → post-deploy ran, minted `postdeploy-read:solaris`, wrote the token file, authenticates `/napi/approvals` + `/napi/home` → **200**. This PR makes that the default.

## Tests
`registry.local.test.ts`: Built-in-miss → registry fallback; no-source order preserved; absent template still null.

## Follow-ups (separate)
- Box registry hygiene: config→`mdopp/solbay`, on-disk→`mdopp/oscar`, current→`mdopp/solarisbay` (all stale).
- Runner `catch {}` should LOG a skipped/unresolved post-deploy (defence in depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)