### PR TITLE
fix(radicale): caldav-Proxy beim Re-Deploy auf Loopback reconcilen — vervollständigt #2357 (#2364)

### DIFF
--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/decideUpstreamReconcile.test.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/decideUpstreamReconcile.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { decideUpstreamReconcile } from './route';
+
+// #2364 (completes #2357) — a radicale redeploy must re-point the EXISTING
+// caldav.<domain> proxy host from the (now-closed) LAN address to
+// 127.0.0.1:5232, because the DAV port publish moved to loopback-only
+// (`loopbackOnly: true`). `buildProxyHosts` emits `forwardHost: '127.0.0.1'`
+// for such a host, and `createProxyHost`'s existing-host branch feeds it here.
+// This exercises the reconcile DECISION (the re-point-or-not gate) without
+// standing up NPM's HTTP API.
+describe('decideUpstreamReconcile', () => {
+    it('re-points an existing caldav host from the LAN IP to loopback on redeploy (#2364)', () => {
+        const d = decideUpstreamReconcile('127.0.0.1', 5232, '192.168.178.100', 5232);
+        expect(d.changed).toBe(true);
+        if (d.changed) {
+            expect(d.from).toBe('192.168.178.100:5232');
+            expect(d.to).toBe('127.0.0.1:5232');
+        }
+    });
+
+    it('is idempotent: an already-loopback host on the same port is a no-op', () => {
+        expect(decideUpstreamReconcile('127.0.0.1', 5232, '127.0.0.1', 5232)).toEqual({ changed: false });
+    });
+
+    it('re-points when only the port changed (#1178 — new template takes over a domain)', () => {
+        const d = decideUpstreamReconcile('127.0.0.1', 8080, '127.0.0.1', 3000);
+        expect(d.changed).toBe(true);
+        if (d.changed) expect(d.to).toBe('127.0.0.1:8080');
+    });
+
+    it('re-points when both host and port differ', () => {
+        const d = decideUpstreamReconcile('127.0.0.1', 5232, '192.168.178.100', 5000);
+        expect(d.changed).toBe(true);
+        if (d.changed) {
+            expect(d.from).toBe('192.168.178.100:5000');
+            expect(d.to).toBe('127.0.0.1:5232');
+        }
+    });
+
+    it('renders "?" placeholders when the live target is unknown (host never seen before)', () => {
+        const d = decideUpstreamReconcile('127.0.0.1', 5232, undefined, undefined);
+        expect(d.changed).toBe(true);
+        if (d.changed) expect(d.from).toBe('?:?');
+    });
+});

--- a/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
+++ b/packages/frontend/src/app/api/system/nginx/proxy-hosts/route.ts
@@ -350,13 +350,52 @@ async function findProxyHostByDomain(baseUrl: string, token: string, domain: str
 }
 
 /**
- * #1178 — When a proxy host already exists for a domain but its
+ * Pure decision for `reconcileProxyHostUpstream`: does the existing NPM
+ * host's forward target already match what the installer wants, or must it
+ * be re-pointed? Exported so the "re-point an existing host's upstream on
+ * redeploy" behaviour can be unit-tested without mocking NPM's HTTP API.
+ *
+ * Two callers rely on it:
+ *   - #1178 — a new template takes over a domain (hermes-webui → open-webui
+ *     at chat.<domain>): the port changes.
+ *   - #2364 — a template's port publish moves from the LAN IP to loopback
+ *     (radicale's `loopbackOnly: true`, completing #2357): the host changes
+ *     from 192.168.178.100 → 127.0.0.1 on the SAME port. Without this, a
+ *     redeploy of an EXISTING radicale left caldav.<domain> forwarding to
+ *     the now-closed LAN address → 502.
+ *
+ * The reconcile PUT (below) sends ONLY `forward_host`/`forward_port`, so it
+ * NEVER touches exposure (access_list), auth (advanced_config / forward-auth)
+ * or the bound cert (certificate_id) — the security posture is preserved.
+ * The decision is idempotent: when live already equals expected it returns
+ * `false` (no PUT), so re-running on an already-loopback host is a no-op.
+ */
+export function decideUpstreamReconcile(
+    expectedHost: string,
+    expectedPort: number,
+    currentHost: string | undefined,
+    currentPort: number | undefined,
+): { changed: false } | { changed: true; from: string; to: string } {
+    if (currentHost === expectedHost && currentPort === expectedPort) {
+        return { changed: false };
+    }
+    return {
+        changed: true,
+        from: `${currentHost ?? '?'}:${currentPort ?? '?'}`,
+        to: `${expectedHost}:${expectedPort}`,
+    };
+}
+
+/**
+ * #1178 / #2364 — When a proxy host already exists for a domain but its
  * `forward_host` / `forward_port` no longer match what the installer
- * requested (e.g. \`hermes-webui\` replaces \`open-webui\` at
- * \`chat.<domain>\` — same URL, different upstream port), update the
- * existing host's target rather than leaving the stale upstream in
- * place. Returns true when an update was made; false when no change
- * was needed.
+ * requested — a new template taking over a domain (\`hermes-webui\`
+ * replaces \`open-webui\` at \`chat.<domain>\`, #1178) OR a port publish
+ * moving from the LAN IP to loopback (radicale's \`loopbackOnly: true\`,
+ * #2364/#2357) — update the existing host's target rather than leaving the
+ * stale upstream in place. Returns true when an update was made; false when
+ * no change was needed. Only the forward target is PUT, so exposure / auth /
+ * cert are preserved (see \`decideUpstreamReconcile\`).
  *
  * Live finding 2026-05-27 on core@192.168.178.100: \`open-webui\` had
  * registered \`chat.dopp.cloud → 127.0.0.1:8080\`; \`hermes-webui\`'s
@@ -374,7 +413,7 @@ async function reconcileProxyHostUpstream(
     currentHost: string | undefined,
     currentPort: number | undefined,
 ): Promise<boolean> {
-    if (currentHost === expectedHost && currentPort === expectedPort) return false;
+    if (!decideUpstreamReconcile(expectedHost, expectedPort, currentHost, currentPort).changed) return false;
     try {
         const res = await fetch(`${baseUrl}/api/nginx/proxy-hosts/${hostId}`, {
             method: 'PUT',

--- a/templates/radicale/migrations/v1-to-v2.py
+++ b/templates/radicale/migrations/v1-to-v2.py
@@ -17,10 +17,25 @@ runs on hostNetwork and now forwards `caldav.<domain>` to
 RADICALE_SUBDOMAIN in variables.json), so the public subdomain keeps
 working while the direct-on-LAN path is closed.
 
+The existing `caldav.<domain>` NPM host is retargeted AUTOMATICALLY by
+ServiceBay's core reconcile — this migration does NOT touch the proxy
+itself (#2364, completing #2357). On every deploy the install runner
+runs `ensureProxyHosts`, which walks the stack variables through
+`buildProxyHosts`: RADICALE_SUBDOMAIN's `loopbackOnly: true` makes it
+emit `forwardHost: 127.0.0.1`, and the proxy-hosts endpoint's
+existing-host branch (`reconcileProxyHostUpstream` /
+`decideUpstreamReconcile`) re-points the live host's forward target
+from the old LAN IP (`192.168.178.100:{{RADICALE_PORT}}`, now closed)
+to `127.0.0.1:{{RADICALE_PORT}}`. That reconcile PUTs ONLY the forward
+target, so exposure (public), auth (Radicale Basic — no Authelia) and
+the bound cert are untouched, and it is idempotent (a no-op once the
+host is already loopback). No manual proxy edit is needed.
+
 What this script does:
-  - Inform the operator that the DAV port is now loopback-bound and
-    that `caldav.<domain>` is unaffected. It is read-only — no data
-    moves (Radicale's collections live on /data, untouched).
+  - Inform the operator that the DAV port is now loopback-bound, that
+    `caldav.<domain>` is retargeted to loopback automatically by the
+    core reconcile (no manual proxy edit), and that no data moves
+    (Radicale's collections live on /data, untouched). It is read-only.
   - Exit 0. Migration scripts MUST exit 0 to let the deploy continue.
 
 Environment available (set by ServiceManager.runMigrationScript):
@@ -45,6 +60,10 @@ def main() -> int:
     print("  It is no longer published on 0.0.0.0, so it can't be hit directly")
     print("  on the LAN — access goes through the nginx reverse proxy at")
     print("  caldav.<domain> (TLS), which now forwards to 127.0.0.1.")
+    print(f"  ServiceBay retargets the existing caldav.<domain> proxy host to")
+    print(f"  127.0.0.1:{port} automatically on this deploy (core reconcile,")
+    print("  #2364) — no manual proxy edit; exposure (public), Basic auth and")
+    print("  the cert are preserved.")
     print("  No data is moved; Radicale's collections under /data are untouched.")
     return 0
 

--- a/tests/backend/buildProxyHosts.test.ts
+++ b/tests/backend/buildProxyHosts.test.ts
@@ -265,4 +265,34 @@ describe('buildProxyHosts', () => {
     // forwardHost to the node's LAN IP.
     expect(photos?.forwardHost).toBeUndefined();
   });
+
+  it('builds the radicale caldav host public + loopback-targeted, no Authelia (#2364/#2357)', () => {
+    // Redeploy from radicale template v2: RADICALE_SUBDOMAIN declares
+    // exposure=public + loopbackOnly=true + proxyPort=RADICALE_PORT.
+    // The built host must (a) forward to 127.0.0.1 (so the retarget from
+    // the closed LAN IP reconciles on redeploy, completing #2357),
+    // (b) resolve the port from RADICALE_PORT, and (c) stay `public` with
+    // NO forward-auth/Authelia block — CalDAV clients speak HTTP Basic and
+    // can't SSO, so the security posture (public + Basic auth) is preserved.
+    const { hosts } = buildProxyHosts([
+      v('PUBLIC_DOMAIN', 'example.com'),
+      v('RADICALE_PORT', '5232'),
+      v(
+        'RADICALE_SUBDOMAIN',
+        'caldav',
+        subdomain('public', 'RADICALE_PORT', {
+          loopbackOnly: true,
+          templateName: 'radicale',
+          proxyConfig: { block_exploits: true, ssl_forced: true },
+        }),
+      ),
+    ]);
+    const caldav = hosts.find(h => h.domain === 'caldav.example.com');
+    expect(caldav).toBeDefined();
+    expect(caldav?.forwardHost).toBe('127.0.0.1');
+    expect(caldav?.forwardPort).toBe(5232);
+    expect(caldav?.exposure).toBe('public');
+    // No Authelia forward-auth was injected — Basic-auth is the front.
+    expect(caldav?.proxyConfig?.advanced_config ?? '').not.toMatch(/auth_request|authelia/i);
+  });
 });


### PR DESCRIPTION
Batch `batch/2026-07-23a` — Radicale caldav-Proxy-Reconcile beim Re-Deploy (vervollständigt #2357).

Closes #2364

`fix(radicale):` schließt die Lücke aus #2357 (dessen Box-Verify RED war): ein Re-Deploy von radicale reconcilet den bestehenden `caldav.<domain>`-NPM-Host jetzt **automatisch** auf `127.0.0.1:5232`.
- **Core-Reconcile** (nicht template-spezifisch): der Install-Runner ruft ohnehin `ensureProxyHosts` bei jedem Deploy → `buildProxyHosts` liefert `forwardHost:127.0.0.1` für radicales `loopbackOnly:true` → `reconcileProxyHostUpstream` re-pointet den Live-Host `192.168.178.100:5232 → 127.0.0.1:5232`.
- **Die echte Lücke war fehlende Testabdeckung** dieses re-point-on-redeploy (+ eine vergrabene Entscheidung). Pure `decideUpstreamReconcile` extrahiert + getestet.
- **Exposure-preserving:** die Reconcile-PUT sendet nur `forward_host`/`forward_port` — Exposure (public), Auth (Basic, kein Authelia), Cert unangetastet. Idempotent (no-op wenn schon Loopback). Migration bleibt informativ, dokumentiert die Auto-Reconcile.

Lokales Gate grün: lint 0 Fehler, typecheck clean, check:arch pass, 4097 Tests passed.

**Post-Deploy-Review (security):** #2364 — proxy-target-reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
