### PR TITLE
fix(template): Radicale-DAV-Port an Loopback binden — nicht mehr LAN-exposed (#2357)

### DIFF
--- a/templates/radicale/CHANGELOG.md
+++ b/templates/radicale/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Radicale — template changelog
+
+Tracks breaking changes to the `radicale` template's pod structure /
+variable shape (not Radicale itself — that's versioned by the upstream
+image tag). Each H2 corresponds to a value of `servicebay.schema-version`
+in `template.yml`.
+
+The ServiceBay update flow reads the section header(s) between the
+operator's installed schema-version and the current one and surfaces them
+in the re-deploy dialog. Each `(breaking)` section needs an explicit
+acknowledgement before the deploy can proceed.
+
+## v2 (breaking)
+
+**DAV port bound to loopback — no longer LAN-exposed (#2357).**
+
+Radicale's published CalDAV/CardDAV port (`RADICALE_PORT`, default 5232)
+used to be published via `hostPort` with no `hostIP`, so podman bound it
+on `0.0.0.0`. That left the calendar/contacts HTTP API — web UI,
+collection listing, DAV verbs — reachable **directly on the LAN** at
+`http://<box-lan-ip>:5232/`, bypassing the nginx reverse proxy that
+fronts `caldav.<domain>` (TLS termination + the intended single entry
+point).
+
+This release adds `hostIP: 127.0.0.1` to the port publish so podman binds
+`127.0.0.1:5232` instead. nginx runs on `hostNetwork`, so it still
+reaches Radicale over the host loopback; the `caldav.<domain>` proxy host
+is retargeted at `127.0.0.1:5232` via the new `loopbackOnly: true` flag on
+`RADICALE_SUBDOMAIN`. `caldav.<domain>` keeps working exactly as before;
+only the direct-on-LAN path is closed.
+
+Required action: **re-deploy** the radicale service so the new port bind
+takes effect. Existing installs keep the old `0.0.0.0` bind until the pod
+is recreated — the running container was started from the v1 manifest and
+does not auto-rebind. After the re-deploy, `curl http://<box-lan-ip>:5232/`
+from another LAN host is refused while `https://caldav.<domain>/` still
+serves normally.

--- a/templates/radicale/migrations/v1-to-v2.py
+++ b/templates/radicale/migrations/v1-to-v2.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Migration: radicale v1 → v2 (#2357).
+
+What changed between v1 and v2: the Radicale DAV port
+(`RADICALE_PORT`, default 5232) is now published to the host
+**loopback only** (`hostIP: 127.0.0.1`) instead of `0.0.0.0`. Under
+v1 the port had no `hostIP`, so podman bound it on every interface and
+Radicale's HTTP API was reachable directly on the LAN at
+`http://<box-lan-ip>:5232/`, bypassing the nginx reverse proxy that
+fronts `caldav.<domain>`.
+
+The actual rebind is structural: `podman play kube` recreates the pod
+from the v2 manifest, which carries the `hostIP: 127.0.0.1`. nginx
+runs on hostNetwork and now forwards `caldav.<domain>` to
+`127.0.0.1:{{RADICALE_PORT}}` (the `loopbackOnly: true` flag on
+RADICALE_SUBDOMAIN in variables.json), so the public subdomain keeps
+working while the direct-on-LAN path is closed.
+
+What this script does:
+  - Inform the operator that the DAV port is now loopback-bound and
+    that `caldav.<domain>` is unaffected. It is read-only — no data
+    moves (Radicale's collections live on /data, untouched).
+  - Exit 0. Migration scripts MUST exit 0 to let the deploy continue.
+
+Environment available (set by ServiceManager.runMigrationScript):
+  - OLD_SCHEMA_VERSION = 1
+  - NEW_SCHEMA_VERSION = 2
+  - OLD_DATA_DIR, NEW_DATA_DIR (defaults to DATA_DIR for both)
+  - Every wizard variable (PUBLIC_DOMAIN, RADICALE_SUBDOMAIN, …)
+  - SB_NODE, SB_API_URL, SB_API_TOKEN (for callbacks into ServiceBay)
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    port = os.environ.get("RADICALE_PORT", "5232")
+    print(f"Radicale v1 → v2: DAV port {port} is now bound to 127.0.0.1 only (#2357).")
+    print("  It is no longer published on 0.0.0.0, so it can't be hit directly")
+    print("  on the LAN — access goes through the nginx reverse proxy at")
+    print("  caldav.<domain> (TLS), which now forwards to 127.0.0.1.")
+    print("  No data is moved; Radicale's collections under /data are untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: radicale
   annotations:
     servicebay.label: "Calendar & Contacts"
-    servicebay.schema-version: "1"
+    servicebay.schema-version: "2"
     servicebay.ports: "{{RADICALE_PORT}}/tcp"
     # caldav.<domain> goes through nginx; auth is the SSO front.
     servicebay.dependencies: "nginx,auth"
@@ -98,8 +98,18 @@ spec:
       - name: RADICALE_CONFIG
         value: /config/config
     ports:
+      # Bind the published DAV port to the host LOOPBACK only (#2357).
+      # Without `hostIP` podman publishes on 0.0.0.0, so Radicale's HTTP
+      # API (household calendars + address books) is reachable directly
+      # on the LAN at <lan-ip>:{{RADICALE_PORT}}, bypassing the nginx
+      # reverse proxy that fronts caldav.<domain> (TLS + single entry
+      # point). nginx runs on hostNetwork, so it still reaches this port
+      # via 127.0.0.1 — the `loopbackOnly: true` flag on
+      # RADICALE_SUBDOMAIN (variables.json) points the proxy target at
+      # 127.0.0.1:{{RADICALE_PORT}} accordingly.
       - containerPort: {{RADICALE_PORT}}
         hostPort: {{RADICALE_PORT}}
+        hostIP: 127.0.0.1
     volumeMounts:
       - mountPath: /data
         name: radicale-data

--- a/templates/radicale/variables.json
+++ b/templates/radicale/variables.json
@@ -24,6 +24,7 @@
     "default": "caldav",
     "exposure": "public",
     "proxyPort": "RADICALE_PORT",
+    "loopbackOnly": true,
     "proxyConfig": {
       "block_exploits": true,
       "ssl_forced": true


### PR DESCRIPTION
Batch `batch/2026-07-23a` — Radicale-DAV-Port an Loopback binden (Security).

Closes #2357

`fix(template):` Radicales CalDAV-Port (5232) wurde via `hostPort` **ohne `hostIP`** publiziert → podman band `0.0.0.0` → direkt im LAN erreichbar, **umging nginx+Authelia**.
- `template.yml`: `hostIP: 127.0.0.1` am `hostPort:{{RADICALE_PORT}}` → Loopback-Bind.
- Proxy-Kohärenz: `loopbackOnly: true` auf `RADICALE_SUBDOMAIN` → `caldav.<domain>` forwardet auf `127.0.0.1:5232` (nginx läuft hostNetwork, erreicht Loopback; Muster wie chat/sync/ollama).
- Template-Contract: schema-version 1→2 + CHANGELOG v2 + informative `migrations/v1-to-v2.py` (kein Daten-Move; **Operator muss radicale re-deployen**, damit der Rebind greift — der laufende Service kam aus Template v1).

Lokales Gate grün: lint 0 Fehler, typecheck clean, check:arch pass, 4091 Tests (Template-Tests 103) passed.

**Post-Deploy-Review (security):** #2357 — Port-Exposure-Fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
