### PR TITLE
fix(templates,backend): radicale rights model + durable-write corruption hardening (#2411 #2414)

### DIFF
--- a/docs/ARCHITECTURE_INVARIANTS.md
+++ b/docs/ARCHITECTURE_INVARIANTS.md
@@ -99,6 +99,18 @@ Thresholds are **deliberate decisions**, not aspirational defaults. Two paths:
 
 **Service test gate — 70% diff-coverage floor, ≥85% total target, build-gates-on-tests (#2345).** A ServiceBay *service* (shipped as a template, built in its own repo) is held to the same test discipline the platform holds itself to: the box must never run code that did not pass tests at threshold. A new/changed service must ship a real test suite (Python: `pytest` — unit + TestClient API tests + the SSO-guard check + bad-input-is-4xx-not-500), measure coverage over the app package with **thread/async coverage on** (`concurrency=["thread"]`, or background-job code reads false-low), hold the platform's **70% diff-coverage floor** and target **≥85% total**, and — critically — its **CI must gate image publish on a green test job** (the build/publish job `needs:` the test job; a build-only CI is non-compliant). This is a service-repo standard (enforced in that repo's CI, not in this repo's `check:arch`); it is canonical here so `get_service_standards` and box-verify can hold a service to it. Full checklist: `assists/testing-and-ci-gate.md`.
 
+### Durable state (crash safety)
+
+| Invariant | Current | Threshold | Enforced by |
+|---|---:|---:|---|
+| Bare `fs.writeFile`/`writeFileSync` in durable-state modules | 0 | 0 | `check-invariants.ts:DURABLE_STATE_BARE_WRITE_BUDGET` |
+
+**Durable-state writes are atomic (#2414).** `config.json` and `checks.json` under `DATA_DIR` are the operator's data, not caches: losing `config.json` re-onboards the box (domain, auth and service config gone, wizard opens on a configured box), losing `checks.json` drops every configured health check. A bare `fs.writeFile`/`writeFileSync` truncates the target *before* the new bytes land, so a power cut / OOM-kill / container stop mid-write destroys the file permanently. `packages/backend/src/lib/util/atomicWrite.ts` is the only sanctioned writer — `atomicWriteFile` (async) and `atomicWriteFileSync` (sync twin, for the stores whose public API is sync) both do tmp → fsync → rename, so a crash leaves the *original* intact.
+
+The modules held to this are listed in `DURABLE_STATE_MODULES` (`check-invariants.ts`): `packages/backend/src/lib/config.ts`, `packages/backend/src/lib/config/transformer.ts`, `packages/backend/src/lib/health/store.ts`. The list is repo-relative and **forward-only** — add a module when it starts owning durable `DATA_DIR` state; never delete one to make a bare write pass. Unlike the older path-based checks, a listed path that does **not** resolve is itself a violation, so a move/rename can't silently disable the gate the way the pre-#2379 `SECURITY_PATHS` did. `atomicWrite.ts` is deliberately not on the list — it *is* the primitive. Crash behaviour is proved by fault injection in `tests/backend/durable_write_crash_safety.test.ts` (each survival case is paired with a control that performs the pre-fix truncate-then-partial-write and must destroy the file).
+
+Explicitly out of scope: `health/store.ts` result files and `health/bootState.ts` are caches, cheap to rebuild — `writeResults` rides the atomic helper anyway because it shares the module, `bootState.ts` does not.
+
 ### Security boundaries (pattern enforcement)
 
 Enforced by `.semgrep.yml`. ERROR severity = build-blocking; WARNING = reported only.

--- a/packages/backend/src/lib/config/transformer.ts
+++ b/packages/backend/src/lib/config/transformer.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { logger } from '../logger';
+import { atomicWriteFile } from '../util/atomicWrite';
 
 interface JsonRecord {
     [key: string]: unknown;
@@ -95,7 +96,11 @@ export class ConfigTransformer {
         }
 
         await this.createBackup();
-        await fs.writeFile(this.configPath, JSON.stringify(configData, null, 2));
+        // Atomic (tmp → fsync → rename): this runs at boot, before the first
+        // getConfig(), on the one file whose loss re-onboards the box. A plain
+        // writeFile interrupted by a power cut / OOM-kill / container stop
+        // truncates config.json permanently (#2414).
+        await atomicWriteFile(this.configPath, JSON.stringify(configData, null, 2));
         logger.info('ConfigTransformer', `Config normalized at ${this.configPath}`);
         return true;
     }

--- a/packages/backend/src/lib/health/store.ts
+++ b/packages/backend/src/lib/health/store.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { CheckConfig, CheckResult } from './types';
 import { DATA_DIR } from '../dirs';
 import { logger } from '../logger';
+import { atomicWriteFileSync } from '../util/atomicWrite';
 
 const CONFIG_DIR = DATA_DIR;
 const CHECKS_FILE = path.join(CONFIG_DIR, 'checks.json');
@@ -98,9 +99,14 @@ export class HealthStore {
   }
 
   /** Persist checks.json and invalidate the read cache so a same-process
-   *  read-after-write can't serve stale data within mtime granularity. */
+   *  read-after-write can't serve stale data within mtime granularity.
+   *
+   *  Atomic (tmp → fsync → rename, #2414): checks.json is the operator's
+   *  configured health checks — persistent user data, not a cache — so a
+   *  crash mid-write must leave the previous file intact rather than
+   *  truncated. */
   private static writeChecks(checks: CheckConfig[]) {
-    fs.writeFileSync(CHECKS_FILE, JSON.stringify(checks, null, 2));
+    atomicWriteFileSync(CHECKS_FILE, JSON.stringify(checks, null, 2));
     checksCache.entry = null;
   }
 
@@ -158,7 +164,7 @@ export class HealthStore {
   private static writeResults(checkId: string, results: CheckResult[]) {
     const resultFile = path.join(RESULTS_DIR, `${checkId}.json`);
     try {
-      fs.writeFileSync(resultFile, JSON.stringify(results, null, 2));
+      atomicWriteFileSync(resultFile, JSON.stringify(results, null, 2));
       resultsCache.delete(checkId);
     } catch (e) {
       logger.error('HealthStore', `Failed to save result for ${checkId}:`, e);

--- a/packages/backend/src/lib/util/atomicWrite.ts
+++ b/packages/backend/src/lib/util/atomicWrite.ts
@@ -1,6 +1,17 @@
 import fs from 'fs/promises';
+import fsSync from 'fs';
 import { randomBytes } from 'crypto';
 import path from 'path';
+
+/** Temp-file name used by both variants: same directory as the target (so the
+ *  rename is a same-filesystem, atomic operation), hidden, pid+random-suffixed
+ *  so two concurrent writers never collide on it. */
+function tmpPathFor(filePath: string): string {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const suffix = randomBytes(6).toString('hex');
+  return path.join(dir, `.${base}.${process.pid}.${suffix}.tmp`);
+}
 
 /**
  * Atomically write a file: write to a temp file in the same directory, fsync,
@@ -8,10 +19,7 @@ import path from 'path';
  * untouched (rather than truncated/half-written).
  */
 export async function atomicWriteFile(filePath: string, data: string | Buffer, encoding: BufferEncoding = 'utf-8'): Promise<void> {
-  const dir = path.dirname(filePath);
-  const base = path.basename(filePath);
-  const suffix = randomBytes(6).toString('hex');
-  const tmp = path.join(dir, `.${base}.${process.pid}.${suffix}.tmp`);
+  const tmp = tmpPathFor(filePath);
 
   let handle: fs.FileHandle | undefined;
   try {
@@ -28,6 +36,33 @@ export async function atomicWriteFile(filePath: string, data: string | Buffer, e
   } catch (e) {
     if (handle) await handle.close().catch(() => {});
     await fs.unlink(tmp).catch(() => {});
+    throw e;
+  }
+}
+
+/**
+ * Synchronous twin of {@link atomicWriteFile} — same tmp → fsync → rename
+ * contract. Exists because some durable-state stores (e.g. `health/store.ts`)
+ * expose a sync public API that dozens of call sites across the MCP, portal
+ * and service-lifecycle bundles depend on; they still must not truncate the
+ * operator's data on a crash mid-write.
+ */
+export function atomicWriteFileSync(filePath: string, data: string | Buffer, encoding: BufferEncoding = 'utf-8'): void {
+  const tmp = tmpPathFor(filePath);
+
+  let fd: number | undefined;
+  try {
+    fd = fsSync.openSync(tmp, 'w', 0o600);
+    fsSync.writeFileSync(fd, data, typeof data === 'string' ? { encoding } : {});
+    fsSync.fsyncSync(fd);
+    fsSync.closeSync(fd);
+    fd = undefined;
+    fsSync.renameSync(tmp, filePath);
+  } catch (e) {
+    if (fd !== undefined) {
+      try { fsSync.closeSync(fd); } catch { /* already closed */ }
+    }
+    try { fsSync.unlinkSync(tmp); } catch { /* never created */ }
     throw e;
   }
 }

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -299,6 +299,78 @@ async function checkTwinFanIn() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// 6. Durable-state files are written atomically.
+//
+// `config.json` and `checks.json` under DATA_DIR are the operator's data, not
+// caches: losing one re-onboards the box or drops every configured health
+// check. A bare `fs.writeFile`/`writeFileSync` truncates the target before the
+// new bytes land, so a power cut / OOM-kill / container stop mid-write leaves
+// the file permanently half-written. `lib/util/atomicWrite.ts` is the only
+// sanctioned way to touch them (tmp → fsync → rename: a crash leaves the
+// ORIGINAL intact).
+//
+// #2414: `config/transformer.ts` — the boot-time normalizer that runs before
+// the first `getConfig()` on every backend start — wrote config.json bare while
+// `config.ts` next door already used `atomicWriteFile`. Two writers, two
+// durability contracts, on the one file whose loss is unrecoverable from the UI.
+// This check is the ratchet that keeps the second writer from coming back.
+//
+// The budget is 0 and the list is forward-only: add a module when it starts
+// owning durable DATA_DIR state; never delete one to make a bare write pass.
+// `lib/util/atomicWrite.ts` is deliberately absent — it IS the primitive, and
+// its own `writeFileSync` is the fsync'd temp-file write.
+// ---------------------------------------------------------------------------
+const DURABLE_STATE_MODULES = [
+    'packages/backend/src/lib/config.ts',
+    'packages/backend/src/lib/config/transformer.ts',
+    'packages/backend/src/lib/health/store.ts',
+];
+const DURABLE_STATE_BARE_WRITE_BUDGET = 0;
+
+// `fs.writeFile(` / `fsSync.writeFileSync(` (namespace import) and the bare
+// `writeFile(` / `writeFileSync(` named-import form. The `(?<![.\w])` guard
+// keeps `atomicWriteFile(`, `atomicWriteFileSync(` and `executor.writeFile(`
+// (a remote/agent write, not a local durable-state one) out of the count.
+const BARE_WRITE_RE = /\bfs\w*\.writeFile(?:Sync)?\s*\(|(?<![.\w])writeFile(?:Sync)?\s*\(/g;
+
+async function checkDurableStateAtomicWrites() {
+    let count = 0;
+    const offenders: string[] = [];
+    for (const target of DURABLE_STATE_MODULES) {
+        const abs = path.join(REPO_ROOT, target);
+        let files: string[];
+        try {
+            const s = await stat(abs);
+            files = s.isDirectory() ? await walk(abs, isTs) : [abs];
+        } catch {
+            // Unlike the older checks, a missing entry is a VIOLATION, not a
+            // silent skip (#2379): a moved/renamed module must not quietly
+            // disable its own durability gate.
+            violations.push({
+                check: 'durable-state-atomic-write',
+                detail: `${target} is listed as a durable-state module but does not exist — update DURABLE_STATE_MODULES to its new path (do not drop it).`,
+            });
+            continue;
+        }
+        for (const file of files) {
+            if (isTestFile(file)) continue;
+            const content = await readFile(file, 'utf-8');
+            const hits = content.match(BARE_WRITE_RE)?.length ?? 0;
+            if (hits > 0) {
+                count += hits;
+                offenders.push(`${path.relative(REPO_ROOT, file)} (${hits})`);
+            }
+        }
+    }
+    if (count > DURABLE_STATE_BARE_WRITE_BUDGET) {
+        violations.push({
+            check: 'durable-state-atomic-write',
+            detail: `${count} bare fs.writeFile/writeFileSync call(s) in durable-state modules (budget ${DURABLE_STATE_BARE_WRITE_BUDGET}). Use atomicWriteFile / atomicWriteFileSync from packages/backend/src/lib/util/atomicWrite.ts — a bare write truncates the file a crash lands in. Offenders: ${offenders.join(', ')}`,
+        });
+    }
+}
+
 // Retired in Phase 3.3 (#764). The three FE↔BE ratchet counts
 // (`fe-template-lib-imports`, `fe-backend-imports`, `fe-install-helpers`)
 // became vacuous once Phase 3.2 (#763) moved the FE dirs out of `src/`,
@@ -317,6 +389,7 @@ async function main() {
         checkExecTemplateLiterals(),
         checkWithApiHandlerAdoption(),
         checkTwinFanIn(),
+        checkDurableStateAtomicWrites(),
     ]);
 
     if (violations.length === 0) {

--- a/templates/radicale/CHANGELOG.md
+++ b/templates/radicale/CHANGELOG.md
@@ -10,6 +10,47 @@ operator's installed schema-version and the current one and surfaces them
 in the re-deploy dialog. Each `(breaking)` section needs an explicit
 acknowledgement before the deploy can proceed.
 
+## v3 (breaking)
+
+**Rights model swapped from `owner_only` to `from_file` (#2411).**
+
+Radicale's access rules used to be the built-in `owner_only` module: every
+authenticated user may touch their own `/<user>/` tree and nothing else. That
+module cannot express a single cross-principal exception, so the household
+automation account (`solaris`) had no way to write the shared calendar and
+address book it maintains for each resident — and the rule that granted it had
+to be hand-patched onto the running pod, where every re-render (an
+`AutoUpdate=registry` image pull re-running `podman kube play --replace`) wiped
+it again.
+
+The `[rights]` section now reads `type = from_file` with `file = /config/rights`,
+and the pod's `write-config` initContainer seeds that ruleset alongside
+`/config/config` on every deploy — so it is part of the manifest and survives a
+re-render. The ruleset is:
+
+| Section | Who | What it grants |
+|---|---|---|
+| `[root]` | any authenticated user | read the root collection (`.well-known` discovery) |
+| `[owner]` | any authenticated user | full read/write on their OWN `/<user>/` subtree |
+| `[solaris-subcal]` | `solaris` only | read/write `<resident>/solaris` (shared calendar) |
+| `[solaris-contacts]` | `solaris` only | read/write `<resident>/solaris-contacts` (shared address book) |
+
+`[root]` + `[owner]` together are the equivalent of the old `owner_only`
+module, so **a normal user's access is unchanged**: they still see exactly
+their own collections, and no user can read another user's tree. The two
+`solaris` sections are the only additions — a service account named `solaris`
+(if one exists in LLDAP) can read/write those two named collections under any
+principal, and nothing else. On a box with no such LLDAP account they grant
+nothing.
+
+Required action: **re-deploy** the radicale service so the initContainer writes
+the new `/config/rights` and Radicale starts with `from_file`. Existing installs
+keep `owner_only` until the pod is recreated. If you hand-edited
+`/config/rights` on a running pod, note that it is now generated from the
+template on every deploy — that copy is replaced (which is the point: a
+hand-patched file did not survive a re-render either). Collections on `/data`
+are untouched.
+
 ## v2 (breaking)
 
 **DAV port bound to loopback — no longer LAN-exposed (#2357).**

--- a/templates/radicale/README.md
+++ b/templates/radicale/README.md
@@ -27,7 +27,9 @@ CalDAV/CardDAV clients (DAVx⁵, Thunderbird, iOS, macOS, Outlook) send HTTP Bas
 3. Radicale BIND-DN checks `uid=<username>,ou=people,<base-dn>` against LLDAP
 4. Match → request authorized; user reads/writes their own collections at `/<username>/`
 
-The `[rights] type = owner_only` policy enforces that user X can only see/edit collections at `/X/`. To share a calendar between users, put the principal-collection-set together via the Radicale web UI.
+The `[rights] type = from_file` policy (ruleset at `/config/rights`, written into the pod on every deploy) enforces that user X can only see/edit collections at `/X/` — the same rule the built-in `owner_only` module applies, plus read access to the root collection so `.well-known` discovery works. To share a calendar between users, put the principal-collection-set together via the Radicale web UI.
+
+The one exception in the shipped ruleset: a service account named `solaris` — the household automation account, if you run one — may also read/write exactly two collections under any user, `/<user>/solaris` (calendar) and `/<user>/solaris-contacts` (address book). That is how the automation writes a resident's shared calendar/contacts into their own tree, where they read it as themselves. It cannot touch their other collections or their principal root, and on a box with no such LLDAP user it grants nothing. Edit the `write-config` initContainer in `template.yml` to change the ruleset — a hand-edit on the running pod is wiped on the next re-render.
 
 ## Setup
 

--- a/templates/radicale/migrations/v2-to-v3.py
+++ b/templates/radicale/migrations/v2-to-v3.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Migration: radicale v2 → v3 (#2411).
+
+What changed between v2 and v3: the access-rights MODEL. Under v2 the
+`[rights]` section of Radicale's config was the built-in
+`type = owner_only` module — each authenticated user may touch their
+own `/<user>/` tree and nothing else, with no way to express a single
+exception. v3 switches to `type = from_file` with
+`file = /config/rights`, and the pod's `write-config` initContainer
+seeds that ruleset next to `/config/config` on every deploy.
+
+The ruleset is deliberately owner_only-equivalent plus exactly two
+named exceptions:
+
+  [root]             any authenticated user  → read the root collection
+                     (so /.well-known/{caldav,carddav} discovery works;
+                     this is what owner_only itself returns for `/`)
+  [owner]            any authenticated user  → RrWw on their OWN
+                     `/<user>/` subtree, and nothing else
+  [solaris-subcal]   user `solaris` only     → RrWw on
+                     `<resident>/solaris` (shared calendar)
+  [solaris-contacts] user `solaris` only     → RrWw on
+                     `<resident>/solaris-contacts` (shared address book)
+
+So a normal user's access is unchanged. The two `solaris` sections are
+the only widening: a service account named `solaris` (if such an LLDAP
+user exists at all) may read/write those two named collections under
+any principal — not the principal root, not the resident's other
+calendars or address books. On a box with no `solaris` LLDAP account
+they grant nothing.
+
+Why it had to move into the template: the `[solaris-subcal]` rule used
+to be patched onto the RUNNING pod by hand. `/config` is an in-pod
+emptyDir seeded by the initContainer, so every re-render — an
+`AutoUpdate=registry` image pull re-running `podman kube play
+--replace` — recreated it from the v2 manifest and silently reverted
+the rights to `owner_only`. Carrying the ruleset in the manifest is
+what makes it stick.
+
+The switch is structural: `podman play kube` recreates the pod from
+the v3 manifest, whose initContainer writes both `/config/config` (now
+pointing `[rights]` at the file) and `/config/rights`. Nothing on disk
+moves — Radicale's collections under `/data/collections` are untouched,
+and no collection is created, renamed or deleted by this hop.
+
+What this script does:
+  - Inform the operator that the rights model changed, that normal
+    users see no behaviour change, what the two `solaris` grants are,
+    and that a hand-edited `/config/rights` on a running pod is from
+    now on regenerated from the template on every deploy.
+  - Exit 0. Migration scripts MUST exit 0 to let the deploy continue;
+    a non-zero exit aborts the deploy before the new yaml lands.
+
+This script is intentionally read-only and idempotent — it just logs
+guidance and returns.
+
+Environment available (set by ServiceManager.runMigrationScript):
+  - OLD_SCHEMA_VERSION = 2
+  - NEW_SCHEMA_VERSION = 3
+  - OLD_DATA_DIR, NEW_DATA_DIR (defaults to DATA_DIR for both)
+  - Every wizard variable (PUBLIC_DOMAIN, RADICALE_SUBDOMAIN, …)
+  - SB_NODE, SB_API_URL, SB_API_TOKEN (for callbacks into ServiceBay)
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    print("Radicale v2 → v3: access rights move from the built-in `owner_only`")
+    print("  module to `from_file` (/config/rights), seeded by the pod's")
+    print("  write-config initContainer on every deploy (#2411).")
+    print("  Normal users: NO change. [root] + [owner] reproduce owner_only —")
+    print("  read on the root collection for discovery, full read/write on your")
+    print("  own /<user>/ subtree, no access to anyone else's.")
+    print("  Added: the `solaris` service account (only if such an LLDAP user")
+    print("  exists) may read/write exactly `<resident>/solaris` and")
+    print("  `<resident>/solaris-contacts` under any principal — the shared")
+    print("  calendar and address book the household sync maintains. It still")
+    print("  gets 403 on a resident's other collections and on the principal")
+    print("  root.")
+    print("  Why in the template: a hand-patched /config/rights lived in an")
+    print("  in-pod emptyDir and was wiped on every re-render (image auto-update")
+    print("  → podman kube play --replace), silently reverting to owner_only.")
+    print("  If you hand-edited /config/rights, that copy is now regenerated")
+    print("  from the template on each deploy — edit the template instead.")
+    print("  No data is moved; Radicale's collections under /data are untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/radicale/template.yml
+++ b/templates/radicale/template.yml
@@ -6,7 +6,7 @@ metadata:
     app: radicale
   annotations:
     servicebay.label: "Calendar & Contacts"
-    servicebay.schema-version: "2"
+    servicebay.schema-version: "3"
     servicebay.ports: "{{RADICALE_PORT}}/tcp"
     # caldav.<domain> goes through nginx; auth is the SSO front.
     servicebay.dependencies: "nginx,auth"
@@ -68,13 +68,71 @@ spec:
         filesystem_folder = /data/collections
 
         [rights]
-        type = owner_only
+        # Ruleset lives in /config/rights, written by the second heredoc
+        # below. `owner_only` (the old value) cannot express the one
+        # cross-principal grant the household needs (#2411), and the
+        # equivalent of it is re-expressed as the [root]/[owner] rules there.
+        type = from_file
+        file = /config/rights
 
         [web]
         type = internal
 
         [logging]
         level = info
+        EOF
+        # The rights ruleset, seeded here for the same reason as the config
+        # above: it is part of the pod manifest, so every `podman kube play
+        # --replace` re-creates it. Kept as a live-patched file on the box it
+        # was silently reverted to `owner_only` every time AutoUpdate=registry
+        # pulled a new image and re-rendered the unit from the template
+        # (#2411). Radicale's from_file contract: first matching section
+        # wins; `{0}` is the first capture group of that section's `user`
+        # pattern; upper-case permissions apply to plain collections,
+        # lower-case to calendar/address-book collections and their items.
+        cat > /config/rights <<'EOF'
+        # Any authenticated user may READ the root collection, so
+        # /.well-known/{caldav,carddav} -> `/` principal discovery keeps
+        # working. This is what the built-in `owner_only` module returns for
+        # the root path.
+        [root]
+        user: (.+)
+        collection:
+        permissions: R
+
+        # Owner-only base: every authenticated user has full read/write over
+        # their OWN principal subtree - and nothing else. (Equivalent to the
+        # built-in `owner_only` module.)
+        [owner]
+        user: (.+)
+        collection: {0}(/.*)?
+        permissions: RrWw
+
+        # The `solaris` service account may ADDITIONALLY read/write ONLY the
+        # `solaris` calendar under ANY resident's principal - the per-resident
+        # calendar the deadlines/tasks sync writes. It reaches
+        # `<resident>/solaris` + its items, but NOT the resident's other
+        # calendars nor the principal root: no shared password, no broad
+        # access.
+        [solaris-subcal]
+        user: solaris
+        collection: [^/]+/solaris(/.*)?
+        permissions: RrWw
+
+        # Same deal for contacts: the CardDAV address book that sync writes
+        # per resident lives at `<resident>/solaris-contacts` (#2411). Without
+        # this the account had nowhere to put an address book - the calendar
+        # rule matches `.../solaris` exactly, a calendar is a leaf so nothing
+        # nests under it, and the account's own `/solaris/...` tree is exactly
+        # the one the resident may not read.
+        # Deliberately a second rule rather than widening the pattern above to
+        # `solaris(-[a-z]+)?`: every collection this service account may touch
+        # is then named explicitly, and `<resident>/solaris-<anything-else>`
+        # stays a 403.
+        [solaris-contacts]
+        user: solaris
+        collection: [^/]+/solaris-contacts(/.*)?
+        permissions: RrWw
         EOF
     volumeMounts:
       - mountPath: /config

--- a/tests/backend/durable_write_crash_safety.test.ts
+++ b/tests/backend/durable_write_crash_safety.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsSync from 'fs';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+/**
+ * #2414 — a crash landing inside a durable-state write must leave the ORIGINAL
+ * file intact, never a truncated one.
+ *
+ * `config.json` and `checks.json` under DATA_DIR are operator data, not caches:
+ * a truncated `config.json` re-onboards the box (domain / auth / service config
+ * gone), a truncated `checks.json` drops every configured health check. Both
+ * used to be written with a bare `fs.writeFile` / `fs.writeFileSync`, which
+ * truncates the target *before* the new bytes land — so a power cut, OOM-kill
+ * or container stop mid-write destroyed the file permanently.
+ *
+ * The fault isn't reproducible on a live box, so it is injected here: a real,
+ * fully populated file sits in a temp DATA_DIR while the write syscall is made
+ * to land a partial prefix and then throw. Each `survives` case is paired with
+ * a `control` case that performs the *pre-fix* truncate-then-partial-write
+ * against the same file — the control must destroy it, otherwise the injection
+ * would be vacuous and the survival assertion would prove nothing.
+ */
+
+let dataDir = '';
+
+vi.mock('@/lib/dirs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/dirs')>();
+  return {
+    ...actual,
+    get DATA_DIR() { return dataDir; },
+    get SSH_DIR() { return path.join(dataDir, 'ssh'); },
+  };
+});
+
+const eio = () => Object.assign(new Error('EIO: injected crash mid-write'), { code: 'EIO' });
+
+/** Files vitest/atomicWrite may leave behind: `.config.json.<pid>.<hex>.tmp`. */
+const strayTmpFiles = () => fsSync.readdirSync(dataDir).filter(f => f.endsWith('.tmp'));
+
+/**
+ * What a bare `fs.writeFile(path, data)` does when the process dies mid-call:
+ * open with 'w' (which truncates immediately), write part of the payload, then
+ * stop. No temp file, no rename — the original bytes are already gone.
+ */
+async function bareWriteInterrupted(target: string, data: string) {
+  const handle = await fs.open(target, 'w');
+  await handle.writeFile(data.slice(0, Math.floor(data.length / 2)));
+  await handle.close();
+}
+
+// ---------------------------------------------------------------------------
+// ConfigTransformer — the boot-time normalizer (async, atomicWriteFile).
+// ---------------------------------------------------------------------------
+describe('ConfigTransformer config write survives a crash mid-write (#2414)', () => {
+  let configPath = '';
+  // Legacy shape, so both transforms fire and the transformer actually writes.
+  const ORIGINAL = {
+    serverName: 'already-configured-box',
+    setupCompleted: true,
+    gateway: { type: 'fritzbox', host: '192.168.178.1', username: 'admin' },
+    publicDomain: 'example.com',
+    externalLinks: [
+      { id: 'legacy', name: 'Legacy', url: 'https://example.com', ip_targets: ['10.0.0.1:80'] },
+    ],
+  };
+  const ORIGINAL_TEXT = JSON.stringify(ORIGINAL, null, 2);
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-durable-config-'));
+    configPath = path.join(dataDir, 'config.json');
+    await fs.writeFile(configPath, ORIGINAL_TEXT);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Fault-inject the write itself, at BOTH entry points the module could use,
+   * so the outcome is a property of the writer and not of the injection:
+   *  - `fs.open` (the atomic path) — real open, but the returned handle's
+   *    `writeFile` lands half the payload on the temp file and then throws;
+   *  - `fs.writeFile` (the bare path) — truncating open, half the payload,
+   *    then throw, i.e. exactly what a crash inside a bare write looks like.
+   * Only the atomic writer can survive this; a bare writer loses the file.
+   */
+  function injectPartialWriteThenCrash() {
+    const realOpen = fs.open.bind(fs);
+    const halve = (data: unknown) => {
+      const text = typeof data === 'string' ? data : Buffer.from(data as Uint8Array).toString();
+      return text.slice(0, Math.floor(text.length / 2));
+    };
+    vi.spyOn(fs, 'writeFile').mockImplementation((async (target: unknown, data: unknown) => {
+      const handle = await realOpen(String(target), 'w');
+      await handle.writeFile(halve(data));
+      await handle.close();
+      throw eio();
+    }) as typeof fs.writeFile);
+    vi.spyOn(fs, 'open').mockImplementation((async (...args: Parameters<typeof fs.open>) => {
+      const handle = await realOpen(...args);
+      const realWrite = handle.writeFile.bind(handle);
+      handle.writeFile = (async (data: string | Uint8Array, opts?: unknown) => {
+        await realWrite(halve(data), opts as Parameters<typeof handle.writeFile>[1]);
+        throw eio();
+      }) as typeof handle.writeFile;
+      return handle;
+    }) as typeof fs.open);
+  }
+
+  it('leaves config.json fully intact when the write dies half-written', async () => {
+    injectPartialWriteThenCrash();
+    const { ConfigTransformer } = await import('@/lib/config/transformer');
+    const outcome = await new ConfigTransformer(configPath).run().then(() => null, (e: Error) => e);
+
+    // The load-bearing assertion: whatever the writer did, the operator's
+    // config must still be on disk, whole and parseable.
+    const after = fsSync.readFileSync(configPath, 'utf-8');
+    expect(after).toBe(ORIGINAL_TEXT);
+    expect(JSON.parse(after)).toEqual(ORIGINAL);
+    expect(strayTmpFiles()).toEqual([]);
+    expect(outcome?.message).toMatch(/injected crash/);
+  });
+
+  it('leaves config.json fully intact when the crash lands on the rename', async () => {
+    vi.spyOn(fs, 'rename').mockRejectedValue(eio());
+    const { ConfigTransformer } = await import('@/lib/config/transformer');
+
+    await expect(new ConfigTransformer(configPath).run()).rejects.toThrow(/injected crash/);
+
+    expect(JSON.parse(await fs.readFile(configPath, 'utf-8'))).toEqual(ORIGINAL);
+    expect(strayTmpFiles()).toEqual([]);
+  });
+
+  it('control: the pre-fix bare write truncates config.json under the same fault', async () => {
+    await bareWriteInterrupted(configPath, JSON.stringify({ ...ORIGINAL, schemaVersion: 1 }, null, 2));
+
+    const after = await fs.readFile(configPath, 'utf-8');
+    expect(after).not.toBe(ORIGINAL_TEXT);
+    expect(() => JSON.parse(after)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HealthStore.writeChecks — the operator's configured checks (sync).
+// ---------------------------------------------------------------------------
+describe('HealthStore.writeChecks survives a crash mid-write (#2414)', () => {
+  let checksFile = '';
+  const FIRST = { id: 'check-1', name: 'Gateway', type: 'ping', target: '192.168.178.1', interval: 60 };
+  const SECOND = { id: 'check-2', name: 'Portal', type: 'http', target: 'https://example.com', interval: 60 };
+
+  async function loadStore() {
+    vi.resetModules();
+    return (await import('@/lib/health/store')).HealthStore;
+  }
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sb-durable-checks-'));
+    checksFile = path.join(dataDir, 'checks.json');
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  /** Land a partial payload on the (temp) fd, then throw. */
+  function injectPartialWriteSyncThenCrash() {
+    const real = fsSync.writeFileSync.bind(fsSync);
+    return vi.spyOn(fsSync, 'writeFileSync').mockImplementation(((
+      target: Parameters<typeof fsSync.writeFileSync>[0],
+      data: Parameters<typeof fsSync.writeFileSync>[1],
+      opts?: Parameters<typeof fsSync.writeFileSync>[2],
+    ) => {
+      const text = typeof data === 'string' ? data : Buffer.from(data as Uint8Array).toString();
+      real(target, text.slice(0, Math.floor(text.length / 2)), opts);
+      throw eio();
+    }) as typeof fsSync.writeFileSync);
+  }
+
+  it('leaves checks.json fully intact when the write dies half-written', async () => {
+    const HealthStore = await loadStore();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    HealthStore.saveCheck(FIRST as any);
+    const before = fsSync.readFileSync(checksFile, 'utf-8');
+    expect(JSON.parse(before)).toHaveLength(1);
+
+    injectPartialWriteSyncThenCrash();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => HealthStore.saveCheck(SECOND as any)).toThrow(/injected crash/);
+    vi.restoreAllMocks();
+
+    const after = fsSync.readFileSync(checksFile, 'utf-8');
+    expect(after).toBe(before);
+    expect(JSON.parse(after).map((c: { id: string }) => c.id)).toEqual(['check-1']);
+    expect(strayTmpFiles()).toEqual([]);
+  });
+
+  it('control: the pre-fix bare write truncates checks.json under the same fault', async () => {
+    const HealthStore = await loadStore();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    HealthStore.saveCheck(FIRST as any);
+    const before = fsSync.readFileSync(checksFile, 'utf-8');
+
+    await bareWriteInterrupted(checksFile, JSON.stringify([FIRST, SECOND], null, 2));
+
+    const after = fsSync.readFileSync(checksFile, 'utf-8');
+    expect(after).not.toBe(before);
+    expect(() => JSON.parse(after)).toThrow();
+  });
+});

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -456,6 +456,160 @@ describe('Auth template: LLDAP HTTP port is loopback-bound (#2380)', () => {
   });
 });
 
+// ─── 3b3. Radicale template: rights ruleset is baked in (#2411) ─────────────
+describe('Radicale template: rights ruleset (#2411)', () => {
+  const radicale = templates.find(t => t.name === 'radicale')!;
+
+  /** Render the pod and return the write-config initContainer's shell script. */
+  const initScript = (): string => {
+    const view: Record<string, string> = {};
+    for (const v of catalogVars) view[v] = `stub-${v.toLowerCase()}`;
+    for (const [name, meta] of Object.entries(radicale.variables)) {
+      if (meta && typeof meta === 'object' && 'default' in meta && typeof meta.default === 'string') {
+        view[name] = meta.default;
+      }
+    }
+    const rendered = Mustache.render(radicale.yamlContent, view);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pod = yaml.loadAll(rendered).find((d: any) => d?.kind === 'Pod') as any;
+    const init = (pod?.spec?.initContainers ?? []).find((c: { name: string }) => c.name === 'write-config');
+    return (init?.args ?? []).join('\n');
+  };
+
+  /** Pull one `cat > <file> <<'EOF' … EOF` heredoc body out of that script. */
+  const heredoc = (file: string): string => {
+    const lines = initScript().split('\n');
+    const start = lines.findIndex(l => l.startsWith(`cat > ${file} <<`));
+    expect(start, `no heredoc writing ${file} in the write-config initContainer`).toBeGreaterThanOrEqual(0);
+    const end = lines.indexOf('EOF', start + 1);
+    expect(end, `unterminated heredoc for ${file}`).toBeGreaterThan(start);
+    return lines.slice(start + 1, end).join('\n');
+  };
+
+  /** Minimal INI parse of a Radicale rights file, preserving section order. */
+  const rules = (): { name: string; user: string; collection: string; permissions: string }[] => {
+    const out: { name: string; user: string; collection: string; permissions: string }[] = [];
+    for (const raw of heredoc('/config/rights').split('\n')) {
+      const line = raw.trim();
+      if (!line || line.startsWith('#')) continue;
+      const section = line.match(/^\[(.+)\]$/);
+      if (section) {
+        out.push({ name: section[1], user: '', collection: '', permissions: '' });
+        continue;
+      }
+      const kv = line.match(/^([a-z]+)\s*:\s*(.*)$/);
+      if (!kv || out.length === 0) continue;
+      const cur = out[out.length - 1];
+      if (kv[1] === 'user') cur.user = kv[2];
+      else if (kv[1] === 'collection') cur.collection = kv[2];
+      else if (kv[1] === 'permissions') cur.permissions = kv[2];
+    }
+    return out;
+  };
+
+  /**
+   * Evaluate the ruleset the way Radicale's `from_file` rights backend does:
+   * fullmatch the `user` pattern against the login, substitute that match's
+   * capture groups into the `collection` pattern's `{N}` placeholders,
+   * fullmatch it against the sanitised path — FIRST matching section wins,
+   * everything else is a 403. `''` means no access.
+   */
+  const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const authorization = (user: string, collectionPath: string): string => {
+    const path = collectionPath.replace(/^\/+|\/+$/g, '');
+    for (const rule of rules()) {
+      const userMatch = new RegExp(`^(?:${rule.user})$`).exec(user);
+      if (!userMatch) continue;
+      const pattern = rule.collection.replace(/\{(\d+)\}/g, (_m, i: string) =>
+        escapeRe(userMatch[Number(i) + 1] ?? ''));
+      if (new RegExp(`^(?:${pattern})$`).test(path)) return rule.permissions;
+    }
+    return '';
+  };
+
+  it('points [rights] at the generated /config/rights file instead of owner_only', () => {
+    // owner_only is a built-in module with no way to express a single
+    // cross-principal exception, so the household sync account had to be
+    // granted by hand on the running pod — where /config is an in-pod
+    // emptyDir, so the next `podman kube play --replace` wiped it.
+    const config = heredoc('/config/config');
+    expect(config).toMatch(/^\[rights\]$/m);
+    expect(config).toMatch(/^type = from_file$/m);
+    expect(config).toMatch(/^file = \/config\/rights$/m);
+    expect(config).not.toMatch(/^type = owner_only$/m);
+  });
+
+  it('seeds /config/rights from the pod manifest, so it survives a re-render', () => {
+    // The whole point of #2411: the ruleset is part of the manifest the
+    // initContainer replays on EVERY deploy. If this heredoc ever moves
+    // back out to a host file or a live patch, the rule silently reverts
+    // the next time AutoUpdate=registry pulls an image.
+    expect(rules().map(r => r.name)).toEqual([
+      'root', 'owner', 'solaris-subcal', 'solaris-contacts',
+    ]);
+    for (const r of rules()) {
+      expect(r.permissions, `section [${r.name}] declares no permissions`).not.toBe('');
+    }
+  });
+
+  it('reproduces owner_only for a normal resident', () => {
+    // [root] + [owner] must be behaviourally equivalent to the module they
+    // replace: read on the root collection (so .well-known discovery still
+    // resolves a principal), full access to your own subtree, nothing else.
+    expect(authorization('mdopp', '/')).toBe('R');
+    expect(authorization('mdopp', '/mdopp/')).toBe('RrWw');
+    expect(authorization('mdopp', '/mdopp/calendar/')).toBe('RrWw');
+    expect(authorization('mdopp', '/mdopp/solaris/')).toBe('RrWw');
+    expect(authorization('mdopp', '/mdopp/solaris-contacts/')).toBe('RrWw');
+    expect(authorization('mdopp', '/mdopp/calendar/event.ics')).toBe('RrWw');
+    // …and no reach into another resident's tree, at any depth.
+    expect(authorization('mdopp', '/alice/')).toBe('');
+    expect(authorization('mdopp', '/alice/calendar/')).toBe('');
+    expect(authorization('alice', '/mdopp/solaris-contacts/')).toBe('');
+  });
+
+  it('lets the solaris account write the shared calendar AND address book', () => {
+    // The address-book half is the fix (#2411): before it, all three
+    // plausible paths failed — /<resident>/solaris-contacts/ 403 (the
+    // calendar rule matches `…/solaris` exactly), /<resident>/solaris/…
+    // 403 (a calendar is a leaf), and /solaris/contacts/ landed in the
+    // service account's own tree, which the resident may not read.
+    expect(authorization('solaris', '/mdopp/solaris/')).toBe('RrWw');
+    expect(authorization('solaris', '/mdopp/solaris-contacts/')).toBe('RrWw');
+    expect(authorization('solaris', '/mdopp/solaris-contacts/card.vcf')).toBe('RrWw');
+    // Lower-case letters are the ones that matter for MKCOL/MKCALENDAR on a
+    // calendar/address-book collection; upper-case covers plain collections.
+    expect(authorization('solaris', '/mdopp/solaris-contacts/')).toContain('w');
+  });
+
+  it('keeps the solaris account out of everything else', () => {
+    // The grant stays two named collections wide. A resident's own
+    // calendars, their principal root, and any other solaris-prefixed name
+    // are all still 403 — which is why this is two explicit sections rather
+    // than a widened `solaris(-[a-z]+)?` pattern.
+    expect(authorization('solaris', '/mdopp/')).toBe('');
+    expect(authorization('solaris', '/mdopp/eb58abcb-1234-5678-9abc-def012345678/')).toBe('');
+    expect(authorization('solaris', '/mdopp/calendar/')).toBe('');
+    expect(authorization('solaris', '/mdopp/contacts/')).toBe('');
+    expect(authorization('solaris', '/mdopp/solaris-secrets/')).toBe('');
+    expect(authorization('solaris', '/alice/')).toBe('');
+    // Its own principal subtree is still its own — via [owner], like anyone.
+    expect(authorization('solaris', '/solaris/')).toBe('RrWw');
+  });
+
+  it('schema-version is bumped to 3 with a CHANGELOG section and a v2-to-v3 migration', () => {
+    expect(radicale.yamlContent).toMatch(/servicebay\.schema-version:\s*"3"/);
+    const changelog = fs.readFileSync(path.join(TEMPLATES_DIR, 'radicale', 'CHANGELOG.md'), 'utf-8');
+    expect(changelog).toMatch(/##\s*v3\b.*\(breaking\)/);
+    const mig = fs.readFileSync(
+      path.join(TEMPLATES_DIR, 'radicale', 'migrations', 'v2-to-v3.py'), 'utf-8',
+    );
+    // Config-only hop — no collection may be moved, renamed or deleted.
+    expect(mig).not.toMatch(/shutil\.(move|rmtree)|os\.remove|\.unlink\(|\.rename\(/);
+    expect(mig).toMatch(/untouched/i);
+  });
+});
+
 // ─── 3c. Media template retires Audiobookshelf for fresh installs (#1725) ───
 describe('Media template: Audiobookshelf retired for fresh installs (#1725)', () => {
   const media = templates.find(t => t.name === 'media')!;


### PR DESCRIPTION
Autoloop batch `batch/2026-07-28d` — 2 units.

- **radicale rights model baked into the template** (#2411): the `solaris` service account's calendar-write rule existed only as a live/manual patch, wiped on every re-render. Now the full `from_file` rights mechanism (owner-only base + the solaris calendar rule + a new solaris-contacts rule) is generated by the template itself. Schema v2→v3.
- **Durable-state writes hardened against mid-write corruption** (#2414): `config.json`'s boot-time normalizer and the health-check store both wrote via a bare `fs.writeFile`, unlike every other config writer's tmp→fsync→rename. A crash mid-write could permanently truncate the box's whole config. Both routed through `atomicWriteFile`; a new check-invariants ratchet (`durable-state-atomic-write`) fails CI if a bare write touches a listed durable-state module again, or if a listed module is renamed away without updating the list.

Closes #2411
Closes #2414

Local safety-net gate green: lint, typecheck, check:arch, npm test (491 files, 4427 passed / 2 skipped).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
