### PR TITLE
fix(templates): media — Jellyfin post-deploy first-setup 401 race (#2375)

### DIFF
--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -89,6 +89,13 @@ REQUEST_TIMEOUT = 30.0
 JELLYFIN_READY_TIMEOUT = 5 * 60
 JELLYFIN_READY_INTERVAL = 5
 
+# Bounded window for the "is the startup wizard already done?" probe
+# (#2375). Much shorter than JELLYFIN_READY_TIMEOUT: this only has to
+# outlast a container restart's Kestrel-not-listening-yet gap, and on a
+# genuinely fresh install every second spent here is wasted before the
+# real first-run wait starts.
+JELLYFIN_WIZARD_PROBE_TIMEOUT = 60
+
 # Pod-container names. Podman names a Pod's containers `<pod>-<container>`;
 # this pod is `media`, the container is `jellyfin` (see template.yml).
 # Used by the Jellyfin LDAP plugin restart (#1718).
@@ -142,32 +149,72 @@ JELLYFIN_AUTH_HEADER = (
 )
 
 
-def jellyfin_wait_default_user(base_url: str) -> bool:
-    """Poll `GET /Startup/FirstUser` until it returns 200.
+def jellyfin_wizard_completed(base_url: str) -> bool:
+    """Probe `GET /System/Info/Public` over a bounded window and report
+    whether Jellyfin's first-run wizard is already completed.
 
-    That endpoint runs the UserManager's async init pass — which creates
-    Jellyfin's default user — *before* responding. A successful GET
-    therefore both confirms Jellyfin is up AND guarantees the default
-    user exists. `POST /Startup/User` does NOT initialize the
-    UserManager; it just calls `GetFirstUser()` and returns 404
-    ("NotFound") when no user exists yet. So without this wait the admin
-    seed races first-run init and Jellyfin answers 404.
+    Retried rather than single-shot (#2375). A redeploy that changes the
+    pod's topology fully restarts the container, so Kestrel can still be
+    coming up when the first probe fires. A single missed probe used to
+    fall through to `jellyfin_wait_default_user`, whose /Startup/FirstUser
+    poll can never return 200 on an already-initialized server — burning
+    the whole JELLYFIN_READY_TIMEOUT and silently skipping every step
+    gated behind first-setup (music providers, plugins, libraries, user
+    access).
 
-    Phase 3C retired the install runner's per-template readiness probe
-    that used to do this wait, so it has to live back in this script
-    (#809). Returns True once ready, False if the deadline passes."""
+    A 200 answer is authoritative in *both* directions: a false
+    `StartupWizardCompleted` means this really is a fresh install, so
+    return immediately and let the first-run walk proceed instead of
+    idling out the probe window. Returns False when the window elapses
+    without any usable answer."""
+    started = time.time()
+    while True:
+        code, info = request_json("GET", f"{base_url}/System/Info/Public", timeout=10)
+        if code == 200 and isinstance(info, dict):
+            return bool(info.get("StartupWizardCompleted"))
+        if time.time() - started >= JELLYFIN_WIZARD_PROBE_TIMEOUT:
+            return False
+        time.sleep(JELLYFIN_READY_INTERVAL)
+
+
+def jellyfin_wait_default_user(base_url: str) -> str:
+    """Poll `GET /Startup/FirstUser` until Jellyfin's first-run state is
+    settled. Returns one of:
+
+      - `"ready"`             — 200: the default user now exists.
+      - `"already_completed"` — 401/403: the route is locked down, i.e.
+        the wizard finished long ago and there is nothing to wait for.
+      - `"timeout"`           — the deadline passed with neither.
+
+    A 200 runs the UserManager's async init pass — which creates
+    Jellyfin's default user — *before* responding, so it both confirms
+    Jellyfin is up AND guarantees the default user exists. `POST
+    /Startup/User` does NOT initialize the UserManager; it just calls
+    `GetFirstUser()` and returns 404 ("NotFound") when no user exists
+    yet. So without this wait the admin seed races first-run init and
+    Jellyfin answers 404. Phase 3C retired the install runner's
+    per-template readiness probe that used to do this wait, so it has to
+    live back in this script (#809).
+
+    The 401 case is a *positive* signal, not a transient failure (#2375):
+    Jellyfin locks the /Startup/* routes behind auth once
+    `IsStartupWizardCompleted` is true in system.xml, so on an
+    already-initialized server this endpoint answers 401 forever and the
+    poll was structurally guaranteed to burn the full 5-minute budget."""
     started = time.time()
     last_beat = 0.0
     while time.time() - started < JELLYFIN_READY_TIMEOUT:
         code, _ = request_json("GET", f"{base_url}/Startup/FirstUser", timeout=10)
         if code == 200:
-            return True
+            return "ready"
+        if code in (401, 403):
+            return "already_completed"
         elapsed = time.time() - started
         if elapsed - last_beat >= 10:
             log(f"Waiting for Jellyfin to finish first-run init ({int(elapsed)}s elapsed)...")
             last_beat = elapsed
         time.sleep(JELLYFIN_READY_INTERVAL)
-    return False
+    return "timeout"
 
 
 def jellyfin_run_first_setup(base_url: str, admin_user: str, admin_password: str, tz: str) -> bool:
@@ -177,15 +224,22 @@ def jellyfin_run_first_setup(base_url: str, admin_user: str, admin_password: str
     leaving Jellyfin half-configured."""
     # Idempotent guard: if the public info already says wizard is done,
     # skip — this lets the post-deploy re-run without resetting admin.
-    code, info = request_json("GET", f"{base_url}/System/Info/Public", timeout=10)
-    if code == 200 and isinstance(info, dict) and info.get("StartupWizardCompleted"):
+    # Probed over a bounded window, not once, so a container restart's
+    # startup gap can't push a redeploy onto the first-run path (#2375).
+    if jellyfin_wizard_completed(base_url):
         log("ℹ️ Jellyfin startup wizard already completed — leaving the existing admin.")
         return True
 
     # Wait for Jellyfin's UserManager to finish initializing before
     # touching any /Startup/* endpoint (#809) — POST /Startup/User 404s
     # until the default user exists.
-    if not jellyfin_wait_default_user(base_url):
+    state = jellyfin_wait_default_user(base_url)
+    if state == "already_completed":
+        # 401 on /Startup/FirstUser ⇒ the wizard is done and the route is
+        # locked; the guard above just didn't get a clean answer in time.
+        log("ℹ️ Jellyfin: /Startup/FirstUser is locked down (HTTP 401) — the startup wizard is already completed; leaving the existing admin.")
+        return True
+    if state != "ready":
         log(f"⚠️ Jellyfin: /Startup/FirstUser never returned 200 within {JELLYFIN_READY_TIMEOUT // 60} min — install-blocking. Open the Jellyfin web UI and finish the setup wizard manually.")
         return False
 

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -968,6 +968,79 @@ class MediaScript(unittest.TestCase):
         )
         self.assertLess(get_first, post_user)
 
+    # ── #2375: redeploy of an already-initialized Jellyfin ───────────────
+
+    def test_jellyfin_wizard_guard_retries_instead_of_falling_through(self):
+        """#2375: the StartupWizardCompleted guard is probed over a bounded
+        window, not once. A pod-topology change fully restarts the container,
+        so Kestrel can still be coming up when the first probe fires. The
+        guard must retry and short-circuit on the delayed "wizard already
+        completed" answer, never falling through to the /Startup/FirstUser
+        wait (which can only 401 on an already-initialized server)."""
+        m = load_script("media")
+        m.JELLYFIN_WIZARD_PROBE_TIMEOUT = 30
+        m.JELLYFIN_READY_INTERVAL = 0  # don't actually sleep between probes
+        import urllib.error
+        import urllib.request
+
+        calls: list[str] = []
+        probes = {"n": 0}
+        outer = self
+
+        def urlopen(req, *_a, **_kw):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            calls.append(url)
+            if "/System/Info/Public" in url:
+                probes["n"] += 1
+                if probes["n"] < 3:
+                    # Kestrel not listening yet right after the restart.
+                    raise urllib.error.URLError("connection refused")
+                return outer._resp(200, json.dumps({"StartupWizardCompleted": True}))
+            raise urllib.error.URLError(f"unmocked URL: {url}")
+
+        with mock.patch.object(urllib.request, "urlopen", urlopen):
+            ok = m.jellyfin_run_first_setup("http://jf", "admin", "pw", "Europe/Berlin")
+
+        self.assertTrue(ok)
+        self.assertEqual(probes["n"], 3)  # retried, not single-shot
+        # Never fell through to the first-run path.
+        self.assertFalse(any("/Startup/FirstUser" in u for u in calls))
+        self.assertFalse(any("/Startup/Configuration" in u for u in calls))
+
+    def test_jellyfin_first_user_401_means_already_past_first_run(self):
+        """#2375: once the wizard is completed Jellyfin locks /Startup/* down
+        and /Startup/FirstUser answers 401 forever — never 200. If the
+        public-info guard gets no usable answer inside its window, the
+        first-user wait must read that 401 as "already past first-run" and
+        return True promptly, instead of polling to JELLYFIN_READY_TIMEOUT and
+        reporting not-ready (which silently skips music providers, the LrcLib
+        plugin, DLNA, libraries and user access on that redeploy)."""
+        m = load_script("media")
+        m.JELLYFIN_WIZARD_PROBE_TIMEOUT = 0  # guard window already elapsed
+        m.JELLYFIN_READY_INTERVAL = 0
+        import urllib.error
+        import urllib.request
+
+        calls: list[str] = []
+
+        def urlopen(req, *_a, **_kw):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            calls.append(url)
+            if "/System/Info/Public" in url:
+                raise urllib.error.URLError("connection refused")
+            if "/Startup/FirstUser" in url:
+                raise urllib.error.HTTPError(url, 401, "Unauthorized", {}, None)  # type: ignore[arg-type]
+            raise urllib.error.URLError(f"unmocked URL: {url}")
+
+        with mock.patch.object(urllib.request, "urlopen", urlopen):
+            ok = m.jellyfin_run_first_setup("http://jf", "admin", "pw", "Europe/Berlin")
+
+        self.assertTrue(ok)
+        # Exactly one FirstUser probe — the 401 ends the wait, no 5-min poll.
+        self.assertEqual(len([u for u in calls if "/Startup/FirstUser" in u]), 1)
+        # And no first-run walk was attempted against a locked-down server.
+        self.assertFalse(any("/Startup/Configuration" in u for u in calls))
+
     # ── #1718: Jellyfin LDAP-Auth plugin → LLDAP ─────────────────────────
 
     def test_jellyfin_ldap_config_rendered_with_lldap_bind(self):


### PR DESCRIPTION
Autoloop batch `batch/2026-07-27b` — 1 unit.

- **Fix Jellyfin post-deploy first-setup 401-race** (#2375): `jellyfin_wizard_completed()` now retries `GET /System/Info/Public` over a bounded 60s window instead of a single-shot check (returns instantly on any authoritative 200 — no time lost on fresh installs). `jellyfin_wait_default_user()` now returns a three-state `ready|already_completed|timeout`, mapping 401/403 on `/Startup/FirstUser` to `already_completed` instead of looping until the 5-minute timeout. This is what blocked #2282 — a redeploy against an already-initialized Jellyfin burned the full timeout and never reached `jellyfin_enable_music_providers`.
- Two new non-vacuous pytest cases (verified to hang past 120s against pre-fix code): the wizard-guard retry, and the 401→already-done mapping. Full python suite (76/76) + relevant vitest (63/63) + check:arch green.

Closes #2375
Related: unblocks #2282 (music-metadata provider enablement) on the next media redeploy.

Local safety-net gate green on the batch branch: lint, typecheck, check:arch, npm test (474 files, 4099 passed / 2 skipped). gate=normal — not path-mandated, no box-verify expected.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
