### PR TITLE
fix(backend): config — strip stdoutTail-embedded credentials from get_config (#2404 follow-up)

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/postDeployFailed.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/postDeployFailed.test.ts
@@ -141,3 +141,51 @@ describe('post_deploy_failed.rerun_post_deploy', () => {
     expect(mockConfig.servicePostDeploy?.vault?.exitCode).toBe(5);
   });
 });
+
+/**
+ * #2404 follow-up. The probe's items go out over the `diagnose` MCP tool as
+ * well as the dashboard, and the stdout it excerpts is the same stream the
+ * wizard emits `__SB_CREDENTIAL__ {json}` banners on — live passwords and
+ * bearer tokens. The error lines an operator needs must survive; the banner
+ * must not. Every value below is an obviously-fake placeholder.
+ */
+describe('post_deploy_failed probe excerpt (#2404 follow-up)', () => {
+  const banner = `__SB_CREDENTIAL__ ${JSON.stringify({
+    service: 'vault',
+    username: 'admin',
+    password: 'CANARY-fake-probe-excerpt-pw',
+    importance: 'critical',
+  })}`;
+
+  it('drops credential-banner lines from the surfaced tail', async () => {
+    const { checkPostDeployFailed } = await import('./postDeployFailed');
+    mockConfig = {
+      servicePostDeploy: {
+        vault: {
+          exitCode: 5,
+          lastRunAt: '2026-05-09T00:00:00Z',
+          stdoutTail: `starting seed...\n${banner}\n[ERROR] LLDAP refused connection`,
+        },
+      },
+    };
+    const result = await checkPostDeployFailed();
+    const detail = result.items?.[0]?.detail ?? '';
+    expect(detail).not.toContain('__SB_CREDENTIAL__');
+    expect(detail).not.toContain('CANARY-fake-probe-excerpt-pw');
+    expect(detail).toContain('LLDAP refused connection');
+  });
+
+  it('still reports the failure when the banner was the only tail line', async () => {
+    const { checkPostDeployFailed } = await import('./postDeployFailed');
+    mockConfig = {
+      servicePostDeploy: {
+        vault: { exitCode: 5, lastRunAt: '2026-05-09T00:00:00Z', stdoutTail: banner },
+      },
+    };
+    const result = await checkPostDeployFailed();
+    expect(result.status).toBe('warn');
+    const detail = result.items?.[0]?.detail ?? '';
+    expect(detail).toMatch(/exit 5/);
+    expect(detail).not.toContain('CANARY-fake-probe-excerpt-pw');
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/postDeployFailed.ts
+++ b/packages/backend/src/lib/diagnose/probes/postDeployFailed.ts
@@ -25,6 +25,13 @@ import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../
 
 const PROBE_ID = 'post_deploy_failed';
 
+/**
+ * The wizard's credential-banner marker (`docs/TEMPLATE_LOGGING.md`). Lines
+ * carrying it hold live passwords/tokens and must never ride out in a probe
+ * item's detail text.
+ */
+const CREDENTIAL_MARKER = '__SB_CREDENTIAL__';
+
 export interface PostDeployFailedResult {
   status: 'ok' | 'warn' | 'info';
   detail: string;
@@ -54,7 +61,17 @@ export async function checkPostDeployFailed(): Promise<PostDeployFailedResult> {
     // says "exit 1" and the operator has to open the service detail
     // to find the actual error — usually 2-3 lines that name the
     // missing env var / failed API call / etc. directly.
-    const tail = (r.stdoutTail ?? '').trim();
+    //
+    // Credential banners are dropped first (#2404 follow-up): the same
+    // stdout also carries the wizard's `__SB_CREDENTIAL__ {json}` lines
+    // with live passwords/tokens, and this probe's items go out over the
+    // `diagnose` MCP tool as well as the dashboard. The error lines an
+    // operator actually needs survive; only the banner lines are dropped.
+    const tail = (r.stdoutTail ?? '')
+      .split('\n')
+      .filter(line => !line.includes(CREDENTIAL_MARKER))
+      .join('\n')
+      .trim();
     const tailExcerpt = tail
       ? '\n' + tail.split('\n').slice(-3).join('\n').slice(-240)
       : '';

--- a/packages/backend/src/lib/mcp/tools/configTools.test.ts
+++ b/packages/backend/src/lib/mcp/tools/configTools.test.ts
@@ -58,7 +58,35 @@ const CANARY = {
   backupSmbPassword: 'CANARY-fake-smb-pw-18',
   templateSettingToken: 'CANARY-fake-plex-claim-token-19',
   futureAccessToken: 'CANARY-fake-future-field-apikey-20',
+  // #2404 follow-up: credentials embedded in captured post-deploy stdout.
+  postDeployNpmPassword: 'CANARY-fake-npm-postdeploy-pw-21',
+  postDeployAdguardPassword: 'CANARY-fake-adguard-postdeploy-pw-22',
+  postDeployBearerToken: 'CANARY-fake-engine-bearer-token-23',
+  migrationSecret: 'CANARY-fake-migration-emitted-secret-24',
+  futureTailSecret: 'CANARY-fake-future-tail-secret-25',
 };
+
+/**
+ * `post-deploy.py` emits credential banners as `__SB_CREDENTIAL__ {json}` lines
+ * on stdout (docs/TEMPLATE_LOGGING.md); `persistPostDeployResult` then stores
+ * the last ~1KB of that stdout verbatim in `servicePostDeploy[svc].stdoutTail`.
+ * This builds a tail of exactly that shape — the leak box-verify found.
+ */
+function credentialTail(service: string, username: string, password: string): string {
+  const blob = JSON.stringify({
+    service,
+    url: `https://${service}.example.test`,
+    username,
+    password,
+    importance: 'critical',
+    notes: 'Seeded by post-deploy.',
+  });
+  return [
+    `[${service}] waiting for container to become healthy…`,
+    `__SB_CREDENTIAL__ ${blob}`,
+    `[${service}] post-deploy finished`,
+  ].join('\n');
+}
 
 /** Substrings that must never survive into the tool output. */
 const CANARY_NEEDLES = [
@@ -181,8 +209,45 @@ function buildFixture(): AppConfig {
       keycloak: { schemaVersion: 2, installedAt: '2026-07-01T00:00:00Z' },
       vaultwarden: { schemaVersion: 1, installedAt: '2026-07-02T00:00:00Z' },
     },
+    // Captured post-deploy stdout. `passbolt` is the service-name-shaped
+    // negative (its NAME contains "pass"); the other three carry real-shaped
+    // `__SB_CREDENTIAL__` banners inside the tail string, which is how live
+    // credentials survived the key-name-only scrub.
     servicePostDeploy: {
       passbolt: { lastRunAt: '2026-07-20T00:00:00Z', exitCode: 0, stdoutTail: 'seed ok' },
+      nginx: {
+        lastRunAt: '2026-07-21T00:00:00Z',
+        exitCode: 0,
+        stdoutTail: credentialTail('nginx', 'npm-admin@example.test', CANARY.postDeployNpmPassword),
+      },
+      adguard: {
+        lastRunAt: '2026-07-22T00:00:00Z',
+        exitCode: 1,
+        stdoutTail: credentialTail('adguard', 'admin', CANARY.postDeployAdguardPassword),
+      },
+      honcho: {
+        lastRunAt: '2026-07-23T00:00:00Z',
+        exitCode: 0,
+        stdoutTail: `__SB_CREDENTIAL__ ${JSON.stringify({
+          service: 'Honcho engine',
+          url: 'env: HONCHO_BEARER',
+          username: '—',
+          password: CANARY.postDeployBearerToken,
+          importance: 'system',
+        })}`,
+      },
+    },
+    // Migration-script stdout is captured the same way, into the same key name.
+    serviceMigrations: {
+      immich: [
+        {
+          ranAt: '2026-07-24T00:00:00Z',
+          fromVersion: 1,
+          toVersion: 2,
+          exitCode: 0,
+          stdoutTail: credentialTail('immich', 'api', CANARY.migrationSecret),
+        },
+      ],
     },
     accessRequests: [
       {
@@ -203,6 +268,9 @@ function buildFixture(): AppConfig {
     futureIntegration: {
       endpoint: 'https://api.example.test',
       accessToken: CANARY.futureAccessToken,
+      // Neither a secret-shaped key nor `stdoutTail` — only the VALUE gives it
+      // away. The marker backstop is what has to catch this one.
+      lastRunSummary: credentialTail('future-service', 'svc', CANARY.futureTailSecret),
     },
   } as unknown as AppConfig;
 }
@@ -359,10 +427,12 @@ describe('get_config secret scrubbing (#2404)', () => {
   it('does not redact service-name-keyed records whose name contains a secret word', async () => {
     const { parsed } = await callGetConfig(buildFixture());
     expect(at(parsed, 'installedTemplates.keycloak')).toEqual({ schemaVersion: 2, installedAt: '2026-07-01T00:00:00Z' });
+    // `passbolt` survives as a record (the key is a service name, not a secret);
+    // only its captured stdout is withheld.
     expect(at(parsed, 'servicePostDeploy.passbolt')).toEqual({
       lastRunAt: '2026-07-20T00:00:00Z',
       exitCode: 0,
-      stdoutTail: 'seed ok',
+      stdoutTail: REDACTED_SENTINEL,
     });
   });
 
@@ -389,6 +459,80 @@ describe('get_config secret scrubbing (#2404)', () => {
   });
 });
 
+/**
+ * #2404 follow-up — the key-name scrubber shipped, then box-verify found live
+ * credentials still leaving the box inside `servicePostDeploy[*].stdoutTail`:
+ * captured `post-deploy.py` stdout, whose KEY name is innocuous but whose
+ * string CONTENT embeds `__SB_CREDENTIAL__ {json}` banners with usable
+ * passwords and bearer tokens. Same shape applies to
+ * `serviceMigrations[*][].stdoutTail`.
+ */
+describe('get_config withholds captured script output (#2404 follow-up)', () => {
+  it('leaves no __SB_CREDENTIAL__ marker anywhere in the serialized output', async () => {
+    const { text } = await callGetConfig(buildFixture());
+    expect(text).not.toContain('__SB_CREDENTIAL__');
+  });
+
+  it('withholds every servicePostDeploy stdoutTail, secret-bearing or not', async () => {
+    const { parsed } = await callGetConfig(buildFixture());
+    const records = parsed.servicePostDeploy as Record<string, Record<string, unknown>>;
+    expect(Object.keys(records).sort()).toEqual(['adguard', 'honcho', 'nginx', 'passbolt']);
+    for (const [service, record] of Object.entries(records)) {
+      expect(record.stdoutTail, `servicePostDeploy.${service}.stdoutTail`).toBe(REDACTED_SENTINEL);
+    }
+  });
+
+  it('keeps lastRunAt and exitCode so "did post-deploy succeed" is still answerable', async () => {
+    const { parsed } = await callGetConfig(buildFixture());
+    expect(at(parsed, 'servicePostDeploy.nginx.lastRunAt')).toBe('2026-07-21T00:00:00Z');
+    expect(at(parsed, 'servicePostDeploy.nginx.exitCode')).toBe(0);
+    expect(at(parsed, 'servicePostDeploy.adguard.lastRunAt')).toBe('2026-07-22T00:00:00Z');
+    expect(at(parsed, 'servicePostDeploy.adguard.exitCode')).toBe(1);
+    expect(at(parsed, 'servicePostDeploy.passbolt.exitCode')).toBe(0);
+  });
+
+  it('withholds migration-script stdoutTail but keeps the version delta', async () => {
+    const { parsed } = await callGetConfig(buildFixture());
+    const entries = at(parsed, 'serviceMigrations.immich') as Array<Record<string, unknown>>;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      ranAt: '2026-07-24T00:00:00Z',
+      fromVersion: 1,
+      toVersion: 2,
+      exitCode: 0,
+      stdoutTail: REDACTED_SENTINEL,
+    });
+  });
+
+  it('catches a credential banner in a field whose key is not secret-shaped', async () => {
+    const { parsed } = await callGetConfig(buildFixture());
+    expect(at(parsed, 'futureIntegration.lastRunSummary')).toBe(REDACTED_SENTINEL);
+  });
+
+  it('redacts a PEM private key found in a string value at any key', async () => {
+    const fixture = buildFixture() as unknown as Record<string, unknown>;
+    fixture.someNote = '-----BEGIN OPENSSH PRIVATE KEY-----\nCANARY-fake-pem-in-a-note\n-----END OPENSSH PRIVATE KEY-----';
+    const { parsed, text } = await callGetConfig(fixture as unknown as AppConfig);
+    expect(parsed.someNote).toBe(REDACTED_SENTINEL);
+    expect(text).not.toContain('PRIVATE KEY-----');
+  });
+
+  it('leaves an ordinary stdout tail-free record untouched', async () => {
+    const fixture = buildFixture();
+    fixture.servicePostDeploy = { media: { lastRunAt: '2026-07-25T00:00:00Z', exitCode: 0 } };
+    const { parsed } = await callGetConfig(fixture);
+    expect(at(parsed, 'servicePostDeploy.media')).toEqual({
+      lastRunAt: '2026-07-25T00:00:00Z',
+      exitCode: 0,
+    });
+  });
+
+  it('announces the withholding in the tool description', async () => {
+    const description = tools.get('get_config')?.description ?? '';
+    expect(description).toMatch(/stdoutTail/);
+  });
+});
+
 describe('isSecretKey (#2404)', () => {
   it.each([
     'password', 'passwd', 'pass', 'passphrase', 'passwordHash',
@@ -410,6 +554,9 @@ describe('isSecretKey (#2404)', () => {
     'schemaVersion', 'dayOfWeek', 'installedTemplates', 'servicePostDeploy',
     'templateSettings', 'publicDomain', 'lanIpHistory', 'accessRequests',
     'importance', 'notes', 'savedAt', 'allowDangerousExec', 'bypass',
+    // Why the follow-up fix needs its own layer: the key name is innocuous,
+    // only the captured stdout it holds is dangerous.
+    'stdoutTail', 'ranAt', 'fromVersion', 'exitCode', 'lastRunAt',
   ])('does not treat %s as secret', async (key) => {
     const { isSecretKey } = await import('./configTools');
     expect(isSecretKey(key)).toBe(false);

--- a/packages/backend/src/lib/mcp/tools/configTools.ts
+++ b/packages/backend/src/lib/mcp/tools/configTools.ts
@@ -68,6 +68,44 @@ export function isSecretKey(key: string): boolean {
 }
 
 /**
+ * Keys whose value is raw, unparsed output captured from a script the box ran
+ * (#2404 follow-up). Key-name matching alone cannot save these: `stdoutTail` is
+ * not a secret-shaped *name*, but its *content* is the last ~1KB of a template's
+ * `post-deploy.py` / migration-script stdout — and that stdout is exactly where
+ * the wizard's credential-banner protocol emits `__SB_CREDENTIAL__ {json}` lines
+ * carrying live passwords, bearer tokens and private keys (see
+ * `docs/TEMPLATE_LOGGING.md`). Box-verify confirmed real credentials for several
+ * services surviving the key-name scrub inside these strings.
+ *
+ * Two fields on `AppConfig` are of this class today —
+ * `servicePostDeploy[<service>].stdoutTail` and
+ * `serviceMigrations[<service>][].stdoutTail` — and both share the same key name,
+ * so matching the name covers both plus any future field that persists a tail.
+ *
+ * Dropped wholesale rather than pattern-scrubbed: the tail is operator-facing
+ * diagnostic text surfaced by the dashboard's diagnose page, not something an
+ * LLM tool-caller needs to read `logLevel` / `autoUpdate` / proxy hosts. The
+ * sibling `lastRunAt` / `exitCode` — the actual "did this service's post-deploy
+ * succeed" signal — are non-secret and survive untouched.
+ */
+const RAW_OUTPUT_KEYS = new Set(['stdouttail']);
+
+const isRawOutputKey = (key: string): boolean => RAW_OUTPUT_KEYS.has(key.toLowerCase());
+
+/**
+ * Structural markers that make a *string value* secret-bearing regardless of the
+ * key it hangs off. Backstop for the class above: if credential-bearing text
+ * reaches some future field this fix has never seen, the marker still catches
+ * it. Both are unambiguous — ServiceBay emits the first itself as its
+ * credential-capture protocol, and a PEM private-key header is never legitimate
+ * config content.
+ */
+const SECRET_VALUE_MARKERS = ['__SB_CREDENTIAL__', 'PRIVATE KEY-----'];
+
+const hasSecretMarker = (value: string): boolean =>
+  SECRET_VALUE_MARKERS.some(marker => value.includes(marker));
+
+/**
  * What a secret-shaped key's value becomes. Objects and arrays are replaced
  * wholesale — that is what strips `installedSecrets[]` and
  * `installManifest.credentials[]`, which an LLM tool-caller never needs (they
@@ -86,11 +124,12 @@ function redactValue(value: unknown): unknown {
 
 /** Recursive, whole-object scrub. Pure — builds a copy, never mutates. */
 function scrub(value: unknown): unknown {
+  if (typeof value === 'string' && hasSecretMarker(value)) return REDACTED_SENTINEL;
   if (Array.isArray(value)) return value.map(scrub);
   if (value !== null && typeof value === 'object') {
     const out: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      out[key] = isSecretKey(key) ? redactValue(val) : scrub(val);
+      out[key] = isSecretKey(key) || isRawOutputKey(key) ? redactValue(val) : scrub(val);
     }
     return out;
   }
@@ -99,6 +138,12 @@ function scrub(value: unknown): unknown {
 
 /**
  * Strip secrets before returning config to the LLM (#2404).
+ *
+ * Three layers, because one is not enough: the key *name* (`isSecretKey`), the
+ * key names that hold raw captured script output (`isRawOutputKey`), and the
+ * string *value* itself (`hasSecretMarker`). The first pass shipped with only
+ * the first layer and box-verify found live credentials still riding out inside
+ * `stdoutTail` strings.
  *
  * Read-path only: `update_config`'s allowlist is what governs writes, and it
  * is untouched by this.
@@ -124,7 +169,7 @@ const ConfigPatchSchema = z.object({
 }).strict();
 
 export function registerConfigTools({ server }: ToolRegistration) {
-  server.tool('get_config', 'Read the ServiceBay app config. Every secret-shaped field (password/secret/token/key/hash/credential/…) is redacted at any depth, and secret-bearing collections like installedSecrets and installManifest.credentials are replaced with an entry count.', {}, async () => {
+  server.tool('get_config', 'Read the ServiceBay app config. Every secret-shaped field (password/secret/token/key/hash/credential/…) is redacted at any depth, secret-bearing collections like installedSecrets and installManifest.credentials are replaced with an entry count, and captured script output (servicePostDeploy/serviceMigrations stdoutTail) is withheld because it embeds credential banners — lastRunAt/exitCode still show whether a post-deploy run succeeded.', {}, async () => {
     const config = await getConfig();
     return textResult(sanitizeConfig(config));
   });


### PR DESCRIPTION
Autoloop batch `batch/2026-07-28d` — 1 unit, urgent follow-up.

- **Closes the remaining `get_config` secret leak** (#2404, security): the prior key-name scrubber (PR #2407) missed credentials embedded as string *values* rather than in secret-named fields. `servicePostDeploy.<service>.stdoutTail` and `serviceMigrations.<service>[].stdoutTail` carry raw post-deploy/migration stdout, including `__SB_CREDENTIAL__` banner lines with real passwords/tokens; the `post_deploy_failed` diagnose probe excerpted the same tail. Fix: strip all `stdoutTail` fields from `get_config`'s output entirely (keeping `lastRunAt`/`exitCode`), add a value-level backstop that redacts any string containing a `__SB_CREDENTIAL__` marker or a PEM private-key header regardless of key name, and filter banner lines out of the diagnose probe's excerpt.
- Mutation-proved with 4 independent ablations (full revert, backstop-only removed, key-strip-only removed, probe-filter removed) — all reproduce the leak, all fixed.

Closes #2404 (reopened after a premature close on the incomplete first pass — this batch closes it for real)

Local safety-net gate green: lint, typecheck, check:arch, npm test (487 files, 4394 passed / 2 skipped). security=true, gate=verify — box-verify must re-confirm live with a real get_config call, reporting any residual by field name only, never by value.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
