### PR TITLE
MCP-Oberfläche verschlanken: Tool-Konsolidierung + Standards-Index + scope-gefilterte tools/list (#2323 #2324 #2325)

### DIFF
--- a/.claude/skills/comment-responder/SKILL.md
+++ b/.claude/skills/comment-responder/SKILL.md
@@ -44,7 +44,7 @@ Don't reply to the surface. For each thread:
 
 If the comment makes a technical claim, or your reply would assert how the system behaves, **check the actual state first** — don't reason it out from how things "should" work. The dev env and the running box diverge, and a confident wrong answer to a careful contributor costs more trust than taking ten minutes to look.
 
-- Read the **code** that's actually in play, and — when the claim is about runtime/permissions/config/networking — inspect the **live box** (SSH via `build/fcos/servicebay-ssh/id_rsa`, or the `mcp__servicebay__*` tools: `exec_command`, `get_container_logs`, `diagnose`, `list_containers`). `reference_mcp_servicebay_access` has the connection paths and the reinstall gotchas.
+- Read the **code** that's actually in play, and — when the claim is about runtime/permissions/config/networking — inspect the **live box** (SSH via `build/fcos/servicebay-ssh/id_rsa`, or the `mcp__servicebay__*` tools: `exec_command`, `get_logs`, `diagnose`, `list_containers`). `reference_mcp_servicebay_access` has the connection paths and the reinstall gotchas.
 - Let the findings **change the answer**, including your own earlier framing. The #1311 case below is the cautionary tale: the obvious "set `UMASK=002` on the writers" fix was *wrong* — inspecting the box showed those services run as root with no umask knob, which flipped the recommendation to a default ACL. We'd have shipped bad advice without looking.
 - When the investigation overturns or sharpens what the **issue/PR body** says, fold the corrected facts back into the body (via `gh api -X PATCH repos/mdopp/servicebay/issues/<N> -F body=@file`) so the next reader starts from the truth — then reference it in the reply.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,11 @@ COPY --from=builder /app/stacks ./stacks
 # tools; resolves at /app/assists via process.cwd(), like templates/ + stacks/.
 COPY --from=builder /app/assists ./assists
 
+# ADR titles scanned at runtime by the get_service_standards MCP tool (#2323)
+# so its mustRespectAdrs one-liners never drift from the source. Resolves at
+# /app/docs/adr via process.cwd(), like assists/. Only the ADR dir is shipped.
+COPY --from=builder /app/docs/adr ./docs/adr
+
 # Markdown content rendered at runtime by /api/help (per-page contextual
 # help, plus the CHANGELOG entry for the sidebar "What's new" modal). The
 # route reads `process.cwd()/src/content/help/<id>.md`, so the files must

--- a/README.md
+++ b/README.md
@@ -201,11 +201,11 @@ keypair that the in-container agent uses to manage the host.
 
 Every UI action has an HTTP equivalent under `/api/`. For LLM-driven
 automation, ServiceBay also exposes a [Model Context Protocol](https://modelcontextprotocol.io)
-server at `/mcp` (session-cookie auth — same as the UI), publishing 62 tools
+server at `/mcp` (session-cookie auth — same as the UI), publishing tools
 across services, containers, proxy, backups, health checks, and config:
-read paths like `list_nodes`, `list_services`, `get_container_logs`,
+read paths like `list_nodes`, `list_services`, `get_logs`,
 `get_network_graph`, `get_health_checks`, …, and write paths like
-`start_service`/`stop_service`/`restart_service`, `update_service_yaml`,
+`manage_service` (start/stop/restart), `update_service_yaml`,
 `add_proxy_route`/`remove_proxy_route`, `run_backup`/`restore_backup`,
 `create_health_check`/`run_check_now`, `get_config`/`update_config`,
 `exec_command`. Sensitive fields (`auth.passwordHash`, `oidc.clientSecret`,

--- a/assists/generic-project-standards.md
+++ b/assists/generic-project-standards.md
@@ -1,0 +1,47 @@
+---
+title: Generic project standards — platform-agnostic dev discipline
+whenToUse: You want the provider- and platform-agnostic development standards (commit convention, release discipline, coverage floor, secret hygiene, scripts-over-prose) for any new project, without the ServiceBay-specific ADRs or template details.
+kind: checklist
+tags: [standards, generic, commit-convention, release, coverage, secret-hygiene, index]
+---
+
+# Generic project standards
+
+Platform-agnostic development discipline for building any new project. No
+ServiceBay-specific ADRs or template details — those live in the `servicebay`
+flavor of `get_service_standards`. Fetch that flavor when you're inside this
+repo; use this one for a fresh, unrelated project.
+
+## commitConvention — Conventional Commits
+
+Commit subjects follow `type(scope): description` (e.g. `fix(api): reject empty
+body`). Keep the subject parser-clean — no extra parentheses beyond the
+conventional `(scope)`, since release tooling parses these.
+
+## releaseDiscipline — never hand-bump versions
+
+Releases are automated from the commit history (the release-please principle):
+never edit a version, changelog, or release manifest by hand. Let the release
+tool derive the next version from the Conventional Commits since the last tag.
+
+## testAndCoverage — a diff-coverage floor
+
+New and changed code carries tests. Hold a **diff-coverage floor of 70 %** on
+changed lines — a change that drops coverage on the lines it touches doesn't
+merge. Prefer a test that encodes each acceptance criterion so it can't silently
+regress later.
+
+## secretHygiene — no literal secrets in the repo
+
+Committed files (source, tests, fixtures, docs) contain **no** real secrets: no
+private keys, API tokens, passwords, or bearer credentials. Express secrets as
+typed variables injected at deploy/runtime; placeholders are fine, concrete
+values are not. Assume any secret-scanning backstop won't catch every shape —
+be careful at the source.
+
+## scriptsOverProse — deterministic steps belong in scripts
+
+Deterministic, repeatable steps belong in a checked-in script, not in prose an
+agent re-interprets each run. Reserve human/LLM judgment for what to verify and
+why a failure happened; let a script run the mechanics (fixed flags, hard-capped
+polls, guaranteed cleanup) — cheaper and zero-variance.

--- a/assists/new-service-standards.md
+++ b/assists/new-service-standards.md
@@ -1,0 +1,66 @@
+---
+title: ServiceBay service-standards index — what a new service must respect
+whenToUse: You're starting a new ServiceBay service and need the curated pointer index — which platform ADRs to respect, the enforced invariants + gate commands, which assists to read in full, and where the template contract lives.
+kind: checklist
+tags: [standards, new-service, adr, invariants, template-contract, index, servicebay]
+---
+
+# ServiceBay service-standards index
+
+A curated *pointer* index (not the full text) for building a new ServiceBay
+service. Fetch the referenced assists in full via `get_assist(id)`, and read the
+referenced `docs/` files directly. The `get_service_standards` MCP tool
+(`flavor: 'servicebay'`) assembles a live version of this index — the ADR
+one-liners are scanned from `docs/adr/*.md` titles at runtime so they never
+drift from the source.
+
+## mustRespectAdrs — the platform decisions a new service is bound by
+
+A new service does not get to re-litigate these. Read the one-liner, then the
+full ADR at the given path when it touches your service.
+
+- **0001** — every user-facing service authenticates via Authelia SSO (or at
+  minimum LDAP against LLDAP). `docs/adr/0001-authentication-via-authelia-sso-or-lldap.md`
+- **0003** — versioning and releases go through release-please only; never
+  hand-bump a version, keep commit subjects parser-clean.
+  `docs/adr/0003-releases-via-release-please-only.md`
+- **0004** — installs/redeploys are non-destructive; they never wipe other
+  services. `docs/adr/0004-installs-are-non-destructive.md`
+- **0007** — app containers run in an isolated netns; only named carve-outs stay
+  on host networking. `docs/adr/0007-container-network-isolation-and-carveouts.md`
+- **0009** — the token & trust model between services (scoped, short-lived
+  grants; no ambient authority). `docs/adr/0009-service-tokens-and-trust.md`
+- **0010** — the Node runtime tracks the Node 20 line, kept consistent across
+  all sources. `docs/adr/0010-node-20-minor-floats.md`
+
+## enforcedInvariants — mechanically checked, run the gates
+
+The full list lives in `docs/ARCHITECTURE_INVARIANTS.md`. They are enforced by
+scripts, not prose, so run the gates before an architecture change and before
+opening a PR:
+
+- `npm run check:arch` — architecture invariants + dependency-cruiser.
+- `npm run lint` — zero errors; don't raise the warning count.
+- Diff-coverage floor: **70 %** on changed lines.
+
+## assistsToRead — fetch these in full via `get_assist(id)`
+
+- `new-service-architecture` — recommended defaults (language, structure,
+  libraries, tests, storage, secrets) plus the ADRs a new service must respect.
+- `create-service` — the concrete recipe to build and deploy a service repo
+  behind SSO.
+- `servicebay-overview` — what the platform is and how the pieces fit together.
+- Footguns to skim: `footgun-forward-auth-acme-collision`,
+  `footgun-subdomain-needs-public-domain`.
+
+Read `whenToUse` on each (via `list_assists`) to self-select, then
+`get_assist(id)` for the full body.
+
+## templateContract — where the template rules live
+
+Services ship as **templates**, not code. The contract:
+
+- `docs/TEMPLATE_AUTHORING.md` — how to author a template (variables, secrets,
+  kube pod shape).
+- `templates/CLAUDE.md` — the template contract that auto-loads under
+  `templates/`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ A deeper structural pass surfaced seven additional issues beyond the original au
 
 ### Investigated but ruled out
 
-- **`get_container_logs` / `get_service_logs` command injection.** Zod regex `/^[a-zA-Z0-9_.-]+$/` admits no shell metacharacters; `lines`/`tail`/`since` are typed integers. Not exploitable.
+- **`get_logs` (service/container sources) command injection.** Zod regex `/^[a-zA-Z0-9_.-]+$/` on `name`/`container` admits no shell metacharacters; `lines`/`since` are typed integers. Not exploitable.
 - **MCP `update_config` prototype pollution.** Zod `.strict()` rejects unknown keys; `templateSettings` values are string-typed; `deepMerge` only recurses when both sides are objects, so a string `__proto__` assignment is a no-op.
 
 ## Overview
@@ -406,10 +406,10 @@ sequenceDiagram
 *   **Endpoint**: `POST /mcp` — handled directly in `server.ts` (intercepts the request before the Next.js handler) and bridged to `@modelcontextprotocol/sdk`'s `StreamableHTTPServerTransport`. Authentication is the same `session` cookie the UI uses, decoded via `getSessionFromCookieHeader`. No additional token surface.
 *   **Stateless**: a fresh `McpServer` + transport are created per request, both closed when the response stream ends. No long-lived sessions.
 *   **Tool surface** (`packages/backend/src/lib/mcp/server.ts`, 37 tools):
-    *   *Read*: `list_nodes`, `list_services`, `list_containers`, `get_container_logs`, `get_service_logs`, `get_system_info`, `get_network_graph`, `get_health_checks`, `get_gateway_status`, `get_proxy_routes`, `list_templates`, `get_template_readme`/`yaml`/`variables`, `verify_node_connection`, `get_podman_logs`, `list_system_services`, `get_config`.
-    *   *Mutate*: `start_service`/`stop_service`/`restart_service`, `deploy_service`/`update_service_yaml`/`delete_service`/`rename_service`, `add_proxy_route`/`remove_proxy_route`, `run_backup`/`restore_backup`/`list_backups`, `create_health_check`/`delete_health_check`/`run_check_now`, `update_config`, `exec_command`, `refresh_agent`.
+    *   *Read*: `list_nodes`, `list_services`, `list_containers`, `get_logs` (`source: service\|container\|podman`), `get_system_info`, `get_network_graph`, `get_health_checks`, `get_gateway_status`, `get_proxy_routes`, `list_templates`, `get_template_artifact` (`artifact: readme\|yaml\|variables`), `verify_node_connection`, `list_system_services`, `get_config`.
+    *   *Mutate*: `manage_service` (`action: start\|stop\|restart`), `deploy_service`/`update_service_yaml`/`delete_service`/`rename_service`, `add_proxy_route`/`remove_proxy_route`, `run_backup`/`restore_backup`/`list_backups`, `create_health_check`/`delete_health_check`/`run_check_now`, `update_config`, `exec_command`, `refresh_agent`.
 *   **SoT alignment**: all tools route through the same Digital Twin / `ServiceManager` / `HealthStore` paths the UI uses — no parallel mutation surface. `update_config` is allow-listed (`logLevel`, `serverName`, `domain`, `autoUpdate`, `templateSettings`); auth/OIDC/SMTP credentials are intentionally excluded so they always need a human in the loop.
-*   **Secret hygiene**: `get_config` redacts `auth.passwordHash`, `oidc.clientSecret`, `notifications.email.pass`. Inputs that flow into a shell command (container id, service name, domain) are constrained with regex schemas to prevent command injection through the `exec_command` / `get_container_logs` / `get_service_logs` paths.
+*   **Secret hygiene**: `get_config` redacts `auth.passwordHash`, `oidc.clientSecret`, `notifications.email.pass`. Inputs that flow into a shell command (container id, service name, domain) are constrained with regex schemas to prevent command injection through the `exec_command` / `get_logs` paths.
 
 ### 5. Network Graph Aggregation
 *   **Goal**: Visualize the relationships between Nodes, Services, and the Internet.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -62,8 +62,8 @@ shell should join that allowlist explicitly rather than route around
 it. See `safety.ts` for the pattern.
 
 **Worked example:** `lib/mcp/server.ts:257` (`list_nodes`) for a
-read tool; `lib/mcp/server.ts` `start_service`/`stop_service` for the
-mutating-with-scope pattern.
+read tool; `lib/mcp/server.ts` `manage_service` for the
+mutating-with-scope + discriminator pattern.
 
 **Testing:** add a case to `lib/mcp/safety.test.ts` if the tool wraps
 something dangerous, and rely on the integration coverage that already

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -169,6 +169,49 @@ release discipline, coverage floor, secret hygiene, scripts-over-prose) with no
 ServiceBay ADRs or template details. Backing prose lives single-sourced in the
 `new-service-standards` / `generic-project-standards` assists.
 
+## Tool visibility is scoped to your token (#2325)
+
+`tools/list` returns **only the tools your token could actually call**. A tool
+is advertised iff its required scope (`TOOL_SCOPES` in
+`packages/backend/src/lib/mcp/server.ts`) is within your token's granted scopes,
+using the same implication ladder the gate uses (`destroy` implies `reboot` +
+`exec`; see `SCOPE_AUDIT.md`). So:
+
+- a **read-only** token sees only the `read`-tier tools — no
+  mutate/destroy/exec/lifecycle tools ever appear in its list;
+- a **lifecycle** token additionally sees `manage_service`, `run_backup`, … ;
+- a **cookie / session (operator)** client sees the full surface (cookie auth
+  carries all scopes by design).
+
+This is **visibility only** — it changes what's *advertised*, never what's
+*allowed*. Enforcement is unchanged: `safeHandler` remains the single authority,
+so a tool that a token can't see still exists and, if called by id, is refused
+at the scope gate (`Token scope '…' required for …`) — **not** with a
+"tool not found". Advertising less means fewer tokens in-context and fewer
+wrong picks for small models, plus least-privilege (don't advertise what you
+can't invoke).
+
+**Deterministic ordering.** The returned list is sorted by tool name and is
+stable per token across requests. Tool definitions render at prompt position 0
+(`tools → system → messages`), so a stable, deterministic order is what lets a
+client prompt-cache them: any add/remove/reorder invalidates that cache, and a
+scope-filtered list is cache-safe precisely because it's fixed per token and
+isn't rebuilt mid-session.
+
+### `defer_loading` kernel set
+
+A small **always-on core** is designated in `MCP_KERNEL_TOOLS`
+(`server.ts`): `list_services`, `list_containers`, `diagnose`, `get_logs`,
+`get_system_info` — all `read`-tier, so every token (down to read-only) sees the
+whole kernel. A client using the Anthropic **Tool Search Tool**
+(`tool_search_tool_regex_20251119` / `tool_search_tool_bm25_20251119`) can keep
+this kernel eagerly loaded and mark the rest `defer_loading: true`, lazy-loading
+a tool's schema only when it's needed. Because deferred schemas are **appended,
+not swapped**, the prompt cache stays intact. Enabling Tool Search is a
+**client-side decision** — ServiceBay doesn't force it; it just designates the
+kernel and keeps descriptions terse so the remaining surface is cheap to search
+and lazy-load.
+
 ### Channel switching
 
 `get_channel` and `set_channel` let an LLM (or the operator) flip the

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -3,10 +3,11 @@
 ServiceBay exposes a [Model Context Protocol](https://modelcontextprotocol.io)
 server at `/mcp` so an AI assistant — Claude Code, Claude Desktop, or anything
 else that speaks MCP — can drive your homelab directly. Available tools include
-`list_services`, `start_service` / `stop_service` / `restart_service`,
-`update_service_yaml`, `add_proxy_route`, `run_backup`, `get_health_checks`,
-`exec_command`, and ~30 others. Sensitive fields (`auth.passwordHash`,
-SMTP/OIDC secrets) are redacted on read and write-allowlisted.
+`list_services`, `manage_service` (start/stop/restart via an `action`),
+`get_logs` (service/container/podman via a `source`), `update_service_yaml`,
+`add_proxy_route`, `run_backup`, `get_health_checks`, `exec_command`, and ~30
+others. Sensitive fields (`auth.passwordHash`, SMTP/OIDC secrets) are redacted
+on read and write-allowlisted.
 
 ## Quick start (Claude Code)
 
@@ -136,12 +137,20 @@ Claude Code) to see the live tool registry on your version.
 
 | Category | Tools |
 |----------|-------|
-| Services | `list_services`, `start_service`, `stop_service`, `restart_service`, `deploy_service`, `update_service_yaml`, `delete_service`, `rename_service` |
-| Containers | `list_containers`, `get_container_logs`, `get_podman_logs` |
+| Services | `list_services`, `manage_service` (`action: start\|stop\|restart`), `deploy_service`, `update_service_yaml`, `delete_service`, `rename_service` |
+| Containers / logs | `list_containers`, `get_logs` (`source: service\|container\|podman`) |
+| Templates | `list_templates`, `get_template_artifact` (`artifact: readme\|yaml\|variables`), `install_template` |
 | Health | `get_health_checks`, `create_health_check`, `delete_health_check`, `run_check_now` |
-| Proxy | `get_proxy_routes`, `add_proxy_route`, `remove_proxy_route` |
+| Proxy | `get_proxy_routes`, `add_proxy_route`, `create_proxy_route`, `remove_proxy_route` |
+| Requests | `list_requests` (`type: access\|token`), `file_access_request`, `get_access_request_status`, `request_token`, `poll_token_request` |
 | Backups | `list_backups`, `run_backup`, `restore_backup` |
 | System | `list_nodes`, `get_system_info`, `get_network_graph`, `get_config`, `update_config`, `exec_command`, `get_channel`, `set_channel` |
+
+The three merged tools above (`manage_service`, `get_logs`,
+`get_template_artifact`) plus `list_requests` replaced nine (+2) narrower tools
+in #2324 — a **breaking change** to the tool surface. Each stays in its original
+scope: `get_logs` / `get_template_artifact` / `list_requests` are `read`,
+`manage_service` is `lifecycle`.
 
 Sensitive config fields (`auth.passwordHash`, `oidc.clientSecret`, SMTP
 passwords) are redacted from `get_config` and write-allowlisted in

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -145,6 +145,7 @@ Claude Code) to see the live tool registry on your version.
 | Requests | `list_requests` (`type: access\|token`), `file_access_request`, `get_access_request_status`, `request_token`, `poll_token_request` |
 | Backups | `list_backups`, `run_backup`, `restore_backup` |
 | System | `list_nodes`, `get_system_info`, `get_network_graph`, `get_config`, `update_config`, `exec_command`, `get_channel`, `set_channel` |
+| Knowledge | `list_assists`, `get_assist`, `get_service_standards` (`flavor: servicebay\|generic`) |
 
 The three merged tools above (`manage_service`, `get_logs`,
 `get_template_artifact`) plus `list_requests` replaced nine (+2) narrower tools
@@ -155,6 +156,18 @@ scope: `get_logs` / `get_template_artifact` / `list_requests` are `read`,
 Sensitive config fields (`auth.passwordHash`, `oidc.clientSecret`, SMTP
 passwords) are redacted from `get_config` and write-allowlisted in
 `update_config`.
+
+`get_service_standards` (`read` scope) returns a curated *pointer* index for
+building a new project. `flavor: 'servicebay'` (default) yields four blocks —
+`mustRespectAdrs` (the platform ADRs a new service is bound by, with titles
+scanned live from `docs/adr/*.md` so they never drift), `enforcedInvariants`
+(pointer to `docs/ARCHITECTURE_INVARIANTS.md` + the gate commands and 70 %
+diff-coverage floor), `assistsToRead` (ids resolvable via `get_assist`), and
+`templateContract` (pointers to `docs/TEMPLATE_AUTHORING.md` + `templates/CLAUDE.md`).
+`flavor: 'generic'` yields platform-agnostic dev standards (commit convention,
+release discipline, coverage floor, secret hygiene, scripts-over-prose) with no
+ServiceBay ADRs or template details. Backing prose lives single-sourced in the
+`new-service-standards` / `generic-project-standards` assists.
 
 ### Channel switching
 

--- a/docs/SCOPE_AUDIT.md
+++ b/docs/SCOPE_AUDIT.md
@@ -70,6 +70,15 @@ Source of truth is `TOOL_SCOPES`. Summary by tier (see `server.ts` for the full 
 | `destroy` | `delete_service`, `delete_health_check`, `remove_proxy_route`, `restore_backup`, `purge_trashed_service`, `set_boot_next_usb`, `factory_reset` |
 | `exec` | `exec_command`, `container_exec` |
 
+**Scope-filtered visibility (#2325).** Surface (1) also *hides* what a token
+can't call: `tools/list` advertises only tools whose `TOOL_SCOPES` scope is
+within the caller's granted scopes (same `tokenHasScope` ladder), sorted by name
+and stable per token. A read-only token therefore never *sees* a
+mutate/destroy/exec tool. This is visibility only — the gate above is unchanged,
+so a filtered-out tool called by id is still refused at `safeHandler` (scope
+error, not "not found"). A no-auth/cookie caller (all scopes) sees the full
+surface. See `docs/MCP.md` → "Tool visibility is scoped to your token".
+
 ## REST route → scope (surface 2)
 
 Every REST route that accepts a named API token, with the scope it gates on. Routes

--- a/docs/SCOPE_AUDIT.md
+++ b/docs/SCOPE_AUDIT.md
@@ -64,7 +64,7 @@ Source of truth is `TOOL_SCOPES`. Summary by tier (see `server.ts` for the full 
 | Scope | Tools |
 |---|---|
 | `read` | `list_*`, `get_*`, `diagnose`, `read_file`, `list_dir`, `disk_usage`, `verify_node_connection`, `verify_usb_boot`, … |
-| `lifecycle` | `start_service`, `stop_service`, `restart_service`, `run_check_now`, `refresh_agent`, `run_backup`, `set_channel` |
+| `lifecycle` | `manage_service`, `run_check_now`, `refresh_agent`, `run_backup`, `set_channel` |
 | `mutate` | `deploy_service`, `update_service_yaml`, `rename_service`, `add_proxy_route`, `create_health_check`, `restore_trashed_service`, `file_access_request`, `update_config` |
 | `reboot` | `reboot_node` |
 | `destroy` | `delete_service`, `delete_health_check`, `remove_proxy_route`, `restore_backup`, `purge_trashed_service`, `set_boot_next_usb`, `factory_reset` |

--- a/docs/TEMPLATE_LOGGING.md
+++ b/docs/TEMPLATE_LOGGING.md
@@ -19,7 +19,7 @@ That covers the four things a log line needs: **when**, **who**,
 containers emit JSON-lines on stdout matching the same shape land in
 the same searchable surface once the JSON-ingester is wired up.
 Templates whose containers emit raw stdout work today via
-`get_container_logs` and `get_podman_logs` (which stream stdout
+`get_logs` (source="container" / source="podman", which stream stdout
 verbatim) — they're just not searchable by structured fields.
 
 ## What to emit
@@ -89,7 +89,7 @@ separate from the log store.
 
 ## What ServiceBay does with the output today
 
-- `get_container_logs` / `get_podman_logs` MCP tools stream the raw
+- `get_logs` (source="container" / source="podman") MCP tool streams the raw
   stdout of a service's containers to the operator on demand.
 - The journald shipper indexes by service name and timestamp, so
   searches by container + time window work without any structured

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -55,7 +55,7 @@ short-lived, least-privilege token rather than being handed one — an admin
 approves it out-of-band.
 
 **How it works.** `packages/backend/src/lib/auth/tokenRequests.ts` +
-the MCP tools `request_token`, `poll_token_request`, `list_token_requests` (#2139):
+the MCP tools `request_token`, `poll_token_request`, `list_requests(type="token")` (#2139):
 
 1. The caller names the scopes it wants, a human reason, and a requested TTL —
    and gets back a **pending request id, not a token**.

--- a/packages/backend/src/lib/mcp/redact.ts
+++ b/packages/backend/src/lib/mcp/redact.ts
@@ -1,8 +1,8 @@
 /**
  * Secret-redaction helpers for MCP read tools (#321).
  *
- * Three of the read-scope MCP tools (`get_service_files`,
- * `get_service_logs`, `get_container_logs`) can otherwise hand back the
+ * The read-scope MCP tools `get_service_files` and `get_logs` (the
+ * service/container log sources) can otherwise hand back the
  * very secrets the operator typed into the install wizard:
  *
  *  - The kube YAML returned by `get_service_files` has env vars like

--- a/packages/backend/src/lib/mcp/safety.ts
+++ b/packages/backend/src/lib/mcp/safety.ts
@@ -54,7 +54,7 @@ async function mutationsAllowed(): Promise<boolean> {
  * Gate a mutating tool. Returns null if allowed; an error result otherwise.
  * Caller pattern:
  *
- *     const blocked = await guardMutation('start_service');
+ *     const blocked = await guardMutation('manage_service');
  *     if (blocked) return blocked;
  *     // ...do the mutation...
  */

--- a/packages/backend/src/lib/mcp/server.accessRequest.test.ts
+++ b/packages/backend/src/lib/mcp/server.accessRequest.test.ts
@@ -153,7 +153,7 @@ describe('access-request MCP tools (#1818)', () => {
     await client.close();
   });
 
-  it('list_access_requests filters by status (pending by default, approved/denied/all)', async () => {
+  it('list_requests(type="access") filters by status (pending by default, approved/denied/all)', async () => {
     const { client } = await connectClient();
     await client.callTool({ name: 'file_access_request', arguments: { subject: 'Pending One' } });
     await client.callTool({ name: 'file_access_request', arguments: { subject: 'Approved One' } });
@@ -163,18 +163,18 @@ describe('access-request MCP tools (#1818)', () => {
     store.accessRequests![2].status = 'denied';
     store.accessRequests![3].status = 'resolved'; // legacy → approved
 
-    const pending = parse(await client.callTool({ name: 'list_access_requests', arguments: {} }));
+    const pending = parse(await client.callTool({ name: 'list_requests', arguments: { type: 'access' } }));
     expect(pending.requests.map((r: { subject: string }) => r.subject)).toEqual(['Pending One']);
 
-    const approved = parse(await client.callTool({ name: 'list_access_requests', arguments: { status: 'approved' } }));
+    const approved = parse(await client.callTool({ name: 'list_requests', arguments: { type: 'access', status: 'approved' } }));
     expect(approved.requests.map((r: { subject: string }) => r.subject)).toEqual(['Approved One', 'Legacy Resolved']);
     // Legacy 'resolved' is normalized in the response too.
     expect(approved.requests.every((r: { status: string }) => r.status === 'approved')).toBe(true);
 
-    const denied = parse(await client.callTool({ name: 'list_access_requests', arguments: { status: 'denied' } }));
+    const denied = parse(await client.callTool({ name: 'list_requests', arguments: { type: 'access', status: 'denied' } }));
     expect(denied.requests.map((r: { subject: string }) => r.subject)).toEqual(['Denied One']);
 
-    const all = parse(await client.callTool({ name: 'list_access_requests', arguments: { status: 'all' } }));
+    const all = parse(await client.callTool({ name: 'list_requests', arguments: { type: 'access', status: 'all' } }));
     expect(all.requests).toHaveLength(4);
     await client.close();
   });

--- a/packages/backend/src/lib/mcp/server.test.ts
+++ b/packages/backend/src/lib/mcp/server.test.ts
@@ -5,7 +5,7 @@ import { createMcpServer, TOOL_SCOPES, tokenHasScope } from './server';
 import { ALL_SCOPES } from '@/lib/auth/apiScope';
 
 // #1732: the MCP server describes itself — a top-level `instructions` string
-// teaching the node → service → container model, and the four
+// teaching the node → service → container model, and the
 // service/container/log tools mention that model in their descriptions.
 // Verified end-to-end through the SDK initialize + tools/list handshake.
 async function connectClient() {
@@ -27,7 +27,7 @@ describe('createMcpServer self-description (#1732)', () => {
     expect(instructions).toMatch(/node\s*→\s*service\s*→\s*container/);
     // Tells the agent how to find an app's logs and to resolve names itself.
     expect(instructions).toMatch(/list_services/);
-    expect(instructions).toMatch(/get_container_logs/);
+    expect(instructions).toMatch(/get_logs/);
     expect(instructions).toMatch(/resolve.*names?.*yourself|rather than asking the user/i);
     await client.close();
   });
@@ -40,9 +40,70 @@ describe('createMcpServer self-description (#1732)', () => {
     expect(byName.list_services).toMatch(/container/i);
     expect(byName.list_services).toMatch(/associatedContainerIds/);
     expect(byName.list_containers).toMatch(/<service>-<app>/);
-    expect(byName.get_service_logs).toMatch(/get_container_logs/);
-    expect(byName.get_container_logs).toMatch(/<service>-<app>/);
+    // get_logs (#2324) is the merged reader — it explains the service vs
+    // container source and points at the `<service>-<app>` naming model.
+    expect(byName.get_logs).toMatch(/source/);
+    expect(byName.get_logs).toMatch(/<service>-<app>/);
     await client.close();
+  });
+});
+
+// #2324: consolidate 9 near-duplicate tools into 3 parameterised ones,
+// hard-replacing the old names. Each merged tool keeps its cluster's scope.
+describe('MCP tool consolidation (#2324)', () => {
+  const OLD_NAMES = [
+    'get_service_logs', 'get_container_logs', 'get_podman_logs',
+    'start_service', 'stop_service', 'restart_service',
+    'get_template_readme', 'get_template_yaml', 'get_template_variables',
+    // Tier-2 merged pair (list_requests):
+    'list_access_requests', 'list_token_requests',
+  ];
+
+  it('drops all 9 (+2 Tier-2) old tool names from the tool list', async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const names = new Set(tools.map(t => t.name));
+    for (const old of OLD_NAMES) {
+      expect(names.has(old), `${old} must be gone (hard replace)`).toBe(false);
+    }
+    await client.close();
+  });
+
+  it('registers the 3 merged Tier-1 tools + Tier-2 list_requests', async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const names = new Set(tools.map(t => t.name));
+    for (const merged of ['get_logs', 'manage_service', 'get_template_artifact', 'list_requests']) {
+      expect(names.has(merged), `${merged} must be registered`).toBe(true);
+    }
+    await client.close();
+  });
+
+  it('exposes the discriminator param on each merged tool', async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const prop = (name: string, key: string) => {
+      const t = tools.find(x => x.name === name);
+      return (t?.inputSchema?.properties ?? {}) as Record<string, unknown>;
+    };
+    expect(prop('get_logs', 'source').source).toBeTruthy();
+    expect(prop('manage_service', 'action').action).toBeTruthy();
+    expect(prop('get_template_artifact', 'artifact').artifact).toBeTruthy();
+    expect(prop('list_requests', 'type').type).toBeTruthy();
+    await client.close();
+  });
+
+  it('keeps each merged tool in its cluster scope', () => {
+    // get_logs / get_template_artifact / list_requests stay read; the old
+    // members were all read. manage_service stays lifecycle.
+    expect(TOOL_SCOPES.get_logs).toBe('read');
+    expect(TOOL_SCOPES.get_template_artifact).toBe('read');
+    expect(TOOL_SCOPES.list_requests).toBe('read');
+    expect(TOOL_SCOPES.manage_service).toBe('lifecycle');
+    // The old names carry no scope entry anymore.
+    for (const old of OLD_NAMES) {
+      expect(TOOL_SCOPES[old], `${old} scope entry removed`).toBeUndefined();
+    }
   });
 });
 
@@ -116,7 +177,7 @@ describe('reboot scope split (#1765)', () => {
 
   it('lets an operate token reboot but refuses delete/factory_reset', () => {
     const operate = ['read', 'lifecycle', 'mutate', 'reboot'] as const;
-    expect(tokenHasScope(operate, TOOL_SCOPES.restart_service)).toBe(true);
+    expect(tokenHasScope(operate, TOOL_SCOPES.manage_service)).toBe(true);
     expect(tokenHasScope(operate, TOOL_SCOPES.reboot_node)).toBe(true);
     expect(tokenHasScope(operate, TOOL_SCOPES.delete_service)).toBe(false);
     expect(tokenHasScope(operate, TOOL_SCOPES.factory_reset)).toBe(false);

--- a/packages/backend/src/lib/mcp/server.tokenRequest.test.ts
+++ b/packages/backend/src/lib/mcp/server.tokenRequest.test.ts
@@ -6,7 +6,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
 // #2139: MCP scoped-token request tools (request_token / poll_token_request /
-// list_token_requests). The store is file-backed under DATA_DIR, so use a
+// list_requests(type="token")). The store is file-backed under DATA_DIR, so use a
 // real-fs temp dir per test (mirrors auth/tokenRequests.test.ts).
 let dataDir = '';
 vi.mock('@/lib/dirs', async (importOriginal) => {
@@ -56,7 +56,7 @@ describe('request_token / poll_token_request MCP tools (#2139)', () => {
     expect(polled.token).toBeNull();
 
     // Visible on the audit list with the caller identity captured.
-    const listed = parse(await client.callTool({ name: 'list_token_requests', arguments: {} }));
+    const listed = parse(await client.callTool({ name: 'list_requests', arguments: { type: 'token' } }));
     expect(listed.requests.map((r: { id: string }) => r.id)).toContain(filed.id);
     expect(listed.requests[0].requestedBy).toBe('agent:tester');
     await client.close();
@@ -89,7 +89,7 @@ describe('request_token / poll_token_request MCP tools (#2139)', () => {
     await client.close();
   });
 
-  it('list_token_requests filters by status and never leaks a secret', async () => {
+  it('list_requests(type="token") filters by status and never leaks a secret', async () => {
     const { client } = await connectClient();
     const a = parse(await client.callTool({ name: 'request_token', arguments: { scopes: ['read'], reason: 'a', ttl_seconds: 60 } }));
     const b = parse(await client.callTool({ name: 'request_token', arguments: { scopes: ['read'], reason: 'b', ttl_seconds: 60 } }));
@@ -98,12 +98,12 @@ describe('request_token / poll_token_request MCP tools (#2139)', () => {
     await approveTokenRequest(a.id);
     await denyTokenRequest(b.id);
 
-    const approved = parse(await client.callTool({ name: 'list_token_requests', arguments: { status: 'approved' } }));
+    const approved = parse(await client.callTool({ name: 'list_requests', arguments: { type: 'token', status: 'approved' } }));
     expect(approved.requests.map((r: { id: string }) => r.id)).toEqual([a.id]);
     // The one-time secret is never present on the list view.
     expect(JSON.stringify(approved)).not.toMatch(/pendingSecret/);
 
-    const denied = parse(await client.callTool({ name: 'list_token_requests', arguments: { status: 'denied' } }));
+    const denied = parse(await client.callTool({ name: 'list_requests', arguments: { type: 'token', status: 'denied' } }));
     expect(denied.requests.map((r: { id: string }) => r.id)).toEqual([b.id]);
     await client.close();
   });

--- a/packages/backend/src/lib/mcp/server.toolVisibility.test.ts
+++ b/packages/backend/src/lib/mcp/server.toolVisibility.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Scope-filtered + deterministically-ordered tools/list (#2325).
+//
+// A token's advertised tool list contains only tools whose TOOL_SCOPES scope is
+// within the token's granted scopes: a read-only token must NOT see
+// mutate/destroy/exec tools. Enforcement is unchanged (safeHandler stays the
+// authority) — a filtered-out tool called by id still fails at the scope gate.
+// The list is sorted by name so it is deterministic + stable per token.
+
+// Keep the safety/audit layer cheap so registering + listing tools is inert.
+vi.mock('@/lib/config', () => ({
+  getConfig: vi.fn().mockResolvedValue({ mcp: { allowMutations: true } }),
+  updateConfig: vi.fn(),
+}));
+vi.mock('./safety', async (orig) => {
+  const actual = await orig<typeof import('./safety')>();
+  return { ...actual, snapshotBeforeMutation: vi.fn().mockResolvedValue(undefined) };
+});
+vi.mock('./audit', () => ({ recordAudit: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./notify', () => ({ notifyDestructiveOp: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@/lib/approvals', () => ({
+  submitApproval: vi.fn().mockResolvedValue({ id: 'appr-1' }),
+  registerMcpDispatcher: vi.fn(),
+  registerTokenMinter: vi.fn(),
+}));
+vi.mock('@/lib/nodes', () => ({
+  listNodes: vi.fn().mockResolvedValue([{ Name: 'Local' }]),
+  getNodeConnection: vi.fn(),
+}));
+
+import {
+  createMcpServer,
+  TOOL_SCOPES,
+  MCP_KERNEL_TOOLS,
+  isToolVisibleForScopes,
+} from './server';
+import type { ApiScope } from '@/lib/auth/apiScope';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+async function connect(opts?: Parameters<typeof createMcpServer>[0]) {
+  const server = createMcpServer(opts);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return { client };
+}
+
+const READ_ONLY: ApiScope[] = ['read'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('scope-filtered tools/list (#2325)', () => {
+  it('a read-only token sees only read-tier tools — no mutate/destroy/exec', async () => {
+    const { client } = await connect({ auth: { user: 'token:ro', scopes: [...READ_ONLY] } });
+    const { tools } = await client.listTools();
+    const names = tools.map(t => t.name);
+
+    // Every advertised tool must be a read-tier tool.
+    for (const name of names) {
+      expect(TOOL_SCOPES[name] ?? 'read', `${name} advertised to read-only token`).toBe('read');
+    }
+    // Concretely: no mutate/destroy/exec tool leaks into the list.
+    expect(names).not.toContain('deploy_service'); // mutate
+    expect(names).not.toContain('delete_service'); // destroy
+    expect(names).not.toContain('exec_command');   // exec
+    expect(names).not.toContain('reboot_node');    // reboot
+    expect(names).not.toContain('manage_service'); // lifecycle
+
+    // And it still sees the read core.
+    expect(names).toContain('list_services');
+    expect(names).toContain('get_logs');
+  });
+
+  it('a full-scope token sees the mutate/destroy/exec tools too', async () => {
+    const { client } = await connect({
+      auth: { user: 'token:admin', scopes: ['read', 'lifecycle', 'mutate', 'destroy', 'exec', 'reboot'] },
+    });
+    const names = (await client.listTools()).tools.map(t => t.name);
+    expect(names).toContain('deploy_service');
+    expect(names).toContain('delete_service');
+    expect(names).toContain('exec_command');
+    expect(names).toContain('reboot_node');
+    expect(names).toContain('manage_service');
+  });
+
+  it('no-auth (cookie/operator) sees every registered tool', async () => {
+    const { client: full } = await connect({
+      auth: { user: 't', scopes: ['read', 'lifecycle', 'mutate', 'destroy', 'exec', 'reboot'] },
+    });
+    const { client: anon } = await connect();
+    const fullNames = new Set((await full.listTools()).tools.map(t => t.name));
+    const anonNames = (await anon.listTools()).tools.map(t => t.name);
+    // The anon (no-auth) list is a superset-or-equal of the full-scope list.
+    for (const n of fullNames) expect(anonNames).toContain(n);
+  });
+
+  it('the kernel set is entirely visible to a read-only token', async () => {
+    const { client } = await connect({ auth: { user: 'token:ro', scopes: [...READ_ONLY] } });
+    const names = (await client.listTools()).tools.map(t => t.name);
+    for (const k of MCP_KERNEL_TOOLS) {
+      expect(names, `kernel tool ${k} visible to read-only`).toContain(k);
+      // Kernel must stay read-tier so it's always advertisable.
+      expect(TOOL_SCOPES[k] ?? 'read').toBe('read');
+    }
+  });
+});
+
+describe('deterministic ordering (#2325)', () => {
+  it('tools are sorted by name, stable across repeated requests', async () => {
+    const { client } = await connect({ auth: { user: 'token:ro', scopes: [...READ_ONLY] } });
+    const first = (await client.listTools()).tools.map(t => t.name);
+    const second = (await client.listTools()).tools.map(t => t.name);
+
+    const sorted = [...first].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    expect(first).toEqual(sorted);          // sorted by name
+    expect(second).toEqual(first);          // stable across requests
+  });
+});
+
+describe('enforcement unchanged — visibility != authorization (#2325)', () => {
+  it('a filtered-out tool still fails at the scope gate when called by id', async () => {
+    const { client } = await connect({ auth: { user: 'token:ro', scopes: [...READ_ONLY] } });
+    // deploy_service is hidden from the read-only list, but calling it by id
+    // must still be refused by safeHandler's scope gate (not "tool not found").
+    const res = await client.callTool({
+      name: 'deploy_service',
+      arguments: { name: 'x', kubeContent: 'apiVersion: v1\nkind: Pod' },
+    });
+    expect(res.isError).toBe(true);
+    const text = (res.content as { text?: string }[])[0]?.text ?? '';
+    expect(text).toMatch(/scope 'mutate' required/i);
+    expect(text).not.toMatch(/not found/i);
+  });
+});
+
+describe('isToolVisibleForScopes helper (#2325)', () => {
+  it('mirrors the scope gate; undefined scopes ⇒ everything visible', () => {
+    expect(isToolVisibleForScopes('deploy_service', ['read'])).toBe(false);
+    expect(isToolVisibleForScopes('deploy_service', ['read', 'mutate'])).toBe(true);
+    expect(isToolVisibleForScopes('list_services', ['read'])).toBe(true);
+    // destroy implies exec + reboot (apiScope ladder).
+    expect(isToolVisibleForScopes('exec_command', ['destroy'])).toBe(true);
+    expect(isToolVisibleForScopes('reboot_node', ['destroy'])).toBe(true);
+    // No auth ⇒ all visible.
+    expect(isToolVisibleForScopes('exec_command', undefined)).toBe(true);
+  });
+});

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { randomUUID } from 'crypto';
 import {
@@ -278,6 +279,46 @@ export function tokenHasScope(tokenScopes: readonly ApiScope[], required: ApiSco
   // Single-sourced scope-implication ladder lives in apiScope.ts (#2048) so
   // the delegated-mint subset check and this MCP gate can't drift.
   return scopeSatisfiedBy(tokenScopes, required);
+}
+
+/**
+ * `defer_loading` kernel set (#2325). A small always-on core that a client
+ * using the Anthropic Tool Search Tool keeps eagerly loaded; every other tool
+ * is a `defer_loading` candidate the client can lazy-load on demand. This is a
+ * *hint surface* only — we don't force Tool Search (client-side decision), we
+ * just designate + advertise the core so a client CAN lazy-load the rest
+ * (schemas append, not swap → prompt cache stays intact). Kept read-only so the
+ * core is safe to always advertise; it must stay a subset of the read tier so a
+ * read-only token still sees the whole kernel.
+ */
+export const MCP_KERNEL_TOOLS: readonly string[] = [
+  'list_services',
+  'list_containers',
+  'diagnose',
+  'get_logs',
+  'get_system_info',
+];
+
+/** True when `toolName` is in the always-on kernel (see MCP_KERNEL_TOOLS). */
+export function isKernelTool(toolName: string): boolean {
+  return MCP_KERNEL_TOOLS.includes(toolName);
+}
+
+/**
+ * Whether a token holding `scopes` may SEE `toolName` in `tools/list` (#2325).
+ * Visibility mirrors the scope gate: a tool is advertised only when the token
+ * could actually call it — a read-only token must not see mutate/destroy/exec
+ * tools. Enforcement is unchanged (`safeHandler` stays the authority); this only
+ * changes *visibility*. No auth (cookie/operator/internal dispatch) ⇒ all tools
+ * visible, matching the "cookie has all scopes" gate rule.
+ */
+export function isToolVisibleForScopes(
+  toolName: string,
+  scopes: readonly ApiScope[] | undefined,
+): boolean {
+  if (!scopes) return true;
+  const required = TOOL_SCOPES[toolName] ?? 'read';
+  return tokenHasScope(scopes, required);
 }
 
 /**
@@ -2108,5 +2149,44 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     },
   );
 
+  // Scope-filtered + deterministically-ordered tools/list (#2325).
+  //
+  // Enforcement is unchanged — every tool above is registered with its
+  // safeHandler, which remains the authority: a filtered-out tool called by id
+  // still hits the scope gate and is refused. This ONLY changes *visibility*:
+  //   - a read-only token's advertised list omits mutate/destroy/exec tools
+  //     (least-privilege + fewer wrong picks + fewer tokens), and
+  //   - the list is sorted by name so it's deterministic + stable per token
+  //     across requests (prompt-cache friendliness).
+  //
+  // We wrap the SDK's own list handler rather than rebuild the tool-definition
+  // serialization (zod→JSON-schema) so the shapes never drift from the SDK.
+  applyToolListView(baseServer, opts?.auth?.scopes);
+
   return server;
+}
+
+/**
+ * Override the low-level `tools/list` handler on `baseServer.server` to (1)
+ * hide tools the current token can't call and (2) sort the survivors by name
+ * (#2325). It delegates to the SDK's default handler (installed by the first
+ * `.tool()` registration) for the actual tool-definition serialization, then
+ * filters + sorts its result — so this stays robust to SDK schema changes.
+ */
+function applyToolListView(baseServer: McpServer, scopes: readonly ApiScope[] | undefined) {
+  // The low-level Server keeps request handlers in a private Map keyed by the
+  // method literal ("tools/list"). Read the SDK's default handler so we can
+  // delegate to it, then reinstall our filtering/sorting wrapper over it.
+  const lowLevel = baseServer.server as unknown as {
+    _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<{ tools: { name: string }[] }>>;
+  };
+  const defaultHandler = lowLevel._requestHandlers.get('tools/list');
+  if (!defaultHandler) return; // no tools registered → nothing to view
+  baseServer.server.setRequestHandler(ListToolsRequestSchema, async (request, extra) => {
+    const full = await defaultHandler(request, extra);
+    const tools = full.tools
+      .filter(t => isToolVisibleForScopes(t.name, scopes))
+      .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return { ...full, tools };
+  });
 }

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -14,6 +14,7 @@ import {
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { getTemplates, getReadme, getTemplateYaml, getTemplateVariables } from '@/lib/registry';
 import { listAssists, getAssist, ASSIST_KINDS } from '@/lib/assists/catalog';
+import { buildServiceStandards, SERVICE_STANDARDS_FLAVORS } from './serviceStandards';
 import { listNodes, getNodeConnection } from '@/lib/nodes';
 import { verifyNodeConnection } from '@/lib/nodes/verify';
 import { agentManager } from '@/lib/agent/manager';
@@ -204,7 +205,7 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   list_nodes: 'read', list_services: 'read', list_containers: 'read',
   get_logs: 'read', get_service_files: 'read',
   list_templates: 'read', get_template_artifact: 'read',
-  list_assists: 'read', get_assist: 'read',
+  list_assists: 'read', get_assist: 'read', get_service_standards: 'read',
   get_system_info: 'read', get_network_graph: 'read', get_health_checks: 'read',
   get_gateway_status: 'read', get_proxy_routes: 'read', get_config: 'read',
   list_system_services: 'read',
@@ -967,6 +968,27 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
       const body = await getAssist(id);
       if (!body) return errorResult(`No assist found with id "${id}". Use list_assists to see available entries.`);
       return textResult(body);
+    },
+  );
+
+  // --- Get Service Standards (#2323) ---
+  // A curated *pointer* index (not full text) for building a new project. The
+  // `servicebay` flavor lists the platform ADRs a new service must respect
+  // (titles scanned from docs/adr/*.md at runtime so they don't drift), the
+  // enforced invariants + gate commands, the assists to read in full, and the
+  // template contract. The `generic` flavor returns platform-agnostic dev
+  // standards. Backing prose lives in the new-service-standards /
+  // generic-project-standards assists (single source of truth).
+  server.tool(
+    'get_service_standards',
+    'Fetch a curated pointer index of the standards for building a new project. flavor="servicebay" (default) returns the platform ADRs a new ServiceBay service must respect (with titles scanned live from docs/adr), the enforced invariants + gate commands, the assists to read in full via get_assist, and the template contract. flavor="generic" returns platform-agnostic dev standards (commit convention, release discipline, coverage floor, secret hygiene, scripts-over-prose). Use this FIRST when starting a new service/project so you build against the standards instead of re-deriving them.',
+    {
+      flavor: z.enum(SERVICE_STANDARDS_FLAVORS).optional().default('servicebay')
+        .describe('"servicebay" (default) for a new ServiceBay service; "generic" for platform-agnostic dev standards.'),
+    },
+    async ({ flavor }) => {
+      const standards = await buildServiceStandards(flavor);
+      return textResult(standards);
     },
   );
 

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -172,7 +172,7 @@ async function assertReadableRegularFile(
  * (true | absent ⇒ allowed; false ⇒ blocked).
  */
 const MUTATING_TOOLS = new Set([
-  'start_service', 'stop_service', 'restart_service',
+  'manage_service',
   'deploy_service', 'delete_service', 'rename_service', 'update_service_yaml',
   'restore_trashed_service', 'purge_trashed_service',
   'add_proxy_route', 'create_proxy_route', 'remove_proxy_route',
@@ -202,19 +202,18 @@ const MUTATING_TOOLS = new Set([
 export const TOOL_SCOPES: Record<string, ApiScope> = {
   // read
   list_nodes: 'read', list_services: 'read', list_containers: 'read',
-  get_service_logs: 'read', get_container_logs: 'read', get_service_files: 'read',
-  list_templates: 'read', get_template_readme: 'read', get_template_yaml: 'read',
-  get_template_variables: 'read',
+  get_logs: 'read', get_service_files: 'read',
+  list_templates: 'read', get_template_artifact: 'read',
   list_assists: 'read', get_assist: 'read',
   get_system_info: 'read', get_network_graph: 'read', get_health_checks: 'read',
   get_gateway_status: 'read', get_proxy_routes: 'read', get_config: 'read',
-  get_podman_logs: 'read', list_system_services: 'read',
+  list_system_services: 'read',
   list_backups: 'read', diagnose: 'read', verify_node_connection: 'read',
   verify_usb_boot: 'read',
   list_trashed_services: 'read',
   get_unmanaged_bundles: 'read',
   get_channel: 'read',
-  list_access_requests: 'read', get_access_request_status: 'read',
+  get_access_request_status: 'read',
   // Scoped-token request flow (#2139). A token *request* itself grants
   // nothing — it just files a pending item the admin must approve — so it
   // needs only the lowest scope (`read`). This is deliberate: a caller with
@@ -222,13 +221,13 @@ export const TOOL_SCOPES: Record<string, ApiScope> = {
   // read-only token can ASK for a broader, short-lived grant that a human
   // signs off on. Making request_token require a high scope would defeat the
   // point (you'd need the very authority you're trying to request).
-  request_token: 'read', poll_token_request: 'read', list_token_requests: 'read',
+  request_token: 'read', poll_token_request: 'read', list_requests: 'read',
   // read-oriented file/disk tools (#1872) — jailed reads, no mutation
   read_file: 'read', list_dir: 'read', disk_usage: 'read',
   // install progress is a read-only poll of a job's state (#2141)
   get_install_progress: 'read',
   // lifecycle
-  start_service: 'lifecycle', stop_service: 'lifecycle', restart_service: 'lifecycle',
+  manage_service: 'lifecycle',
   run_check_now: 'lifecycle', refresh_agent: 'lifecycle',
   run_backup: 'lifecycle',
   set_channel: 'lifecycle',
@@ -528,8 +527,8 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         "To find an app's logs, resolve the names yourself instead of asking the user:",
         '1. `list_services` — find the owning service and its `associatedContainerIds`.',
         '2. `list_containers` — find the `<service>-<app>` container name (e.g. `media-jellyfin`).',
-        '3. `get_container_logs(id)` — fetch that container\'s logs.',
-        'For whole-unit (systemd) logs use `get_service_logs(name)` instead of per-container logs.',
+        '3. `get_logs(source="container", container=id)` — fetch that container\'s logs.',
+        'For whole-unit (systemd) logs use `get_logs(source="service", name=…)` instead of per-container logs.',
         '',
         'Always resolve service/container names and ids from `list_services` / `list_containers`',
         'rather than asking the user for them. Use `diagnose`, `get_health_checks`, and',
@@ -576,107 +575,79 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   });
 
   // --- List Containers ---
-  server.tool('list_containers', 'List running containers with image, state, ports. Container names follow `<service>-<app>` (e.g. `media-jellyfin`); use the resolved name with get_container_logs.', { node: nodeParam }, async ({ node }) => {
+  server.tool('list_containers', 'List running containers with image, state, ports. Container names follow `<service>-<app>` (e.g. `media-jellyfin`); use the resolved name with get_logs(source="container").', { node: nodeParam }, async ({ node }) => {
     const nodeName = await resolveNode(node);
     return textResult(getContainers(nodeName));
   });
 
-  // --- Get Service Logs ---
+  // --- Get Logs (#2324) — one read-scoped tool with a `source` discriminator ---
+  // Replaces get_service_logs / get_container_logs / get_podman_logs.
+  //   source='service'   → systemd journal for a whole service (the unit).
+  //   source='container' → container stdout/stderr (`<service>-<app>` name).
+  //   source='podman'    → raw podman daemon/system logs for the node.
   server.tool(
-    'get_service_logs',
-    'Fetch systemd journal logs for a whole service (the systemd unit). For a single app inside a multi-container service, use get_container_logs with the `<service>-<app>` name instead. Use `since` (Unix seconds) on subsequent calls to get only newer lines for a debug-loop pattern.',
+    'get_logs',
+    'Fetch logs from one of three sources via `source`. source="service": systemd journal for a whole service (the systemd unit) — pass `name`. source="container": container stdout/stderr — pass `container` as the `<service>-<app>` name (e.g. `media-jellyfin`), resolve it via list_containers. source="podman": raw podman daemon/system logs for the node. Use `since` (Unix seconds) on subsequent service/container calls to get only newer lines for a debug-loop pattern.',
     {
-      name: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid service name').describe('Service name'),
+      source: z.enum(['service', 'container', 'podman']).describe('Which log source to read: service (systemd unit journal), container (podman container stdout/stderr), or podman (raw podman daemon/system logs).'),
       node: nodeParam,
-      lines: z.number().int().min(1).max(10000).optional().describe('Number of lines from the end (default 200)'),
-      since: z.number().int().optional().describe('Unix seconds — return only entries newer than this'),
+      name: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid service name').optional().describe('Service name — required when source="service".'),
+      container: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid container id').optional().describe('Container ID or `<service>-<app>` name — required when source="container".'),
+      lines: z.number().int().min(1).max(10000).optional().describe('service/container: number of lines from the end (default 200).'),
+      since: z.number().int().optional().describe('service/container: Unix seconds — return only entries newer than this.'),
     },
-    async ({ name, node, lines, since }) => {
+    async ({ source, node, name, container, lines, since }) => {
       const nodeName = await resolveNode(node);
+      if (source === 'podman') {
+        const logs = await ServiceManager.getPodmanLogs(nodeName);
+        return textResult(logs);
+      }
       try {
         const agent = agentManager.getAgent(nodeName);
-        const unit = name.match(/\.(service|scope|socket|timer)$/) ? name : `${name}.service`;
-        const args = [`--user`, `-u`, unit, `-n`, String(lines ?? 200), '--no-pager', '--output', 'short-iso'];
-        if (since) args.push('--since', `@${since}`);
-        const result = await agent.sendCommand('exec', { command: `journalctl ${args.join(' ')} 2>&1` });
+        let command: string;
+        if (source === 'service') {
+          if (!name) return errorResult('source="service" requires `name` (the service name).');
+          const unit = name.match(/\.(service|scope|socket|timer)$/) ? name : `${name}.service`;
+          const args = [`--user`, `-u`, unit, `-n`, String(lines ?? 200), '--no-pager', '--output', 'short-iso'];
+          if (since) args.push('--since', `@${since}`);
+          command = `journalctl ${args.join(' ')} 2>&1`;
+        } else {
+          if (!container) return errorResult('source="container" requires `container` (the `<service>-<app>` name).');
+          const args = [`--tail ${lines ?? 200}`, '--timestamps'];
+          if (since) args.push(`--since ${since}`);
+          command = `podman logs ${args.join(' ')} ${container} 2>&1`;
+        }
+        const result = await agent.sendCommand('exec', { command });
         return textResult({
-          // Strip credentials before handing journalctl output back to
-          // the MCP client (#321) — service journals catch any
-          // post-deploy line that prints rendered passwords plus
-          // anything the service itself dumps at startup.
+          // Strip credentials before handing log output back to the MCP
+          // client (#321) — journals/containers catch any post-deploy line
+          // that prints rendered passwords plus anything dumped at startup.
           stdout: redactLogText(result.stdout ?? ''),
           exitCode: result.code,
           fetchedAt: Math.floor(Date.now() / 1000),
         });
       } catch (err) {
-        return errorResult(`Error fetching service logs: ${err instanceof Error ? err.message : String(err)}`);
+        return errorResult(`Error fetching ${source === 'service' ? 'service' : 'container'} logs: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
   );
 
-  // --- Get Container Logs ---
+  // --- Manage Service (#2324) — one lifecycle-scoped tool with an `action`
+  // discriminator. Replaces start_service / stop_service / restart_service.
+  // Returns the post-action service status (same as the old tools). ---
   server.tool(
-    'get_container_logs',
-    'Fetch container stdout/stderr logs. `id` is the `<service>-<app>` container name (e.g. `media-jellyfin`); resolve it via list_containers. Use `since` (Unix seconds) on subsequent calls to get only newer lines for a debug-loop pattern.',
+    'manage_service',
+    'Start, stop, or restart a service via `action`. Returns the service status after the action (same shape the old start/stop/restart tools returned).',
     {
-      id: z.string().regex(/^[a-zA-Z0-9_.-]+$/, 'invalid container id').describe('Container ID or name'),
+      action: z.enum(['start', 'stop', 'restart']).describe('Lifecycle action to perform on the service.'),
+      name: z.string().describe('Service name'),
       node: nodeParam,
-      tail: z.number().int().min(1).max(10000).optional().describe('Number of lines from the end (default 200)'),
-      since: z.number().int().optional().describe('Unix seconds — return only lines newer than this'),
     },
-    async ({ id, node, tail, since }) => {
+    async ({ action, name, node }) => {
       const nodeName = await resolveNode(node);
-      try {
-        const agent = agentManager.getAgent(nodeName);
-        const args = [`--tail ${tail ?? 200}`, '--timestamps'];
-        if (since) args.push(`--since ${since}`);
-        const result = await agent.sendCommand('exec', { command: `podman logs ${args.join(' ')} ${id} 2>&1` });
-        return textResult({
-          // Same redaction as get_service_logs — see #321.
-          stdout: redactLogText(result.stdout ?? ''),
-          exitCode: result.code,
-          fetchedAt: Math.floor(Date.now() / 1000),
-        });
-      } catch (err) {
-        return errorResult(`Error fetching container logs: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    },
-  );
-
-  // --- Start Service ---
-  server.tool(
-    'start_service',
-    'Start a stopped service',
-    { name: z.string().describe('Service name'), node: nodeParam },
-    async ({ name, node }) => {
-      const nodeName = await resolveNode(node);
-      await ServiceManager.startService(nodeName, name);
-      const status = await ServiceManager.getServiceStatus(nodeName, name);
-      return textResult(status);
-    },
-  );
-
-  // --- Stop Service ---
-  server.tool(
-    'stop_service',
-    'Stop a running service',
-    { name: z.string().describe('Service name'), node: nodeParam },
-    async ({ name, node }) => {
-      const nodeName = await resolveNode(node);
-      await ServiceManager.stopService(nodeName, name);
-      const status = await ServiceManager.getServiceStatus(nodeName, name);
-      return textResult(status);
-    },
-  );
-
-  // --- Restart Service ---
-  server.tool(
-    'restart_service',
-    'Restart a service',
-    { name: z.string().describe('Service name'), node: nodeParam },
-    async ({ name, node }) => {
-      const nodeName = await resolveNode(node);
-      await ServiceManager.restartService(nodeName, name);
+      if (action === 'start') await ServiceManager.startService(nodeName, name);
+      else if (action === 'stop') await ServiceManager.stopService(nodeName, name);
+      else await ServiceManager.restartService(nodeName, name);
       const status = await ServiceManager.getServiceStatus(nodeName, name);
       return textResult(status);
     },
@@ -853,46 +824,29 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     return textResult(templates);
   });
 
-  // --- Get Template Readme ---
+  // --- Get Template Artifact (#2324) — one read-scoped tool with an
+  // `artifact` discriminator. Replaces get_template_readme / get_template_yaml
+  // / get_template_variables. ---
   server.tool(
-    'get_template_readme',
-    'Get the README/documentation for a deployment template',
+    'get_template_artifact',
+    'Get one artifact of a deployment template via `artifact`: "readme" (README/docs), "yaml" (the kube YAML), or "variables" (configurable variables).',
     {
+      artifact: z.enum(['readme', 'yaml', 'variables']).describe('Which template artifact to fetch.'),
       name: z.string().describe('Template name'),
-      type: z.enum(['template', 'stack']).optional().describe('Template type (default: template)'),
+      type: z.enum(['template', 'stack']).optional().describe('Template type (default: template) — only used for artifact="readme".'),
       source: z.string().optional().describe('Registry source'),
     },
-    async ({ name, type, source }) => {
-      const readme = await getReadme(name, type ?? 'template', source);
-      if (!readme) return errorResult(`No README found for template "${name}"`);
-      return textResult(readme);
-    },
-  );
-
-  // --- Get Template YAML ---
-  server.tool(
-    'get_template_yaml',
-    'Get the kube YAML content for a deployment template',
-    {
-      name: z.string().describe('Template name'),
-      source: z.string().optional().describe('Registry source'),
-    },
-    async ({ name, source }) => {
-      const yaml = await getTemplateYaml(name, source);
-      if (!yaml) return errorResult(`No YAML found for template "${name}"`);
-      return textResult(yaml);
-    },
-  );
-
-  // --- Get Template Variables ---
-  server.tool(
-    'get_template_variables',
-    'Get configurable variables for a deployment template',
-    {
-      name: z.string().describe('Template name'),
-      source: z.string().optional().describe('Registry source'),
-    },
-    async ({ name, source }) => {
+    async ({ artifact, name, type, source }) => {
+      if (artifact === 'readme') {
+        const readme = await getReadme(name, type ?? 'template', source);
+        if (!readme) return errorResult(`No README found for template "${name}"`);
+        return textResult(readme);
+      }
+      if (artifact === 'yaml') {
+        const yaml = await getTemplateYaml(name, source);
+        if (!yaml) return errorResult(`No YAML found for template "${name}"`);
+        return textResult(yaml);
+      }
       const vars = await getTemplateVariables(name, source);
       if (!vars) return errorResult(`No variables found for template "${name}"`);
       return textResult(vars);
@@ -1138,18 +1092,6 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     async ({ name }) => {
       const result = await verifyNodeConnection(name);
       return textResult(result);
-    },
-  );
-
-  // --- Get Podman Logs ---
-  server.tool(
-    'get_podman_logs',
-    'Get raw podman daemon/system logs',
-    { node: nodeParam },
-    async ({ node }) => {
-      const nodeName = await resolveNode(node);
-      const logs = await ServiceManager.getPodmanLogs(nodeName);
-      return textResult(logs);
     },
   );
 
@@ -2015,13 +1957,25 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   const normalizeStatus = (s: AccessRequest['status']): 'pending' | 'approved' | 'denied' =>
     s === 'resolved' ? 'approved' : s;
 
+  // --- List Requests (#2324) — Tier-2 merge. One read-scoped tool with a
+  // `type` discriminator over the two request lists that share the same call
+  // shape + status enum, differing only in their backing store:
+  //   type="access" → admin access/approval list (config.accessRequests)
+  //   type="token"  → scoped-token request lifecycle (auth/tokenRequests)
+  // Deliberately NOT merged with poll_token_request / get_access_request_status
+  // (those poll one id; poll_token_request is non-idempotent) — see #2324. ---
   server.tool(
-    'list_access_requests',
-    'List access/approval requests on the admin\'s central list. Defaults to pending only; pass status="approved", "denied", or "all".',
+    'list_requests',
+    'List pending/resolved requests via `type`: "access" (access/approval requests on the admin\'s central list) or "token" (scoped-token request lifecycle, request_token). Defaults to pending; pass status="approved", "denied", or "all". Token requests never return secrets — only metadata, granted scopes, expiry, and minted token id.',
     {
+      type: z.enum(['access', 'token']).describe('Which request list to read: access (approval requests) or token (scoped-token requests).'),
       status: z.enum(['pending', 'approved', 'denied', 'all']).optional().default('pending').describe('Filter by status. Default: pending.'),
     },
-    async ({ status }) => {
+    async ({ type, status }) => {
+      if (type === 'token') {
+        const requests = await listTokenRequests(status as TokenRequestStatus | 'all');
+        return textResult({ requests });
+      }
       const config = await getConfig();
       const all = config.accessRequests ?? [];
       const filtered = status === 'all' ? all : all.filter(r => normalizeStatus(r.status) === status);
@@ -2129,18 +2083,6 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     async ({ id }) => {
       const result = await pollTokenRequest(id);
       return textResult(result);
-    },
-  );
-
-  server.tool(
-    'list_token_requests',
-    'List scoped-token requests (request_token lifecycle) for admin/audit visibility. Defaults to pending; pass status="approved", "denied", or "all". Never returns token secrets — only the request metadata, granted scopes, expiry, and minted token id.',
-    {
-      status: z.enum(['pending', 'approved', 'denied', 'all']).optional().default('pending').describe('Filter by status. Default: pending.'),
-    },
-    async ({ status }) => {
-      const requests = await listTokenRequests(status as TokenRequestStatus | 'all');
-      return textResult({ requests });
     },
   );
 

--- a/packages/backend/src/lib/mcp/serviceStandards.ts
+++ b/packages/backend/src/lib/mcp/serviceStandards.ts
@@ -1,0 +1,171 @@
+/**
+ * Backing logic for the `get_service_standards` MCP tool (#2323).
+ *
+ * A read-scoped, curated *pointer* index (not full text) that an external
+ * client/agent can fetch before building a new project. Two flavors:
+ *   - `servicebay` — the platform-specific index for a new ServiceBay service:
+ *     the ADRs it must respect, the enforced invariants + gate commands, the
+ *     assists to read in full, and the template contract.
+ *   - `generic`    — platform-agnostic dev standards (commit / release /
+ *     coverage / secret-hygiene / scripts-over-prose) for any new project.
+ *
+ * Single source of truth: the prose lives in the backing assist files
+ * `assists/new-service-standards.md` and `assists/generic-project-standards.md`
+ * (kind: checklist), not as hard-coded prose here — this handler only assembles
+ * pointers. The ADR one-liners are scanned from `docs/adr/*.md` titles at
+ * runtime (below) so the *selection* is hand-curated but the *titles* never
+ * drift from the source.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { logger } from '@/lib/logger';
+
+export const SERVICE_STANDARDS_FLAVORS = ['servicebay', 'generic'] as const;
+export type ServiceStandardsFlavor = (typeof SERVICE_STANDARDS_FLAVORS)[number];
+
+/** Repo-root `docs/adr/` (shipped to /app/docs/adr in the container image). */
+const ADR_DIR = () => path.join(process.cwd(), 'docs', 'adr');
+
+/** The curated ADR selection a new ServiceBay service is bound by (#2323). */
+const CURATED_ADRS: { num: string; note: string }[] = [
+  { num: '0001', note: 'Every user-facing service authenticates via Authelia SSO (or at minimum LDAP against LLDAP).' },
+  { num: '0003', note: 'Versioning and releases go through release-please only; never hand-bump a version, keep commit subjects parser-clean.' },
+  { num: '0004', note: 'Installs/redeploys are non-destructive — they never wipe other services.' },
+  { num: '0007', note: 'App containers run in an isolated netns; only named carve-outs stay on host networking.' },
+  { num: '0009', note: 'The token & trust model between services: scoped, short-lived grants; no ambient authority.' },
+  { num: '0010', note: 'The Node runtime tracks the Node 20 line, kept consistent across all sources.' },
+];
+
+// The 0009 slot has two files (repair-is-reconciliation and service-tokens);
+// this tool means the tokens-and-trust one for its trust-model pointer.
+const ADR_FILE_HINTS: Record<string, string> = {
+  '0009': 'service-tokens',
+};
+
+export interface AdrPointer {
+  adr: string;
+  title: string;
+  note: string;
+  path: string;
+}
+
+/**
+ * Scan `docs/adr/*.md` and return the title + relative path for each curated
+ * ADR number, keyed by its `# ADR NNNN — <title>` heading. Drift-free: only the
+ * *selection* (`CURATED_ADRS`) is hand-maintained; titles come from the source.
+ * If the dir is unavailable at runtime, falls back to the curated note as title
+ * so the tool still returns a usable pointer.
+ */
+export async function scanCuratedAdrs(): Promise<AdrPointer[]> {
+  const dir = ADR_DIR();
+  let files: string[] = [];
+  try {
+    files = (await fs.readdir(dir)).filter(f => f.endsWith('.md') && /^\d{4}-/.test(f));
+  } catch (e) {
+    logger.warn('mcp', `get_service_standards: docs/adr unavailable, using curated fallbacks: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  const result: AdrPointer[] = [];
+  for (const { num, note } of CURATED_ADRS) {
+    // Prefer a hinted file when the number has more than one ADR (0009).
+    const candidates = files.filter(f => f.startsWith(`${num}-`));
+    const hint = ADR_FILE_HINTS[num];
+    const file = (hint && candidates.find(f => f.includes(hint))) ?? candidates[0];
+
+    let title = '';
+    if (file) {
+      try {
+        const raw = await fs.readFile(path.join(dir, file), 'utf-8');
+        title = extractAdrTitle(raw);
+      } catch {
+        /* fall through to fallback title */
+      }
+    }
+    result.push({
+      adr: num,
+      title: title || note,
+      note,
+      path: file ? `docs/adr/${file}` : `docs/adr/${num}-*.md`,
+    });
+  }
+  return result;
+}
+
+/** Pull the human title out of an ADR's `# ADR NNNN — <title>` heading. */
+function extractAdrTitle(raw: string): string {
+  const line = raw.split('\n').find(l => /^#\s+/.test(l));
+  if (!line) return '';
+  // Strip the leading `# ADR NNNN — ` prefix, keep the descriptive title.
+  return line
+    .replace(/^#\s+/, '')
+    .replace(/^ADR\s+\d{4}\s*[—-]\s*/, '')
+    .trim();
+}
+
+interface StandardsBlocks {
+  flavor: ServiceStandardsFlavor;
+  summary: string;
+  fullTextAssist: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Assemble the standards index for a flavor. Read-only; pure assembly of
+ * pointers over the curated ADR scan + backing-assist references.
+ */
+export async function buildServiceStandards(flavor: ServiceStandardsFlavor): Promise<StandardsBlocks> {
+  if (flavor === 'generic') {
+    return {
+      flavor,
+      summary:
+        'Platform-agnostic development standards for any new project. Fetch the full text via get_assist("generic-project-standards").',
+      fullTextAssist: 'generic-project-standards',
+      standards: {
+        commitConvention:
+          'Conventional Commits: `type(scope): description`. Keep subjects parser-clean — no extra parentheses beyond the conventional (scope).',
+        releaseDiscipline:
+          'Never hand-bump versions/changelogs. Releases are derived from the commit history (release-please principle).',
+        testAndCoverage:
+          'New/changed code carries tests. Hold a diff-coverage floor of 70% on changed lines; prefer a test per acceptance criterion.',
+        secretHygiene:
+          'No literal secrets in committed files (keys, tokens, passwords). Inject secrets at deploy/runtime; placeholders only in source.',
+        scriptsOverProse:
+          'Deterministic, repeatable steps belong in a checked-in script (fixed flags, hard-capped polls, guaranteed cleanup), not prose an agent re-interprets.',
+      },
+    };
+  }
+
+  // flavor === 'servicebay'
+  const mustRespectAdrs = await scanCuratedAdrs();
+  return {
+    flavor,
+    summary:
+      'Curated pointer index for building a new ServiceBay service. Read the referenced docs/ files directly and fetch each assist in full via get_assist(id). Full checklist: get_assist("new-service-standards").',
+    fullTextAssist: 'new-service-standards',
+    mustRespectAdrs,
+    enforcedInvariants: {
+      pointer: 'docs/ARCHITECTURE_INVARIANTS.md',
+      note: 'Enforced by scripts, not prose. Run the gates before an architecture change and before opening a PR.',
+      gateCommands: [
+        'npm run check:arch  # architecture invariants + dependency-cruiser',
+        'npm run lint        # zero errors; do not raise the warning count',
+      ],
+      diffCoverageFloor: '70% on changed lines',
+    },
+    assistsToRead: {
+      note: 'Fetch full text via get_assist(id); use list_assists to read each whenToUse and self-select.',
+      ids: [
+        { id: 'new-service-architecture', why: 'Recommended defaults (language, structure, libraries, tests, storage, secrets) + the ADRs a new service must respect.' },
+        { id: 'create-service', why: 'Concrete recipe to build and deploy a service repo behind SSO.' },
+        { id: 'servicebay-overview', why: 'What the platform is and how the pieces fit together.' },
+        { id: 'footgun-forward-auth-acme-collision', why: 'Footgun: forward-auth vs ACME cert collision.' },
+        { id: 'footgun-subdomain-needs-public-domain', why: 'Footgun: a public subdomain needs a public domain.' },
+      ],
+    },
+    templateContract: {
+      note: 'Services ship as templates, not code.',
+      pointers: ['docs/TEMPLATE_AUTHORING.md', 'templates/CLAUDE.md'],
+    },
+  };
+}

--- a/tests/backend/mcp_service_standards.test.ts
+++ b/tests/backend/mcp_service_standards.test.ts
@@ -1,0 +1,138 @@
+/**
+ * get_service_standards MCP tool (#2323).
+ *
+ * Covers both flavors of the curated standards index:
+ *   - servicebay: the four blocks (mustRespectAdrs / enforcedInvariants /
+ *     assistsToRead / templateContract), with ADR titles scanned live from
+ *     docs/adr/*.md so they can't drift from the source.
+ *   - generic: platform-agnostic dev standards with NO ServiceBay ADRs or
+ *     template details.
+ * Plus the read scope and that the referenced assist ids actually resolve.
+ *
+ * Pure file-system + parsing (process.cwd() is the repo root under vitest). No
+ * agent / network needed.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+  buildServiceStandards,
+  scanCuratedAdrs,
+  SERVICE_STANDARDS_FLAVORS,
+} from '@/lib/mcp/serviceStandards';
+import { TOOL_SCOPES } from '@/lib/mcp/server';
+import { getAssist } from '@/lib/assists/catalog';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const ADR_DIR = path.join(REPO_ROOT, 'docs', 'adr');
+
+/** Pull the descriptive title from an ADR file's `# ADR NNNN — <title>` head. */
+function adrTitleFromFile(file: string): string {
+  const raw = fs.readFileSync(path.join(ADR_DIR, file), 'utf-8');
+  const line = raw.split('\n').find(l => /^#\s+/.test(l)) ?? '';
+  return line.replace(/^#\s+/, '').replace(/^ADR\s+\d{4}\s*[—-]\s*/, '').trim();
+}
+
+describe('get_service_standards scope (#2323)', () => {
+  it('is registered as a read-scoped tool', () => {
+    expect(TOOL_SCOPES.get_service_standards).toBe('read');
+  });
+
+  it('exposes exactly the two documented flavors', () => {
+    expect([...SERVICE_STANDARDS_FLAVORS]).toEqual(['servicebay', 'generic']);
+  });
+});
+
+describe('get_service_standards — servicebay flavor (#2323)', () => {
+  it('returns the four curated blocks', async () => {
+    const s = await buildServiceStandards('servicebay');
+    expect(s.flavor).toBe('servicebay');
+    expect(s.mustRespectAdrs).toBeDefined();
+    expect(s.enforcedInvariants).toBeDefined();
+    expect(s.assistsToRead).toBeDefined();
+    expect(s.templateContract).toBeDefined();
+  });
+
+  it('mustRespectAdrs titles match docs/adr/*.md exactly (drift-free)', async () => {
+    const s = await buildServiceStandards('servicebay');
+    const adrs = s.mustRespectAdrs as { adr: string; title: string; path: string }[];
+    // The curated selection required by the issue.
+    expect(adrs.map(a => a.adr)).toEqual(['0001', '0003', '0004', '0007', '0009', '0010']);
+
+    for (const a of adrs) {
+      const file = path.basename(a.path);
+      expect(fs.existsSync(path.join(ADR_DIR, file)), `ADR file exists: ${file}`).toBe(true);
+      // Title is scanned from the source, not hard-coded.
+      expect(a.title).toBe(adrTitleFromFile(file));
+    }
+  });
+
+  it('resolves the 0009 slot to the tokens-and-trust ADR, not repair', async () => {
+    const s = await buildServiceStandards('servicebay');
+    const adrs = s.mustRespectAdrs as { adr: string; path: string }[];
+    const nine = adrs.find(a => a.adr === '0009');
+    expect(nine?.path).toContain('service-tokens');
+  });
+
+  it('enforcedInvariants points at ARCHITECTURE_INVARIANTS and carries the gate commands', async () => {
+    const s = await buildServiceStandards('servicebay');
+    const inv = s.enforcedInvariants as { pointer: string; gateCommands: string[]; diffCoverageFloor: string };
+    expect(inv.pointer).toBe('docs/ARCHITECTURE_INVARIANTS.md');
+    expect(inv.gateCommands.join(' ')).toContain('npm run check:arch');
+    expect(inv.gateCommands.join(' ')).toContain('npm run lint');
+    expect(inv.diffCoverageFloor).toContain('70');
+  });
+
+  it('templateContract points at the authoring doc + template contract', async () => {
+    const s = await buildServiceStandards('servicebay');
+    const tc = s.templateContract as { pointers: string[] };
+    expect(tc.pointers).toContain('docs/TEMPLATE_AUTHORING.md');
+    expect(tc.pointers).toContain('templates/CLAUDE.md');
+  });
+
+  it('every assistsToRead id resolves via get_assist', async () => {
+    const s = await buildServiceStandards('servicebay');
+    const block = s.assistsToRead as { ids: { id: string }[] };
+    for (const { id } of block.ids) {
+      const body = await getAssist(id);
+      expect(body, `assist "${id}" resolves`).not.toBeNull();
+    }
+    // The single-source backing checklist itself is resolvable.
+    expect(await getAssist('new-service-standards')).not.toBeNull();
+  });
+});
+
+describe('get_service_standards — generic flavor (#2323)', () => {
+  it('returns platform-agnostic standards', async () => {
+    const s = await buildServiceStandards('generic');
+    expect(s.flavor).toBe('generic');
+    const std = s.standards as Record<string, string>;
+    expect(std.commitConvention).toBeTruthy();
+    expect(std.releaseDiscipline).toBeTruthy();
+    expect(std.testAndCoverage).toContain('70');
+    expect(std.secretHygiene).toBeTruthy();
+    expect(std.scriptsOverProse).toBeTruthy();
+  });
+
+  it('carries NO ServiceBay ADRs or template details', async () => {
+    const s = await buildServiceStandards('generic');
+    expect(s.mustRespectAdrs).toBeUndefined();
+    expect(s.templateContract).toBeUndefined();
+    expect(JSON.stringify(s)).not.toContain('docs/adr');
+  });
+
+  it('points at its single-source backing assist, which resolves', async () => {
+    const s = await buildServiceStandards('generic');
+    expect(s.fullTextAssist).toBe('generic-project-standards');
+    expect(await getAssist('generic-project-standards')).not.toBeNull();
+  });
+});
+
+describe('scanCuratedAdrs (#2323)', () => {
+  it('never returns an empty selection', async () => {
+    const adrs = await scanCuratedAdrs();
+    expect(adrs.length).toBe(6);
+    for (const a of adrs) expect(a.title.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Batch `batch/2026-07-18a` — MCP-Oberfläche verschlanken (3 Units).

Closes #2323
Closes #2324
Closes #2325

**Commits**
- `refactor(mcp)!:` 9 nahezu doppelte Tools zu `get_logs`/`manage_service`/`get_template_artifact` gemerged (#2324). BREAKING: harter Ersatz der öffentlichen MCP-Tools; zusätzlich `list_requests` gemerged; `upsert_proxy_route`/`stat_jail` dokumentiert abgelehnt.
- `feat(mcp):` neues read-scoped `get_service_standards` (kuratierter Standards-Index, `flavor: servicebay|generic`) (#2323).
- `perf(mcp):` scope-gefilterte `tools/list` + deterministische Ordnung + `defer_loading`-Kernset (#2325).

**Lokales Safety-Net-Gate grün:** lint 0 Fehler, typecheck clean, check:arch pass, vitest 3996 passed / 2 skipped.

**Für Review geparkt (Dependabot, nicht in diesem Batch):** #2290 dependency-cruiser 18 (droppt Node-20-Support), #2291 TypeScript 7 (bricht Next.js-Erkennung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
