### PR TITLE
chore(deps-dev): dependency-cruiser 17.4.3 → 18.1.0 (#2290)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@types/ssh2": "^1.15.5",
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "4.1.10",
-        "dependency-cruiser": "^17.4.3",
+        "dependency-cruiser": "^18.1.0",
         "esbuild": "^0.28.1",
         "eslint": "^10.7.0",
         "eslint-config-next": "16.2.10",
@@ -67,7 +67,7 @@
         "vitest": "^4.0.16"
       },
       "engines": {
-        "node": "20.x"
+        "node": "22.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4633,9 +4633,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5638,13 +5638,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -6072,30 +6072,30 @@
       }
     },
     "node_modules/dependency-cruiser": {
-      "version": "17.4.3",
-      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.4.3.tgz",
-      "integrity": "sha512-L4GLuAvmXevWnPCIaFfOz6eD92c+yY+pDgVqgufrLDnW3xYA799CSZQlly2r2N13nhAlnZY6VzY7Rx5pHNvk2w==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-18.1.0.tgz",
+      "integrity": "sha512-pbsH0gQ15BxXi97SCuMeVgsh8VzYpziGIVaMdnALbVu+TYjSZrW9/nOvsPU+NjHLmJSF9R1UijjoACq6Ne/ybQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "8.16.0",
+        "acorn": "8.17.0",
         "acorn-jsx": "5.3.2",
         "acorn-jsx-walk": "2.0.0",
         "acorn-loose": "8.5.2",
         "acorn-walk": "8.3.5",
-        "commander": "14.0.3",
-        "enhanced-resolve": "5.22.1",
-        "ignore": "7.0.5",
+        "commander": "15.0.0",
+        "enhanced-resolve": "5.24.2",
+        "ignore": "7.0.6",
         "interpret": "3.1.1",
         "is-installed-globally": "1.0.0",
         "json5": "2.2.3",
-        "picomatch": "4.0.4",
+        "picomatch": "4.0.5",
         "prompts": "2.4.2",
         "rechoir": "0.8.0",
         "safe-regex": "2.1.1",
-        "semver": "7.8.1",
+        "semver": "7.8.5",
         "tsconfig-paths-webpack-plugin": "4.2.0",
-        "watskeburt": "5.0.3"
+        "watskeburt": "6.0.0"
       },
       "bin": {
         "depcruise": "bin/dependency-cruise.mjs",
@@ -6106,13 +6106,13 @@
         "dependency-cruiser": "bin/dependency-cruise.mjs"
       },
       "engines": {
-        "node": "^20.12||^22||>=24"
+        "node": "^22||^24||>=26"
       }
     },
     "node_modules/dependency-cruiser/node_modules/enhanced-resolve": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
-      "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7618,6 +7618,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8185,9 +8186,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11346,9 +11347,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12223,9 +12224,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14058,16 +14059,16 @@
       }
     },
     "node_modules/watskeburt": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz",
-      "integrity": "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-6.0.0.tgz",
+      "integrity": "sha512-jfiuDABaxSkC71T6oZ3vCS99roYkSHm/+As+G0Dz8taAHQb+SJBvLEm5RlsgG71XdfAj3rv7eudUBTgwcQUPlQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "watskeburt": "dist/run-cli.js"
       },
       "engines": {
-        "node": "^20.12||^22.13||>=24.0"
+        "node": "^22.13||^24||>=26"
       }
     },
     "node_modules/webidl-conversions": {
@@ -14535,18 +14536,6 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "packages/backend/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/backup-worker": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@types/ssh2": "^1.15.5",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "4.1.10",
-    "dependency-cruiser": "^17.4.3",
+    "dependency-cruiser": "^18.1.0",
     "esbuild": "^0.28.1",
     "eslint": "^10.7.0",
     "eslint-config-next": "16.2.10",


### PR DESCRIPTION
Batch `batch/2026-07-18a` — dependency-cruiser 17.4.3 → 18.1.0.

Closes #2290

`chore(deps-dev):` hebt dependency-cruiser auf 18.1.0 (jetzt von Node 22 entsperrt — v18 verlangt Node ≥22). **Keine Config-Migration nötig:** v18-Breaking ist nur der Node-20/25-Drop + interner Resolver-Refactor (enhanced-resolve liefert tsconfig-paths nativ); die `.dependency-cruiser.cjs`-Schlüssel sind unverändert.

Gate grün: lint 0 Fehler, typecheck clean, vitest 3996 passed; `check:deps` (v18) 1082 Module / 0 Violations. CI auf Node 22 ist der Backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
