### PR TITLE
fix(backend): post-deploy scripts run verbatim, not through Mustache (#2415)

### DIFF
--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -283,6 +283,18 @@ if __name__ == "__main__":
   on POSTs to `SB_API_URL`; without it the same-origin guard
   rejects the call (see `auth/post-deploy.py` for the canonical
   pattern).
+- `LAN_IP` / `OPERATOR_EMAIL` — best-effort server-side context (the
+  LAN address rootless podman forwards to, and the operator's
+  notification address). Unset if ServiceBay doesn't know them.
+
+The env is the **only** channel. The script body ships to the box
+**verbatim** — it is *not* Mustache-rendered (#2415), so `{{VAR}}` in a
+script is dead text, not a substitution. Read `os.environ` instead.
+The upside: podman/docker `--format '{{.Image}}'` Go templates, Helm
+and Jinja snippets, and Python f-string `{{…}}` escapes all survive
+intact. (Rendering used to delete every unrecognised `{{…}}` silently,
+turning a `--format` string into `--format '|'` — which podman answers
+with exit 0, so it read as "empty field" for five debugging rounds.)
 
 #### Output protocol
 
@@ -353,6 +365,12 @@ versions behind. See #352 phase 3.
 The script protocol is identical to `post-deploy.py` (env file →
 `source` → `python3`, stdout streamed live to the install log)
 with two important differences:
+
+> **One asymmetry to know about:** unlike `post-deploy.py`, migration
+> bodies are still Mustache-rendered before they run, so an unrecognised
+> `{{…}}` is deleted (#2435 tracks removing that). Read your values from
+> `os.environ` and don't put Go-template/Jinja/Helm syntax in a migration
+> until it's closed.
 
 1. **Migrations are fail-fast.** A non-zero exit aborts the deploy
    *before* the new yaml lands — the existing service keeps running

--- a/packages/backend/src/lib/install/runner.test.ts
+++ b/packages/backend/src/lib/install/runner.test.ts
@@ -8,6 +8,8 @@
  * The twin is mocked the same way `stackRunner.test.ts` does it, so the
  * gate reads deterministic fixtures instead of a live digital twin.
  */
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const twinStub: {
@@ -35,7 +37,18 @@ vi.mock('@/lib/auth/internalToken', () => ({
   getInternalApiToken: () => 'test-token',
 }));
 
-import { isServiceReady, waitForDependencies, ensureProxyHosts, authDynamicVars } from './runner';
+// #2415 — post-deploy.py bodies must reach the box byte-identical. The
+// registry is the source of the raw script; stub it so the test controls
+// the exact bytes going in.
+const postDeployScriptMock = vi.fn<(name: string, source?: string) => Promise<string | null>>();
+vi.mock('@/lib/registry', () => ({
+  getTemplatePostDeployScript: (name: string, source?: string) => postDeployScriptMock(name, source),
+  getTemplateMigrationScripts: vi.fn(),
+  getTemplateYaml: vi.fn(),
+  syncRegistries: vi.fn(),
+}));
+
+import { isServiceReady, waitForDependencies, ensureProxyHosts, authDynamicVars, loadPostDeployScript } from './runner';
 import type { StackVariable } from '@/lib/stackInstall/postInstall';
 
 const fetchSpy = vi.spyOn(globalThis, 'fetch');
@@ -153,5 +166,69 @@ describe('ensureProxyHosts', () => {
   it('no-ops when there are no subdomain-typed variables', async () => {
     await ensureProxyHosts('job1', [{ name: 'PUBLIC_DOMAIN', value: 'dopp.cloud' }], undefined);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('loadPostDeployScript — script bodies ship verbatim (#2415)', () => {
+  beforeEach(() => {
+    postDeployScriptMock.mockReset();
+  });
+
+  it('returns the raw script byte-identical, foreign {{…}} expressions intact', async () => {
+    // The exact shape that cost mdopp/solarisbay#1092 five debugging
+    // rounds: Mustache deleted both Go-template tags, leaving `--format '|'`,
+    // which podman answers with `|` and exit 0.
+    const raw = [
+      '#!/usr/bin/env python3',
+      'import os, subprocess',
+      'FMT = \'{{.Image}}|{{index .Config.Labels "org.opencontainers.image.revision"}}\'',
+      'HOST = os.environ.get("HOST", "localhost")',
+      'JINJA = "{{ ansible_hostname }}"',
+      'HELM = "{{ .Values.image.tag }}"',
+      'SUBJECT = f\'subject: "[Authelia] {{title}}"\'',
+      'print(subprocess.run(["podman", "inspect", "--format", FMT]))',
+    ].join('\n');
+    postDeployScriptMock.mockResolvedValue(raw);
+
+    const out = await loadPostDeployScript('solaris', 'Built-in');
+
+    // Byte-identical — no substitution, no deletion, no re-encoding.
+    expect(out).toBe(raw);
+    expect(out).toContain('{{.Image}}');
+    expect(out).toContain('{{index .Config.Labels "org.opencontainers.image.revision"}}');
+    expect(out).toContain('{{ ansible_hostname }}');
+    expect(out).toContain('{{ .Values.image.tag }}');
+    expect(out).toContain('{{title}}');
+    // The pre-#2415 behaviour: every unknown tag rendered to empty.
+    expect(out).not.toContain("--format '|'");
+    expect(postDeployScriptMock).toHaveBeenCalledWith('solaris', 'Built-in');
+  });
+
+  it('leaves a known ServiceBay variable name alone too — env is the only channel', async () => {
+    // `HOST`/`DATA_DIR` ARE in the render view, so the old code would have
+    // substituted them into the source. Scripts read them from os.environ.
+    const raw = 'BASE = os.environ.get("DATA_DIR", "/mnt/data")  # not {{DATA_DIR}}\n';
+    postDeployScriptMock.mockResolvedValue(raw);
+    expect(await loadPostDeployScript('auth')).toBe(raw);
+  });
+
+  it('returns undefined when the template ships no script or the fetch fails', async () => {
+    postDeployScriptMock.mockResolvedValue(null);
+    expect(await loadPostDeployScript('nginx')).toBeUndefined();
+    postDeployScriptMock.mockResolvedValue('');
+    expect(await loadPostDeployScript('nginx')).toBeUndefined();
+    postDeployScriptMock.mockRejectedValue(new Error('registry unreachable'));
+    await expect(loadPostDeployScript('nginx')).resolves.toBeUndefined();
+  });
+
+  it('the deploy call site never re-introduces a render pass', () => {
+    // Guards the seam: the behavioural test above only proves the loader is
+    // a pass-through, not that `deployItem` stopped wrapping it.
+    const src = fs.readFileSync(path.join(__dirname, 'runner.ts'), 'utf-8');
+    const assignment = src.match(/const postDeployScript = .*/);
+    expect(assignment?.[0]).toBe(
+      'const postDeployScript = await loadPostDeployScript(item.name, input.templateSource);',
+    );
+    expect(src).not.toMatch(/postDeployScript\s*=\s*renderTemplate/);
   });
 });

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -556,6 +556,39 @@ export async function preserveAutheliaOidcClients(
   }
 }
 
+/**
+ * Load a template's `post-deploy.py` **verbatim** — never Mustache-rendered (#2415).
+ *
+ * Template values reach the script through its process environment
+ * (`postDeployEnv` in `deployItem`: every wizard variable plus HOST,
+ * LAN_IP and OPERATOR_EMAIL), so a text-substitution pass over the
+ * script body buys nothing and costs a lot:
+ *
+ *   - Mustache DELETES every `{{…}}` it doesn't recognise as a known
+ *     variable. That silently ate a `podman inspect --format
+ *     '{{.Image}}|{{index .Config.Labels "…"}}'` down to `--format '|'`,
+ *     which podman answers with `|` and exit 0 — indistinguishable from
+ *     "field is empty" (mdopp/solarisbay#1092: five debugging rounds
+ *     chasing a race that never existed). Go templates, Helm, Jinja and
+ *     Python f-string `{{…}}` escapes are all in the blast radius.
+ *   - Splicing a raw value into Python *source* is a correctness hazard
+ *     in its own right: a quote, apostrophe or newline in the value
+ *     breaks the script's syntax. `os.environ` has no such failure mode.
+ *
+ * Keep this a pass-through. If a script needs a value, add it to
+ * `postDeployEnv` — do not reintroduce rendering.
+ */
+export async function loadPostDeployScript(
+  name: string,
+  source?: string,
+): Promise<string | undefined> {
+  try {
+    return (await getTemplatePostDeployScript(name, source)) || undefined;
+  } catch {
+    return undefined; // template ships no script — fine
+  }
+}
+
 /** Deploy a single template via /api/services?stream=1. Returns true on
  *  successful deploy, false on terminal failure. Retries transient
  *  failures up to MAX_DEPLOY_ATTEMPTS. */
@@ -695,12 +728,9 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
 
   // Optional per-template post-deploy.py — server runs it after the unit
   // starts; output streams back via `progress` events. Parsed below for
-  // `__SB_CREDENTIAL__ {json}` markers.
-  let postDeployScript: string | undefined;
-  try {
-    const raw = await getTemplatePostDeployScript(item.name, input.templateSource);
-    if (raw) postDeployScript = renderTemplate(raw, view);
-  } catch { /* template ships no script — fine */ }
+  // `__SB_CREDENTIAL__ {json}` markers. The body ships VERBATIM: values
+  // travel via `postDeployEnv` below, not by text substitution (#2415).
+  const postDeployScript = await loadPostDeployScript(item.name, input.templateSource);
 
   // Migration chain — discover via upgrade-preview, render any selected
   // steps with Mustache. Best-effort: a fetch failure here shouldn't

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -2514,5 +2514,101 @@ class ImmichScript(unittest.TestCase):
         self.assertIn("admin row pre-dates this install", out)
 
 
+class VerbatimScriptBodies(unittest.TestCase):
+    """#2415 — post-deploy.py bodies are no longer Mustache-rendered.
+
+    Every `{{…}}` left in a first-party script is either prose (a
+    docstring/comment naming the template.yml placeholder) or a Python
+    f-string brace escape. None of them was ever a value-delivery
+    mechanism: the values arrive through the process environment
+    (`postDeployEnv` in packages/backend/src/lib/install/runner.ts).
+    These cases pin that down site by site, so a future author can't
+    quietly start depending on a render pass that no longer happens.
+    """
+
+    # The seven `{{…}}` sites across templates/*/post-deploy.py, and the
+    # env var that actually carries the value (None = prose only).
+    SITES = [
+        ("auth", "DATA_DIR"),            # authelia_db_path() docstring
+        ("auth", None),                  # f-string escape: subject "[Authelia] {title}"
+        ("nginx", "DATA_DIR"),           # npm_db_path() docstring
+        ("file-share", "DATA_DIR"),      # _notes_dir() docstring
+        ("home-assistant", "DATA_DIR"),  # _ha_config_dir() docstring
+        ("home-assistant", "ZWAVE_DEVICE"),  # udev/zwave.port docstring
+        ("immich", None),                # comment: podman --format '{{.State}}'
+    ]
+
+    def test_all_seven_sites_are_accounted_for(self):
+        """Guard the inventory: if a new `{{…}}` appears in a post-deploy
+        script, this fails until someone confirms it doesn't need a render."""
+        found = []
+        for script in sorted(TEMPLATES_DIR.glob("*/post-deploy.py")):
+            text = script.read_text(encoding="utf-8")
+            found.extend([script.parent.name] * text.count("{{"))
+        self.assertEqual(
+            sorted(found),
+            sorted(name for name, _ in self.SITES),
+            "post-deploy.py `{{…}}` inventory changed — confirm the new site "
+            "reads its value from os.environ, then update SITES.",
+        )
+
+    def test_data_dir_paths_resolve_from_the_environment(self):
+        """The four DATA_DIR docstring sites: the path helper next to each
+        docstring reads DATA_DIR from os.environ, with a sane default."""
+        cases = [
+            ("auth", "authelia_db_path", ("auth", "authelia-data", "db.sqlite3")),
+            ("nginx", "npm_db_path", ("nginx-proxy-manager", "data", "database.sqlite")),
+            ("file-share", "_notes_dir", ("file-share", "data", "notes")),
+            ("home-assistant", "_ha_config_dir", ("home-assistant", "homeassistant")),
+        ]
+        for template, fn_name, tail in cases:
+            with self.subTest(template=template):
+                m = load_script(template)
+                fn = getattr(m, fn_name)
+                with run_with_env({"DATA_DIR": "/srv/from-env"}):
+                    self.assertEqual(fn(), os.path.join("/srv/from-env", *tail))
+                # Unset → documented fallback, never an empty path.
+                with run_with_env({}):
+                    self.assertEqual(fn(), os.path.join("/mnt/data", *tail))
+
+    def test_zwave_device_resolves_from_the_environment(self):
+        """home-assistant's `{{ZWAVE_DEVICE}}` docstring names the
+        template.yml mount; the script itself reads the value from env."""
+        m = load_script("home-assistant")
+        with run_with_env({"ZWAVE_DEVICE": "/dev/ttyACM0"}):
+            self.assertEqual(m.env("ZWAVE_DEVICE"), "/dev/ttyACM0")
+        with run_with_env({}):
+            self.assertEqual(m.env("ZWAVE_DEVICE"), "")
+
+    def test_authelia_smtp_subject_keeps_its_title_placeholder(self):
+        """The one site the render pass actively BROKE: `{{title}}` is an
+        f-string escape producing Authelia's own `{title}` token. Mustache
+        deleted it, deploying `subject: "[Authelia] "`."""
+        m = load_script("auth")
+        block = m._smtp_notifier_block({
+            "host": "smtp.gmail.com",
+            "port": 587,
+            "secure": False,
+            "user": "me@example.com",
+            "pass": "p",
+            "from": "me@example.com",
+        })
+        self.assertIn('subject: "[Authelia] {title}"', block)
+        self.assertNotIn('subject: "[Authelia] "', block)
+
+    def test_go_template_format_strings_survive_in_a_script_body(self):
+        """The mdopp/solarisbay#1092 shape, asserted on the Python side:
+        a script may embed a podman/docker Go-template format string and
+        it must still be there when the file is read for execution."""
+        sample = "'{{.Image}}|{{index .Config.Labels \"org.opencontainers.image.revision\"}}'"
+        # Compiles as valid Python source with the tags intact (the runner
+        # ships exactly these bytes; see runner.test.ts for the transport).
+        compile(f"FMT = {sample}\n", "<sample>", "exec")
+        scope: dict[str, Any] = {}
+        exec(f"FMT = {sample}\n", scope)  # noqa: S102 - fixed literal
+        self.assertIn("{{.Image}}", scope["FMT"])
+        self.assertNotEqual(scope["FMT"].strip("'"), "|")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Autoloop batch `batch/2026-07-28a` — 1 unit.

- **post-deploy.py scripts no longer run through Mustache** (#2415): every template variable a post-deploy script needs is already delivered via environment (`postDeployEnv`), so rendering the script body through Mustache was a redundant second channel — one that silently deleted any foreign `{{...}}` expression (Go-template, Jinja, Helm) it didn't recognize. Confirmed all 7 existing `{{VAR}}`-shaped sites across first-party post-deploy scripts were already docstring prose or comments read via `os.environ` — except one real live bug this fix corrects: Authelia's mail-subject `{{title}}` f-string was being actively mangled by the render, deploying subjects as `"[Authelia] "` with the title stripped.
- Migration scripts share the same render-then-exec risk — deliberately deferred rather than silently expanding scope; filed as #2435 and documented in `docs/TEMPLATE_AUTHORING.md`.

Closes #2415

Local safety-net gate green: lint, typecheck, check:arch, npm test (491 files, 4431 passed / 2 skipped).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
