### PR TITLE
feat(mcp): Assist-Katalog nativ über MCP Resources + Prompts (Epic #2326 s6, schließt Epic)

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -200,6 +200,31 @@ the promotion backlog. Each entry carries a `promotionHint`; making a runtime
 assist permanent (shipped in the image) is a later manual repo PR that adds the
 file.
 
+### Native distribution: assists as MCP resources + prompts (#2326 s6)
+
+The assist catalog is ALSO exposed over MCP's **native** primitives, so a client
+can discover + load knowledge without knowing our tool names (`list_assists` /
+`get_assist` stay unchanged — this is purely **additive**):
+
+- **Resources.** Every assist — built-in and landed local — is an MCP
+  **Resource** under an `assist://<id>` URI (`text/markdown`), served via a
+  ResourceTemplate whose list callback enumerates the catalog **live** (the same
+  `listAssists` loader the tools use), so newly-landed local-assists appear
+  without a restart. Each resource's `source` (Built-in/Local) and `kind` ride
+  in the description + `_meta`. Read a resource to get the full assist markdown.
+- **Prompts.** The curated **actionable** subset (kinds `guide` / `recipe` /
+  `checklist` / `adr` — e.g. `servicebay-overview`, `create-service`,
+  `new-service-architecture`) is exposed as MCP **Prompts** (`assist_<id>`), each
+  returning the assist content as a prompt message so a client can invoke an
+  operational how-to by name. `footgun` / `snippet` / `template` kinds stay
+  resources-only (reference/gotcha material, not a runnable walkthrough).
+
+Registering a resource/prompt makes the SDK advertise the `resources` /
+`prompts` capabilities automatically. Reading assists is read-tier knowledge —
+assists carry no secrets by contract (the secret-scan gate) and are already
+readable via the read-scoped tools — so the native surface introduces no new
+privilege. The mapping lives in `packages/backend/src/lib/mcp/assistCatalog.ts`.
+
 ## Tool visibility is scoped to your token (#2325)
 
 `tools/list` returns **only the tools your token could actually call**. A tool

--- a/packages/backend/src/lib/mcp/assistCatalog.ts
+++ b/packages/backend/src/lib/mcp/assistCatalog.ts
@@ -1,0 +1,205 @@
+/**
+ * Assist-catalog → MCP native-primitive mapping (#2326 slice 6).
+ *
+ * Slices 1–5 exposed the assist catalog over two MCP *tools* (`list_assists` /
+ * `get_assist`). Those stay for back-compat. This module adds the mapping that
+ * lets `createMcpServer` register the SAME catalog as MCP-*native* primitives:
+ *
+ *   - **Resources** — every assist (built-in + landed local) is an MCP Resource
+ *     under an `assist://<id>` URI, so any MCP client natively lists + reads
+ *     them without knowing our tool names. Resources reflect newly-landed
+ *     local-assists dynamically because they enumerate via the same `listAssists`
+ *     loader the tools use — nothing is snapshotted at server-construction time.
+ *
+ *   - **Prompts** — the curated, ACTIONABLE guides (kinds `guide`/`recipe`/
+ *     `checklist`; ADR recommendations are `guide`-adjacent orientation and are
+ *     included) are ALSO exposed as MCP Prompts, so a client can invoke an
+ *     operational how-to by name. `footgun`/`snippet` kinds stay resources-only
+ *     (they're reference/gotcha material, not a runnable walkthrough).
+ *
+ * The mapping lives here — a small, pure-ish data layer over the catalog — so it
+ * is unit-testable directly without spinning up the full MCP server + a
+ * transport. `server.ts` calls `registerAssistCatalog(server)` to wire it.
+ *
+ * Scope/visibility (#2325 consistency): reading assists is read-tier knowledge.
+ * Assists carry no secrets by contract (the secret-scan gate,
+ * tests/backend/assist_consistency.test.ts) and are already exposed to any
+ * read-scoped token via list_assists/get_assist, so the resource/prompt surface
+ * introduces no new privilege — it's an additional, equivalent read surface.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ListResourcesResult, ReadResourceResult, GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import { listAssists, getAssist, type AssistKind, type AssistSummary } from '@/lib/assists/catalog';
+
+/** The `assist://` URI scheme every assist resource is served under. */
+export const ASSIST_URI_SCHEME = 'assist';
+
+/**
+ * Assist kinds that make good ACTIONABLE prompts (runnable how-tos an agent can
+ * follow start-to-finish). `guide` covers the orientation/how-to assists (e.g.
+ * servicebay-overview) AND the ADR-style recommendation assists — the catalog
+ * coerces an unknown kind to `guide`, and new-service-architecture is kind
+ * `adr` which we intentionally include below. `footgun`/`snippet`/`template`
+ * stay resources-only (reference/gotcha material, not a walkthrough).
+ */
+export const PROMPT_ASSIST_KINDS: readonly AssistKind[] = ['guide', 'recipe', 'checklist', 'adr'];
+
+/** Build the canonical `assist://<id>` URI for an assist id. */
+export function assistUri(id: string): string {
+  return `${ASSIST_URI_SCHEME}://${id}`;
+}
+
+/**
+ * Parse an `assist://<id>` URI back to its assist id, or null if the URI is not
+ * an assist URI. Handles the landed `local/<slug>` namespaced ids: the `local/`
+ * shows up in the URI path, so we recover it from the full href rather than
+ * `URL.host` alone (which drops the path segment).
+ */
+export function assistIdFromUri(uri: string | URL): string | null {
+  const href = typeof uri === 'string' ? uri : uri.href;
+  const prefix = `${ASSIST_URI_SCHEME}://`;
+  if (!href.startsWith(prefix)) return null;
+  const id = decodeURIComponent(href.slice(prefix.length));
+  return id.length > 0 ? id : null;
+}
+
+/**
+ * A stable, MCP-safe prompt name for an assist. Prompt names should be simple
+ * identifiers; the landed `local/<slug>` ids contain a `/`, so we flatten it to
+ * `local_<slug>`. Prefixed `assist_` so the prompt namespace is self-describing
+ * and can't collide with a future non-assist prompt.
+ */
+export function assistPromptName(id: string): string {
+  return `assist_${id.replace(/\//g, '_')}`;
+}
+
+/**
+ * Map an assist summary to its MCP Resource descriptor (the `resources/list`
+ * entry shape). `source` (Built-in/Local) rides in both the description and the
+ * `_meta`, and `kind` rides in `_meta` so a client can filter without a read.
+ */
+export function assistResourceDescriptor(a: AssistSummary): ListResourcesResult['resources'][number] {
+  return {
+    uri: assistUri(a.id),
+    name: a.id,
+    title: a.title,
+    description: `[${a.source} · ${a.kind}] ${a.whenToUse}`.trim(),
+    mimeType: 'text/markdown',
+    _meta: { source: a.source, kind: a.kind, tags: a.tags },
+  };
+}
+
+/** Enumerate every catalog assist as an MCP resource-list result. */
+export async function listAssistResources(): Promise<ListResourcesResult> {
+  const assists = await listAssists();
+  return { resources: assists.map(assistResourceDescriptor) };
+}
+
+/**
+ * Read one assist by its `assist://<id>` URI and return the MCP
+ * read-resource result (the raw markdown). Throws if the id is unknown/unsafe —
+ * the SDK turns a thrown error into a proper MCP error response.
+ */
+export async function readAssistResource(uri: URL): Promise<ReadResourceResult> {
+  const id = assistIdFromUri(uri);
+  if (!id) throw new Error(`Not an assist URI: ${uri.href}`);
+  const body = await getAssist(id);
+  if (body == null) throw new Error(`No assist found with id "${id}".`);
+  return {
+    contents: [{ uri: uri.href, mimeType: 'text/markdown', text: body }],
+  };
+}
+
+/**
+ * The curated set of assists exposed as MCP prompts: the actionable-kind
+ * subset (guide/recipe/checklist/adr). Data-driven from the catalog — new
+ * actionable assists (built-in OR landed local) appear automatically.
+ */
+export async function listPromptAssists(): Promise<AssistSummary[]> {
+  const assists = await listAssists();
+  const promptKinds = new Set<AssistKind>(PROMPT_ASSIST_KINDS);
+  return assists.filter(a => promptKinds.has(a.kind));
+}
+
+/**
+ * Read one assist and wrap its markdown as an MCP prompt result (a single user
+ * message carrying the guide content). Throws for an unknown id.
+ */
+export async function readAssistPrompt(id: string): Promise<GetPromptResult> {
+  const body = await getAssist(id);
+  if (body == null) throw new Error(`No assist found with id "${id}".`);
+  return {
+    messages: [
+      { role: 'user', content: { type: 'text', text: body } },
+    ],
+  };
+}
+
+/**
+ * Register the assist catalog as MCP **resources** on `server` (synchronous).
+ *
+ * Registering a resource makes the SDK advertise the `resources` capability to
+ * clients automatically (capability declaration is registration-driven), so
+ * this is all that's needed for that advertisement — nothing in server.ts
+ * suppresses it.
+ *
+ * Uses a ResourceTemplate (`assist://{id}`) whose list callback enumerates the
+ * catalog LIVE and whose read callback resolves the id at read time — so
+ * newly-landed local-assists show up without re-registration. Because the
+ * enumeration is deferred to the (async) list callback, this registration
+ * itself is synchronous and safe to call from the sync `createMcpServer`.
+ */
+export function registerAssistResources(server: McpServer): void {
+  server.registerResource(
+    'assist',
+    new ResourceTemplate(`${ASSIST_URI_SCHEME}://{id}`, {
+      list: async () => listAssistResources(),
+    }),
+    {
+      title: 'ServiceBay assist catalog',
+      description:
+        'Task-help knowledge entries (guides, recipes, ADR-style recommendations, checklists, footguns, snippets) — built-in and landed local. Read one to get its full markdown.',
+      mimeType: 'text/markdown',
+    },
+    async (uri) => readAssistResource(uri),
+  );
+}
+
+/**
+ * Register the curated actionable guides as MCP **prompts** on `server` (async).
+ *
+ * Registering a prompt makes the SDK advertise the `prompts` capability
+ * automatically. Prompts are per-assist named (`assist_<id>`) and registered
+ * from a snapshot of the current actionable assists — unlike resources, MCP
+ * prompts have no template/list primitive to defer enumeration, so this must
+ * fetch the catalog up front (hence async). A fresh server is built per MCP
+ * request path, so a landed actionable assist becomes a prompt on the next
+ * server construction; the resource surface is the always-live view, prompts
+ * are the curated convenience layer over the actionable subset.
+ */
+export async function registerAssistPrompts(server: McpServer): Promise<void> {
+  const promptAssists = await listPromptAssists();
+  for (const a of promptAssists) {
+    server.registerPrompt(
+      assistPromptName(a.id),
+      {
+        title: a.title,
+        description: `[${a.source} · ${a.kind}] ${a.whenToUse}`.trim(),
+      },
+      async () => readAssistPrompt(a.id),
+    );
+  }
+}
+
+/**
+ * Register the full assist catalog (resources + prompts) on `server`. Async
+ * because the prompt half needs a catalog snapshot; call it after
+ * `createMcpServer(...).__baseServer` at the transport boundary (where an await
+ * is available) so every MCP client gets both native surfaces.
+ */
+export async function registerAssistCatalog(server: McpServer): Promise<void> {
+  registerAssistResources(server);
+  await registerAssistPrompts(server);
+}

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -15,6 +15,7 @@ import {
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { getTemplates, getReadme, getTemplateYaml, getTemplateVariables } from '@/lib/registry';
 import { listAssists, getAssist, ASSIST_KINDS, listAssistDrift } from '@/lib/assists/catalog';
+import { registerAssistResources } from './assistCatalog';
 import {
   submitProposal,
   ProposalError,
@@ -608,7 +609,20 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
       baseServer.tool(name, desc, schema, safeHandler(name, handler, opts?.auth)),
     connect: baseServer.connect.bind(baseServer),
     close: baseServer.close.bind(baseServer),
+    // The underlying McpServer, exposed so the transport boundary can register
+    // the async half of the assist catalog (prompts) — see registerAssistCatalog
+    // (#2326 s6). Resources are registered synchronously below.
+    __baseServer: baseServer,
   };
+
+  // --- Native assist-catalog distribution (#2326 s6) ---
+  // Expose the SAME assist catalog (list_assists/get_assist stay, additive) as
+  // MCP-native resources so any client can list + read assists without our tool
+  // names. Read-tier knowledge: assists carry no secrets (secret-scan gate) and
+  // are already readable via the read-scoped tools, so this adds no privilege.
+  // Resources register synchronously (template defers enumeration); the prompt
+  // half is async and wired at the transport boundary via registerAssistCatalog.
+  registerAssistResources(baseServer);
 
   // --- List Nodes ---
   server.tool('list_nodes', 'List all registered nodes with connection status and resources', {}, async () => {

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -39,6 +39,7 @@ import { syncRegistries } from './lib/registry';
 import { reconcileLanIp } from './lib/lanIp';
 import { lazyInitializeExpiry as initBootstrapTokenExpiry } from './lib/mcp/bootstrapToken';
 import { createMcpServer } from './lib/mcp/server';
+import { registerAssistPrompts } from './lib/mcp/assistCatalog';
 import { isMcpApprovePath, handleMcpApproveRequest } from './lib/mcp/approveRoute';
 import { scheduleBackup } from './lib/backup/service';
 import { scheduleExternalNasBackup } from './lib/externalBackup/producer';
@@ -266,6 +267,11 @@ app.prepare().then(() => {
         // Stateless: create a fresh server + transport per request, with
         // the auth context closed over so each tool call can scope-check.
         const mcpServer = createMcpServer({ auth });
+        // Register the curated actionable guides as MCP prompts (#2326 s6). The
+        // async prompt half needs a catalog snapshot, so it's wired here at the
+        // transport boundary before connect; resources are already registered
+        // synchronously inside createMcpServer.
+        await registerAssistPrompts(mcpServer.__baseServer);
         const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
         await mcpServer.connect(transport);
         const body = await collectBody(req);

--- a/tests/backend/mcp_assist_native_distribution.test.ts
+++ b/tests/backend/mcp_assist_native_distribution.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+// Native MCP distribution of the assist catalog (#2326 slice 6):
+//   - assists are exposed as MCP Resources (assist://<id>), list + read,
+//     including landed local-assists, with `source` in the metadata;
+//   - the curated actionable guides (kinds guide/recipe/checklist/adr) are
+//     exposed as MCP Prompts that return the assist markdown;
+//   - list_assists / get_assist tools stay unchanged (additive invariant).
+//
+// We test the catalog→MCP mapping data layer directly (the SDK's
+// resource/prompt registration is awkward to drive through a full transport in
+// a unit test; the mapping is where the real logic lives).
+
+const dirState = vi.hoisted(() => ({ dir: '/tmp/sb-native-boot' }));
+
+vi.mock('@/lib/dirs', () => ({
+  get DATA_DIR() {
+    return dirState.dir;
+  },
+}));
+
+import {
+  assistUri,
+  assistIdFromUri,
+  assistPromptName,
+  assistResourceDescriptor,
+  listAssistResources,
+  readAssistResource,
+  listPromptAssists,
+  readAssistPrompt,
+  PROMPT_ASSIST_KINDS,
+  ASSIST_URI_SCHEME,
+} from '@/lib/mcp/assistCatalog';
+import { DATA_DIR } from '@/lib/dirs';
+
+function builtinDir() {
+  return path.join(dirState.dir, 'assists');
+}
+function landedDir() {
+  return path.join(DATA_DIR, 'local-assists', 'landed');
+}
+
+async function writeAssist(
+  dir: string,
+  slug: string,
+  opts: { title?: string; kind?: string; whenToUse?: string } = {},
+) {
+  await fs.mkdir(dir, { recursive: true });
+  const title = opts.title ?? 'Test Assist';
+  const kind = opts.kind ?? 'guide';
+  const when = opts.whenToUse ?? 'When you need to test.';
+  const content = `---
+title: "${title}"
+whenToUse: "${when}"
+kind: ${kind}
+tags: ["test"]
+---
+# ${title}
+
+Body of ${slug}.
+`;
+  await fs.writeFile(path.join(dir, `${slug}.md`), content, 'utf-8');
+}
+
+let origCwd: string;
+
+beforeEach(async () => {
+  dirState.dir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-native-'));
+  origCwd = process.cwd();
+  // Built-in dir = process.cwd()/assists; chdir into the tmp dir so we control
+  // the built-in catalog contents.
+  process.chdir(dirState.dir);
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  process.chdir(origCwd);
+  await fs.rm(dirState.dir, { recursive: true, force: true });
+});
+
+describe('assist URI helpers (#2326 s6)', () => {
+  it('round-trips a bare id through assist://', () => {
+    const uri = assistUri('servicebay-overview');
+    expect(uri).toBe(`${ASSIST_URI_SCHEME}://servicebay-overview`);
+    expect(assistIdFromUri(uri)).toBe('servicebay-overview');
+    expect(assistIdFromUri(new URL(uri))).toBe('servicebay-overview');
+  });
+
+  it('round-trips a namespaced landed id (keeps the local/ path segment)', () => {
+    const uri = assistUri('local/my-recipe');
+    expect(assistIdFromUri(uri)).toBe('local/my-recipe');
+  });
+
+  it('returns null for a non-assist URI', () => {
+    expect(assistIdFromUri('https://example.com/x')).toBeNull();
+    expect(assistIdFromUri(`${ASSIST_URI_SCHEME}://`)).toBeNull();
+  });
+
+  it('flattens the slash in a prompt name', () => {
+    expect(assistPromptName('servicebay-overview')).toBe('assist_servicebay-overview');
+    expect(assistPromptName('local/my-recipe')).toBe('assist_local_my-recipe');
+  });
+});
+
+describe('assist resources (#2326 s6)', () => {
+  it('lists built-in assists AND a landed local-assist as resources', async () => {
+    await writeAssist(builtinDir(), 'servicebay-overview', { title: 'ServiceBay Overview', kind: 'guide' });
+    await writeAssist(landedDir(), 'my-landed-recipe', { title: 'My Landed Recipe', kind: 'recipe' });
+
+    const { resources } = await listAssistResources();
+    const byUri = new Map(resources.map(r => [r.uri, r]));
+
+    // Built-in resource present.
+    const builtin = byUri.get(assistUri('servicebay-overview'));
+    expect(builtin).toBeDefined();
+    expect(builtin!.name).toBe('servicebay-overview');
+    expect(builtin!.mimeType).toBe('text/markdown');
+    expect(builtin!.description).toContain('Built-in');
+    expect((builtin!._meta as Record<string, unknown>).source).toBe('Built-in');
+
+    // Landed local-assist present under its namespaced id + Local source.
+    const landed = byUri.get(assistUri('local/my-landed-recipe'));
+    expect(landed).toBeDefined();
+    expect(landed!.name).toBe('local/my-landed-recipe');
+    expect(landed!.description).toContain('Local');
+    expect((landed!._meta as Record<string, unknown>).source).toBe('Local');
+  });
+
+  it('reflects a newly-landed local-assist dynamically (same loader as the tools)', async () => {
+    const before = (await listAssistResources()).resources;
+    expect(before.map(r => r.uri)).not.toContain(assistUri('local/fresh'));
+
+    await writeAssist(landedDir(), 'fresh', { title: 'Fresh' });
+
+    const after = (await listAssistResources()).resources;
+    expect(after.map(r => r.uri)).toContain(assistUri('local/fresh'));
+  });
+
+  it('reads a resource and returns the assist markdown body', async () => {
+    await writeAssist(builtinDir(), 'servicebay-overview', { title: 'ServiceBay Overview' });
+
+    const result = await readAssistResource(new URL(assistUri('servicebay-overview')));
+    expect(result.contents).toHaveLength(1);
+    const c = result.contents[0] as { uri: string; mimeType?: string; text: string };
+    expect(c.uri).toBe(assistUri('servicebay-overview'));
+    expect(c.mimeType).toBe('text/markdown');
+    expect(String(c.text)).toContain('Body of servicebay-overview.');
+    expect(String(c.text)).toContain('title:');
+  });
+
+  it('reads a landed local-assist by its namespaced URI', async () => {
+    await writeAssist(landedDir(), 'my-landed-recipe', { title: 'My Landed Recipe' });
+    const result = await readAssistResource(new URL(assistUri('local/my-landed-recipe')));
+    expect(String((result.contents[0] as { text: string }).text)).toContain('Body of my-landed-recipe.');
+  });
+
+  it('throws for an unknown assist id', async () => {
+    await expect(readAssistResource(new URL(assistUri('does-not-exist')))).rejects.toThrow(/No assist found/);
+  });
+
+  it('descriptor carries source + kind in _meta', () => {
+    const d = assistResourceDescriptor({
+      id: 'x',
+      title: 'X',
+      whenToUse: 'when x',
+      kind: 'footgun',
+      tags: ['a'],
+      source: 'Built-in',
+    });
+    expect(d.uri).toBe(assistUri('x'));
+    expect(d.mimeType).toBe('text/markdown');
+    expect((d._meta as Record<string, unknown>).source).toBe('Built-in');
+    expect((d._meta as Record<string, unknown>).kind).toBe('footgun');
+  });
+});
+
+describe('assist prompts (#2326 s6)', () => {
+  it('exposes actionable-kind assists as prompts and excludes footgun/snippet', async () => {
+    await writeAssist(builtinDir(), 'a-guide', { title: 'A Guide', kind: 'guide' });
+    await writeAssist(builtinDir(), 'a-recipe', { title: 'A Recipe', kind: 'recipe' });
+    await writeAssist(builtinDir(), 'a-checklist', { title: 'A Checklist', kind: 'checklist' });
+    await writeAssist(builtinDir(), 'an-adr', { title: 'An ADR', kind: 'adr' });
+    await writeAssist(builtinDir(), 'a-footgun', { title: 'A Footgun', kind: 'footgun' });
+    await writeAssist(builtinDir(), 'a-snippet', { title: 'A Snippet', kind: 'snippet' });
+
+    const prompts = await listPromptAssists();
+    const ids = prompts.map(p => p.id).sort();
+    expect(ids).toEqual(['a-checklist', 'a-guide', 'a-recipe', 'an-adr']);
+    // footgun/snippet stay resources-only.
+    expect(ids).not.toContain('a-footgun');
+    expect(ids).not.toContain('a-snippet');
+  });
+
+  it('PROMPT_ASSIST_KINDS is the curated actionable subset', () => {
+    expect([...PROMPT_ASSIST_KINDS].sort()).toEqual(['adr', 'checklist', 'guide', 'recipe']);
+  });
+
+  it('reads a prompt and returns the assist content as a user message', async () => {
+    await writeAssist(builtinDir(), 'a-guide', { title: 'A Guide', kind: 'guide' });
+    const result = await readAssistPrompt('a-guide');
+    expect(result.messages).toHaveLength(1);
+    const msg = result.messages[0];
+    expect(msg.role).toBe('user');
+    expect(msg.content.type).toBe('text');
+    expect(String((msg.content as { text: string }).text)).toContain('Body of a-guide.');
+  });
+
+  it('includes a landed actionable local-assist as a prompt', async () => {
+    await writeAssist(landedDir(), 'landed-recipe', { title: 'Landed Recipe', kind: 'recipe' });
+    const prompts = await listPromptAssists();
+    expect(prompts.map(p => p.id)).toContain('local/landed-recipe');
+  });
+
+  it('throws for an unknown prompt id', async () => {
+    await expect(readAssistPrompt('nope')).rejects.toThrow(/No assist found/);
+  });
+});
+
+describe('additive invariant: list_assists / get_assist tools unchanged (#2326 s6)', () => {
+  it('the catalog tools remain read-scoped in TOOL_SCOPES (no new scope, additive)', async () => {
+    const { TOOL_SCOPES } = await import('@/lib/mcp/server');
+    expect(TOOL_SCOPES['list_assists']).toBe('read');
+    expect(TOOL_SCOPES['get_assist']).toBe('read');
+  });
+
+  it('createMcpServer still constructs (tools + native resources) after s6', async () => {
+    // A fresh server construction must not throw when the native resource/prompt
+    // surface was added, and must expose the underlying McpServer for the
+    // prompt-registration boundary.
+    const { createMcpServer } = await import('@/lib/mcp/server');
+    const server = createMcpServer();
+    expect(server).toBeTruthy();
+    expect(typeof server.__baseServer).toBe('object');
+    // The list_assists / get_assist tools are still registered on the base
+    // server's private registry (additive — s6 didn't remove them).
+    const reg = (server.__baseServer as unknown as {
+      _registeredTools: Record<string, unknown>;
+    })._registeredTools;
+    expect(reg).toHaveProperty('list_assists');
+    expect(reg).toHaveProperty('get_assist');
+  });
+});


### PR DESCRIPTION
Batch `batch/2026-07-18a` — Epic #2326 Slice 6: native MCP-Verteilung.

Closes #2326

`feat(mcp):` exponiert den Assist-Katalog nativ über MCP — zusätzlich zu `list_assists`/`get_assist` (additiv):
- **Resources** `assist://{id}` — Live-`list` via `listAssists`, `read` liefert Markdown, `source`+`kind` im Deskriptor; dynamisch inkl. gelandeter local-assists.
- **Prompts** für die kuratierte, actionable Teilmenge (guide/recipe/checklist/adr → `assist_<id>`, z. B. servicebay-overview, create-service, new-service-architecture); footgun/snippet/template bleiben resources-only.
- SDK bewirbt resources/prompts-Capabilities automatisch. Kein neuer Scope (read-tier). Neue testbare Datenschicht `lib/mcp/assistCatalog.ts`. docs/MCP.md aktualisiert.

**Damit ist Epic #2326 vollständig (s1–s6).**

Lokales Gate grün: lint 0 Fehler, typecheck clean, check:arch pass, 4070 Tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
