### PR TITLE
batch: unify container list, fix paperless forward-auth, Jellyfin DLNA default (#2367 #2368 #2369)

### DIFF
--- a/packages/backend/src/lib/health/probes/domain.ts
+++ b/packages/backend/src/lib/health/probes/domain.ts
@@ -23,6 +23,28 @@ import { registerProbe } from './registry';
 import { getConfig } from '../../config';
 import { resolveDnsRouting, type DnsRoutingPayload } from './dnsRouting';
 
+/**
+ * #2368 — KNOWN BLIND SPOT for forward-auth (Authelia-gated) hosts.
+ *
+ * This probe fetches `http://<lanIp>:80/` anonymously and treats any 2xx/3xx
+ * as healthy. That correctly catches a *hard* failure (a forward-auth
+ * misconfig surfaces as nginx 500 → this throws), but it does NOT reflect two
+ * softer states on a gated host:
+ *   1. An anonymous request that returns `200` — on a gated host the healthy
+ *      answer is a redirect to the auth domain; a bare 200 means auth wasn't
+ *      enforced on this scheme, yet the probe reads it "ok".
+ *   2. A scheme-dependent auth failure that only manifests on the scheme real
+ *      users hit. `paperless.dopp.cloud` 500'd authenticated **https** traffic
+ *      (Authelia rejected a non-https X-Original-URL) while this port-80 probe
+ *      kept reporting `HTTP 200` — the root cause was fixed in
+ *      `stackInstall/forwardAuth.ts`, but the probe itself still can't tell a
+ *      gated host is broken unless it returns a 5xx.
+ * Closing this properly needs the check to know a host is forward-auth gated
+ * (thread a flag from the route/config into `domainConfig`) and then assert an
+ * anonymous request redirects to the auth domain rather than returning 200.
+ * Tracked as a follow-up; not done here to avoid false-reds on the ~20 live
+ * domain checks. See issue #2368.
+ */
 async function checkNpmRouting(lanIp: string, target: string, expectedScheme?: string) {
   const url = `http://${lanIp}:80/`;
   const controller = new AbortController();

--- a/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.test.ts
@@ -46,6 +46,21 @@ describe('expandForwardAuthSentinel', () => {
     expect(expandForwardAuthSentinel(undefined)).toBeUndefined();
   });
 
+  // #2368 — the auth-request subrequest must send a HARDCODED https scheme in
+  // X-Original-URL. Authelia 400s any non-https scheme; nginx maps that to a
+  // 500. Using `$scheme` (the client's transport) 500'd paperless.dopp.cloud
+  // whenever it was reached over plain http (a LAN browser or the platform's
+  // own port-80 domain health probe). https is scheme-agnostic for identity
+  // (Authelia only parses the URL to match its access_control domain rule).
+  it('sends X-Original-URL with a hardcoded https scheme, never $scheme (#2368)', () => {
+    const out = renderForwardAuthAdvancedConfig(AUTHELIA_FORWARD_AUTH_SENTINEL, '9091')!;
+    expect(out).toContain('proxy_set_header X-Original-URL https://$http_host$request_uri;');
+    // The regression: a $scheme-derived scheme would be `http` on a plain-http
+    // request → Authelia 400 → nginx 500. It must not survive anywhere in the
+    // auth-request block.
+    expect(out).not.toContain('X-Original-URL $scheme://');
+  });
+
   // #2143 — the acme-challenge bypass duplicates NPM's own on LE hosts.
   it('emits the acme-challenge bypass by default (LAN / cert-less hosts)', () => {
     const out = expandForwardAuthSentinel(AUTHELIA_FORWARD_AUTH_SENTINEL)!;

--- a/packages/backend/src/lib/stackInstall/forwardAuth.ts
+++ b/packages/backend/src/lib/stackInstall/forwardAuth.ts
@@ -98,10 +98,23 @@ export const AUTHELIA_LOCATION_HEADERS = [
  * Authelia validates the scheme in `X-Original-URL` — anything other
  * than `https://` triggers *"Target URL has an insecure scheme 'http',
  * only the 'https' and 'wss' schemes are supported so session cookies
- * can be transmitted securely"* and a 400. So this snippet is only
- * useful on hosts that actually serve traffic over HTTPS (= have a
- * cert bound). For cert-less LAN-only hosts, gate auth differently
- * (or don't gate at all).
+ * can be transmitted securely"* and a 400. nginx maps that unexpected
+ * auth-request status to a 500 (`auth request unexpected status: 400`),
+ * so the browser gets a 500 instead of a login redirect.
+ *
+ * #2368 — the subrequest MUST therefore send a hardcoded `https://`
+ * scheme, NOT `$scheme`. `$scheme` is the *client's* transport, so a
+ * plain-HTTP request (a LAN browser hitting `http://<host>/`, or the
+ * platform's own `domain` health probe, which fetches port 80) made
+ * `X-Original-URL` carry `http://…` → Authelia 400 → nginx 500. That is
+ * exactly what stranded `paperless.dopp.cloud`: identical to the working
+ * https-only hosts (files/sync) in every other respect, it 500'd only
+ * because it was also reached over http. Hardcoding `https` is safe and
+ * scheme-agnostic for identity: Authelia never connects to the URL, it
+ * only parses it to match the `access_control` domain rule and set the
+ * `?rd=` return target, and the session cookie is scoped to the parent
+ * domain regardless of transport. For an https client `$scheme` was
+ * already `https`, so this is a no-op there and a strict fix for http.
  *
  * `error_page 401 =302 $redirect` converts the 401 back to a 302 the
  * browser can follow; `$redirect` is captured from
@@ -127,7 +140,10 @@ const AUTHELIA_FORWARD_AUTH_CORE = [
   '    proxy_pass http://127.0.0.1:{{AUTHELIA_PORT}}/api/authz/auth-request;',
   '    proxy_pass_request_body off;',
   '    proxy_set_header Content-Length "";',
-  '    proxy_set_header X-Original-URL $scheme://$http_host$request_uri;',
+  // #2368 — hardcode https (NOT $scheme): Authelia 400s a non-https
+  // X-Original-URL → nginx 500. A plain-http client/probe would otherwise
+  // send http:// here. See the endpoint docstring above.
+  '    proxy_set_header X-Original-URL https://$http_host$request_uri;',
   '    proxy_set_header X-Original-Method $request_method;',
   '    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;',
   '    proxy_set_header X-Real-IP $remote_addr;',

--- a/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperateContainersTab.tsx
+++ b/packages/frontend/src/app/(dashboard)/services/[name]/_lib/OperateContainersTab.tsx
@@ -8,9 +8,11 @@ import { Card } from '@/components/ui';
 /**
  * Containers tab of a service's Operate page (IA slice 1, #2029 / spec §4.2).
  * Absorbs the per-service rows of the old `/health?tab=containers` surface so a
- * service's containers live on its one Operate page. Reuses ContainerList (the
- * same component the box-wide containers view uses) fed with only THIS service's
- * attached containers, so the per-container logs/shell/actions stay available.
+ * service's containers live on its one Operate page. Renders the canonical
+ * shared ContainerList (#2367) — the exact component the box-wide Status →
+ * Containers view uses — fed with only THIS service's attached containers, so
+ * this view has the identical card layout AND the per-container Logs / Terminal
+ * / Actions drawer (the "open terminal" action Status has).
  */
 export default function OperateContainersTab({ service }: { service: ServiceViewModel }) {
   const containers = (service.attachedContainers ?? []).map(c => ({

--- a/packages/frontend/src/components/ContainerList.test.tsx
+++ b/packages/frontend/src/components/ContainerList.test.tsx
@@ -1,8 +1,9 @@
 /**
- * ContainerList migration (#2078) — the Operate Containers tab table. Operator
- * called the old table "bunt": Node purple, ID blue, Image green, Names orange.
- * These tests lock the rebuild onto the shared <DataTable> primitive: one calm
- * surface, no random per-column colour literals.
+ * ContainerList is the canonical container-list component (#2367): the Status →
+ * Containers card layout with a per-container Logs / Terminal / Actions row,
+ * shared by Service → Containers so both views render identically and Service
+ * gains the "open terminal" action. (Supersedes the #2078 DataTable, which was
+ * the divergent Service-only list this unification removed.)
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -12,6 +13,15 @@ import ContainerList from './ContainerList';
 vi.mock('@/hooks/useDigitalTwin', () => ({
   useDigitalTwin: () => ({ data: null }),
 }));
+vi.mock('@/hooks/useContainerActions', () => ({
+  useContainerActions: () => ({
+    openActions: vi.fn(),
+    closeActions: vi.fn(),
+    overlay: null,
+    isOpen: false,
+  }),
+}));
+vi.mock('@/hooks/useEscapeKey', () => ({ useEscapeKey: () => {} }));
 
 function container(over: Partial<EnrichedContainer> = {}): Partial<EnrichedContainer> {
   return {
@@ -26,26 +36,30 @@ function container(over: Partial<EnrichedContainer> = {}): Partial<EnrichedConta
   };
 }
 
-describe('ContainerList (#2078 DataTable migration)', () => {
-  it('renders the rows via DataTable and shows the cell content', () => {
+describe('ContainerList (#2367 canonical card layout)', () => {
+  it('renders a container card with name, image, node and domain link', () => {
     render(<ContainerList containers={[container()]} />);
     expect(screen.getByText('Local')).toBeDefined();
     expect(screen.getByText('immich-server')).toBeDefined();
-    // 12-char truncated id
-    expect(screen.getByText('abcdef012345')).toBeDefined();
-    // a verified domain stays a clickable link
+    expect(screen.getByText('ghcr.io/immich-app/immich-server:v1.0')).toBeDefined();
+    // a verified domain stays a clickable link (Service-only feature preserved)
     const link = screen.getByRole('link', { name: 'photos.dopp.cloud' });
     expect(link.getAttribute('href')).toBe('https://photos.dopp.cloud');
+  });
+
+  it('exposes the Logs, Terminal and Actions per-container controls', () => {
+    render(<ContainerList containers={[container()]} />);
+    // The "open terminal" action Service/Container gained from Status.
+    expect(screen.getByRole('button', { name: 'Terminal' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Logs & Info' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Actions' })).toBeDefined();
   });
 
   it('uses no random per-column colour literals (the old "bunte Tabelle")', () => {
     const { container: root } = render(<ContainerList containers={[container()]} />);
     const html = root.innerHTML;
-    // none of the old per-column rainbow colours
     for (const banned of ['text-purple-400', 'text-blue-400', 'text-green-400', 'text-yellow-400']) {
       expect(html).not.toContain(banned);
     }
-    // the calm DataTable surface: a token-bordered table wrapper
-    expect(root.querySelector('table')).not.toBeNull();
   });
 });

--- a/packages/frontend/src/components/ContainerList.tsx
+++ b/packages/frontend/src/components/ContainerList.tsx
@@ -1,126 +1,400 @@
 'use client';
 
-// V4 Update: Use Digital Twin data
+// Canonical container-list component (#2367). The Status → Containers view was
+// the richer of the two container lists (card rows + per-container Logs /
+// Terminal / Actions drawer); this is that view extracted into one shared
+// component so Service → Containers (OperateContainersTab) renders the identical
+// layout and gains the "open terminal" action instead of a divergent DataTable.
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
-import { useEffect, useMemo, useState } from 'react';
-import { RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { Activity, Eraser, MoreVertical, RefreshCw, Terminal as TerminalIcon, X } from 'lucide-react';
 import type { EnrichedContainer } from '@servicebay/api-client';
-import { Card, DataTable, type Column } from '@/components/ui';
+import { Card, SectionHeading, StatusDot } from '@/components/ui';
+import { useContainerActions } from '@/hooks/useContainerActions';
+import { useEscapeKey } from '@/hooks/useEscapeKey';
+import ContainerLogsPanel, { type ContainerLogsPanelData } from '@/components/ContainerLogsPanel';
+import type { TerminalRef } from '@/components/Terminal';
 
-interface ContainerItem extends Partial<EnrichedContainer> {
-  // Allow partial for legacy passed props, but prefer EnrichedContainer shape
-  nodeName?: string;
-}
-
-interface ContainerListProps {
-  containers?: ContainerItem[];
-}
+const DynamicTerminal = dynamic(() => import('@/components/Terminal'), { ssr: false });
 
 const CONNECT_TIMEOUT_MS = 15_000;
 
-function names(c: ContainerItem): string {
-  return Array.isArray(c.names) ? c.names.join(', ') : (c.names ?? '');
+export interface ContainerListItem extends Partial<EnrichedContainer> {
+  nodeName?: string;
+  // Owning service/bundle badge (Status view). Optional so callers that don't
+  // resolve parentage (Service view) simply omit the badge.
+  parent?: { type: 'service' | 'bundle'; name: string };
 }
 
-// Calm, consistent columns on the shared DataTable primitive (#2078). Replaces
-// the old "bunte Tabelle" — Node purple, ID blue, Image green, Names orange —
-// with one quiet surface; only the clickable Domains keep an accent colour.
-const columns: Column<ContainerItem>[] = [
-  { key: 'node', header: 'Node', cell: c => c.nodeName ?? '-' },
-  {
-    key: 'id',
-    header: 'ID',
-    className: 'font-mono text-text-muted',
-    cell: c => <span title={c.id}>{c.id?.substring(0, 12)}</span>,
-  },
-  {
-    key: 'image',
-    header: 'Image',
-    className: 'max-w-[200px]',
-    cell: c => <span className="block truncate" title={c.image}>{c.image}</span>,
-  },
-  { key: 'state', header: 'State', cell: c => c.state },
-  { key: 'status', header: 'Status', cell: c => c.status },
-  {
-    key: 'domains',
-    header: 'Domains',
-    cell: c =>
-      c.verifiedDomains && c.verifiedDomains.length > 0 ? (
-        <div className="flex flex-wrap gap-space-1">
-          {c.verifiedDomains.map(d => (
-            <a
-              key={d}
-              href={`https://${d}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-accent hover:underline"
-            >
-              {d}
-            </a>
-          ))}
-        </div>
-      ) : (
-        <span className="text-text-subtle">-</span>
-      ),
-  },
-  {
-    key: 'names',
-    header: 'Names',
-    className: 'max-w-[200px]',
-    cell: c => <span className="block truncate" title={names(c)}>{names(c)}</span>,
-  },
-];
+export interface ContainerListGroup {
+  id: string;
+  label: string;
+  containers: ContainerListItem[];
+}
 
-export default function ContainerList({ containers }: ContainerListProps = {}) {
+interface ContainerListProps {
+  /** Explicit container list (Service view, ServiceMonitor). */
+  containers?: ContainerListItem[];
+  /** Stack-grouped rendering (Status view). Takes precedence over `containers`. */
+  groups?: ContainerListGroup[];
+  /** Render the owning service/bundle badge on each row (Status view). */
+  showParentBadge?: boolean;
+  /** Open a drawer on mount for a container id (Status view URL params). */
+  initialDrawer?: { containerId: string; mode: 'logs' | 'terminal' } | null;
+}
+
+function primaryName(c: ContainerListItem): string {
+  const first = Array.isArray(c.names) ? c.names[0] : c.names;
+  return (first ?? c.id ?? '').replace(/^\/+/, '');
+}
+
+export default function ContainerList({ containers, groups, showParentBadge, initialDrawer }: ContainerListProps = {}) {
   const { data: twin } = useDigitalTwin();
   const [slowConnect, setSlowConnect] = useState(false);
+  const [drawerMode, setDrawerMode] = useState<'logs' | 'terminal' | null>(null);
+  const [drawerContainer, setDrawerContainer] = useState<ContainerListItem | null>(null);
+  const [handledInitial, setHandledInitial] = useState<string | null>(null);
+  const terminalRef = useRef<TerminalRef>(null);
+
+  const explicit = groups !== undefined || containers !== undefined;
 
   useEffect(() => {
-    if (containers || twin) return;
+    if (explicit || twin) return;
     const t = setTimeout(() => setSlowConnect(true), CONNECT_TIMEOUT_MS);
     return () => clearTimeout(t);
-  }, [containers, twin]);
+  }, [explicit, twin]);
 
-  const allContainers = useMemo((): ContainerItem[] => {
-     if (containers) return containers;
-     if (!twin) return [];
-     const list: ContainerItem[] = [];
-     Object.entries(twin.nodes).forEach(([nodeName, nodeData]) => {
-         nodeData.containers.forEach(c => {
-             list.push({ ...c, nodeName });
-         });
-     });
-     return list;
-  }, [twin, containers]);
+  // The flat, ordered list backing lookups + the ungrouped render path.
+  const renderGroups = useMemo((): ContainerListGroup[] => {
+    if (groups) return groups;
+    let list: ContainerListItem[];
+    if (containers) {
+      list = containers;
+    } else if (twin) {
+      list = [];
+      Object.entries(twin.nodes).forEach(([nodeName, nodeData]) => {
+        nodeData.containers.forEach(c => list.push({ ...c, nodeName }));
+      });
+    } else {
+      list = [];
+    }
+    return [{ id: '__all__', label: '', containers: list }];
+  }, [groups, containers, twin]);
 
-  if (!allContainers || allContainers.length === 0) {
-    const isLoading = !(containers || twin);
+  const allContainers = useMemo(
+    () => renderGroups.flatMap(g => g.containers),
+    [renderGroups],
+  );
+
+  const closeDrawer = useCallback(() => {
+    setDrawerMode(null);
+    setDrawerContainer(null);
+  }, []);
+
+  const {
+    openActions: openContainerActions,
+    closeActions: closeContainerActions,
+    overlay: containerActionsOverlay,
+    isOpen: containerActionsOpen,
+  } = useContainerActions();
+
+  useEscapeKey(closeContainerActions, containerActionsOpen, true);
+  const shouldCloseDrawerOnEscape = Boolean(drawerMode);
+  useEscapeKey(closeDrawer, shouldCloseDrawerOnEscape, true);
+
+  // Open a drawer from a caller-supplied container id (Status URL params).
+  useEffect(() => {
+    if (!initialDrawer || !allContainers.length) return;
+    if (handledInitial === initialDrawer.containerId) return;
+    const found = allContainers.find(
+      c => c.id === initialDrawer.containerId || c.id?.startsWith(initialDrawer.containerId),
+    );
+    if (found) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot URL→state sync, guarded by handledInitial
+      setDrawerContainer(found);
+      setDrawerMode(initialDrawer.mode);
+      setHandledInitial(initialDrawer.containerId);
+    }
+  }, [initialDrawer, allContainers, handledInitial]);
+
+  const openLogs = useCallback((c: ContainerListItem) => {
+    setDrawerContainer(c);
+    setDrawerMode('logs');
+  }, []);
+
+  const openTerminal = useCallback((c: ContainerListItem) => {
+    setDrawerContainer(c);
+    setDrawerMode('terminal');
+  }, []);
+
+  const openActions = useCallback((c: ContainerListItem) => {
+    openContainerActions({
+      id: c.id ?? '',
+      name: primaryName(c),
+      nodeName: c.nodeName,
+    });
+  }, [openContainerActions]);
+
+  const getVisiblePorts = (c: ContainerListItem) => {
+    if (!c.ports || c.ports.length === 0) return [];
+    if (c.podName && !c.isInfra) return [];
+    return c.ports;
+  };
+
+  if (allContainers.length === 0) {
+    const isLoading = !explicit && !twin;
     return (
-        <Card padding="md" className="text-text-muted italic flex items-center justify-between gap-4">
-            <span>
-              {!isLoading && "No running containers found."}
-              {isLoading && !slowConnect && "Connecting to Digital Twin..."}
-              {isLoading && slowConnect && "Still connecting to Digital Twin… check Settings → Nodes if this persists."}
-            </span>
-            {isLoading && slowConnect && (
-                <button
-                    type="button"
-                    onClick={() => { if (typeof window !== 'undefined') window.location.reload(); }}
-                    className="flex items-center gap-1 px-3 py-1.5 text-xs bg-surface-2 hover:bg-surface-muted text-text rounded transition-colors not-italic"
-                >
-                    <RefreshCw size={12} /> Refresh
-                </button>
-            )}
-        </Card>
+      <Card padding="md" className="text-text-muted italic flex items-center justify-between gap-4">
+        <span>
+          {!isLoading && 'No running containers found.'}
+          {isLoading && !slowConnect && 'Connecting to Digital Twin...'}
+          {isLoading && slowConnect && 'Still connecting to Digital Twin… check Settings → Nodes if this persists.'}
+        </span>
+        {isLoading && slowConnect && (
+          <button
+            type="button"
+            onClick={() => { if (typeof window !== 'undefined') window.location.reload(); }}
+            className="flex items-center gap-1 px-3 py-1.5 text-xs bg-surface-2 hover:bg-surface-muted text-text rounded transition-colors not-italic"
+          >
+            <RefreshCw size={12} /> Refresh
+          </button>
+        )}
+      </Card>
     );
   }
 
+  const renderRow = (c: ContainerListItem, index: number) => {
+    const ports = getVisiblePorts(c);
+    const domains = c.verifiedDomains ?? [];
+    return (
+      <div
+        key={`${c.nodeName || 'local'}-${c.id || `fallback-${index}`}`}
+        className="p-space-3 hover:bg-surface-2 transition-colors"
+      >
+        <div className="flex flex-col md:flex-row md:items-center gap-3 justify-between">
+          <div className="flex items-center gap-3">
+            <StatusDot
+              state={c.state === 'running' ? 'ok' : 'unknown'}
+              label={c.state === 'running' ? 'Running' : (c.state ?? 'unknown')}
+            />
+            <div>
+              <div className="flex flex-wrap items-center gap-2 text-base font-semibold text-text">
+                {primaryName(c)}
+                {c.nodeName && (
+                  <span className="px-2 py-0.5 rounded-full text-[11px] font-semibold bg-surface-2 text-accent border border-border">
+                    {c.nodeName}
+                  </span>
+                )}
+                {showParentBadge && c.parent && (
+                  <span
+                    className="px-2 py-0.5 rounded-full text-[11px] font-semibold border truncate max-w-[180px] bg-surface-2 text-text-muted border-border"
+                    title={`${c.parent.type === 'service' ? 'Service' : 'Bundle'}: ${c.parent.name}`}
+                  >
+                    <span className="uppercase tracking-wide mr-1 text-[10px] opacity-80">
+                      {c.parent.type === 'service' ? 'Svc' : 'Bundle'}
+                    </span>
+                    <span className="font-mono text-[10px]">{c.parent.name}</span>
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-text-muted">{c.status}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={() => openLogs(c)}
+              className="p-1.5 text-text-muted hover:text-accent hover:bg-surface-2 rounded"
+              title="Logs & Info"
+            >
+              <Activity size={18} />
+            </button>
+            <button
+              onClick={() => openTerminal(c)}
+              className="p-1.5 text-text-muted hover:text-accent hover:bg-surface-2 rounded"
+              title="Terminal"
+            >
+              <TerminalIcon size={18} />
+            </button>
+            <button
+              onClick={() => openActions(c)}
+              className="p-1.5 text-text-muted hover:text-accent hover:bg-surface-2 rounded"
+              title="Actions"
+            >
+              <MoreVertical size={18} />
+            </button>
+          </div>
+        </div>
+        <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3 text-xs sm:text-sm text-text-muted">
+          <div>
+            <p className="text-[11px] uppercase tracking-wide text-text-subtle">Image</p>
+            <p className="break-all">{c.image}</p>
+          </div>
+          <div>
+            <p className="text-[11px] uppercase tracking-wide text-text-subtle">Network</p>
+            {c.isHostNetwork ? (
+              <span className="inline-flex items-center gap-1 text-xs font-semibold text-accent bg-surface-2 px-2 py-0.5 rounded">
+                Host Network
+              </span>
+            ) : (
+              <span>{(c.networks && c.networks.length > 0 ? c.networks[0] : null) || 'Default'}</span>
+            )}
+          </div>
+          {domains.length > 0 && (
+            <div className="md:col-span-2">
+              <p className="text-[11px] uppercase tracking-wide text-text-subtle">Domains</p>
+              <div className="flex flex-wrap gap-space-1">
+                {domains.map(d => (
+                  <a
+                    key={d}
+                    href={`https://${d}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-accent hover:underline"
+                  >
+                    {d}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+          {ports.length > 0 && (
+            <div className="md:col-span-2">
+              <p className="text-[11px] uppercase tracking-wide text-text-subtle">Ports</p>
+              <div className="flex flex-wrap gap-1.5">
+                {ports.map((p, i) => {
+                  const protocol = (p.protocol || 'tcp').toLowerCase();
+                  const display = p.hostPort && p.hostPort !== p.containerPort
+                    ? `${p.hostPort}:${p.containerPort}/${protocol}`
+                    : p.hostPort
+                      ? `${p.hostPort}/${protocol}`
+                      : `${p.containerPort}/${protocol}`;
+                  return (
+                    <span key={`${display}-${i}`} className="bg-surface-2 px-2 py-0.5 rounded text-[11px] font-mono border border-border text-text-muted">
+                      {display}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const grouped = groups !== undefined;
+  const drawerNode = drawerContainer?.nodeName && drawerContainer.nodeName !== 'Local'
+    ? drawerContainer.nodeName
+    : drawerContainer
+      ? 'Local'
+      : null;
+
+  const logsPanelData: ContainerLogsPanelData | null = drawerContainer
+    ? {
+        id: drawerContainer.id ?? '',
+        name: primaryName(drawerContainer),
+        image: drawerContainer.image,
+        state: drawerContainer.state,
+        status: drawerContainer.status,
+        created: drawerContainer.created,
+        ports: (drawerContainer.ports ?? []).map(p => ({
+          hostIp: p.hostIp,
+          hostPort: p.hostPort,
+          containerPort: p.containerPort ?? 0,
+          protocol: p.protocol,
+        })),
+        mounts: drawerContainer.mounts as ContainerLogsPanelData['mounts'],
+        hideMeta: true,
+      }
+    : null;
+
   return (
-    <DataTable
-      columns={columns}
-      rows={allContainers}
-      rowKey={(c, index) => `${c.nodeName || 'local'}-${c.id || `fallback-${index}`}`}
-      minWidthClassName="min-w-[800px]"
-    />
+    <>
+      {grouped ? (
+        <div className="space-y-8" data-testid="containers-stack-groups">
+          {renderGroups.map(group => (
+            <section key={group.id} className="space-y-3" data-testid={`container-group-${group.id}`}>
+              <SectionHeading
+                description={`${group.containers.length} container${group.containers.length === 1 ? '' : 's'}`}
+              >
+                {group.label}
+              </SectionHeading>
+              <Card padding="none" className="divide-y divide-border overflow-hidden">
+                {group.containers.map((c, i) => renderRow(c, i))}
+              </Card>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <Card padding="none" className="divide-y divide-border overflow-hidden">
+          {allContainers.map((c, i) => renderRow(c, i))}
+        </Card>
+      )}
+
+      {containerActionsOverlay}
+
+      {drawerMode && drawerContainer && (
+        <div className="fixed inset-0 z-50 flex justify-end bg-background/80 backdrop-blur-sm">
+          <div className="w-full max-w-5xl h-full bg-surface border-l border-border shadow-2xl animate-in slide-in-from-right-10">
+            {drawerMode === 'logs' && logsPanelData ? (
+              <ContainerLogsPanel
+                container={logsPanelData}
+                nodeName={drawerNode ?? undefined}
+                onClose={closeDrawer}
+              />
+            ) : (
+              <div className="h-full flex flex-col bg-surface">
+                <div className="flex items-start justify-between px-6 py-4 border-b border-border bg-surface-2">
+                  <div>
+                    <p className="text-xs uppercase tracking-wider text-text-subtle">Terminal</p>
+                    <div className="flex items-center gap-3 text-text text-lg font-semibold">
+                      <TerminalIcon size={18} />
+                      <span>{primaryName(drawerContainer)}</span>
+                    </div>
+                    {drawerNode && (
+                      <div className="mt-2 inline-flex items-center gap-2 text-xs text-text-muted">
+                        <span className="uppercase tracking-wide">Node</span>
+                        <span className="px-2 py-0.5 rounded-full bg-surface-2 text-text-muted border border-border">{drawerNode}</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => terminalRef.current?.clear()}
+                      className="p-2 rounded-full text-text-muted hover:text-text hover:bg-surface-2"
+                      title="Clear terminal"
+                    >
+                      <Eraser size={18} />
+                    </button>
+                    <button
+                      onClick={() => terminalRef.current?.reconnect()}
+                      className="p-2 rounded-full text-text-muted hover:text-text hover:bg-surface-2"
+                      title="Reconnect"
+                    >
+                      <RefreshCw size={18} />
+                    </button>
+                    <button
+                      onClick={closeDrawer}
+                      className="p-2 rounded-full text-text-muted hover:text-text hover:bg-surface-2"
+                      title="Close"
+                    >
+                      <X size={18} />
+                    </button>
+                  </div>
+                </div>
+                <div className="flex-1 overflow-hidden">
+                  <DynamicTerminal
+                    ref={terminalRef}
+                    id={`container:${(drawerNode && drawerNode !== 'Local' ? drawerNode : 'local')}:${drawerContainer.id}`}
+                    showControls={false}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/packages/frontend/src/dashboards/ContainersDashboard.tsx
+++ b/packages/frontend/src/dashboards/ContainersDashboard.tsx
@@ -1,65 +1,27 @@
-import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import dynamic from 'next/dynamic';
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 import DashboardHydrationGate, { type HydrationPhase } from '@/components/DashboardHydrationGate';
-import { Terminal as TerminalIcon, MoreVertical, X, Activity, Search, RefreshCw, Eraser } from 'lucide-react';
+import { Search } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
-import { useEscapeKey } from '@/hooks/useEscapeKey';
-import { useContainerActions } from '@/hooks/useContainerActions';
-import ContainerLogsPanel, { ContainerLogsPanelData } from '@/components/ContainerLogsPanel';
-import type { TerminalRef } from '@/components/Terminal';
+import ContainerList, { type ContainerListItem } from '@/components/ContainerList';
 import { logger, type ServiceBundle } from '@servicebay/api-client';
-import { Card, SectionHeading, StatusDot } from '@/components/ui';
 import {
     groupContainersByStack,
     type StackSummaryLite,
 } from './_lib/servicesDashboard';
-
-const DynamicTerminal = dynamic(() => import('@/components/Terminal'), {
-    ssr: false,
-});
-// import { getNodes } from '@/app/actions/nodes'; // Not needed
-// import { PodmanConnection } from '@servicebay/api-client'; // Not needed
-
-interface Container {
-  Id: string;
-  Names: string[];
-  Image: string;
-  State: string;
-  Status: string;
-  Created: number;
-  Pod?: string;
-  PodName?: string;
-    isInfra?: boolean;
-  // Support both formats (standard Podman JSON vs Docker-like)
-  Ports?: { hostIp?: string; containerPort: number; hostPort?: number; protocol: string }[];
-  // Mounts?: (string | { Source: string; Destination: string; Type: string })[]; // Not strict check
-  Mounts?: unknown[];
-  Labels?: { [key: string]: string };
-  NetworkMode?: string;
-  IsHostNetwork?: boolean;
-  nodeName?: string;
-    parent?: {
-        type: 'service' | 'bundle';
-        name: string;
-    };
-}
 
 export default function ContainersDashboard() {
   const { data: twin, isConnected, isNodeSynced } = useDigitalTwin();
   const searchParams = useSearchParams();
   const containerIdParam = searchParams?.get('containerId');
   const drawerParam = searchParams?.get('drawer');
-  const [handledQueryContainer, setHandledQueryContainer] = useState<string | null>(null);
 
-    // filteredContainers derived via useMemo below
   const [searchQuery, setSearchQuery] = useState('');
     const [showInfra, setShowInfra] = useState(false);
-    const [drawerMode, setDrawerMode] = useState<'logs' | 'terminal' | null>(null);
-    const [drawerContainer, setDrawerContainer] = useState<Container | null>(null);
     const [stackSummaries, setStackSummaries] = useState<StackSummaryLite[]>([]);
-        const terminalRef = useRef<TerminalRef>(null);
 
     // Stack membership so Status→Containers groups mirror the /services
     // stack-grouping (#2095). Non-fatal: on failure the grouper falls back to
@@ -81,22 +43,6 @@ export default function ContainersDashboard() {
         })();
         return () => { cancelled = true; };
     }, []);
-
-    const closeDrawer = useCallback(() => {
-        setDrawerMode(null);
-        setDrawerContainer(null);
-    }, []);
-
-    const {
-        openActions: openContainerActions,
-        closeActions: closeContainerActions,
-        overlay: containerActionsOverlay,
-        isOpen: containerActionsOpen,
-    } = useContainerActions();
-
-    useEscapeKey(closeContainerActions, containerActionsOpen, true);
-    const shouldCloseDrawerOnEscape = Boolean(drawerMode) && drawerMode !== 'terminal' && drawerMode !== 'logs';
-    useEscapeKey(closeDrawer, shouldCloseDrawerOnEscape, true);
 
   const containerParentMap = useMemo(() => {
     const map = new Map<string, { type: 'service' | 'bundle'; name: string }>();
@@ -125,73 +71,21 @@ export default function ContainersDashboard() {
     return map;
   }, [twin]);
 
-  const containers = useMemo(() => {
+  // The canonical shape the shared ContainerList renders: the enriched twin
+  // container plus its owning node + parent service/bundle.
+  const containers = useMemo((): ContainerListItem[] => {
     if (!twin || !twin.nodes) return [];
-    
-    const list: Container[] = [];
+    const list: ContainerListItem[] = [];
     Object.entries(twin.nodes).forEach(([nodeName, nodeState]) => {
         nodeState.containers.forEach(ec => {
-            // Map enriched container to UI interface
-            list.push({
-                Id: ec.id,
-                Names: ec.names,
-                Image: ec.image,
-                State: ec.state,
-                Status: ec.status,
-                Created: ec.created,
-                nodeName: nodeName,
-                isInfra: ec.isInfra,
-                // Ports need mapping from {hostPort, containerPort, protocol} to UI format
-                Ports: (ec.ports || []).map(p => ({
-                    hostIp: p.hostIp || '0.0.0.0',
-                    hostPort: p.hostPort,
-                    containerPort: p.containerPort || 0,
-                    protocol: p.protocol
-                })),
-                Mounts: ec.mounts || [],
-                Labels: ec.labels || {},
-                // NetworkMode? Not directly available on EnrichedContainer yet, maybe in misc
-                NetworkMode: (ec.networks && ec.networks.length > 0) ? ec.networks[0] : 'default',
-                IsHostNetwork: ec.isHostNetwork,
-                Pod: ec.podId,
-                PodName: ec.podName,
-                parent: containerParentMap.get(ec.id)
-            });
+            list.push({ ...ec, nodeName, parent: containerParentMap.get(ec.id) });
         });
     });
     return list;
   }, [containerParentMap, twin]);
 
-  useEffect(() => {
-    if (!containerIdParam || !containers.length) return;
-    if (handledQueryContainer === containerIdParam) return;
-
-    const found = containers.find(c => c.Id === containerIdParam || c.Id.startsWith(containerIdParam));
-    if (found) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- opens drawer from URL ?container param; controlled URL→state sync, one-shot via handledQueryContainer guard
-        setDrawerContainer(found);
-         
-        setDrawerMode(drawerParam === 'terminal' ? 'terminal' : 'logs');
-         
-        setHandledQueryContainer(containerIdParam);
-    }
-  }, [containerIdParam, drawerParam, containers, handledQueryContainer]);
-
-
   const loading = !isConnected && containers.length === 0;
-  // If we are connected but no data yet, check sync status
   const waitingForSync = isConnected && !isNodeSynced() && containers.length === 0;
-  
-  // const validating = false;
-  // const refreshing = false;
-  // const refresh = () => {}; // No-op as twin updates auto
-
-  // Legacy SSE Removed
-  /*
-  useEffect(() => {
-    // ...
-  }, []);
-  */
 
   const filteredContainers = useMemo(() => {
       let filtered = containers;
@@ -200,43 +94,18 @@ export default function ContainersDashboard() {
           filtered = filtered.filter(c => !c.isInfra);
       }
 
-      // Filter by Search
       if (searchQuery) {
           const q = searchQuery.toLowerCase();
           filtered = filtered.filter(c =>
-              c.Names.some(n => n.toLowerCase().includes(q)) ||
-              c.Id.toLowerCase().includes(q) ||
-              c.Image.toLowerCase().includes(q) ||
-              (c.nodeName && c.nodeName.toLowerCase().includes(q))
+              (c.names ?? []).some(n => n.toLowerCase().includes(q)) ||
+              (c.id ?? '').toLowerCase().includes(q) ||
+              (c.image ?? '').toLowerCase().includes(q) ||
+              (c.nodeName ? c.nodeName.toLowerCase().includes(q) : false)
           );
       }
 
       return filtered;
   }, [containers, searchQuery, showInfra]);
-
-    const openLogs = (container: Container) => {
-        setDrawerContainer(container);
-        setDrawerMode('logs');
-    };
-
-    const openTerminal = (container: Container) => {
-        setDrawerContainer(container);
-        setDrawerMode('terminal');
-    };
-
-  const openActions = useCallback((container: Container) => {
-        openContainerActions({
-            id: container.Id,
-            name: container.Names[0]?.replace(/^\//, '') || container.Id,
-            nodeName: container.nodeName,
-        });
-    }, [openContainerActions]);
-
-    const getVisiblePorts = (container: Container) => {
-        if (!container.Ports || container.Ports.length === 0) return [];
-        if (container.PodName && !container.isInfra) return [];
-        return container.Ports;
-    };
 
   // Group containers under the same stack identity the /services view uses
   // (#2095): each container's parent service maps to its owning stack, with a
@@ -252,46 +121,30 @@ export default function ContainersDashboard() {
     [filteredContainers, stackSummaries],
   );
 
-    const drawerNode = drawerContainer?.nodeName && drawerContainer.nodeName !== 'Local'
-        ? drawerContainer.nodeName
-        : drawerContainer
-            ? 'Local'
-            : null;
-
-    const logsPanelData: ContainerLogsPanelData | null = drawerContainer
-        ? {
-            id: drawerContainer.Id,
-            name: drawerContainer.Names[0]?.replace(/^\/+/, '') || drawerContainer.Id,
-            image: drawerContainer.Image,
-            state: drawerContainer.State,
-            status: drawerContainer.Status,
-            created: drawerContainer.Created,
-            ports: drawerContainer.Ports,
-            mounts: drawerContainer.Mounts as ContainerLogsPanelData['mounts'],
-            hideMeta: true,
-        }
-        : null;
+  const initialDrawer = containerIdParam
+    ? { containerId: containerIdParam, mode: (drawerParam === 'terminal' ? 'terminal' : 'logs') as 'logs' | 'terminal' }
+    : null;
 
     return (
         <div className="h-full flex flex-col relative">
               <PageHeader title="Container Engine" showBack={false} helpId="container-engine">
                         <div className="flex flex-col gap-3 w-full md:flex-row md:items-center">
                             <div className="relative flex-1 min-w-[200px]">
-                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-subtle" />
                                 <input
                                     type="text"
                                     placeholder="Search containers..."
                                     value={searchQuery}
                                     onChange={(e) => setSearchQuery(e.target.value)}
-                                    className="w-full pl-9 pr-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none"
+                                    className="w-full pl-9 pr-4 py-2 rounded-lg border border-border bg-surface text-sm text-text focus:ring-2 focus:ring-accent outline-none"
                                 />
                             </div>
-                            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 select-none">
+                            <label className="flex items-center gap-2 text-sm text-text-muted select-none">
                                 <input
                                     type="checkbox"
                                     checked={showInfra}
                                     onChange={(e) => setShowInfra(e.target.checked)}
-                                    className="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                                    className="rounded border-border text-accent focus:ring-accent"
                                 />
                                 Show infrastructure containers
                             </label>
@@ -301,199 +154,16 @@ export default function ContainersDashboard() {
             <div className="flex-1 overflow-y-auto p-4">
                 {loading || waitingForSync ? (
                         <DashboardHydrationGate
-                            // `loading` flips when the socket transport is
-                            // still connecting (no `isConnected` yet);
-                            // `waitingForSync` flips when the agent is
-                            // streaming the first inventory broadcast. Render
-                            // never reaches this block — the dataset is
-                            // already attached by the time we leave it.
                             phase={(loading ? 'socket' : 'sync') as HydrationPhase}
                         />
                     ) : filteredContainers.length === 0 ? (
-                        <div className="text-center text-gray-500 dark:text-gray-400 mt-10">
+                        <div className="text-center text-text-muted mt-10">
                             {containers.length > 0 ? 'No containers match your filters.' : 'No active containers found.'}
                         </div>
                     ) : (
-                        <div className="space-y-8" data-testid="containers-stack-groups">
-                            {containerGroups.map(group => (
-                                <section key={group.id} className="space-y-3" data-testid={`container-group-${group.id}`}>
-                                    <SectionHeading
-                                        description={`${group.containers.length} container${group.containers.length === 1 ? '' : 's'}`}
-                                    >
-                                        {group.label}
-                                    </SectionHeading>
-                                    <Card padding="none" className="divide-y divide-border overflow-hidden">
-                                        {group.containers.map((c) => {
-                                            const ports = getVisiblePorts(c);
-                                            return (
-                                                <div key={c.Id} className="p-space-3 hover:bg-surface-2 transition-colors">
-                                                    <div className="flex flex-col md:flex-row md:items-center gap-3 justify-between">
-                                                        <div className="flex items-center gap-3">
-                                                            <StatusDot
-                                                                state={c.State === 'running' ? 'ok' : 'unknown'}
-                                                                label={c.State === 'running' ? 'Running' : c.State}
-                                                            />
-                                                            <div>
-                                                                <div className="flex flex-wrap items-center gap-2 text-base font-semibold text-gray-900 dark:text-gray-100">
-                                                                    {c.Names[0].replace(/^\//, '')}
-                                                                    {c.nodeName && (
-                                                                        <span className="px-2 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200 border border-blue-200 dark:border-blue-800">
-                                                                            {c.nodeName}
-                                                                        </span>
-                                                                    )}
-                                                                    {c.parent && (
-                                                                        <span
-                                                                            className={`px-2 py-0.5 rounded-full text-[11px] font-semibold border truncate max-w-[180px] ${
-                                                                                c.parent.type === 'service'
-                                                                                    ? 'bg-purple-50 text-purple-700 dark:bg-purple-900/20 dark:text-purple-200 border-purple-200 dark:border-purple-800'
-                                                                                    : 'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-200 border-amber-200 dark:border-amber-800'
-                                                                            }`}
-                                                                            title={`${c.parent.type === 'service' ? 'Service' : 'Bundle'}: ${c.parent.name}`}
-                                                                        >
-                                                                            <span className="uppercase tracking-wide mr-1 text-[10px] opacity-80">
-                                                                                {c.parent.type === 'service' ? 'Svc' : 'Bundle'}
-                                                                            </span>
-                                                                            <span className="font-mono text-[10px]">{c.parent.name}</span>
-                                                                        </span>
-                                                                    )}
-                                                                </div>
-                                                                <p className="text-xs text-gray-500 dark:text-gray-400">{c.Status}</p>
-                                                            </div>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <button
-                                                                onClick={() => openLogs(c)}
-                                                                className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded"
-                                                                title="Logs & Info"
-                                                            >
-                                                                <Activity size={18} />
-                                                            </button>
-                                                            <button
-                                                                onClick={() => openTerminal(c)}
-                                                                className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-emerald-600 dark:hover:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 rounded"
-                                                                title="Terminal"
-                                                            >
-                                                                <TerminalIcon size={18} />
-                                                            </button>
-                                                            <button
-                                                                onClick={() => openActions(c)}
-                                                                className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded"
-                                                                title="Actions"
-                                                            >
-                                                                <MoreVertical size={18} />
-                                                            </button>
-                                                        </div>
-                                                    </div>
-                                                    <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3 text-xs sm:text-sm text-gray-600 dark:text-gray-400">
-                                                        <div>
-                                                            <p className="text-[11px] uppercase tracking-wide text-gray-500">Image</p>
-                                                            <p className="break-all">{c.Image}</p>
-                                                        </div>
-                                                        <div>
-                                                            <p className="text-[11px] uppercase tracking-wide text-gray-500">Network</p>
-                                                            {c.IsHostNetwork ? (
-                                                                <span className="inline-flex items-center gap-1 text-xs font-semibold text-purple-700 dark:text-purple-300 bg-purple-50 dark:bg-purple-900/20 px-2 py-0.5 rounded">
-                                                                    Host Network
-                                                                </span>
-                                                            ) : (
-                                                                <span>{c.NetworkMode || 'Default'}</span>
-                                                            )}
-                                                        </div>
-                                                        {ports.length > 0 && (
-                                                            <div className="md:col-span-2">
-                                                                <p className="text-[11px] uppercase tracking-wide text-gray-500">Ports</p>
-                                                                <div className="flex flex-wrap gap-1.5">
-                                                                    {ports.map((p, index) => {
-                                                                        const protocol = (p.protocol || 'tcp').toLowerCase();
-                                                                        const display = p.hostPort && p.hostPort !== p.containerPort
-                                                                            ? `${p.hostPort}:${p.containerPort}/${protocol}`
-                                                                            : p.hostPort
-                                                                                ? `${p.hostPort}/${protocol}`
-                                                                                : `${p.containerPort}/${protocol}`;
-                                                                        return (
-                                                                            <span key={`${display}-${index}`} className="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded text-[11px] font-mono border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300">
-                                                                                {display}
-                                                                            </span>
-                                                                        );
-                                                                    })}
-                                                                </div>
-                                                            </div>
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            );
-                                        })}
-                                    </Card>
-                                </section>
-                            ))}
-                        </div>
+                        <ContainerList groups={containerGroups} showParentBadge initialDrawer={initialDrawer} />
                     )}
             </div>
-
-            {containerActionsOverlay}
-
-            {drawerMode && drawerContainer && (
-                <div className="fixed inset-0 z-50 flex justify-end bg-gray-950/70 backdrop-blur-sm">
-                    <div className="w-full max-w-5xl h-full bg-white dark:bg-gray-950 border-l border-gray-200 dark:border-gray-800 shadow-2xl animate-in slide-in-from-right-10">
-                        {drawerMode === 'logs' && logsPanelData ? (
-                            <ContainerLogsPanel
-                                container={logsPanelData}
-                                nodeName={drawerNode ?? undefined}
-                                onClose={closeDrawer}
-                            />
-                        ) : (
-                            <div className="h-full flex flex-col bg-gray-950">
-                                <div className="flex items-start justify-between px-6 py-4 border-b border-gray-800 bg-gray-900">
-                                    <div>
-                                        <p className="text-xs uppercase tracking-wider text-gray-500">Terminal</p>
-                                        <div className="flex items-center gap-3 text-white text-lg font-semibold">
-                                            <TerminalIcon size={18} />
-                                            <span>{drawerContainer.Names[0]?.replace(/^\//, '') || drawerContainer.Id}</span>
-                                            {/* Hide ID on embedded terminal header per UX request */}
-                                        </div>
-                                        {drawerNode && (
-                                            <div className="mt-2 inline-flex items-center gap-2 text-xs text-gray-400">
-                                                <span className="uppercase tracking-wide">Node</span>
-                                                <span className="px-2 py-0.5 rounded-full bg-gray-800 text-gray-200 border border-gray-700">{drawerNode}</span>
-                                            </div>
-                                        )}
-                                    </div>
-                                    <div className="flex items-center gap-2">
-                                        <button
-                                            onClick={() => terminalRef.current?.clear()}
-                                            className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-gray-800"
-                                            title="Clear terminal"
-                                        >
-                                            <Eraser size={18} />
-                                        </button>
-                                        <button
-                                            onClick={() => terminalRef.current?.reconnect()}
-                                            className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-gray-800"
-                                            title="Reconnect"
-                                        >
-                                            <RefreshCw size={18} />
-                                        </button>
-                                        <button
-                                            onClick={closeDrawer}
-                                            className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-gray-800"
-                                            title="Close"
-                                        >
-                                            <X size={18} />
-                                        </button>
-                                    </div>
-                                </div>
-                                <div className="flex-1 overflow-hidden">
-                                    <DynamicTerminal
-                                        ref={terminalRef}
-                                        id={`container:${(drawerNode && drawerNode !== 'Local' ? drawerNode : 'local')}:${drawerContainer.Id}`}
-                                        showControls={false}
-                                    />
-                                </div>
-                            </div>
-                        )}
-                    </div>
-                </div>
-            )}
         </div>
     );
 }

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -729,6 +729,65 @@ def ensure_jellyfin_lrclib_plugin(base_url: str, token: str) -> bool:
     return False
 
 
+# ── Jellyfin built-in DLNA server (durable on reinstall, #2369) ──────────────
+
+# Jellyfin ≥10.9 ships DLNA as the catalog plugin "DLNA" ("Adds DLNA capability
+# to Jellyfin"), whose manifest is in the DEFAULT Jellyfin repository — so a
+# plain package install resolves it without registering a repo (unlike LrcLib).
+# Older cores compile DLNA in; the install then no-ops and the config write
+# below is what turns the server on. The named-configuration key is "dlna".
+JELLYFIN_DLNA_PACKAGE = "DLNA"
+
+
+def ensure_jellyfin_dlna_server(base_url: str, token: str) -> bool:
+    """Enable Jellyfin's built-in DLNA server by default so LAN TVs / DLNA
+    clients can browse the libraries straight from the TV without any manual
+    Dashboard step (#2369). Two best-effort halves:
+
+      1. Request the DLNA plugin install (idempotent — Jellyfin no-ops a
+         re-install of a present plugin; a core with DLNA built in no-ops too).
+      2. Read-modify-write the `dlna` named configuration: GET the current
+         DlnaOptions, flip `EnableServer` on, POST it back — every other DLNA
+         option is preserved, exactly like `jellyfin_enable_music_providers`
+         merges into a library's existing LibraryOptions.
+
+    Best-effort + idempotent: re-asserts EnableServer=true every deploy, so a
+    fresh reinstall never loses it. A failure just logs a breadcrumb (operator
+    can flip it in Dashboard → DLNA); it never blocks the deploy."""
+    auth = {"X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{token}"'}
+
+    # 1. Request the DLNA plugin install (idempotent — no-ops if already present
+    #    or built into the core). Resolves from the default catalog.
+    pkg = urllib.parse.quote(JELLYFIN_DLNA_PACKAGE)
+    code, _ = request_json(
+        "POST", f"{base_url}/Packages/Installed/{pkg}", None, extra_headers=auth,
+    )
+    if code in (200, 204):
+        log("   ✅ Jellyfin DLNA plugin install requested.")
+    else:
+        log(f"   (note) Could not request DLNA plugin install via API ({render_http_code(code)}); "
+            "if DLNA is missing, install 'DLNA' from Dashboard → Plugins → Catalog.")
+
+    # 2. Read-modify-write the DLNA named configuration to enable the server.
+    code, options = request_json(
+        "GET", f"{base_url}/System/Configuration/dlna", None, extra_headers=auth,
+    )
+    if code not in (200, 204) or not isinstance(options, dict):
+        log(f"   (note) Could not read Jellyfin DLNA configuration ({render_http_code(code)}); "
+            "enable the DLNA server from Dashboard → DLNA if LAN TVs can't see Jellyfin.")
+        return False
+    options["EnableServer"] = True
+    code, _ = request_json(
+        "POST", f"{base_url}/System/Configuration/dlna", options, extra_headers=auth,
+    )
+    if code in (200, 204):
+        log("   ✅ Jellyfin built-in DLNA server enabled (LAN TVs/DLNA clients can browse).")
+        return True
+    log(f"   (note) Could not enable the Jellyfin DLNA server ({render_http_code(code)}); "
+        "enable it from Dashboard → DLNA if LAN TVs can't see Jellyfin.")
+    return False
+
+
 def main() -> int:
     host = env("HOST", "<server-ip>")
 
@@ -790,6 +849,9 @@ def main() -> int:
                 )
                 jellyfin_enable_music_providers(jellyfin_base, jf_token, folders)
                 ensure_jellyfin_lrclib_plugin(jellyfin_base, jf_token)
+                # Enable the built-in DLNA server by default so LAN TVs /
+                # DLNA clients can browse Jellyfin with no manual step (#2369).
+                ensure_jellyfin_dlna_server(jellyfin_base, jf_token)
 
         # ── Jellyfin → LLDAP SSO (#1718) ──────────────────────────────
         # Wire the LDAP-Auth plugin against LLDAP so the family signs in

--- a/tests/frontend/ContainerList.test.tsx
+++ b/tests/frontend/ContainerList.test.tsx
@@ -8,6 +8,15 @@ import ContainerList from '@/components/ContainerList';
 vi.mock('@/hooks/useDigitalTwin', () => ({
   useDigitalTwin: vi.fn()
 }));
+vi.mock('@/hooks/useContainerActions', () => ({
+  useContainerActions: () => ({
+    openActions: vi.fn(),
+    closeActions: vi.fn(),
+    overlay: null,
+    isOpen: false,
+  }),
+}));
+vi.mock('@/hooks/useEscapeKey', () => ({ useEscapeKey: () => {} }));
 
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 
@@ -48,12 +57,12 @@ describe('ContainerList', () => {
 
         render(<ContainerList />);
 
-        // Check if both containers are rendered
-        expect(screen.getByText('123456789012')).toBeDefined();
+        // Check if both containers are rendered as cards (name + image + node).
+        expect(screen.getByText('web')).toBeDefined();
         expect(screen.getByText('nginx:latest')).toBeDefined();
         expect(screen.getByText('Local')).toBeDefined();
 
-        expect(screen.getByText('abcdef123456')).toBeDefined();
+        expect(screen.getByText('cache')).toBeDefined();
         expect(screen.getByText('redis:alpine')).toBeDefined();
         expect(screen.getByText('Remote')).toBeDefined();
     });

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1256,6 +1256,81 @@ class MediaScript(unittest.TestCase):
             ok = m.ensure_jellyfin_lrclib_plugin("http://jf", "tok")  # must not raise
         self.assertFalse(ok)
 
+    # ── #2369: built-in DLNA server enabled by default ────────────────────
+
+    def test_jellyfin_dlna_server_installs_plugin_and_enables_server(self):
+        """ensure_jellyfin_dlna_server requests the DLNA plugin install AND
+        read-modify-writes the `dlna` named configuration to flip EnableServer
+        on, preserving every other DLNA option (#2369)."""
+        m = load_script("media")
+        import urllib.request, json
+        install_called: list[str] = []
+        config_posts: list[dict] = []
+        outer = self
+
+        def urlopen(req, *a, **k):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            meth = req.get_method()
+            if meth == "POST" and "/Packages/Installed/" in url:
+                install_called.append(url)
+                return outer._resp(204, "")
+            if meth == "GET" and url.endswith("/System/Configuration/dlna"):
+                # Existing DlnaOptions with a non-default field to prove RMW.
+                return outer._resp(200, json.dumps(
+                    {"EnableServer": False, "EnablePlayTo": True, "BlastAliveMessageIntervalSeconds": 30}))
+            if meth == "POST" and url.endswith("/System/Configuration/dlna"):
+                config_posts.append(json.loads(req.data.decode()))
+                return outer._resp(204, "")
+            return outer._resp(204, "{}")
+
+        with mock.patch.object(urllib.request, "urlopen", urlopen):
+            ok = m.ensure_jellyfin_dlna_server("http://jf", "tok")
+
+        self.assertTrue(ok)
+        # The DLNA plugin install was requested.
+        self.assertTrue(any(u.endswith("/Packages/Installed/DLNA") for u in install_called))
+        # The config POST enabled the server and preserved the other options.
+        self.assertEqual(len(config_posts), 1)
+        self.assertTrue(config_posts[0]["EnableServer"])
+        self.assertTrue(config_posts[0]["EnablePlayTo"])
+        self.assertEqual(config_posts[0]["BlastAliveMessageIntervalSeconds"], 30)
+
+    def test_jellyfin_dlna_server_idempotent(self):
+        """Re-running posts the same EnableServer=true config (self-healing on
+        every redeploy)."""
+        m = load_script("media")
+        import urllib.request, json
+        config_posts: list[dict] = []
+        outer = self
+
+        def urlopen(req, *a, **k):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            meth = req.get_method()
+            if meth == "GET" and url.endswith("/System/Configuration/dlna"):
+                return outer._resp(200, json.dumps({"EnableServer": False}))
+            if meth == "POST" and url.endswith("/System/Configuration/dlna"):
+                config_posts.append(json.loads(req.data.decode()))
+                return outer._resp(204, "")
+            return outer._resp(204, "{}")
+
+        with mock.patch.object(urllib.request, "urlopen", urlopen):
+            m.ensure_jellyfin_dlna_server("http://jf", "tok")
+            m.ensure_jellyfin_dlna_server("http://jf", "tok")
+
+        self.assertEqual(len(config_posts), 2)
+        self.assertEqual(config_posts[0], config_posts[1])
+        self.assertTrue(config_posts[0]["EnableServer"])
+
+    def test_jellyfin_dlna_server_failsoft(self):
+        """If the DLNA config can't be read (endpoint absent / unreachable),
+        log-and-continue: returns False, never raises (the deploy must not be
+        blocked by a DLNA hiccup)."""
+        m = load_script("media")
+        import urllib.request
+        with mock.patch.object(urllib.request, "urlopen", fake_urlopen_factory({})):
+            ok = m.ensure_jellyfin_dlna_server("http://jf", "tok")  # must not raise
+        self.assertFalse(ok)
+
 
 class HomeAssistantScript(unittest.TestCase):
     """The HA post-deploy is gated on Z-Wave device presence (skips


### PR DESCRIPTION
Autoloop batch `batch/2026-07-27a` — 3 units, one integration branch (batch economy).

- **Unify container-list UIs** into one shared canonical component; Service/Container view gains the open-terminal action (#2367)
- **Fix Authelia forward-auth 400→500 for paperless.dopp.cloud** — auth-request now sends `https://$http_host$request_uri` instead of `$scheme://…` (Authelia 400s non-https; paperless is reached over plain LAN http); adds a `forwardAuth.test.ts` assertion. Health-check blind spot for gated hosts documented (#2368)
- **Enable Jellyfin's built-in DLNA server by default** on the media template via a new idempotent `ensure_jellyfin_dlna_server` post-deploy helper (#2369)

Closes #2367
Closes #2368
Closes #2369

Local safety-net gate green on the batch branch: `lint`, `typecheck`, `check:arch`, `npm test` (474 files, 4099 passed / 2 skipped). Two units are `gate=verify` (#2367 visual + terminal, #2368 live forward-auth) → box-verify owed after seal.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
