### PR TITLE
fix(backend): config — distinguish transient read failure from a fresh install (#2399)

### DIFF
--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -788,14 +788,88 @@ export function redactSensitiveConfig<T>(config: T): T {
   return transformConfig(config, SENSITIVE_KEYS, () => REDACTED_SENTINEL) as T;
 }
 
+/**
+ * Config-read resilience (#2399).
+ *
+ * `getConfig()` used to swallow *every* read failure and return
+ * `DEFAULT_CONFIG`. But `DEFAULT_CONFIG` has no gateway and no
+ * `setupCompleted`, which `checkOnboardingStatus()` reads as "this box has
+ * never been set up" — so one momentary EIO/ESTALE/EACCES blip (or a torn
+ * read) on the data volume force-opened the onboarding wizard on a fully
+ * configured box, and finishing that wizard would have written defaults
+ * over the real config.
+ *
+ * "The file genuinely isn't there yet" and "the read failed" are therefore
+ * now different outcomes:
+ *   - absence confirmed by a second look → `DEFAULT_CONFIG` (the unchanged
+ *     fresh-install path)
+ *   - anything else → bounded retry, then throw `ConfigReadError`
+ * Failing loudly is the right call: no caller can tell a lying read from a
+ * fresh box, so returning "unconfigured" on their behalf is the bug.
+ */
+const CONFIG_READ_ATTEMPTS = 3;
+const CONFIG_READ_RETRY_MS = 25;
+
+/** Thrown when `config.json` exists (or may exist) but couldn't be read. */
+export class ConfigReadError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options as ErrorOptions | undefined);
+    this.name = 'ConfigReadError';
+  }
+}
+
+const errnoCode = (error: unknown): string | undefined =>
+  typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+
+/**
+ * An ENOENT from `readFile` is only trustworthy once a follow-up `stat`
+ * agrees the file is gone. A transient ENOENT is exactly the lie #2399 is
+ * about, and it is otherwise indistinguishable from a fresh install.
+ */
+async function configFileConfirmedAbsent(): Promise<boolean> {
+  try {
+    await fs.stat(CONFIG_PATH);
+    return false;
+  } catch (error) {
+    return errnoCode(error) === 'ENOENT';
+  }
+}
+
 export async function getConfig(): Promise<AppConfig> {
   let rawConfig: unknown = {};
-  try {
-    const content = await fs.readFile(CONFIG_PATH, 'utf-8');
-    rawConfig = JSON.parse(content);
-  } catch {
-    // If file is missing or corrupt, return defaults
-    return DEFAULT_CONFIG;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= CONFIG_READ_ATTEMPTS; attempt += 1) {
+    try {
+      const content = await fs.readFile(CONFIG_PATH, 'utf-8');
+      rawConfig = JSON.parse(content);
+      lastError = undefined;
+      break;
+    } catch (error) {
+      lastError = error;
+      if (errnoCode(error) === 'ENOENT' && await configFileConfirmedAbsent()) {
+        // Fresh install: there really is no config file. Defaults are the truth.
+        return DEFAULT_CONFIG;
+      }
+      if (attempt < CONFIG_READ_ATTEMPTS) {
+        logger.warn('config', `Config read attempt ${attempt}/${CONFIG_READ_ATTEMPTS} failed, retrying:`, error);
+        await new Promise(resolve => setTimeout(resolve, CONFIG_READ_RETRY_MS * attempt));
+      }
+    }
+  }
+
+  if (lastError !== undefined) {
+    logger.error(
+      'config',
+      `Config read failed after ${CONFIG_READ_ATTEMPTS} attempts — refusing to report this box as unconfigured:`,
+      lastError,
+    );
+    throw new ConfigReadError(
+      `Failed to read ${CONFIG_PATH} after ${CONFIG_READ_ATTEMPTS} attempts`,
+      { cause: lastError },
+    );
   }
 
   // Decrypt sensitive fields. transformConfig uses decrypt which

--- a/packages/frontend/src/components/OnboardingWizard.tsx
+++ b/packages/frontend/src/components/OnboardingWizard.tsx
@@ -513,6 +513,12 @@ export default function OnboardingWizard() {
         // No setup needed — clear any stale draft.
         clearPersistedWizardState();
       }
+    }).catch(err => {
+      // The status read failed (e.g. getConfig() couldn't read config.json —
+      // it now throws instead of returning defaults, #2399). "Unknown" must
+      // never be treated as "needs setup": leave the wizard closed and the
+      // draft untouched rather than slamming the modal over a configured box.
+      console.error('[OnboardingWizard] Failed to read onboarding status:', err);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/tests/backend/config_read_resilience.test.ts
+++ b/tests/backend/config_read_resilience.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsSync from 'fs';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+/**
+ * #2399 — a transient config-read failure must never be indistinguishable
+ * from "this box has literally never been configured".
+ *
+ * `getConfig()` used to swallow every read error and return `DEFAULT_CONFIG`
+ * (no gateway, no `setupCompleted`), which `checkOnboardingStatus()` reads as
+ * `needsSetup: true` — so one EIO/ESTALE/permission blip on the data volume
+ * force-opened the onboarding wizard on a fully configured box.
+ *
+ * The failure isn't reproducible on a live box, so it is fault-injected here:
+ * a real, fully populated `config.json` sits in a temp DATA_DIR while
+ * `fs.readFile` is made to fail for the first N calls.
+ */
+
+let dataDir = '';
+
+vi.mock('@/lib/dirs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/dirs')>();
+  return {
+    ...actual,
+    get DATA_DIR() { return dataDir; },
+    get SSH_DIR() { return path.join(dataDir, 'ssh'); },
+  };
+});
+
+/** Exactly the expression `checkOnboardingStatus()` derives needsSetup from. */
+const derivesNeedsSetup = (config: { setupCompleted?: boolean; gateway?: unknown }): boolean =>
+  !config.setupCompleted && !config.gateway;
+
+const POPULATED_CONFIG = {
+  serverName: 'already-configured-box',
+  setupCompleted: true,
+  gateway: { type: 'fritzbox', host: '192.168.178.1', username: 'admin' },
+  publicDomain: 'example.com',
+  autoUpdate: { enabled: true, schedule: '0 0 * * *', channel: 'stable' },
+};
+
+const errno = (code: string): NodeJS.ErrnoException =>
+  Object.assign(new Error(`${code}: injected fault`), { code });
+
+/** Fresh module graph so CONFIG_PATH is recomputed against the temp DATA_DIR. */
+async function loadConfigModule() {
+  vi.resetModules();
+  return import('@/lib/config');
+}
+
+/**
+ * Make `fs.readFile` fail for the first `failures.length` calls, then fall
+ * through to the real implementation. Only the config path is faulted so the
+ * rest of the module graph keeps working.
+ */
+function injectReadFailures(failures: NodeJS.ErrnoException[]) {
+  const configPath = path.join(dataDir, 'config.json');
+  const real = fs.readFile.bind(fs);
+  let seen = 0;
+  return vi.spyOn(fs, 'readFile').mockImplementation((async (file: Parameters<typeof fs.readFile>[0], options?: unknown) => {
+    if (String(file) === configPath && seen < failures.length) {
+      throw failures[seen++];
+    }
+    return real(file as string, options as Parameters<typeof fs.readFile>[1]);
+  }) as typeof fs.readFile);
+}
+
+describe('getConfig() config-read resilience (#2399)', () => {
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-config-read-'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    await fs.rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  const writePopulatedConfig = () =>
+    fs.writeFile(path.join(dataDir, 'config.json'), JSON.stringify(POPULATED_CONFIG, null, 2));
+
+  it('a transient non-ENOENT read failure does not report a configured box as unconfigured', async () => {
+    await writePopulatedConfig();
+    const spy = injectReadFailures([errno('EIO')]);
+
+    const { getConfig } = await loadConfigModule();
+    const config = await getConfig();
+
+    expect(spy.mock.calls.length).toBeGreaterThan(1); // it retried
+    expect(config.setupCompleted).toBe(true);
+    expect(config.gateway?.host).toBe('192.168.178.1');
+    expect(derivesNeedsSetup(config)).toBe(false);
+  });
+
+  it('a transient ENOENT on a file that is really there is retried, not believed', async () => {
+    await writePopulatedConfig();
+    injectReadFailures([errno('ENOENT'), errno('ENOENT')]);
+
+    const { getConfig } = await loadConfigModule();
+    const config = await getConfig();
+
+    expect(config.setupCompleted).toBe(true);
+    expect(derivesNeedsSetup(config)).toBe(false);
+  });
+
+  it('recovers from an ESTALE blip and still returns the persisted gateway', async () => {
+    await writePopulatedConfig();
+    injectReadFailures([errno('ESTALE')]);
+
+    const { getConfig } = await loadConfigModule();
+    expect(derivesNeedsSetup(await getConfig())).toBe(false);
+  });
+
+  it('a genuinely fresh install (file truly absent) still returns defaults and triggers onboarding', async () => {
+    // No config.json written at all — the legitimate first-boot case.
+    const { getConfig } = await loadConfigModule();
+    const config = await getConfig();
+
+    expect(config.setupCompleted).toBeUndefined();
+    expect(config.gateway).toBeUndefined();
+    expect(derivesNeedsSetup(config)).toBe(true);
+  });
+
+  it('a persistent read failure surfaces as ConfigReadError instead of silent defaults', async () => {
+    await writePopulatedConfig();
+    injectReadFailures([errno('EACCES'), errno('EACCES'), errno('EACCES')]);
+
+    const { getConfig, ConfigReadError } = await loadConfigModule();
+    await expect(getConfig()).rejects.toBeInstanceOf(ConfigReadError);
+  });
+
+  it('a corrupt-but-present config file surfaces an error rather than reading as never-configured', async () => {
+    await fs.writeFile(path.join(dataDir, 'config.json'), '{ this is not json');
+
+    const { getConfig, ConfigReadError } = await loadConfigModule();
+    await expect(getConfig()).rejects.toBeInstanceOf(ConfigReadError);
+  });
+
+  it('confirmed absence is decided by stat, not by readFile alone', async () => {
+    // The file is absent and stat agrees → defaults, and no retry storm.
+    const statSpy = vi.spyOn(fs, 'stat');
+    const { getConfig } = await loadConfigModule();
+    await getConfig();
+    expect(statSpy).toHaveBeenCalledWith(path.join(dataDir, 'config.json'));
+    expect(fsSync.existsSync(path.join(dataDir, 'config.json'))).toBe(false);
+  });
+});

--- a/tests/frontend/OnboardingWizard.test.tsx
+++ b/tests/frontend/OnboardingWizard.test.tsx
@@ -283,6 +283,25 @@ describe('OnboardingWizard', () => {
         });
     });
 
+    // #2399 — getConfig() no longer swallows a transient config-read failure
+    // into DEFAULT_CONFIG, so checkOnboardingStatus can now reject. "Unknown"
+    // must never be treated as "needs setup" on an already-configured box.
+    it('does not force-open when the onboarding-status read fails', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        (checkOnboardingStatus as any).mockRejectedValue(
+            Object.assign(new Error('Failed to read /app/data/config.json after 3 attempts'), { name: 'ConfigReadError' }),
+        );
+
+        render(<OnboardingWizard />);
+
+        await waitFor(() => {
+            expect(consoleError).toHaveBeenCalled();
+        });
+        expect(screen.queryByText(/Welcome to ServiceBay/i)).toBeNull();
+        expect(screen.queryByText(/Install Services/i)).toBeNull();
+        consoleError.mockRestore();
+    });
+
     it('renders welcome screen if setup is needed', async () => {
         (checkOnboardingStatus as any).mockResolvedValue(needsSetupStatus);
 


### PR DESCRIPTION
Autoloop batch `batch/2026-07-28b` — 1 unit.

- **`getConfig()` no longer confuses a transient config-read hiccup with a genuinely fresh install** (#2399): a transient I/O failure (not a real ENOENT) used to silently fall back to `DEFAULT_CONFIG` — no gateway, no `setupCompleted` — which then made the onboarding wizard force-open on an already-fully-configured box. Now `getConfig()` only believes "file doesn't exist" after a confirming `fs.stat`, and retries any other read/parse failure 3× with backoff before surfacing a `ConfigReadError`; `OnboardingWizard`'s status check also now fails closed (leaves the modal closed) on an unexpected status rather than assuming setup is needed.
- Mutation-proved: reverting the fix reproduces the exact reported false positive (`needsSetup:true`, `setupCompleted` undefined) on 6/7 new backend cases while the real fresh-install case stays correctly green.

Closes #2399

Local safety-net gate green on the batch branch: lint, typecheck, check:arch, npm test (485 files, 4282 passed / 2 skipped). gate=verify (`packages/backend/src/lib/config.ts` is path-mandated) — box-verify owed after seal; the transient-fault scenario itself isn't practically reproducible live, so live verification is scoped to confirming normal config reads still work with no regression.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
