### PR TITLE
feat(frontend): portal deep-link + fix(backend): post-deploy restart race (#2405 #2406)

### DIFF
--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -301,6 +301,18 @@ seeding (LLDAP, FileBrowser, ABS), follow the pattern in the existing
 scripts: 5-minute deadline, 10-second heartbeat log, sleep between
 retries. The agent budget is 20 minutes, so leave slack.
 
+You do **not** need a wait loop for your own pod's *unit* to exist,
+though. When a re-deploy changes the rendered spec, core restarts the
+unit and then waits for systemd to report it back up as a **new**
+activation (up to 3 minutes) before invoking `post-deploy.py` (#2406) —
+so `podman` queries against your own containers aren't racing a
+teardown. The install log says which happened: either `<name> restart
+settled after Ns` or an explicit `did not report active within Ns`
+warning if the bound was hit (post-deploy still runs in that case).
+A wait loop is still the right tool for *application* readiness (the
+HTTP endpoint answering, the DB migrated) — the unit being active only
+means the containers were started.
+
 ### `CHANGELOG.md`
 
 Optional but strongly recommended. Each `## v{N}` H2 section is one

--- a/packages/backend/src/lib/services/serviceLifecycle.restartSettle.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.restartSettle.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * #2406 — a template's post-deploy script ran *while* ServiceBay was still
+ * restarting that template's own pod: `systemctl --user --no-block restart`
+ * returns as soon as the job is queued, and the deploy path went straight on
+ * to post-deploy. Anything the script asked about its own pod hit a moving
+ * target (containers gone / coming up / `podman` timing out against a pod
+ * being rebuilt) — three downstream workarounds lost that race in three
+ * different ways (mdopp/solarisbay#1090/#1097/#1099).
+ *
+ * The fix waits for the unit to genuinely be back up before continuing. These
+ * tests pin (a) the readiness primitive's semantics — including the trap that
+ * makes a naive `is-active` poll useless — and (b) the deploy-level ordering:
+ * post-deploy is invoked only after the restart settled.
+ */
+
+const mockSendCommand = vi.fn();
+vi.mock('../agent/manager', () => ({
+    agentManager: {
+        ensureAgent: async () => ({ sendCommand: mockSendCommand, pullImage: async () => undefined }),
+    },
+}));
+vi.mock('@/lib/auth/internalToken', () => ({ getInternalApiToken: () => 'INTERNAL_HMAC' }));
+vi.mock('@/lib/auth/apiTokens', () => ({
+    createToken: async () => ({ token: { id: 'aa11', name: 'postdeploy-read:solaris' }, secret: 'sb_read_secret' }),
+    listTokens: async () => [],
+    revokeToken: async () => true,
+}));
+
+import { ServiceLifecycle, RESTART_SETTLE_TUNING, type ServiceRunState } from './serviceLifecycle';
+
+const SOLARIS_YAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: solaris
+spec:
+  containers:
+    - name: chat
+      image: docker.io/library/solaris:latest
+`;
+
+/** `systemctl show` stdout for a given run-state. */
+function showOutput(s: Partial<ServiceRunState>): string {
+    return [
+        `ActiveState=${s.activeState ?? 'inactive'}`,
+        `SubState=${s.subState ?? 'dead'}`,
+        `InvocationID=${s.invocationId ?? ''}`,
+        `ActiveEnterTimestampMonotonic=${s.activeEnterStamp ?? '0'}`,
+    ].join('\n') + '\n';
+}
+
+const OLD_RUN: ServiceRunState = {
+    activeState: 'active', subState: 'running', invocationId: 'OLD', activeEnterStamp: '100',
+};
+
+const originalTuning = { ...RESTART_SETTLE_TUNING };
+
+beforeEach(() => {
+    mockSendCommand.mockReset();
+    // Poll fast so a "slow restart" is simulated in poll counts, not seconds.
+    RESTART_SETTLE_TUNING.pollIntervalMs = 1;
+    RESTART_SETTLE_TUNING.timeoutMs = 2_000;
+});
+
+afterEach(() => {
+    Object.assign(RESTART_SETTLE_TUNING, originalTuning);
+});
+
+describe('readServiceRunState (#2406)', () => {
+    it('parses the four systemd properties in one show call', async () => {
+        mockSendCommand.mockResolvedValue({
+            code: 0,
+            stdout: showOutput({ activeState: 'active', subState: 'running', invocationId: 'abc123', activeEnterStamp: '42' }),
+            stderr: '',
+        });
+        await expect(ServiceLifecycle.readServiceRunState('local', 'solaris')).resolves.toEqual({
+            activeState: 'active', subState: 'running', invocationId: 'abc123', activeEnterStamp: '42',
+        });
+        expect(mockSendCommand).toHaveBeenCalledWith('exec', {
+            command: 'systemctl --user show solaris.service --property=ActiveState --property=SubState --property=InvocationID --property=ActiveEnterTimestampMonotonic',
+        });
+    });
+
+    it('returns an empty sample when the agent call throws (best-effort)', async () => {
+        mockSendCommand.mockRejectedValue(new Error('agent down'));
+        await expect(ServiceLifecycle.readServiceRunState('local', 'solaris')).resolves.toEqual({
+            activeState: '', subState: '', invocationId: '', activeEnterStamp: '',
+        });
+    });
+});
+
+describe('waitForRestartSettled (#2406)', () => {
+    /**
+     * Simulate a restart that takes time: the first `slowPolls` samples still
+     * show the OLD run (or the teardown), then the NEW invocation comes up.
+     */
+    function simulateRestart(slowPolls: number, tail: Partial<ServiceRunState>[] = []) {
+        let n = 0;
+        mockSendCommand.mockImplementation(async () => {
+            const stages: Partial<ServiceRunState>[] = [
+                // The trap: immediately after `--no-block restart`, systemd
+                // still reports the OLD run as active/running.
+                ...Array.from({ length: slowPolls }, (_, i) =>
+                    i === 0
+                        ? { activeState: 'active', subState: 'running', invocationId: 'OLD', activeEnterStamp: '100' }
+                        : { activeState: 'activating', subState: 'start', invocationId: 'NEW', activeEnterStamp: '0' }),
+                ...(tail.length ? tail : [{ activeState: 'active', subState: 'running', invocationId: 'NEW', activeEnterStamp: '900' }]),
+            ];
+            const stage = stages[Math.min(n, stages.length - 1)];
+            n++;
+            return { code: 0, stdout: showOutput(stage), stderr: '' };
+        });
+    }
+
+    it('does NOT settle on the old run still reported active (the #2406 race)', async () => {
+        simulateRestart(4);
+        const res = await ServiceLifecycle.waitForRestartSettled('local', 'solaris', OLD_RUN);
+        expect(res.settled).toBe(true);
+        expect(res.reason).toBe('active');
+        // It kept polling past the stale-active sample and the activating ones.
+        expect(res.polls).toBe(5);
+        expect(res.state.invocationId).toBe('NEW');
+    });
+
+    it('settles on the very first poll when the new run is already up', async () => {
+        simulateRestart(0);
+        const res = await ServiceLifecycle.waitForRestartSettled('local', 'solaris', OLD_RUN);
+        expect(res).toMatchObject({ settled: true, reason: 'active', polls: 1 });
+    });
+
+    it('treats a changed ActiveEnterTimestamp as a new run when InvocationID is unavailable', async () => {
+        mockSendCommand.mockResolvedValue({
+            code: 0,
+            stdout: showOutput({ activeState: 'active', subState: 'running', invocationId: '', activeEnterStamp: '900' }),
+            stderr: '',
+        });
+        const res = await ServiceLifecycle.waitForRestartSettled('local', 'solaris', OLD_RUN);
+        expect(res.settled).toBe(true);
+    });
+
+    it('returns immediately (unsettled) when the unit comes back failed', async () => {
+        mockSendCommand.mockResolvedValue({
+            code: 0,
+            stdout: showOutput({ activeState: 'failed', subState: 'failed', invocationId: 'NEW', activeEnterStamp: '900' }),
+            stderr: '',
+        });
+        const res = await ServiceLifecycle.waitForRestartSettled('local', 'solaris', OLD_RUN);
+        expect(res).toMatchObject({ settled: false, reason: 'failed', polls: 1 });
+    });
+
+    it('is bounded — a unit that never comes up ends in an explicit timeout, not an indefinite wait', async () => {
+        mockSendCommand.mockResolvedValue({
+            code: 0,
+            stdout: showOutput({ activeState: 'activating', subState: 'start', invocationId: 'NEW', activeEnterStamp: '0' }),
+            stderr: '',
+        });
+        const res = await ServiceLifecycle.waitForRestartSettled('local', 'solaris', OLD_RUN, {
+            timeoutMs: 25, pollIntervalMs: 1,
+        });
+        expect(res).toMatchObject({ settled: false, reason: 'timeout' });
+        expect(res.waitedMs).toBeGreaterThanOrEqual(25);
+        expect(res.polls).toBeGreaterThan(1);
+    });
+
+    it('never throws when the unit is unreadable — it bounds out instead', async () => {
+        mockSendCommand.mockRejectedValue(new Error('podman busy, exec timed out'));
+        const res = await ServiceLifecycle.waitForRestartSettled('local', 'solaris', OLD_RUN, {
+            timeoutMs: 10, pollIntervalMs: 1,
+        });
+        expect(res).toMatchObject({ settled: false, reason: 'timeout' });
+    });
+});
+
+describe('deployKubeService — post-deploy runs AFTER the restart settled (#2406)', () => {
+    /**
+     * Drive the real deploy path with a mocked agent and assert the command
+     * timeline: restart → readiness polls → post-deploy. Before the fix the
+     * post-deploy `mkdir` landed straight after the restart, with no poll in
+     * between.
+     */
+    function driveDeploy(restartPolls: number) {
+        const timeline: string[] = [];
+        let shows = 0;
+        mockSendCommand.mockImplementation(async (action: string, params: unknown) => {
+            if (action !== 'exec') {
+                timeline.push(`write_file:${(params as { path?: string })?.path ?? ''}`);
+                return 'ok';
+            }
+            const cmd = (params as { command?: string })?.command ?? '';
+            timeline.push(cmd);
+            if (/systemctl --user is-active/.test(cmd)) {
+                return { code: 0, stdout: 'active\n', stderr: '' };
+            }
+            if (/systemctl --user show/.test(cmd)) {
+                shows++;
+                // First `show` is the pre-restart sample; then `restartPolls`
+                // samples that still show the old run; then the new run.
+                const stage: Partial<ServiceRunState> = shows <= restartPolls + 1
+                    ? { activeState: 'active', subState: 'running', invocationId: 'OLD', activeEnterStamp: '100' }
+                    : { activeState: 'active', subState: 'running', invocationId: 'NEW', activeEnterStamp: '900' };
+                return { code: 0, stdout: showOutput(stage), stderr: '' };
+            }
+            if (/\.container && echo present/.test(cmd)) {
+                return { code: 0, stdout: 'absent\n', stderr: '' };
+            }
+            return { code: 0, stdout: '', stderr: '' };
+        });
+        return timeline;
+    }
+
+    const deploy = (onProgress?: (m: string) => void) =>
+        ServiceLifecycle.deployKubeService(
+            'local', 'solaris',
+            '[Kube]\nYaml=solaris.yml\n',
+            SOLARIS_YAML,
+            'solaris.yml',
+            undefined,
+            onProgress,
+            'print("post-deploy")',
+            {},
+        );
+
+    it('does not invoke post-deploy until the restarted unit reports a new active run', async () => {
+        const timeline = driveDeploy(3);
+        await deploy();
+
+        const restartAt = timeline.findIndex(c => /--no-block restart solaris\.service/.test(c));
+        const postDeployAt = timeline.findIndex(c => /mkdir -p ~\/\.local\/share\/servicebay\/post-deploy/.test(c));
+        expect(restartAt).toBeGreaterThanOrEqual(0);
+        expect(postDeployAt).toBeGreaterThan(restartAt);
+
+        // The readiness polls sit BETWEEN the restart and post-deploy — this is
+        // the assertion that fails without the fix (they'd be adjacent).
+        const pollsBetween = timeline
+            .slice(restartAt + 1, postDeployAt)
+            .filter(c => /systemctl --user show solaris\.service/.test(c));
+        expect(pollsBetween.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('logs whether post-deploy ran before or after the restart settled', async () => {
+        driveDeploy(2);
+        const lines: string[] = [];
+        await deploy(m => lines.push(m));
+
+        const settledIdx = lines.findIndex(l => /restart settled after .*s — unit active\/running/.test(l));
+        const postDeployIdx = lines.findIndex(l => /Running solaris post-deploy script/.test(l));
+        expect(settledIdx).toBeGreaterThanOrEqual(0);
+        expect(postDeployIdx).toBeGreaterThan(settledIdx);
+        expect(lines[settledIdx]).toMatch(/post-deploy, if any, runs AFTER the restart/);
+    });
+
+    it('reports an explicit timeout (and still continues) when the unit never comes back', async () => {
+        // Every `show` keeps reporting the old run → the bound is hit.
+        driveDeploy(Number.MAX_SAFE_INTEGER);
+        RESTART_SETTLE_TUNING.timeoutMs = 15;
+        const lines: string[] = [];
+        await deploy(m => lines.push(m));
+
+        expect(lines.some(l => /did not report active within .*s of the restart/.test(l))).toBe(true);
+        // Deploy is not aborted — post-deploy still runs, but the log says why.
+        expect(lines.some(l => /Running solaris post-deploy script/.test(l))).toBe(true);
+    });
+
+    it('adds no wait to the plain-start path (first install / unchanged render)', async () => {
+        const timeline: string[] = [];
+        mockSendCommand.mockImplementation(async (action: string, params: unknown) => {
+            if (action !== 'exec') {
+                // read_file of the previous quadlets returns the SAME content →
+                // specChanged=false → plain start, no restart, no wait.
+                const path = (params as { path?: string })?.path ?? '';
+                if (action === 'read_file') {
+                    if (path.endsWith('solaris.yml')) return SOLARIS_YAML;
+                    if (path.endsWith('solaris.kube')) return '[Kube]\nYaml=solaris.yml\n';
+                }
+                return 'ok';
+            }
+            const cmd = (params as { command?: string })?.command ?? '';
+            timeline.push(cmd);
+            if (/\.container && echo present/.test(cmd)) return { code: 0, stdout: 'absent\n', stderr: '' };
+            return { code: 0, stdout: '', stderr: '' };
+        });
+
+        await deploy();
+
+        expect(timeline.some(c => /--no-block start solaris\.service/.test(c))).toBe(true);
+        expect(timeline.some(c => /--no-block restart solaris\.service/.test(c))).toBe(false);
+        expect(timeline.some(c => /systemctl --user show solaris\.service/.test(c))).toBe(false);
+    });
+});

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -27,6 +27,36 @@ import type { PodLikeDoc, PodLikeVolumeMount } from './containerNameMatcher';
 
 const SYSTEMD_DIR = '.config/containers/systemd';
 
+/** A single systemd run-state sample of a unit. See readServiceRunState (#2406). */
+export interface ServiceRunState {
+    /** `active` | `activating` | `deactivating` | `inactive` | `failed` | '' (unreadable). */
+    activeState: string;
+    /** `running` | `start` | `dead` | … — for a `.kube` unit, `running` means kube-play finished. */
+    subState: string;
+    /** systemd's per-activation id; changes on every (re)start. '' when unreadable. */
+    invocationId: string;
+    /** Monotonic µs of the last activation; secondary discriminator when InvocationID is unavailable. */
+    activeEnterStamp: string;
+}
+
+/** Outcome of the post-restart readiness wait (#2406). */
+export interface RestartSettleResult {
+    /** True only when the unit came back up as a NEW run within the bound. */
+    settled: boolean;
+    reason: 'active' | 'timeout' | 'failed';
+    waitedMs: number;
+    polls: number;
+    state: ServiceRunState;
+}
+
+/**
+ * Bound + cadence for the post-restart readiness wait (#2406). A `.kube`
+ * unit's restart is a full pod teardown + kube-play, which on a slow box with
+ * large images is minutes, not seconds — hence the generous bound. Mutable so
+ * tests can shrink the poll without faking timers.
+ */
+export const RESTART_SETTLE_TUNING = { timeoutMs: 180_000, pollIntervalMs: 2_000 };
+
 /** Minimal agent shape needed to ship files to a node. */
 interface FileWritingAgent {
     sendCommand(action: string, params?: unknown): Promise<unknown>;
@@ -259,6 +289,90 @@ export class ServiceLifecycle {
             return (res?.stdout ?? '').trim() === 'active';
         } catch {
             return false;
+        }
+    }
+
+    /**
+     * One sample of a unit's systemd run-state, used to decide whether a
+     * restart has actually settled (#2406).
+     *
+     * `invocationId` / `activeEnterStamp` are the discriminators that make
+     * this more than an `is-active` check: right after `systemctl --no-block
+     * restart` the unit still reports the OLD run as `active`, so polling
+     * `is-active` alone returns true immediately and doesn't wait for
+     * anything. Both values change on every (re)activation, so "active AND a
+     * different invocation than before the restart" is the first moment the
+     * NEW pod is up.
+     */
+    static async readServiceRunState(nodeName: string, serviceName: string): Promise<ServiceRunState> {
+        try {
+            const agent = await agentManager.ensureAgent(nodeName);
+            const res = await agent.sendCommand('exec', {
+                command: `systemctl --user show ${serviceName}.service --property=ActiveState --property=SubState --property=InvocationID --property=ActiveEnterTimestampMonotonic`,
+            });
+            const out = String(res?.stdout ?? '');
+            const prop = (key: string) => (out.match(new RegExp(`^${key}=(.*)$`, 'm'))?.[1] ?? '').trim();
+            return {
+                activeState: prop('ActiveState'),
+                subState: prop('SubState'),
+                invocationId: prop('InvocationID'),
+                activeEnterStamp: prop('ActiveEnterTimestampMonotonic'),
+            };
+        } catch {
+            return { activeState: '', subState: '', invocationId: '', activeEnterStamp: '' };
+        }
+    }
+
+    /**
+     * Block until `<serviceName>.service` has come back up after a restart —
+     * or until the bound is hit (#2406).
+     *
+     * Why this exists: `restartService` uses `--no-block`, which returns as
+     * soon as systemd has *queued* the job. Everything the deploy path does
+     * next (notably the template's post-deploy script) therefore ran
+     * concurrently with the pod's own restart — containers gone, coming up,
+     * or `podman` calls timing out against a pod being rebuilt. Three
+     * consecutive workarounds downstream (mdopp/solarisbay#1090/#1097/#1099:
+     * `Pull=newer`, an in-script `podman exec` probe, an in-script
+     * `/health` wait) each lost that race in a different way, because the
+     * race is in ServiceBay's deploy sequence, not in the scripts.
+     *
+     * The wait is a real readiness check, not a sleep: poll the unit's
+     * systemd state until it reports `active`/`running` with an invocation
+     * *different* from the pre-restart sample. A `failed` unit returns
+     * immediately (no point waiting out the bound), and the bound itself is
+     * hard — we return `settled:false` with a reason and the caller logs it
+     * loudly. Never throws; the deploy continues either way, but the install
+     * log now says which of the two happened.
+     */
+    static async waitForRestartSettled(
+        nodeName: string,
+        serviceName: string,
+        before: ServiceRunState,
+        opts?: { timeoutMs?: number; pollIntervalMs?: number },
+    ): Promise<RestartSettleResult> {
+        const timeoutMs = opts?.timeoutMs ?? RESTART_SETTLE_TUNING.timeoutMs;
+        const pollIntervalMs = opts?.pollIntervalMs ?? RESTART_SETTLE_TUNING.pollIntervalMs;
+        const startedAt = Date.now();
+        let state: ServiceRunState = before;
+        let polls = 0;
+
+        for (;;) {
+            state = await ServiceLifecycle.readServiceRunState(nodeName, serviceName);
+            polls++;
+            const isNewRun =
+                (state.invocationId !== '' && state.invocationId !== before.invocationId) ||
+                (state.activeEnterStamp !== '' && state.activeEnterStamp !== before.activeEnterStamp);
+            if (state.activeState === 'active' && state.subState === 'running' && isNewRun) {
+                return { settled: true, reason: 'active', waitedMs: Date.now() - startedAt, polls, state };
+            }
+            if (state.activeState === 'failed') {
+                return { settled: false, reason: 'failed', waitedMs: Date.now() - startedAt, polls, state };
+            }
+            if (Date.now() - startedAt >= timeoutMs) {
+                return { settled: false, reason: 'timeout', waitedMs: Date.now() - startedAt, polls, state };
+            }
+            await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
         }
     }
 
@@ -920,11 +1034,32 @@ export class ServiceLifecycle {
         // unit), so restart to actually apply the changed topology. First
         // install (inactive) or an unchanged re-render falls through to a plain
         // start.
+        //
+        // #2406 — the restart is `--no-block`: systemd returns as soon as the
+        // job is QUEUED. Everything after this point (above all the template's
+        // post-deploy script) used to run while the pod was still tearing down
+        // and coming back, so a post-deploy that queried its own pod hit a
+        // moving target. Wait for the unit to actually be up again — a real
+        // readiness check on a NEW invocation, not a sleep — before continuing.
+        // The plain-start path (first install / unchanged render) is untouched:
+        // no wait is added there, since nothing was torn down.
         try {
              const alreadyActive = specChanged && (await ServiceLifecycle.isServiceActive(nodeName, name));
              if (alreadyActive) {
                  onProgress?.(`Pod spec changed — restarting ${name} to apply the new topology...`);
+                 const before = await ServiceLifecycle.readServiceRunState(nodeName, name);
                  await ServiceLifecycle.restartService(nodeName, name);
+                 const settle = await ServiceLifecycle.waitForRestartSettled(nodeName, name, before);
+                 const secs = (settle.waitedMs / 1000).toFixed(1);
+                 if (settle.settled) {
+                     onProgress?.(`${name} restart settled after ${secs}s — unit active/running; continuing (post-deploy, if any, runs AFTER the restart).`);
+                 } else if (settle.reason === 'failed') {
+                     onProgress?.(`⚠️ ${name} failed to come back up after the restart (systemd reports ${settle.state.activeState}/${settle.state.subState || '?'} after ${secs}s). Continuing anyway — anything that queries this pod next may not find it.`);
+                     logger.warn('ServiceManager', `Service ${name} restart ended in failed state`, settle.state);
+                 } else {
+                     onProgress?.(`⚠️ ${name} did not report active within ${secs}s of the restart (last state: ${settle.state.activeState || 'unreadable'}/${settle.state.subState || '?'}). Continuing anyway — anything that queries this pod next may not find it.`);
+                     logger.warn('ServiceManager', `Service ${name} restart readiness wait timed out`, settle.state);
+                 }
              } else {
                  await ServiceLifecycle.startService(nodeName, name);
              }

--- a/packages/frontend/src/app/portal/PortalLanOnlyNotice.tsx
+++ b/packages/frontend/src/app/portal/PortalLanOnlyNotice.tsx
@@ -1,0 +1,22 @@
+import ServiceBayLogo from '@/components/ServiceBayLogo';
+
+/** Shown instead of the portal when `config.portalLanOnly` is on and the
+ *  visitor isn't on the home network (#1456). Shared by `/portal` and the
+ *  deep-linkable `/portal/requests` route (#2405) so both surfaces apply the
+ *  same gate with the same wording. */
+export default function PortalLanOnlyNotice() {
+  return (
+    <main className="relative max-w-2xl mx-auto px-space-5 py-space-8 text-center">
+      <div className="flex items-center justify-center gap-space-3 mb-space-5">
+        <ServiceBayLogo size={36} className="text-accent shrink-0" />
+        <h1 className="text-3xl font-bold text-text">Home</h1>
+      </div>
+      <p className="text-lg text-text">
+        This page is available on the home network only.
+      </p>
+      <p className="mt-space-3 text-sm text-text-muted">
+        Connect to the home Wi-Fi (or its VPN) and reload to request access or open a service.
+      </p>
+    </main>
+  );
+}

--- a/packages/frontend/src/app/portal/RequestAccessButton.test.tsx
+++ b/packages/frontend/src/app/portal/RequestAccessButton.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * RequestAccessButton — the /portal CTA. After #2405 the modal body lives
+ * in RequestAccessDialog (so /portal/requests can render it pre-opened);
+ * these tests pin that the button's own behaviour is unchanged: closed by
+ * default, opens on click, closes again on Cancel.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RequestAccessButton from './RequestAccessButton';
+
+describe('RequestAccessButton', () => {
+  it('renders no form until the button is clicked', () => {
+    render(<RequestAccessButton />);
+    expect(screen.getByRole('button', { name: /have an account/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Send request/i })).toBeNull();
+  });
+
+  it('opens the request-access form on click', () => {
+    render(<RequestAccessButton />);
+    fireEvent.click(screen.getByRole('button', { name: /have an account/i }));
+    expect(screen.getByRole('heading', { name: /Request Access/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Send request/i })).toBeTruthy();
+  });
+
+  it('closes again on Cancel', () => {
+    render(<RequestAccessButton />);
+    fireEvent.click(screen.getByRole('button', { name: /have an account/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Cancel$/ }));
+    expect(screen.queryByRole('button', { name: /Send request/i })).toBeNull();
+  });
+});

--- a/packages/frontend/src/app/portal/RequestAccessButton.tsx
+++ b/packages/frontend/src/app/portal/RequestAccessButton.tsx
@@ -1,99 +1,21 @@
 'use client';
 
 import { useState } from 'react';
-import { UserPlus, Loader2 } from 'lucide-react';
+import { UserPlus } from 'lucide-react';
+import RequestAccessDialog from './RequestAccessDialog';
 
 /**
  * "Don't have an account?" affordance on the family portal (#242
  * follow-up). Renders a small button below the card grid; clicking
- * opens a modal that collects everything LLDAP needs to provision an
- * account — first/last name, desired login, email, optional note —
- * and POSTs to /api/system/access-requests (public). The admin
- * approves in Settings → Access Requests; #405 wired this form to
- * gather the profile data so approval is one click rather than a
- * round-trip to ask the requester for a username.
+ * opens the request-access modal (RequestAccessDialog), which collects
+ * the profile data and POSTs it to /api/system/access-requests.
+ *
+ * The modal lives in its own component since #2405 so `/portal/requests`
+ * can render it already open for a deep link from the companion app.
+ * Mounting it == open; unmounting == closed, which resets the form.
  */
-/** Shared token-wired classes for the request-access form controls so
- *  the inputs/labels read as one consistent, design-system surface
- *  (dark-mode-correct, no raw gray-300/blue-500 literals). */
-const FIELD_LABEL = 'block text-xs font-medium text-text-muted';
-const FIELD_INPUT =
-  'w-full px-space-3 py-space-2 text-sm rounded-card border border-border bg-surface-2 ' +
-  'text-text placeholder:text-text-subtle focus:outline-none focus:ring-2 focus:ring-accent';
-
 export default function RequestAccessButton() {
   const [open, setOpen] = useState(false);
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [username, setUsername] = useState('');
-  const [email, setEmail] = useState('');
-  const [message, setMessage] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [submitted, setSubmitted] = useState(false);
-
-  const reset = () => {
-    setFirstName('');
-    setLastName('');
-    setUsername('');
-    setEmail('');
-    setMessage('');
-    setError(null);
-    setSubmitted(false);
-  };
-
-  const onClose = () => {
-    setOpen(false);
-    // Slight delay so the closing transition doesn't show the form snapping back to empty.
-    setTimeout(reset, 200);
-  };
-
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSubmitting(true);
-    setError(null);
-    const trimmedUsername = username.trim().toLowerCase();
-    if (!/^[a-z0-9._-]{1,60}$/.test(trimmedUsername)) {
-      setError('Username may only contain lowercase letters, digits, dots, underscores, and hyphens (max 60 characters).');
-      setSubmitting(false);
-      return;
-    }
-    try {
-      const res = await fetch('/api/system/access-requests', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          firstName: firstName.trim(),
-          lastName: lastName.trim(),
-          username: trimmedUsername,
-          email: email.trim(),
-          message: message.trim() || undefined,
-        }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        setError(typeof data.error === 'string' ? data.error : `Submission failed (${res.status}).`);
-        return;
-      }
-      // #1001 — persist the request id so the portal's state-aware CTA
-      // can render "Your request is being reviewed" on subsequent
-      // visits without a session. The status endpoint flips this to a
-      // "Set your password" link once the admin approves.
-      if (typeof data.id === 'string') {
-        try {
-          window.localStorage.setItem(
-            'sb.portal.lastAccessRequest',
-            JSON.stringify({ id: data.id, submittedAt: new Date().toISOString() }),
-          );
-        } catch { /* quota / disabled storage — non-fatal */ }
-      }
-      setSubmitted(true);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Network error.');
-    } finally {
-      setSubmitting(false);
-    }
-  };
 
   return (
     <>
@@ -107,147 +29,7 @@ export default function RequestAccessButton() {
         </button>
       </div>
 
-      {open && (
-        <div
-          className="fixed inset-0 bg-black/60 backdrop-blur-md flex items-center justify-center p-4 z-50 transition-all duration-300"
-          onClick={onClose}
-        >
-          <div
-            className="glass-panel rounded-card shadow-2xl max-w-md w-full p-space-6 max-h-[90vh] overflow-y-auto border border-border"
-            onClick={e => e.stopPropagation()}
-          >
-            {submitted ? (
-              <div className="text-center py-space-6 space-y-space-4">
-                <div className="text-5xl animate-bounce">✨</div>
-                <h2 className="text-2xl font-bold text-text tracking-wide">Request Sent Successfully!</h2>
-                <p className="text-sm text-text-muted leading-relaxed font-medium">
-                  The family administrator has been notified. They will create your account in the local identity pool and notify you when it is ready.
-                </p>
-                <button
-                  onClick={onClose}
-                  className="mt-space-4 px-space-5 py-2.5 bg-accent hover:bg-accent-strong text-on-accent text-sm font-semibold rounded-card shadow transition-colors"
-                >
-                  Got it
-                </button>
-              </div>
-            ) : (
-              <form onSubmit={onSubmit} className="space-y-space-5">
-                <div>
-                  <h2 className="text-2xl font-extrabold text-text tracking-wide">Request Access</h2>
-                  <p className="text-sm text-text-muted mt-1.5 font-medium leading-relaxed">
-                    The administrator will create your personal account. Enter your details below to get started.
-                  </p>
-                </div>
-
-                <div className="grid grid-cols-2 gap-space-3">
-                  <div className="space-y-space-1">
-                    <label className={FIELD_LABEL}>
-                      First name <span className="text-status-fail">*</span>
-                    </label>
-                    <input
-                      type="text"
-                      value={firstName}
-                      onChange={e => setFirstName(e.target.value)}
-                      required
-                      maxLength={60}
-                      autoComplete="given-name"
-                      className={FIELD_INPUT}
-                    />
-                  </div>
-                  <div className="space-y-space-1">
-                    <label className={FIELD_LABEL}>
-                      Last name <span className="text-status-fail">*</span>
-                    </label>
-                    <input
-                      type="text"
-                      value={lastName}
-                      onChange={e => setLastName(e.target.value)}
-                      required
-                      maxLength={60}
-                      autoComplete="family-name"
-                      className={FIELD_INPUT}
-                    />
-                  </div>
-                </div>
-
-                <div className="space-y-space-1">
-                  <label className={FIELD_LABEL}>
-                    Desired username <span className="text-status-fail">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={username}
-                    onChange={e => setUsername(e.target.value.toLowerCase())}
-                    required
-                    minLength={1}
-                    maxLength={60}
-                    pattern="[a-z0-9._\-]{1,60}"
-                    autoComplete="username"
-                    placeholder="e.g. max.mustermann"
-                    className={FIELD_INPUT}
-                  />
-                  <p className="text-[11px] text-text-subtle">
-                    Your login — lowercase letters, digits, dots, underscores, and hyphens only. Can&apos;t be changed later.
-                  </p>
-                </div>
-
-                <div className="space-y-space-1">
-                  <label className={FIELD_LABEL}>
-                    Your email <span className="text-status-fail">*</span>
-                  </label>
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={e => setEmail(e.target.value)}
-                    required
-                    maxLength={200}
-                    autoComplete="email"
-                    className={FIELD_INPUT}
-                  />
-                </div>
-
-                <div className="space-y-space-1">
-                  <label className={FIELD_LABEL}>
-                    Anything else? <span className="text-text-subtle">(optional)</span>
-                  </label>
-                  <textarea
-                    value={message}
-                    onChange={e => setMessage(e.target.value)}
-                    maxLength={1000}
-                    rows={3}
-                    placeholder="e.g. which services you'd like access to"
-                    className={FIELD_INPUT}
-                  />
-                </div>
-
-                {error && (
-                  <div className="px-space-3 py-space-2 text-xs text-status-fail bg-status-fail/10 rounded-card">
-                    {error}
-                  </div>
-                )}
-
-                <div className="flex justify-end gap-space-2 pt-space-2">
-                  <button
-                    type="button"
-                    onClick={onClose}
-                    className="px-space-4 py-space-2 text-sm text-text-muted hover:text-text"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="submit"
-                    disabled={submitting}
-                    className="inline-flex items-center gap-space-2 px-space-4 py-space-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded-card disabled:opacity-50"
-                  >
-                    {submitting && <Loader2 size={14} className="animate-spin" />}
-                    Send request
-                  </button>
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
-      )}
+      {open && <RequestAccessDialog onClose={() => setOpen(false)} />}
     </>
   );
 }

--- a/packages/frontend/src/app/portal/RequestAccessDialog.tsx
+++ b/packages/frontend/src/app/portal/RequestAccessDialog.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+
+/**
+ * The request-access modal itself — the form that collects everything
+ * LLDAP needs to provision an account (first/last name, desired login,
+ * email, optional note) and POSTs it to `/api/system/access-requests`
+ * (public). The admin approves in Settings → Access Requests; #405 wired
+ * this form to gather the profile data so approval is one click rather
+ * than a round-trip to ask the requester for a username.
+ *
+ * Extracted from RequestAccessButton (#2405) so it can also be rendered
+ * **already open** by the deep-linkable `/portal/requests` route, which
+ * the Solaris companion app links straight into. The owner decides when
+ * it is mounted; mounting == open, unmounting == closed (which also
+ * resets the form state for free).
+ */
+/** Shared token-wired classes for the request-access form controls so
+ *  the inputs/labels read as one consistent, design-system surface
+ *  (dark-mode-correct, no raw gray-300/blue-500 literals). */
+const FIELD_LABEL = 'block text-xs font-medium text-text-muted';
+const FIELD_INPUT =
+  'w-full px-space-3 py-space-2 text-sm rounded-card border border-border bg-surface-2 ' +
+  'text-text placeholder:text-text-subtle focus:outline-none focus:ring-2 focus:ring-accent';
+
+export default function RequestAccessDialog({ onClose }: { onClose: () => void }) {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    const trimmedUsername = username.trim().toLowerCase();
+    if (!/^[a-z0-9._-]{1,60}$/.test(trimmedUsername)) {
+      setError('Username may only contain lowercase letters, digits, dots, underscores, and hyphens (max 60 characters).');
+      setSubmitting(false);
+      return;
+    }
+    try {
+      const res = await fetch('/api/system/access-requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: firstName.trim(),
+          lastName: lastName.trim(),
+          username: trimmedUsername,
+          email: email.trim(),
+          message: message.trim() || undefined,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data.error === 'string' ? data.error : `Submission failed (${res.status}).`);
+        return;
+      }
+      // #1001 — persist the request id so the portal's state-aware CTA
+      // can render "Your request is being reviewed" on subsequent
+      // visits without a session. The status endpoint flips this to a
+      // "Set your password" link once the admin approves.
+      if (typeof data.id === 'string') {
+        try {
+          window.localStorage.setItem(
+            'sb.portal.lastAccessRequest',
+            JSON.stringify({ id: data.id, submittedAt: new Date().toISOString() }),
+          );
+        } catch { /* quota / disabled storage — non-fatal */ }
+      }
+      setSubmitted(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Network error.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-md flex items-center justify-center p-4 z-50 transition-all duration-300"
+      onClick={onClose}
+    >
+      <div
+        className="glass-panel rounded-card shadow-2xl max-w-md w-full p-space-6 max-h-[90vh] overflow-y-auto border border-border"
+        onClick={e => e.stopPropagation()}
+      >
+        {submitted ? (
+          <div className="text-center py-space-6 space-y-space-4">
+            <div className="text-5xl animate-bounce">✨</div>
+            <h2 className="text-2xl font-bold text-text tracking-wide">Request Sent Successfully!</h2>
+            <p className="text-sm text-text-muted leading-relaxed font-medium">
+              The family administrator has been notified. They will create your account in the local identity pool and notify you when it is ready.
+            </p>
+            <button
+              onClick={onClose}
+              className="mt-space-4 px-space-5 py-2.5 bg-accent hover:bg-accent-strong text-on-accent text-sm font-semibold rounded-card shadow transition-colors"
+            >
+              Got it
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={onSubmit} className="space-y-space-5">
+            <div>
+              <h2 className="text-2xl font-extrabold text-text tracking-wide">Request Access</h2>
+              <p className="text-sm text-text-muted mt-1.5 font-medium leading-relaxed">
+                The administrator will create your personal account. Enter your details below to get started.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-space-3">
+              <div className="space-y-space-1">
+                <label className={FIELD_LABEL}>
+                  First name <span className="text-status-fail">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={firstName}
+                  onChange={e => setFirstName(e.target.value)}
+                  required
+                  maxLength={60}
+                  autoComplete="given-name"
+                  className={FIELD_INPUT}
+                />
+              </div>
+              <div className="space-y-space-1">
+                <label className={FIELD_LABEL}>
+                  Last name <span className="text-status-fail">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={lastName}
+                  onChange={e => setLastName(e.target.value)}
+                  required
+                  maxLength={60}
+                  autoComplete="family-name"
+                  className={FIELD_INPUT}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-space-1">
+              <label className={FIELD_LABEL}>
+                Desired username <span className="text-status-fail">*</span>
+              </label>
+              <input
+                type="text"
+                value={username}
+                onChange={e => setUsername(e.target.value.toLowerCase())}
+                required
+                minLength={1}
+                maxLength={60}
+                pattern="[a-z0-9._\-]{1,60}"
+                autoComplete="username"
+                placeholder="e.g. max.mustermann"
+                className={FIELD_INPUT}
+              />
+              <p className="text-[11px] text-text-subtle">
+                Your login — lowercase letters, digits, dots, underscores, and hyphens only. Can&apos;t be changed later.
+              </p>
+            </div>
+
+            <div className="space-y-space-1">
+              <label className={FIELD_LABEL}>
+                Your email <span className="text-status-fail">*</span>
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                required
+                maxLength={200}
+                autoComplete="email"
+                className={FIELD_INPUT}
+              />
+            </div>
+
+            <div className="space-y-space-1">
+              <label className={FIELD_LABEL}>
+                Anything else? <span className="text-text-subtle">(optional)</span>
+              </label>
+              <textarea
+                value={message}
+                onChange={e => setMessage(e.target.value)}
+                maxLength={1000}
+                rows={3}
+                placeholder="e.g. which services you'd like access to"
+                className={FIELD_INPUT}
+              />
+            </div>
+
+            {error && (
+              <div className="px-space-3 py-space-2 text-xs text-status-fail bg-status-fail/10 rounded-card">
+                {error}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-space-2 pt-space-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-space-4 py-space-2 text-sm text-text-muted hover:text-text"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="inline-flex items-center gap-space-2 px-space-4 py-space-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded-card disabled:opacity-50"
+              >
+                {submitting && <Loader2 size={14} className="animate-spin" />}
+                Send request
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -6,6 +6,7 @@ import { buildPortalCards } from '@/lib/portal/services';
 import { isPortalBlockedForRequest } from '@/lib/portal/lanGate';
 import { verifyAutheliaSession } from '@/lib/portal/auth';
 import PortalGrid from './PortalGrid';
+import PortalLanOnlyNotice from './PortalLanOnlyNotice';
 import PortalLogoutLink from './PortalLogoutLink';
 import PortalUserChip from './PortalUserChip';
 import AccessRequestStatusCTA from './AccessRequestStatusCTA';
@@ -138,24 +139,5 @@ function PortalHero({
         </p>
       )}
     </header>
-  );
-}
-
-/** Shown instead of the portal when `config.portalLanOnly` is on and the
- *  visitor isn't on the home network (#1456). */
-function PortalLanOnlyNotice() {
-  return (
-    <main className="relative max-w-2xl mx-auto px-space-5 py-space-8 text-center">
-      <div className="flex items-center justify-center gap-space-3 mb-space-5">
-        <ServiceBayLogo size={36} className="text-accent shrink-0" />
-        <h1 className="text-3xl font-bold text-text">Home</h1>
-      </div>
-      <p className="text-lg text-text">
-        This page is available on the home network only.
-      </p>
-      <p className="mt-space-3 text-sm text-text-muted">
-        Connect to the home Wi-Fi (or its VPN) and reload to request access or open a service.
-      </p>
-    </main>
   );
 }

--- a/packages/frontend/src/app/portal/requests/RequestAccessDeepLink.tsx
+++ b/packages/frontend/src/app/portal/requests/RequestAccessDeepLink.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import RequestAccessDialog from '../RequestAccessDialog';
+
+/**
+ * The `/portal/requests` deep link (#2405): renders the request-access
+ * modal **already open**, so the Solaris companion app's "Request access"
+ * button (mdopp/solaris-android#50) lands the visitor straight in the form
+ * instead of on the portal root with one more click to make.
+ *
+ * Dismissing (backdrop, Cancel, or "Got it" after submitting) returns to
+ * `/portal` — the deep-link route has nothing else to show, and the portal
+ * root is where the state-aware CTA (#1001) picks the story up.
+ */
+export default function RequestAccessDeepLink() {
+  const router = useRouter();
+  return <RequestAccessDialog onClose={() => router.push('/portal')} />;
+}

--- a/packages/frontend/src/app/portal/requests/page.test.tsx
+++ b/packages/frontend/src/app/portal/requests/page.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * `/portal/requests` — deep-linkable request-access route (#2405).
+ *
+ * The companion app (mdopp/solaris-android#50) links straight here, so the
+ * contract these tests pin is: the form is **already open** for an
+ * anonymous visitor (no extra click), the LAN gate behaves exactly like
+ * `/portal`'s, and a signed-in visitor is sent to `/portal` instead of
+ * being shown a form for an account they already have.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const { redirect, getConfig, verifyAutheliaSession, headersMock, buildPortalCards } = vi.hoisted(() => ({
+  redirect: vi.fn(),
+  getConfig: vi.fn(),
+  verifyAutheliaSession: vi.fn(),
+  headersMock: vi.fn(),
+  buildPortalCards: vi.fn(),
+}));
+
+// The real redirect() throws to unwind rendering; the unit under test is
+// "where do we send a signed-in visitor", so the spy call is the contract
+// (same pattern as app/(dashboard)/redirects.test.tsx).
+vi.mock('next/navigation', () => ({
+  redirect,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock('next/headers', () => ({ headers: headersMock }));
+vi.mock('@/lib/config', () => ({ getConfig, getAdminBaseUrl: () => null }));
+vi.mock('@/lib/portal/auth', () => ({ verifyAutheliaSession }));
+vi.mock('@/lib/portal/services', () => ({ buildPortalCards }));
+// The LAN gate itself is NOT mocked — both routes must run the real
+// isPortalBlockedForRequest so "same gate" is actually proven.
+
+/** Anonymous, LAN-shaped visit (X-Real-IP set by NPM). */
+const lanHeaders = () => new Headers({ 'x-real-ip': '192.168.1.42' });
+/** Off-LAN visit — a public source IP forwarded by the proxy. */
+const wanHeaders = () => new Headers({ 'x-real-ip': '203.0.113.7' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  getConfig.mockResolvedValue({ portalLanOnly: false });
+  verifyAutheliaSession.mockResolvedValue({ user: null, name: null });
+  buildPortalCards.mockResolvedValue([]);
+  headersMock.mockResolvedValue(lanHeaders());
+});
+
+async function renderRequestsPage() {
+  const { default: Page } = await import('./page');
+  render(await Page());
+}
+
+describe('/portal/requests — deep link opens the form', () => {
+  it('renders the request-access form already open, with no extra click', async () => {
+    await renderRequestsPage();
+    expect(screen.getByRole('heading', { name: /Request Access/i })).toBeTruthy();
+    // The actual form controls, not just a CTA button.
+    expect(screen.getByRole('button', { name: /Send request/i })).toBeTruthy();
+    expect(screen.getByPlaceholderText(/max\.mustermann/i)).toBeTruthy();
+    // …and no "Don't have an account yet?" button to click first.
+    expect(screen.queryByRole('button', { name: /have an account/i })).toBeNull();
+  });
+
+  it('does not redirect an anonymous visitor', async () => {
+    await renderRequestsPage();
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});
+
+describe('/portal/requests — signed-in visitor', () => {
+  it('goes to /portal instead of a form for an account they already have', async () => {
+    verifyAutheliaSession.mockResolvedValue({ user: 'max', name: 'Max Mustermann' });
+    await renderRequestsPage();
+    expect(redirect).toHaveBeenCalledWith('/portal');
+  });
+});
+
+describe('/portal/requests — LAN gate parity with /portal', () => {
+  it('shows the same LAN-only notice off-LAN when portalLanOnly is on', async () => {
+    getConfig.mockResolvedValue({ portalLanOnly: true });
+    headersMock.mockResolvedValue(wanHeaders());
+    await renderRequestsPage();
+    expect(screen.getByText(/available on the home network only/i)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Send request/i })).toBeNull();
+  });
+
+  it('/portal blocks under exactly the same conditions', async () => {
+    getConfig.mockResolvedValue({ portalLanOnly: true });
+    headersMock.mockResolvedValue(wanHeaders());
+    const { default: PortalPage } = await import('../page');
+    render(await PortalPage());
+    expect(screen.getByText(/available on the home network only/i)).toBeTruthy();
+  });
+
+  it('renders the form on-LAN when portalLanOnly is on', async () => {
+    getConfig.mockResolvedValue({ portalLanOnly: true });
+    headersMock.mockResolvedValue(lanHeaders());
+    await renderRequestsPage();
+    expect(screen.getByRole('button', { name: /Send request/i })).toBeTruthy();
+  });
+});
+
+describe('/portal is unaffected by the new route', () => {
+  it('still renders the CTA button, not an open form', async () => {
+    const { default: PortalPage } = await import('../page');
+    render(await PortalPage());
+    expect(screen.getByRole('button', { name: /have an account/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Send request/i })).toBeNull();
+  });
+});

--- a/packages/frontend/src/app/portal/requests/page.tsx
+++ b/packages/frontend/src/app/portal/requests/page.tsx
@@ -1,0 +1,70 @@
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import ServiceBayLogo from '@/components/ServiceBayLogo';
+import { getConfig } from '@/lib/config';
+import { isPortalBlockedForRequest } from '@/lib/portal/lanGate';
+import { verifyAutheliaSession } from '@/lib/portal/auth';
+import AccessRequestStatusCTA from '../AccessRequestStatusCTA';
+import PortalLanOnlyNotice from '../PortalLanOnlyNotice';
+import RequestAccessDeepLink from './RequestAccessDeepLink';
+
+export const revalidate = 0;
+export const dynamic = 'force-dynamic';
+
+/**
+ * `/portal/requests` — the deep-linkable, pre-auth twin of the portal's
+ * request-access CTA (#2405). The Solaris companion app points its
+ * "Request access" button here (mdopp/solaris-android#50) so a visitor
+ * with no account lands **in the form**, not on the portal root one click
+ * away from it.
+ *
+ * Same gates as `/portal`, deliberately reusing the same helpers:
+ *   - `isPortalBlockedForRequest` (#1456) — LAN-only gate, same notice.
+ *   - `verifyAutheliaSession` (#417) — a signed-in visitor already has an
+ *     account, so there is nothing to request: send them to `/portal`
+ *     (which greets them by name) rather than showing a dangling form.
+ *   - `AccessRequestStatusCTA` (#1001) — a visitor who already submitted
+ *     a request sees its pending/resolved status instead of a second
+ *     blank form; only the default case opens the form.
+ *
+ * Reachable pre-auth for the same reason `/portal` is: `proxy.ts` gates
+ * `/api/*` and `/napi/*`, not pages. On the apex/www host the rewrite in
+ * `proxy.ts` passes `/portal…` paths through untouched, so
+ * `https://<domain>/portal/requests` resolves here as well.
+ */
+export default async function PortalRequestAccessPage() {
+  const hdrs = await headers();
+  const config = await getConfig();
+
+  // LAN-only gate (#1456): behind NPM the RSC's TCP peer is always
+  // loopback, so passing '127.0.0.1' makes the resolver trust the
+  // proxy's X-Real-IP / last-XFF hop (same rule as /portal).
+  const headerMap: Record<string, string> = {};
+  hdrs.forEach((v, k) => { headerMap[k] = v; });
+  if (isPortalBlockedForRequest(config.portalLanOnly, headerMap, '127.0.0.1')) {
+    return <PortalLanOnlyNotice />;
+  }
+
+  const visitor = await verifyAutheliaSession(hdrs.get('cookie'));
+  if (visitor.user) redirect('/portal');
+
+  return (
+    <main className="relative max-w-2xl mx-auto px-space-5 py-space-8 text-center">
+      <div className="flex items-center justify-center gap-space-3 mb-space-5">
+        <ServiceBayLogo size={36} className="text-accent shrink-0" />
+        <h1 className="text-3xl font-bold text-text">Home</h1>
+      </div>
+      <p className="text-base text-text-muted">
+        Ask the family administrator for your own account.
+      </p>
+
+      <AccessRequestStatusCTA fallback={<RequestAccessDeepLink />} />
+
+      <p className="mt-space-7 text-sm">
+        <a href="/portal" className="text-text-subtle hover:text-text underline-offset-2 hover:underline">
+          Back to Home
+        </a>
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
Autoloop batch `batch/2026-07-28a` — 2 units.

- **Deep-linkable portal request-access route** (#2405): `/portal/requests` renders the request-access form pre-opened for the companion app, reusing the same LAN gate and Authelia-session handling as `/portal`. Signed-in visitors redirect back to `/portal`.
- **Post-deploy no longer races its own pod's restart** (#2406): `systemctl --user --no-block restart` returns as soon as the job is queued, not when the unit is actually active again. A new readiness wait (polls ActiveState/SubState + invocation identity, not a naive `is-active` or fixed sleep — both previously tried and known-bad per mdopp/solarisbay#1090/#1097/#1098/#1099) now settles before post-deploy runs, bounded at 180s with a clear failure log if it never comes up.

Closes #2405
Closes #2406

Local safety-net gate green: lint, typecheck, check:arch, npm test (490 files, 4416 passed / 2 skipped). #2405 is gate=verify (path-mandated + user-facing) — box-verify owed after seal.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
