### PR TITLE
feat: Frontend-Komponentisierung erzwingen + auffindbar machen (#2352 #2353 #2354)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,12 @@ jobs:
         if: steps.cache-npm.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
       - run: npm run check:invariants
+      # Frontend copy-paste / duplicate-JSX report (#2354). Report-only
+      # (mirrors the #2353 lint-rule WARN staging + the semgrep/audit tiering):
+      # prints extraction candidates to the CI log but never blocks the merge.
+      # Ratchet to blocking with `-- --strict` once the frontend is deduped.
+      - name: Frontend duplicate-JSX report (report-only)
+        run: npm run check:frontend-dup || true
 
   depcruise:
     runs-on: ubuntu-latest

--- a/assists/service-ui-design-standard.md
+++ b/assists/service-ui-design-standard.md
@@ -20,6 +20,15 @@ Two rules of thumb: **:root IS dark** (the admin UI's default is dark; a
 color literals** — reference `--surface` / `--accent` / `--status-ok`, never a
 hard-coded hex, so a theme change is one place.
 
+> Inside ServiceBay's own frontend (`packages/frontend/`) this second rule is
+> **machine-enforced**, not just advisory: the `sb/no-raw-color-literal` and
+> `sb/no-raw-ui-primitive` ESLint rules flag raw colour literals (hex / `rgb()` /
+> `hsl()` / raw Tailwind ramps like `text-blue-500`) and raw
+> `<button>`/`<table>`/`<input>` in favour of the `@/components/ui` primitives +
+> `@theme` tokens (`components/ui/` itself is exempt). See
+> `docs/ARCHITECTURE_INVARIANTS.md` § *UI-primitive and design-token reuse*
+> (#2353). Adopt the same discipline in your own service and drift stays out.
+
 ## Palette (dark default)
 
 Surfaces, borders, and text — the chrome:

--- a/docs/ARCHITECTURE_INVARIANTS.md
+++ b/docs/ARCHITECTURE_INVARIANTS.md
@@ -147,6 +147,40 @@ Frontend reaches the backend exclusively through:
 
 ---
 
+### UI-primitive and design-token reuse (#2353)
+
+The frontend ships a hand-rolled design system — the primitives under
+`packages/frontend/src/components/ui/`
+(`Button`/`Card`/`Field`/`DataTable`/`Badge`/`StatusDot`/`SectionHeading`/`PageScroll`,
+imported from `@/components/ui`) and the semantic token layer in
+`packages/frontend/src/app/globals.css` (`@theme inline`: `accent`, `surface`,
+`border`, `text`, the `status-*` ramp, `on-accent`, radius/spacing scales,
+Tailwind v4). Two ESLint rules keep new UI on those rails instead of
+re-authoring raw elements + hard-coded colours (which caused drift + duplicates):
+
+- **`sb/no-raw-ui-primitive`**: forbids raw JSX `<button>` (→ `Button`),
+  `<table>` (→ `DataTable`), and `<input>`/`<select>`/`<textarea>` (→ `Field`)
+  in frontend surfaces. The message names the primitive to use.
+- **`sb/no-raw-color-literal`**: forbids raw colour literals — hex
+  (`#rrggbb`), `rgb()/hsl()`, and raw Tailwind numeric colour utilities
+  (`text-/bg-/border-/ring-/from-/to-{palette}-{n}` like `text-blue-500`) — in
+  favour of the semantic `@theme` token utilities.
+
+Both are **scoped to `packages/frontend/src/**` and EXEMPT
+`packages/frontend/src/components/ui/**`** (the primitives legitimately wrap the
+raw elements and map raw colours to tokens internally) plus `*.test.*`.
+
+**Severity is `warn` during rollout.** A one-shot fix was infeasible: the
+colour rule alone fires ~3,100 times across ~85 files, and rewriting each to a
+token while keeping every component visually identical is far past one unit's
+safe blast radius. `warn` keeps the 0-error lint gate green while surfacing
+every new + legacy violation in the editor and CI. **Ratchet plan:** burn the
+count down file-by-file via lint-sweep units, then flip each rule to `error`
+once its class reaches 0 — forward-only, never loosen. The `TODO(#2353)` in
+`eslint.config.mjs` tracks the two flips (colour-literal, ui-primitive).
+
+---
+
 ## What this rubric does *not* enforce
 
 These are still LLM-review territory. If you're booking another architect-review pass, scope it to these:

--- a/docs/ARCHITECTURE_INVARIANTS.md
+++ b/docs/ARCHITECTURE_INVARIANTS.md
@@ -179,6 +179,34 @@ count down file-by-file via lint-sweep units, then flip each rule to `error`
 once its class reaches 0 — forward-only, never loosen. The `TODO(#2353)` in
 `eslint.config.mjs` tracks the two flips (colour-literal, ui-primitive).
 
+### Component discovery + duplicate detection (#2354)
+
+Two companions to the reuse rules above — *you can only reuse what you can
+find, and only extract what you can see*:
+
+- **Component catalog — `/dev/components`** (`packages/frontend/src/app/(dashboard)/dev/components/page.tsx`).
+  A living gallery that renders every `@/components/ui` primitive in its key
+  states, driven off the barrel. Lightweight in-app route (no Storybook — the
+  CLAUDE.md ethos of not adding a heavy dependency), gated **dev-only**: the
+  whole `(dashboard)` group already sits behind the single-admin session, and
+  the page additionally `notFound()`s under a production build. When you add a
+  primitive to `@/components/ui`, add its gallery entry here — the catalog test
+  (`tests/frontend/ComponentCatalog.test.tsx`) asserts one section per primitive.
+
+- **Frontend duplicate-JSX report — `npm run check:frontend-dup`**
+  (`scripts/check-frontend-dup.ts`). A self-hosted copy-paste detector for
+  `packages/frontend/src` (the "same Card rendered 5× inline" smell), flagging
+  repeated normalized-line windows as extraction candidates. **A tsx/node-only
+  script, not jscpd** — same house pattern as `check-diff-coverage.ts`, no new
+  dependency for what ~120 LOC of line-shingle hashing does. **Report-only:**
+  it prints clusters and exits 0 (mirrors the #2353 lint WARN staging + the
+  semgrep/audit report-only tiering) so mature-tree duplication doesn't hard-
+  fail the build. Runs non-blocking in CI's `invariants` job. **Ratchet plan:**
+  dedupe the flagged surfaces into `@/components/ui` primitives, then flip the
+  gate blocking with `npm run check:frontend-dup -- --strict` (or lower
+  `MIN_LINES`) — forward-only. It is deliberately **not** part of `check:arch`
+  so the per-issue fast gate stays green.
+
 ---
 
 ## What this rubric does *not* enforce

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -142,6 +142,132 @@ const servicebayPlugin = {
         };
       },
     },
+    // -----------------------------------------------------------------------
+    // #2353 — UI-primitive + design-token reuse. The frontend ships a
+    // hand-rolled design system (packages/frontend/src/components/ui/:
+    // Button/Card/Field/DataTable/Badge/StatusDot/SectionHeading/PageScroll)
+    // and semantic tokens (globals.css @theme inline, Tailwind v4). These two
+    // rules fire at the decision point (editor/CI) when someone inlines what
+    // should be a primitive or a token. Both are scoped to
+    // packages/frontend/src and EXEMPT components/ui/ (the primitives wrap the
+    // raw elements + intentionally map raw colours to tokens internally). See
+    // docs/ARCHITECTURE_INVARIANTS.md § ui-primitive-and-design-token-reuse.
+    //
+    // ROLLOUT: introduced at "warn" (not "error"). A one-shot fix was
+    // infeasible — the raw-colour rule alone fires ~3100 times across ~85
+    // files, and rewriting each to a semantic token while keeping every
+    // component visually identical is far past a single unit's safe blast
+    // radius. warn keeps the 0-error gate green while surfacing every new + old
+    // violation. RATCHET PLAN: burn the count down file-by-file (lint-sweep
+    // units), then flip each rule to "error" once its class is at 0 — never
+    // loosen. TODO(#2353): ratchet no-raw-color-literal → error after the
+    // colour-token migration; ratchet no-raw-ui-primitive → error after the
+    // <button>/<table>/<input> migration.
+    "no-raw-ui-primitive": {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description:
+            "Use @/components/ui primitives instead of raw <button>/<table>/<input>/<select>/<textarea> in the frontend.",
+        },
+        schema: [],
+        messages: {
+          raw: "Raw <{{tag}}> in a frontend surface. Use the {{primitive}} primitive from @/components/ui instead (components/ui/ is exempt). See docs/ARCHITECTURE_INVARIANTS.md § ui-primitive-and-design-token-reuse.",
+        },
+      },
+      create(context) {
+        // tag → primitive it should be replaced with.
+        const PRIMITIVE = {
+          button: "Button",
+          table: "DataTable",
+          input: "Field",
+          select: "Field",
+          textarea: "Field",
+        };
+        return {
+          JSXOpeningElement(node) {
+            const name = node.name;
+            if (name.type !== "JSXIdentifier") return;
+            // Lowercase name === intrinsic (raw DOM) element; a custom
+            // component (Button, DataTable) is PascalCase and fine.
+            const primitive = PRIMITIVE[name.name];
+            if (!primitive) return;
+            context.report({
+              node,
+              messageId: "raw",
+              data: { tag: name.name, primitive },
+            });
+          },
+        };
+      },
+    },
+    "no-raw-color-literal": {
+      meta: {
+        type: "suggestion",
+        docs: {
+          description:
+            "Use @theme semantic tokens (text-accent, bg-surface, status ramp, …) instead of raw colour literals (hex / rgb() / hsl() / raw Tailwind numeric colour utilities like text-blue-500) in the frontend.",
+        },
+        schema: [],
+        messages: {
+          hex: "Raw colour literal `{{value}}`. Use a semantic @theme token (accent / surface / border / text / status-* / on-accent) from globals.css instead of a hard-coded hex/rgb/hsl. See docs/ARCHITECTURE_INVARIANTS.md § ui-primitive-and-design-token-reuse.",
+          tailwind:
+            "Raw Tailwind colour utility `{{value}}`. Use a semantic token utility (text-accent, bg-surface, text-status-ok, border-border, …) mapped in globals.css @theme instead of a numeric colour ramp. See docs/ARCHITECTURE_INVARIANTS.md § ui-primitive-and-design-token-reuse.",
+        },
+      },
+      create(context) {
+        // Raw hex (#rgb / #rrggbb / #rrggbbaa) and rgb()/hsl() function
+        // literals embedded in a string.
+        const HEX = /#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b/;
+        const RGB_HSL = /\b(?:rgba?|hsla?)\s*\(/;
+        // Raw Tailwind numeric colour utility: {prefix}-{palette}-{n}, e.g.
+        // text-blue-500, bg-gray-800, border-red-400, hover:ring-emerald-500/40.
+        const PALETTE =
+          "slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose";
+        const PREFIX =
+          "text|bg|border|ring|from|to|via|divide|outline|decoration|shadow|fill|stroke|accent|caret|placeholder";
+        // Allow modifiers + arbitrary opacity suffix. Word-boundary at the
+        // start so `border-border` etc. don't match (palette list is explicit).
+        const TAILWIND = new RegExp(
+          `(?:^|[\\s"'\`:])(?:(?:${PREFIX})-(?:${PALETTE})-[0-9]{2,3})(?:/[0-9]{1,3})?\\b`,
+        );
+        function check(value, node) {
+          if (typeof value !== "string") return;
+          if (HEX.test(value)) {
+            context.report({
+              node,
+              messageId: "hex",
+              data: { value: (value.match(HEX) || [value])[0] },
+            });
+            return;
+          }
+          if (RGB_HSL.test(value)) {
+            context.report({
+              node,
+              messageId: "hex",
+              data: { value: (value.match(RGB_HSL) || [value])[0] },
+            });
+            return;
+          }
+          const tw = value.match(TAILWIND);
+          if (tw) {
+            context.report({
+              node,
+              messageId: "tailwind",
+              data: { value: tw[0].trim() },
+            });
+          }
+        }
+        return {
+          Literal(node) {
+            if (typeof node.value === "string") check(node.value, node);
+          },
+          TemplateElement(node) {
+            check(node.value.cooked ?? node.value.raw, node);
+          },
+        };
+      },
+    },
     "no-fe-backend-import": {
       meta: {
         type: "problem",
@@ -310,6 +436,24 @@ const eslintConfig = defineConfig([
     ],
     rules: {
       "no-console": "error",
+    },
+  },
+  {
+    // #2353 — UI-primitive + design-token reuse, scoped to the frontend
+    // application surfaces and EXEMPTING the primitives themselves
+    // (components/ui/ wraps the raw elements + maps raw colours to tokens
+    // internally). Introduced at "warn" during rollout; ratchet each rule to
+    // "error" once its violation class is at 0 (see the rule comment + the
+    // invariant doc). Test files are exempt so fixtures/markup snapshots don't
+    // trip the colour rule.
+    files: ["packages/frontend/src/**/*.{ts,tsx,js,jsx}"],
+    ignores: [
+      "packages/frontend/src/components/ui/**",
+      "**/*.test.{ts,tsx,js,jsx}",
+    ],
+    rules: {
+      "sb/no-raw-ui-primitive": "warn",
+      "sb/no-raw-color-literal": "warn",
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "disk-import": "tsx scripts/disk-import.ts",
     "check:invariants": "tsx scripts/check-invariants.ts",
     "check:backup-coverage": "tsx scripts/check-backup-coverage.ts",
+    "check:frontend-dup": "tsx scripts/check-frontend-dup.ts",
     "check:deps": "depcruise --config .dependency-cruiser.cjs packages/frontend/src packages/backend/src",
     "check:arch": "npm run check:invariants && npm run check:backup-coverage && npm run check:deps",
     "prepare": "husky || true",

--- a/packages/backend/src/lib/mcp/assistCatalog.ts
+++ b/packages/backend/src/lib/mcp/assistCatalog.ts
@@ -19,7 +19,8 @@
  *
  * The mapping lives here — a small, pure-ish data layer over the catalog — so it
  * is unit-testable directly without spinning up the full MCP server + a
- * transport. `server.ts` calls `registerAssistCatalog(server)` to wire it.
+ * transport. `server.ts` calls `registerAssistResources` synchronously and
+ * `registerAssistPrompts` at the transport boundary to wire both surfaces.
  *
  * Scope/visibility (#2325 consistency): reading assists is read-tier knowledge.
  * Assists carry no secrets by contract (the secret-scan gate,
@@ -193,13 +194,3 @@ export async function registerAssistPrompts(server: McpServer): Promise<void> {
   }
 }
 
-/**
- * Register the full assist catalog (resources + prompts) on `server`. Async
- * because the prompt half needs a catalog snapshot; call it after
- * `createMcpServer(...).__baseServer` at the transport boundary (where an await
- * is available) so every MCP client gets both native surfaces.
- */
-export async function registerAssistCatalog(server: McpServer): Promise<void> {
-  registerAssistResources(server);
-  await registerAssistPrompts(server);
-}

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -610,7 +610,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
     connect: baseServer.connect.bind(baseServer),
     close: baseServer.close.bind(baseServer),
     // The underlying McpServer, exposed so the transport boundary can register
-    // the async half of the assist catalog (prompts) — see registerAssistCatalog
+    // the async half of the assist catalog (prompts) via registerAssistPrompts
     // (#2326 s6). Resources are registered synchronously below.
     __baseServer: baseServer,
   };
@@ -621,7 +621,7 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
   // names. Read-tier knowledge: assists carry no secrets (secret-scan gate) and
   // are already readable via the read-scoped tools, so this adds no privilege.
   // Resources register synchronously (template defers enumeration); the prompt
-  // half is async and wired at the transport boundary via registerAssistCatalog.
+  // half is async and wired at the transport boundary via registerAssistPrompts.
   registerAssistResources(baseServer);
 
   // --- List Nodes ---

--- a/packages/frontend/src/app/(dashboard)/dev/components/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/dev/components/page.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { notFound } from 'next/navigation';
+import {
+  Button,
+  Card,
+  Panel,
+  DataTable,
+  Badge,
+  StatusDot,
+  SectionHeading,
+  Field,
+  PageScroll,
+  type ButtonVariant,
+  type ButtonSize,
+  type BadgeVariant,
+  type StatusState,
+  type SectionHeadingTone,
+  type CardPadding,
+  type Column,
+} from '@/components/ui';
+
+/**
+ * `/dev/components` — the living component catalog (discovery, issue 2354).
+ *
+ * "You can only reuse what you can find." The `@/components/ui` primitives
+ * existed but were invisible — no gallery, no Storybook — so surfaces
+ * re-authored ad-hoc class-chains instead of importing the shared library.
+ * This route renders EVERY primitive off the barrel in its key states, so the
+ * next author finds `<Badge variant="warn">` instead of inventing one.
+ *
+ * Lightweight on purpose (CLAUDE.md ethos: no heavy new dependency like
+ * Storybook). It's an in-app dev/admin surface: the whole `(dashboard)` group
+ * already sits behind the single-admin session, and this page is additionally
+ * DEV-ONLY — a production build returns 404 (`notFound()`), so the catalog
+ * never ships to an operator's box.
+ *
+ * The page is built from the primitives + `@theme` tokens (no raw
+ * `<button>`/`<table>`/color literals), so it stays honest: if a primitive
+ * regresses, its gallery entry regresses with it. The one exception is the
+ * <Field> demo, which by design wraps a raw form control via its render-prop
+ * (there is no companion Input primitive) — that raw <input> is the correct
+ * usage, so the lint rule is disabled there with justification.
+ */
+
+const BUTTON_VARIANTS: ButtonVariant[] = ['primary', 'secondary', 'ghost', 'danger'];
+const BUTTON_SIZES: ButtonSize[] = ['sm', 'md'];
+const BADGE_VARIANTS: BadgeVariant[] = ['neutral', 'ok', 'warn', 'fail', 'info', 'accent'];
+const STATUS_STATES: StatusState[] = ['ok', 'warn', 'fail', 'unknown'];
+const HEADING_TONES: SectionHeadingTone[] = ['default', 'muted', 'danger'];
+const CARD_PADDINGS: CardPadding[] = ['none', 'sm', 'md', 'lg'];
+
+/** A named block in the gallery — the id doubles as a section anchor + test hook. */
+function Entry({ id, title, children }: { id: string; title: string; children: React.ReactNode }) {
+  return (
+    <Panel title={title} data-catalog-entry={id}>
+      <div className="flex flex-wrap items-start gap-space-4">{children}</div>
+    </Panel>
+  );
+}
+
+/** A single labelled specimen (variant/state name over the rendered primitive). */
+function Specimen({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col items-start gap-space-2">
+      <span className="text-xs font-mono text-text-subtle">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+/** The <Field> control: a raw <input> is the intended payload of Field's
+ *  render-prop (Field owns the id/aria wiring; there is no Input primitive), so
+ *  the raw-ui-primitive rule is correctly disabled for this single element. */
+function DemoInput(
+  props: { id: string; 'aria-describedby'?: string; 'aria-invalid'?: boolean } & {
+    className: string;
+    placeholder?: string;
+    defaultValue?: string;
+  },
+) {
+  // eslint-disable-next-line sb/no-raw-ui-primitive -- Field's render-prop wraps a raw control by design; no Input primitive exists.
+  return <input {...props} />;
+}
+
+interface DemoRow {
+  service: string;
+  state: StatusState;
+  containers: number;
+}
+
+const DEMO_ROWS: DemoRow[] = [
+  { service: 'media', state: 'ok', containers: 3 },
+  { service: 'immich', state: 'warn', containers: 2 },
+  { service: 'vaultwarden', state: 'fail', containers: 1 },
+];
+
+const DEMO_COLUMNS: Column<DemoRow>[] = [
+  { key: 'service', header: 'Service', cell: (r) => <span className="font-medium text-text">{r.service}</span> },
+  { key: 'state', header: 'Health', cell: (r) => <StatusDot state={r.state} showLabel /> },
+  { key: 'containers', header: 'Containers', align: 'right', cell: (r) => r.containers },
+];
+
+function ButtonEntry() {
+  return (
+    <Entry id="button" title="Button">
+      {BUTTON_VARIANTS.map((variant) => (
+        <Specimen key={variant} label={`variant="${variant}"`}>
+          <div className="flex items-center gap-space-2">
+            {BUTTON_SIZES.map((size) => (
+              <Button key={size} variant={variant} size={size}>
+                {size}
+              </Button>
+            ))}
+          </div>
+        </Specimen>
+      ))}
+      <Specimen label="disabled">
+        <Button disabled>disabled</Button>
+      </Specimen>
+    </Entry>
+  );
+}
+
+function CardEntry() {
+  return (
+    <Entry id="card" title="Card / Panel">
+      {CARD_PADDINGS.map((padding) => (
+        <Specimen key={padding} label={`Card padding="${padding}"`}>
+          <Card padding={padding} className="w-40">
+            <span className="text-sm text-text-muted">Surface</span>
+          </Card>
+        </Specimen>
+      ))}
+      <Specimen label="Panel (title + actions)">
+        <Panel title="Panel" actions={<Badge variant="accent">beta</Badge>} className="w-56">
+          <span className="text-sm text-text-muted">Body region</span>
+        </Panel>
+      </Specimen>
+    </Entry>
+  );
+}
+
+function BadgeEntry() {
+  return (
+    <Entry id="badge" title="Badge">
+      {BADGE_VARIANTS.map((variant) => (
+        <Specimen key={variant} label={`variant="${variant}"`}>
+          <Badge variant={variant}>{variant}</Badge>
+        </Specimen>
+      ))}
+    </Entry>
+  );
+}
+
+function StatusDotEntry() {
+  return (
+    <Entry id="status-dot" title="StatusDot">
+      {STATUS_STATES.map((state) => (
+        <Specimen key={state} label={`state="${state}"`}>
+          <StatusDot state={state} showLabel />
+        </Specimen>
+      ))}
+      <Specimen label="dot only (SR label)">
+        <StatusDot state="ok" />
+      </Specimen>
+    </Entry>
+  );
+}
+
+function SectionHeadingEntry() {
+  return (
+    <Entry id="section-heading" title="SectionHeading">
+      {HEADING_TONES.map((tone) => (
+        <Specimen key={tone} label={`tone="${tone}"`}>
+          <SectionHeading tone={tone} description="Optional description line.">
+            {tone} heading
+          </SectionHeading>
+        </Specimen>
+      ))}
+    </Entry>
+  );
+}
+
+function FieldEntry() {
+  return (
+    <Entry id="field" title="Field">
+      <Specimen label="with help">
+        <Field label="Service name" help="Lowercase, used as the systemd unit id.">
+          {(props) => (
+            <DemoInput
+              {...props}
+              className="h-10 rounded-card border border-border bg-surface-2 px-space-3 text-sm text-text"
+              placeholder="media"
+            />
+          )}
+        </Field>
+      </Specimen>
+      <Specimen label="required + error">
+        <Field label="Domain" required error="Not a valid hostname.">
+          {(props) => (
+            <DemoInput
+              {...props}
+              className="h-10 rounded-card border border-status-fail bg-surface-2 px-space-3 text-sm text-text"
+              defaultValue="not a host"
+            />
+          )}
+        </Field>
+      </Specimen>
+    </Entry>
+  );
+}
+
+function DataTableEntry() {
+  return (
+    <Entry id="data-table" title="DataTable">
+      <div className="w-full">
+        <DataTable columns={DEMO_COLUMNS} rows={DEMO_ROWS} rowKey={(r) => r.service} empty="No services." />
+      </div>
+      <Specimen label="empty state">
+        <div className="w-64">
+          <DataTable columns={DEMO_COLUMNS} rows={[]} rowKey={(r) => r.service} empty="No services yet." />
+        </div>
+      </Specimen>
+    </Entry>
+  );
+}
+
+function PageScrollEntry() {
+  return (
+    <Entry id="page-scroll" title="PageScroll">
+      <span className="text-sm text-text-muted">
+        This very page is wrapped in <span className="font-mono">&lt;PageScroll&gt;</span> — the single
+        flex-chain scroll region primitive (also exports{' '}
+        <span className="font-mono">PageShell</span> / <span className="font-mono">PageScrollRegion</span>{' '}
+        for a pinned header).
+      </span>
+    </Entry>
+  );
+}
+
+export default function ComponentCatalogPage() {
+  // Dev-only discovery surface — never ship the gallery to a production box.
+  if (process.env.NODE_ENV === 'production') {
+    notFound();
+  }
+
+  return (
+    <PageScroll className="px-space-6 py-space-6">
+      <SectionHeading
+        as="h1"
+        description="A living gallery of every @/components/ui primitive in its key states — import these instead of re-authoring class-chains. Dev-only route."
+      >
+        Component catalog
+      </SectionHeading>
+      <ButtonEntry />
+      <CardEntry />
+      <BadgeEntry />
+      <StatusDotEntry />
+      <SectionHeadingEntry />
+      <FieldEntry />
+      <DataTableEntry />
+      <PageScrollEntry />
+    </PageScroll>
+  );
+}

--- a/scripts/check-frontend-dup.ts
+++ b/scripts/check-frontend-dup.ts
@@ -1,0 +1,164 @@
+/**
+ * Frontend copy-paste / duplicate-JSX report (#2354).
+ *
+ * "You can only reuse what you can find" has a sibling: you can only extract
+ * what you can *see*. This flags near-identical blocks in
+ * `packages/frontend/src` — the "same Card rendered 5× inline" smell — as
+ * extraction candidates, so a duplicated surface becomes a nudge toward a
+ * `components/ui` primitive instead of silent drift.
+ *
+ * WHY A SCRIPT, NOT jscpd: CLAUDE.md's house pattern is `tsx scripts/*.ts`,
+ * node: builtins only, no new dependency (sibling: scripts/check-diff-coverage.ts,
+ * scripts/check-invariants.ts). jscpd would drag in a transitive tree for what
+ * a tuned line-shingle detector does in ~120 LOC — so we self-host it. The
+ * detection is a classic normalized-line k-window hash: strip whitespace /
+ * import lines / comments, slide a window of MIN_LINES over each file, and
+ * report windows whose normalized text collides across (or within) files.
+ *
+ * REPORT-ONLY, DOCUMENTED RATCHET (mirrors the #2353 lint-rule staging): this
+ * prints clusters and ALWAYS exits 0 (unless `--strict`). Duplication is noisy
+ * on a mature tree; a hard gate now would fail on legacy debt no one is
+ * touching. Once the frontend is deduped we flip `--strict` on in CI (or lower
+ * MIN_LINES) — the ratchet, not a big-bang gate. Exit 2 on a setup error.
+ *
+ *   tsx scripts/check-frontend-dup.ts [--strict] [--json]
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SCAN_ROOT = path.join(REPO_ROOT, 'packages', 'frontend', 'src');
+
+/** Tuned threshold: a run of >= this many normalized lines that repeats is a
+ *  candidate. Low enough to catch a duplicated Card/row, high enough to skip
+ *  incidental 2-3 line coincidences. Ratchet DOWN as the tree gets cleaner. */
+export const MIN_LINES = 8;
+
+export interface DupBlock {
+  /** Normalized text of the repeated window (the fingerprint). */
+  readonly normalized: string;
+  /** Every place the window occurs: file (repo-relative) + 1-based start line. */
+  readonly occurrences: ReadonlyArray<{ readonly file: string; readonly line: number }>;
+  readonly lines: number;
+}
+
+/** Strip a source line to its structural essence so cosmetic diffs (indent,
+ *  trailing commas-only, blank lines) don't hide a real clone, while genuinely
+ *  different lines stay distinct. Returns null for lines that shouldn't seed a
+ *  window (blank, pure comment, import/export-from). */
+export function normalizeLine(raw: string): string | null {
+  let s = raw.trim();
+  if (s === '') return null;
+  if (s.startsWith('//') || s.startsWith('/*') || s.startsWith('*') || s === '*/') return null;
+  if (/^import\b/.test(s) || /^export\s+\{/.test(s) || /^export\s+\*/.test(s)) return null;
+  // Collapse internal whitespace so `a( b )` and `a(b)` match.
+  s = s.replace(/\s+/g, ' ');
+  return s;
+}
+
+interface NormLine {
+  readonly text: string;
+  readonly line: number; // 1-based line number in the original file
+}
+
+function normalizeFile(content: string): NormLine[] {
+  const out: NormLine[] = [];
+  const raw = content.split('\n');
+  for (let i = 0; i < raw.length; i++) {
+    const n = normalizeLine(raw[i]);
+    if (n !== null) out.push({ text: n, line: i + 1 });
+  }
+  return out;
+}
+
+/** Pure core: given a map of file -> source, find windows of >= MIN_LINES
+ *  normalized lines whose text repeats across >= 2 locations. Deterministic
+ *  (files/occurrences sorted), so a test can assert exact output. */
+export function findDuplicates(
+  files: ReadonlyMap<string, string>,
+  minLines: number = MIN_LINES,
+): DupBlock[] {
+  // fingerprint -> occurrences
+  const windows = new Map<string, Array<{ file: string; line: number }>>();
+  const sortedFiles = [...files.keys()].sort();
+
+  for (const file of sortedFiles) {
+    const norm = normalizeFile(files.get(file)!);
+    for (let i = 0; i + minLines <= norm.length; i++) {
+      const slice = norm.slice(i, i + minLines);
+      const fingerprint = slice.map((l) => l.text).join('\n');
+      const at = windows.get(fingerprint) ?? [];
+      at.push({ file, line: slice[0].line });
+      windows.set(fingerprint, at);
+    }
+  }
+
+  const blocks: DupBlock[] = [];
+  for (const [normalized, occ] of windows) {
+    if (occ.length < 2) continue;
+    const sorted = [...occ].sort((a, b) => (a.file === b.file ? a.line - b.line : a.file < b.file ? -1 : 1));
+    blocks.push({ normalized, occurrences: sorted, lines: minLines });
+  }
+  // Report the biggest offenders first (most occurrences), then by fingerprint
+  // for stable ordering.
+  blocks.sort((a, b) => b.occurrences.length - a.occurrences.length || (a.normalized < b.normalized ? -1 : 1));
+  return blocks;
+}
+
+function collectTsxFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      collectTsxFiles(full, acc);
+    } else if (/\.tsx$/.test(entry) && !/\.(test|spec)\.tsx$/.test(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function main(): void {
+  const strict = process.argv.includes('--strict');
+  const asJson = process.argv.includes('--json');
+
+  let files: Map<string, string>;
+  try {
+    const paths = collectTsxFiles(SCAN_ROOT);
+    files = new Map(paths.map((p) => [path.relative(REPO_ROOT, p), readFileSync(p, 'utf-8')]));
+  } catch (err) {
+    console.error(`check-frontend-dup: setup error — ${(err as Error).message}`);
+    process.exit(2);
+  }
+
+  const blocks = findDuplicates(files);
+
+  if (asJson) {
+    console.log(JSON.stringify(blocks, null, 2));
+  } else {
+    console.log(`\nFrontend duplicate-JSX report (report-only) — scanned ${files.size} .tsx files`);
+    console.log(`Threshold: ${MIN_LINES}+ identical normalized lines repeated across locations.\n`);
+    if (blocks.length === 0) {
+      console.log('No duplication clusters above threshold. 🎉\n');
+    } else {
+      console.log(`${blocks.length} extraction candidate(s) — consider hoisting into a @/components/ui primitive:\n`);
+      const shown = blocks.slice(0, 40);
+      for (const b of shown) {
+        console.log(`• ${b.occurrences.length}× (${b.lines} lines) at:`);
+        for (const o of b.occurrences) console.log(`    ${o.file}:${o.line}`);
+      }
+      if (blocks.length > shown.length) {
+        console.log(`\n… and ${blocks.length - shown.length} more (run with --json for the full list).`);
+      }
+      console.log('');
+    }
+  }
+
+  // Report-only by default (documented ratchet, mirrors #2353's WARN staging).
+  process.exit(strict && blocks.length > 0 ? 1 : 0);
+}
+
+// Only run when invoked directly (so the pure core stays importable in tests).
+if (process.argv[1] && path.resolve(process.argv[1]).includes('check-frontend-dup')) {
+  main();
+}

--- a/tests/frontend/ComponentCatalog.test.tsx
+++ b/tests/frontend/ComponentCatalog.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+// #2354 — the /dev/components discovery route. We assert it renders WITHOUT
+// crashing and lists EVERY @/components/ui primitive, so the gallery can't
+// silently drop a primitive when the barrel grows. `notFound()` is only hit in
+// a production build (NODE_ENV==='production'); under vitest we're in 'test',
+// so the full gallery renders. We mock it defensively so an accidental call
+// would throw loudly rather than render an empty tree.
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('notFound() should not be reached in the test environment');
+  }),
+}));
+
+import ComponentCatalogPage from '@/app/(dashboard)/dev/components/page';
+
+// The barrel is the source of truth for "which primitives exist". These are
+// the catalog-entry ids the page must render one gallery section for.
+const EXPECTED_ENTRIES = [
+  'button',
+  'card',
+  'badge',
+  'status-dot',
+  'section-heading',
+  'field',
+  'data-table',
+  'page-scroll',
+];
+
+describe('/dev/components — component catalog', () => {
+  it('renders without crashing and shows the catalog heading', () => {
+    render(<ComponentCatalogPage />);
+    expect(screen.getByRole('heading', { level: 1, name: /component catalog/i })).toBeTruthy();
+  });
+
+  it('renders a gallery entry for every ui primitive', () => {
+    const { container } = render(<ComponentCatalogPage />);
+    for (const id of EXPECTED_ENTRIES) {
+      expect(
+        container.querySelector(`[data-catalog-entry="${id}"]`),
+        `expected a gallery entry for "${id}"`,
+      ).not.toBeNull();
+    }
+    // Exactly one section per primitive — no stray/duplicated entries.
+    expect(container.querySelectorAll('[data-catalog-entry]').length).toBe(EXPECTED_ENTRIES.length);
+  });
+
+  it('renders concrete specimens of the primitives (Button, Badge, StatusDot)', () => {
+    render(<ComponentCatalogPage />);
+    // Every Button variant renders its size labels; at least the primary set.
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+    // Badge variants render their own name as text.
+    expect(screen.getByText('accent')).toBeTruthy();
+    // StatusDot uses role="status" for its accessible announcement.
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+  });
+});

--- a/tests/scripts/check-frontend-dup.test.ts
+++ b/tests/scripts/check-frontend-dup.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { findDuplicates, normalizeLine } from '../../scripts/check-frontend-dup';
+
+// #2354 — pure-logic tests for the frontend duplicate-JSX detector. The core
+// (findDuplicates / normalizeLine) is deterministic and importable, so we can
+// assert its clustering behaviour without touching the filesystem or the tuned
+// repo threshold (tests pass minLines explicitly).
+
+describe('normalizeLine', () => {
+  it('drops blank lines, comments, and import/export-from lines', () => {
+    expect(normalizeLine('   ')).toBeNull();
+    expect(normalizeLine('// a comment')).toBeNull();
+    expect(normalizeLine('/* block */')).toBeNull();
+    expect(normalizeLine(' * jsdoc continuation')).toBeNull();
+    expect(normalizeLine("import { X } from 'y'")).toBeNull();
+    expect(normalizeLine("export { X } from './x'")).toBeNull();
+    expect(normalizeLine('export * from "./barrel"')).toBeNull();
+  });
+
+  it('collapses internal whitespace so cosmetic diffs match', () => {
+    expect(normalizeLine('  foo(  a ,  b )  ')).toBe('foo( a , b )');
+    expect(normalizeLine('foo(a, b)')).toBe('foo(a, b)');
+  });
+
+  it('keeps genuinely different lines distinct', () => {
+    expect(normalizeLine('const a = 1;')).not.toBe(normalizeLine('const b = 2;'));
+  });
+});
+
+describe('findDuplicates', () => {
+  const block = (label: string) =>
+    Array.from({ length: 5 }, (_, i) => `line ${label} ${i}`).join('\n');
+
+  it('returns nothing when no window repeats', () => {
+    const files = new Map<string, string>([
+      ['a.tsx', block('A')],
+      ['b.tsx', block('B')],
+    ]);
+    expect(findDuplicates(files, 5)).toEqual([]);
+  });
+
+  it('flags an identical block duplicated across two files', () => {
+    const shared = block('SHARED');
+    const files = new Map<string, string>([
+      ['a.tsx', `const top = 1;\n${shared}\nconst tail = 2;`],
+      ['b.tsx', `const other = 9;\n${shared}\nconst z = 3;`],
+    ]);
+    const dups = findDuplicates(files, 5);
+    expect(dups.length).toBeGreaterThan(0);
+    const top = dups[0];
+    expect(top.occurrences.length).toBe(2);
+    expect(top.occurrences.map((o) => o.file).sort()).toEqual(['a.tsx', 'b.tsx']);
+    // The reported start lines point at the block (line 2 in each file).
+    expect(top.occurrences.every((o) => o.line === 2)).toBe(true);
+  });
+
+  it('detects duplication WITHIN a single file (same Card rendered twice inline)', () => {
+    const shared = block('INLINE');
+    const files = new Map<string, string>([['a.tsx', `${shared}\nconst x = 0;\n${shared}`]]);
+    const dups = findDuplicates(files, 5);
+    expect(dups.length).toBeGreaterThan(0);
+    expect(dups[0].occurrences.length).toBeGreaterThanOrEqual(2);
+    expect(dups[0].occurrences.every((o) => o.file === 'a.tsx')).toBe(true);
+  });
+
+  it('ignores blocks shorter than the threshold', () => {
+    const three = 'a\nb\nc';
+    const files = new Map<string, string>([
+      ['a.tsx', three],
+      ['b.tsx', three],
+    ]);
+    expect(findDuplicates(files, 8)).toEqual([]);
+  });
+
+  it('ranks the most-duplicated block first', () => {
+    const many = block('MANY');
+    const twice = block('TWICE');
+    const files = new Map<string, string>([
+      ['a.tsx', `${many}\nx\n${twice}`],
+      ['b.tsx', `${many}\ny\n${twice}`],
+      ['c.tsx', many],
+    ]);
+    const dups = findDuplicates(files, 5);
+    // MANY appears in 3 files, TWICE in 2 → MANY ranks first.
+    expect(dups[0].occurrences.length).toBe(3);
+  });
+});


### PR DESCRIPTION
Batch `batch/2026-07-20a` — Frontend-Komponentisierungs-Disziplin (Enforcement + Discovery + Duplikat-Erkennung).

Closes #2352
Closes #2353
Closes #2354

- `fix(build):` **knip-Papierschnitt behoben** (#2352) — ungenutzten `registerAssistCatalog`-Export entfernt; pre-commit-Hook wieder grün, Builder committen ohne `--no-verify`.
- `feat(lint):` **ui-primitive + design-token Reuse erzwungen** (#2353) — Custom-Regeln `sb/no-raw-ui-primitive` (rohes `<button>`/`<table>`/`<input>` → `components/ui`-Primitives) + `sb/no-raw-color-literal` (Hex/rgb()/rohe Tailwind-Farb-Ramps → `@theme`-Tokens), scoped aufs Frontend, `ui/` ausgenommen. **Phased auf `warn`** (fix-all unrealistisch: ~3.100 Farb- + 61 Button-Verstöße) mit dokumentiertem Ratchet-to-error-Plan; in ARCHITECTURE_INVARIANTS + Design-Assist verankert. Greift ab jetzt auf neuen Code.
- `feat(frontend):` **Component-Katalog + Duplikat-Report** (#2354) — `/dev/components`-Route (dev/admin-gated, rendert alle 8 `ui/`-Primitives) für Discovery + `scripts/check-frontend-dup.ts` (tsx/node-only, keine neue Dep, report-only, ratchetbar) als `check:frontend-dup` + non-blocking CI. Findet aktuell 125 Duplikat-Cluster.

Zusammen: **A** (Lint) erzwingt am Entscheidungspunkt, **B** (Katalog + Dup-Report) macht auffindbar + fängt Duplikate — „was Komponente sein sollte, ist auch eine und wird wiederverwendet".

Lokales Gate grün: lint 0 Fehler (2067 warn-level, sichtbar gemachte Alt-Schuld), typecheck clean, check:arch pass, 4091 Tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
