### PR TITLE
fix(security): Z-Wave LAN exposure, claude-dev RCE, OIDC secret rotation + 7 more (deep-eval batch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ name: CI
 #   semgrep     — security & coupling patterns (executor.exec template literals,
 #                 tar extraction bypass, eval/Function, SSRF-prone fetches,
 #                 missing withApiHandler)
+#   dev-image   — builds Dockerfile.dev (the `scripts/dev-container.sh` image)
+#                 and smoke-checks that the backend runtime deps load and the
+#                 bundled server boots without a missing-module crash (#2422)
 #
 # ANY failure blocks merge. Adoption-ratio floors and per-file ratchets in the
 # config files mean today's debt passes — new regressions do not.
@@ -340,3 +343,66 @@ jobs:
       # unusable — the exact failure that would break the release build.
       - name: package-lock.json in sync with manifests (strict, matches Docker npm ci)
         run: npm ci --dry-run --no-audit --no-fund
+
+  # Dev-container image build (#2422). Nothing in CI ever built Dockerfile.dev,
+  # so it rotted silently: its `npm ci` copied only the ROOT manifests, the
+  # `workspaces: ["packages/*"]` glob resolved to nothing, and the dev image
+  # shipped without ssh2 / better-sqlite3 / node-pty / nodemailer — every
+  # `scripts/dev-container.sh up` crash-looped on "Cannot find module 'ssh2'".
+  # This job builds the image the same way dev-container.sh does (host build
+  # first, then `docker build -f Dockerfile.dev`) and then asserts the thing
+  # that actually broke: the backend runtime deps resolve inside the image and
+  # the bundled server boots without a missing-module crash. Build-only — the
+  # dev image is never pushed or published.
+  dev-image:
+    runs-on: ubuntu-latest
+    if: "${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--') }}"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v6
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          # Node version is part of the key: native modules (e.g. better-sqlite3)
+          # are compiled against a specific Node ABI. Without it, a cache built on
+          # Node 20 (ABI 115) is reused on Node 22 (ABI 127), causing ERR_DLOPEN_FAILED.
+          key: node-modules-v3-node22-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        if: steps.cache-npm.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --no-audit --no-fund
+      # Dockerfile.dev deliberately skips the in-container Next build and copies
+      # prebuilt .next/ + dist-server/ from the build context — scripts/dev-container.sh
+      # runs exactly this on the host before invoking the engine.
+      - name: Host build (.next + dist-server)
+        run: npm run build
+      - name: Build dev image
+        run: docker build -f Dockerfile.dev -t servicebay:dev .
+      # The rot this job exists to catch: these four live in
+      # packages/backend/package.json, not the root manifest, and the bundled
+      # server resolves them from /app/node_modules only.
+      - name: Backend runtime deps load inside the image
+        run: |
+          docker run --rm servicebay:dev node -e \
+            "for (const m of ['better-sqlite3','node-pty','nodemailer','ssh2']) { require(m); console.log('ok', m); }"
+      - name: Bundled server boots without a missing-module crash
+        run: |
+          docker run -d --name sb-dev-smoke \
+            -e AUTH_SECRET=0000000000000000000000000000000000000000000000000000000000000000 \
+            servicebay:dev
+          sleep 25
+          docker logs sb-dev-smoke > boot.log 2>&1 || true
+          docker rm -f sb-dev-smoke > /dev/null || true
+          cat boot.log
+          # Only the missing-module class fails this step. The dev container has
+          # no host sshd to reach in CI, so agent/SSH errors in the log are
+          # expected and must not turn the job red.
+          if grep -qE "Cannot find module|MODULE_NOT_FOUND" boot.log; then
+            echo "::error::dev image boots with a missing module — see log above"
+            exit 1
+          fi

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -31,9 +31,28 @@ RUN apt-get update && \
         openssh-client python3-paramiko procps iproute2 ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# Install runtime deps — this rebuilds native modules for Node 20.
+# Install runtime deps — this rebuilds native modules for the container's Node.
 COPY package.json package-lock.json ./
+# Workspace package manifests — `npm ci` against a workspace root needs
+# each member's package.json present so it can resolve their deps too.
+# Without these copies, runtime modules listed in packages/*/package.json
+# (ssh2, better-sqlite3, node-pty, etc. after #767) silently drop out of
+# the image and the custom server crashes on first import (#2422 — the
+# production Dockerfile got this fix, Dockerfile.dev never did).
+COPY packages/api-client/package.json ./packages/api-client/package.json
+COPY packages/backend/package.json ./packages/backend/package.json
+COPY packages/frontend/package.json ./packages/frontend/package.json
+COPY packages/disk-import-worker/package.json ./packages/disk-import-worker/package.json
+COPY packages/backup-worker/package.json ./packages/backup-worker/package.json
 RUN npm ci --omit=dev && npm cache clean --force
+# npm deoptimizes hoisting for some packages (nodemailer today) and leaves
+# them under packages/*/node_modules. dist-server/server.cjs require()s them
+# as externals and node resolves those from /app/node_modules only — it never
+# looks in packages/backend/node_modules. Merge them up (no-clobber, so a
+# hoisted copy always wins), same as the production Dockerfile's runner stage.
+RUN set -e; for d in packages/*/node_modules; do \
+      if [ -d "$d" ]; then cp -rn "$d/." node_modules/; fi; \
+    done
 
 # Pre-built artifacts from the host. `dev-container.sh` ensures these exist.
 COPY packages/frontend/.next ./packages/frontend/.next

--- a/assists/footgun-hostnetwork-lan-bypass.md
+++ b/assists/footgun-hostnetwork-lan-bypass.md
@@ -1,0 +1,112 @@
+---
+title: A hostNetwork pod's admin port is LAN-reachable — SSO on the subdomain does not gate it
+whenToUse: You are adding or reviewing a port on a hostNetwork template, or you want to know whether an app's admin UI can be reached directly on the LAN without passing Authelia.
+kind: footgun
+tags: [security, hostnetwork, lan, authelia, forward-auth, loopback, nftables, template, ports]
+---
+
+# `hostNetwork: true` + a wildcard bind = an SSO bypass
+
+## Symptom
+
+An admin UI or control API is proxied at `https://<sub>.<domain>` with
+`advanced_config: "__authelia_forward_auth__"`, and the gate works — through
+nginx. But `curl http://<box-lan-ip>:<port>/` from any other LAN device answers
+too, with no login at all.
+
+The forward-auth block only gates the **nginx path**. Nothing makes nginx the
+only path.
+
+## Why
+
+A `hostNetwork: true` pod publishes no ports — its containers share the host's
+network namespace, so whatever address the app binds is the address it binds on
+the host. Most apps default to `0.0.0.0` (or "unset = all interfaces"), which
+under `hostNetwork` means **every** interface, LAN included. ServiceBay's target
+OS ships with no firewall enabled, so nothing downstream catches it either.
+
+This has been the same bug three times on three templates: an identity store's
+web UI, its raw LDAP port, and a smart-home stack's Z-Wave admin UI plus its raw
+control websocket. The last one was the sharpest — an unauthenticated websocket
+that could actuate every paired device, door locks included.
+
+The two aggravating factors to look for:
+
+- **Undeclared ports.** A port missing from `servicebay.ports` is invisible to
+  the network map and to review. Declare every listening TCP port, including
+  ones only a sibling container talks to.
+- **"It has a subdomain, so it's gated."** A subdomain gates the proxied route,
+  never the port.
+
+## Fix — in order of preference
+
+**1. Bind the app to the loopback (best).** No privileged host state needed.
+Find the app's bind-address knob and pin it to `127.0.0.1`; it is always
+app-specific, never a pod-spec field:
+
+| shape | example |
+|---|---|
+| env var | `LLDAP_HTTP_HOST`, `HOST`, `STGUIADDRESS: "127.0.0.1:<port>"` |
+| CLI arg via `args:` | `--listen-address 127.0.0.1` |
+| on-disk config the post-deploy seeds | a `serverHost` key in a settings JSON |
+
+If the port is proxied, add `loopbackOnly: true` to its `type: "subdomain"`
+variable. `buildProxyHosts` then emits `forwardHost: 127.0.0.1`, and the core
+reconcile re-points an **existing** proxy host off the now-closed LAN address on
+the next deploy — PUTting only the forward target, so exposure, forward-auth and
+the bound cert survive. No manual proxy edit.
+
+Two traps when you use `args:` — it **replaces** the image's `CMD` (the
+`ENTRYPOINT` stays), so repeat the image's own default arguments verbatim or the
+app starts misconfigured; and check the flag only binds the API server, not the
+protocol stack (a Matter/Thread-style daemon has a separate interface flag for
+its own traffic).
+
+**2. `blockLanAccess: true` on the port variable — only when a loopback bind is
+not available.** Some ports must answer on a host address because *isolated*
+(non-hostNetwork) pods reach them through `host.containers.internal`, which
+rootless podman/pasta maps to the host's LAN address rather than loopback — a
+loopback bind would break those consumers. ServiceBay then renders a host
+nftables rule dropping connections that arrive on a physical interface while
+accepting the ones that arrive on `lo` (where the pasta-proxied path lands).
+This costs privileged host state, so reach for it second.
+
+**3. Leave it LAN-facing, with the reason written down.** Legitimate when the
+port *is* the service (DNS, SMB, a sync protocol, sshd, the reverse proxy's own
+front door) or when the app authenticates the request itself (its own login, or
+proxy-auth mode that 403s a request without the forward-auth header). Write what
+authenticates it — "it has a login" is a claim someone must be able to check.
+
+## Guard rail
+
+The template-consistency suite fails when a `hostNetwork` template declares a
+TCP port that is neither loopback-bound, nor firewalled, nor listed with a
+written reason — and, for a port claimed loopback-bound, it re-reads the config
+file that is supposed to bind it. Adding a port to such a template forces the
+triage above. If the suite points you here, pick one of the three fixes rather
+than widening the exemption list by reflex.
+
+## Rollout on an existing install
+
+Two halves, and the second is the one people miss:
+
+- **Pod-level binds** (env var / `args:`) land structurally — `podman play kube`
+  recreates the pod from the new manifest. Bump `servicebay.schema-version` and
+  add a `(breaking)` CHANGELOG section saying "re-deploy required": a running
+  container started from the old manifest does not re-bind on its own.
+- **On-disk binds** do not. If the bind address lives in a settings file that
+  the post-deploy seeds *only when missing*, every existing install keeps the
+  old wildcard value forever and the "fix" reaches new installs only. Ship a
+  migration that rewrites that value in place, and make the post-deploy
+  converge it on every deploy so a restored backup cannot reintroduce it. Leave
+  a deliberately-pinned non-wildcard address alone — warn instead of
+  overriding.
+
+## Verify
+
+From a **different** LAN host (not the box — loopback works there by
+construction), confirm the port is refused, then confirm the legitimate paths
+still work: the proxied subdomain still serves through nginx with its SSO gate,
+and any sibling container that consumed the port over `localhost` is still
+connected. Check the consumer's own view — a config entry that reconnects, a
+log line — not just that the port answers.

--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -172,8 +172,11 @@ What each `type` does generically (no per-template code needed):
   them.
 
 `templates/settings.json` declares a few global variables (`DATA_DIR`,
-`LLDAP_HOST`, `LLDAP_LDAP_PORT`, `LLDAP_BASE_DN`) that every template
-can reference without re-declaring.
+`LLDAP_HOST`, `LLDAP_LDAP_PORT`, `LLDAP_BASE_DN`, `PUBLIC_DOMAIN`,
+`LAN_IP`, `HOST_GATEWAY_IP`) that every template can reference without
+re-declaring — and **must not** re-declare: a per-template copy of a
+global is how five different `PUBLIC_DOMAIN` descriptions drifted apart
+(#2425). Reference `{{PUBLIC_DOMAIN}}` and leave the declaration alone.
 
 ### Wiring SSO end-to-end
 

--- a/packages/backend/src/lib/assists/secretScan.test.ts
+++ b/packages/backend/src/lib/assists/secretScan.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `SECRET_PATTERNS` is the shared signature list behind BOTH the build-time
+ * backstop (`tests/backend/assist_consistency.test.ts`, which walks `assists/`
+ * and `templates/`) and the runtime landing gate for approved learning
+ * proposals. A signature that silently stops matching disarms both at once, so
+ * the shapes get their own direct tests.
+ *
+ * The plaintext-OIDC shape is the #2417 addition: none of the previous shapes
+ * (PEM / `sb_` / AKIA / `gh_` / `xox`) matched
+ * `client_secret: '$plaintext$servicebay-oidc-secret'`, so the auth template
+ * shipped a real, world-shared credential past a green suite for months.
+ */
+import { describe, it, expect } from 'vitest';
+import { scanForSecrets, SECRET_PATTERNS } from './secretScan';
+
+const OIDC = 'Authelia plaintext OIDC client secret';
+
+describe('SECRET_PATTERNS — Authelia plaintext OIDC client secret (#2417)', () => {
+  it('is registered', () => {
+    expect(SECRET_PATTERNS.map(p => p.name)).toContain(OIDC);
+  });
+
+  it('catches the exact literal the auth template used to ship', () => {
+    // The regression this shape exists for, verbatim from
+    // configuration.yml.mustache before the fix.
+    const line = "        client_secret: '$plaintext$servicebay-oidc-secret'";
+    expect(scanForSecrets(line)).toContain(OIDC);
+  });
+
+  it('catches a generated-looking secret pasted into a committed file', () => {
+    expect(scanForSecrets("client_secret: '$plaintext$Xk29fQpL0aZmR4tYvB7nHc3sWd1eGjU5'")).toContain(OIDC);
+  });
+
+  it('catches it anywhere, not only on a client_secret line', () => {
+    expect(scanForSecrets('the box is using $plaintext$aVeryRealSecretValue right now')).toContain(OIDC);
+  });
+
+  // The false-positive guards. Each of these is a real committed string today;
+  // flagging one would make the backstop unusable and invite an exemption.
+  it('does NOT flag the Mustache placeholder that replaced the literal', () => {
+    const fixed = "        client_secret: '$plaintext${{SERVICEBAY_OIDC_SECRET}}'";
+    expect(scanForSecrets(fixed)).not.toContain(OIDC);
+  });
+
+  it('does NOT flag the angle-bracket stand-in used in template READMEs', () => {
+    // templates/immich/README.md and templates/vaultwarden/README.md.
+    expect(scanForSecrets("        client_secret: '$plaintext$<your-secret>'")).not.toContain(OIDC);
+  });
+
+  it('does NOT flag a short illustrative value in prose', () => {
+    expect(scanForSecrets('e.g. `$plaintext$abc`')).not.toContain(OIDC);
+  });
+
+  it('does NOT flag a HASHED secret — those are safe to commit by construction', () => {
+    expect(scanForSecrets("client_secret: '$pbkdf2-sha512$310000$abcdefghij$klmnopqrst'")).not.toContain(OIDC);
+    expect(scanForSecrets("client_secret: '$argon2id$v=19$m=65536,t=3,p=4$abcdefghij$klmnop'")).not.toContain(OIDC);
+  });
+
+  it('leaves clean text clean', () => {
+    expect(scanForSecrets('Authelia stores cleartext client secrets with a $plaintext$ prefix.')).toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/assists/secretScan.ts
+++ b/packages/backend/src/lib/assists/secretScan.ts
@@ -31,6 +31,21 @@ export const SECRET_PATTERNS: readonly SecretPattern[] = [
   { name: 'GitHub token', re: /\bgh[posru]_[A-Za-z0-9]{20,}\b/ },
   { name: 'GitHub fine-grained PAT', re: /\bgithub_pat_[A-Za-z0-9_]{30,}\b/ },
   { name: 'Slack token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+  // Authelia stores a cleartext OIDC client secret as `$plaintext$<secret>`
+  // (see `extractPlaintextSecret` in the oidc-clients route). A committed one
+  // is a real credential every install would share — exactly the #2417 bug,
+  // where `templates/auth/configuration.yml.mustache` shipped a literal
+  // `client_secret` for the admin panel's own OIDC client on every box in the
+  // world and none of the shapes above matched it. (The offending value lives
+  // in the regression case in `secretScan.test.ts`, not repeated here.)
+  //
+  // Deliberately narrow so the legitimate ways of WRITING about one still
+  // pass: a Mustache placeholder (`$plaintext${{VAR}}`) and a doc angle-
+  // bracket stand-in (`$plaintext$<your-secret>`, used in the immich and
+  // vaultwarden READMEs) both start with a character outside the secret
+  // alphabet. The 8-char floor keeps short illustrative values in prose
+  // (`$plaintext$abc`) from tripping it.
+  { name: 'Authelia plaintext OIDC client secret', re: /\$plaintext\$[A-Za-z0-9_-]{8,}/ },
 ];
 
 /**

--- a/packages/backend/src/lib/capabilities/autheliaClientMerge.test.ts
+++ b/packages/backend/src/lib/capabilities/autheliaClientMerge.test.ts
@@ -35,7 +35,7 @@ identity_providers:
     clients:
       - client_id: 'servicebay'
         client_name: 'ServiceBay'
-        client_secret: '$plaintext$servicebay-oidc-secret'
+        client_secret: '$plaintext$sbNEW'
         redirect_uris:
           - 'https://admin.example.com/api/auth/oidc/callback'
 `;
@@ -48,7 +48,7 @@ identity_providers:
     clients:
       - client_id: 'servicebay'
         client_name: 'ServiceBay'
-        client_secret: '$plaintext$servicebay-oidc-secret'
+        client_secret: '$plaintext$sbOLD'
         redirect_uris:
           - 'https://admin.example.com/api/auth/oidc/callback'
       - client_id: 'immich'
@@ -77,13 +77,34 @@ describe('mergeAutheliaOidcClients (#1724)', () => {
   });
 
   it('lets the fresh render win for a shared client_id (servicebay baseline)', () => {
-    // On-disk servicebay carries a stale secret; the render is authoritative.
-    const staleDisk = ON_DISK.replace('$plaintext$servicebay-oidc-secret', '$plaintext$STALE');
-    const merged = mergeAutheliaOidcClients(RENDERED, staleDisk);
+    // On-disk servicebay carries the OLD secret; the render is authoritative.
+    const merged = mergeAutheliaOidcClients(RENDERED, ON_DISK);
     const sb = clientsOf(merged).find(c => c.client_id === 'servicebay')!;
-    expect(sb.client_secret).toBe('$plaintext$servicebay-oidc-secret');
+    expect(sb.client_secret).toBe('$plaintext$sbNEW');
     // and exactly one servicebay entry — no duplicate
     expect(ids(merged).filter(i => i === 'servicebay')).toHaveLength(1);
+  });
+
+  /**
+   * #2417 — this is the load-bearing asymmetry, so assert it as its own case
+   * rather than leaning on the general "render wins" rule.
+   *
+   * The module's headline property is that it NEVER rotates an already-
+   * registered client's secret (#1559). `servicebay` is the ONE deliberate
+   * exception: because the auth template's mustache declares that client, the
+   * fresh render owns it, and the per-install `SERVICEBAY_OIDC_SECRET` replaces
+   * whatever was on disk — which is exactly the mechanism that migrates an
+   * existing box off the old hardcoded literal. If this ever flipped to
+   * "preserve", the upgrade would silently no-op and every install would keep
+   * the world-readable secret forever.
+   */
+  it('DOES rotate servicebay while preserving every other client secret', () => {
+    const merged = mergeAutheliaOidcClients(RENDERED, ON_DISK);
+    const byId = Object.fromEntries(clientsOf(merged).map(c => [c.client_id, c]));
+    expect(byId.servicebay.client_secret).toBe('$plaintext$sbNEW');   // rotated
+    expect(byId.servicebay.client_secret).not.toBe('$plaintext$sbOLD');
+    expect(byId.immich.client_secret).toBe('$plaintext$immich-real-secret');       // untouched
+    expect(byId.vaultwarden.client_secret).toBe('$plaintext$vault-real-secret');   // untouched
   });
 
   it('is idempotent — re-running yields no duplicate clients', () => {

--- a/packages/backend/src/lib/capabilities/hostFirewall.test.ts
+++ b/packages/backend/src/lib/capabilities/hostFirewall.test.ts
@@ -11,6 +11,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const reconcileMock = vi.fn();
 const getConfigMock = vi.fn();
 const getTemplateVariablesMock = vi.fn();
+const recordFailureMock = vi.fn();
+const clearFailureMock = vi.fn();
+
+vi.mock('@/lib/install/handlerFailures', () => ({
+  recordHandlerFailure: (...a: unknown[]) => recordFailureMock(...a),
+  clearHandlerFailure: (...a: unknown[]) => clearFailureMock(...a),
+}));
 
 vi.mock('@/lib/config', () => ({ getConfig: () => getConfigMock() }));
 vi.mock('@/lib/executor', () => ({ getExecutor: () => ({ tag: 'executor' }) }));
@@ -25,7 +32,13 @@ vi.mock('@/lib/hostFirewall', async () => {
   return { ...actual, reconcileHostFirewall: (...a: unknown[]) => reconcileMock(...a) };
 });
 
-import { handleInstalled, handleUninstalled, reconcileHostFirewallOnBoot } from './hostFirewall';
+import {
+  handleInstalled,
+  handleUninstalled,
+  reconcileHostFirewallOnBoot,
+  planLanBlockedPorts,
+  BOOT_FAILURE_SERVICE,
+} from './hostFirewall';
 import type { TemplateManifest } from '@/lib/template/contract';
 
 const MANIFEST: TemplateManifest = { label: 'Sign-In Gate', tier: 'infrastructure', schemaVersion: 3, dependencies: [] };
@@ -131,5 +144,38 @@ describe('host-firewall boot reconcile (#2388)', () => {
   it('propagates a failure to the caller, which logs it', async () => {
     reconcileMock.mockRejectedValue(new Error('agent down'));
     await expect(reconcileHostFirewallOnBoot()).rejects.toThrow(/agent down/);
+  });
+});
+
+/**
+ * #2420 — a boot reconcile that fails must leave a standing finding, not
+ * just a log line. It writes the same `installHandlerFailures` store the
+ * capability-bus path uses via `runner.ts`, so `install_handler_failed`
+ * surfaces it with a Retry.
+ */
+describe('host-firewall boot reconcile — failure is surfaced (#2420)', () => {
+  it('records a standing failure the diagnose probe can read', async () => {
+    reconcileMock.mockRejectedValue(new Error('sudo: a password is required'));
+    await expect(reconcileHostFirewallOnBoot()).rejects.toThrow(/password/);
+    expect(recordFailureMock).toHaveBeenCalledWith({
+      kind: 'host-firewall',
+      service: BOOT_FAILURE_SERVICE,
+      message: expect.stringContaining('boot reconcile: sudo: a password is required'),
+    });
+    expect(clearFailureMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the record once a later boot converges', async () => {
+    await reconcileHostFirewallOnBoot();
+    expect(recordFailureMock).not.toHaveBeenCalled();
+    expect(clearFailureMock).toHaveBeenCalledWith('host-firewall', BOOT_FAILURE_SERVICE);
+  });
+});
+
+describe('planLanBlockedPorts (#2420)', () => {
+  it('reports the desired port set without touching the host', async () => {
+    const plan = await planLanBlockedPorts();
+    expect(plan.ports).toEqual([3890]);
+    expect(reconcileMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/lib/capabilities/hostFirewall.ts
+++ b/packages/backend/src/lib/capabilities/hostFirewall.ts
@@ -27,13 +27,27 @@
 import { getConfig } from '@/lib/config';
 import { getExecutor } from '@/lib/executor';
 import { getTemplateVariables } from '@/lib/registry';
-import { collectLanBlockedPorts, reconcileHostFirewall, type PortVarDeclaration } from '@/lib/hostFirewall';
+import {
+  collectLanBlockedPorts,
+  reconcileHostFirewall,
+  type LanBlockPlan,
+  type PortVarDeclaration,
+} from '@/lib/hostFirewall';
+import { recordHandlerFailure, clearHandlerFailure } from '@/lib/install/handlerFailures';
 import { logger } from '@/lib/logger';
 import type { CapabilityBus } from './bus';
 import type { FeatureInstalledEvent, FeatureUninstalledEvent, HandlerResult } from './types';
 import type { StackVariable } from '@/lib/stackInstall/types';
 
 const HANDLER_NAME = 'host-firewall.lan-block';
+
+/**
+ * `service` key the boot-reconcile failure is recorded under. Not a real
+ * service — the host firewall is box-level — but the standing-failure
+ * store is keyed `${kind}:${service}` and this is what the operator sees
+ * as the row label.
+ */
+export const BOOT_FAILURE_SERVICE = 'host-firewall';
 
 interface ReconcileOpts {
   /** Template to fold in even if `installedTemplates` doesn't list it yet (fresh install). */
@@ -45,11 +59,13 @@ interface ReconcileOpts {
 }
 
 /**
- * Recompute the desired filtered-port set from config + the template
- * registry and push it to the host. Exported so the boot path can call
- * the same code (see `reconcileHostFirewallOnBoot`).
+ * Compute the DESIRED filtered-port set from config + the template
+ * registry, without touching the host. Split out of
+ * {@link reconcileFromConfig} so the `host_firewall_rule` diagnose probe
+ * can ask "what should be filtered?" and compare it against what the
+ * kernel actually has loaded (#2420) without re-applying anything.
  */
-export async function reconcileFromConfig(opts: ReconcileOpts = {}): Promise<void> {
+export async function planLanBlockedPorts(opts: ReconcileOpts = {}): Promise<LanBlockPlan> {
   const config = await getConfig();
 
   const installed = new Set(Object.keys(config.installedTemplates ?? {}));
@@ -71,7 +87,16 @@ export async function reconcileFromConfig(opts: ReconcileOpts = {}): Promise<voi
     if (v.value) values[v.name] = v.value;
   }
 
-  const plan = collectLanBlockedPorts({ installedTemplates, declarations, values });
+  return collectLanBlockedPorts({ installedTemplates, declarations, values });
+}
+
+/**
+ * Recompute the desired filtered-port set from config + the template
+ * registry and push it to the host. Exported so the boot path can call
+ * the same code (see `reconcileHostFirewallOnBoot`).
+ */
+export async function reconcileFromConfig(opts: ReconcileOpts = {}): Promise<void> {
+  const plan = await planLanBlockedPorts(opts);
   for (const reason of plan.skipped) {
     logger.warn('CapabilityBus', `[${HANDLER_NAME}] skipped ${reason}`);
   }
@@ -109,9 +134,28 @@ export function handleUninstalled(event: FeatureUninstalledEvent): Promise<Handl
  * redeployed), and it self-heals a host where the unit or the table was
  * removed by hand. Idempotent, so a boot with nothing to do converges to
  * a couple of no-op probes.
+ *
+ * A failure here used to be a log line and nothing else, so the #2388
+ * LAN block could silently not apply on a box that depends entirely on
+ * this path (#2420). It now lands in `config.installHandlerFailures` —
+ * the same store the capability-bus path writes through `runner.ts` —
+ * so the `install_handler_failed` probe surfaces it with a retry, and
+ * the error still propagates so the caller's log line is unchanged.
  */
 export async function reconcileHostFirewallOnBoot(): Promise<void> {
-  await reconcileFromConfig();
+  try {
+    await reconcileFromConfig();
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    await recordHandlerFailure({
+      kind: 'host-firewall',
+      service: BOOT_FAILURE_SERVICE,
+      message: `boot reconcile: ${message}`,
+    });
+    throw e;
+  }
+  // Converged — drop any record a previous boot left standing.
+  await clearHandlerFailure('host-firewall', BOOT_FAILURE_SERVICE);
 }
 
 export function registerHostFirewallHandlers(bus: CapabilityBus): void {

--- a/packages/backend/src/lib/capabilities/servicebayOidcSecret.test.ts
+++ b/packages/backend/src/lib/capabilities/servicebayOidcSecret.test.ts
@@ -1,0 +1,190 @@
+/**
+ * #2417 — the `servicebay` Authelia OIDC client's per-install secret.
+ *
+ * These cover the three decisions that make the rotation safe:
+ *   - reading the secret back OUT of Authelia's config (ServiceBay follows the
+ *     file, never leads it);
+ *   - what `config.oidc` becomes, including the cases that must NOT write;
+ *   - the break-glass pre-flight that refuses to rotate the only credential a
+ *     box has.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractServicebayClientSecret,
+  decideOidcSecretUpdate,
+  assertBreakGlassLogin,
+  isServicebaySecretRotation,
+  SERVICEBAY_CLIENT_ID,
+} from './servicebayOidcSecret';
+
+const config = (sbSecret: string, extra = '') => `
+identity_providers:
+  oidc:
+    hmac_secret: 'hmac-xyz'
+    clients:
+      - client_id: 'servicebay'
+        client_name: 'ServiceBay'
+        client_secret: '${sbSecret}'
+        redirect_uris:
+          - 'https://admin.example.com/api/auth/oidc/callback'
+      - client_id: 'other-service'
+        client_secret: '$plaintext$other-secret'
+${extra}`;
+
+describe('extractServicebayClientSecret', () => {
+  it('pulls the servicebay client secret and strips the $plaintext$ prefix', () => {
+    expect(extractServicebayClientSecret(config('$plaintext$perBoxValue'))).toBe('perBoxValue');
+  });
+
+  it('picks servicebay specifically, not just the first client', () => {
+    const reordered = `
+identity_providers:
+  oidc:
+    clients:
+      - client_id: 'other-service'
+        client_secret: '$plaintext$other-secret'
+      - client_id: 'servicebay'
+        client_secret: '$plaintext$theRightOne'
+`;
+    expect(extractServicebayClientSecret(reordered)).toBe('theRightOne');
+  });
+
+  it('honours an explicit client_id argument', () => {
+    expect(extractServicebayClientSecret(config('$plaintext$sb'), 'other-service')).toBe('other-secret');
+  });
+
+  it('exports the client_id the auth template declares', () => {
+    expect(SERVICEBAY_CLIENT_ID).toBe('servicebay');
+  });
+
+  // The refusals below all matter for the same reason: returning a wrong or
+  // useless value here would OVERWRITE a working config.oidc.clientSecret.
+  it('returns null for a HASHED secret — a hash can never be replayed', () => {
+    expect(extractServicebayClientSecret(config('$pbkdf2-sha512$310000$abc$def'))).toBeNull();
+    expect(extractServicebayClientSecret(config('$argon2id$v=19$m=65536$abc$def'))).toBeNull();
+  });
+
+  it('returns null for an empty $plaintext$ value', () => {
+    expect(extractServicebayClientSecret(config('$plaintext$'))).toBeNull();
+  });
+
+  it('returns null when the servicebay client is absent', () => {
+    const noSb = `
+identity_providers:
+  oidc:
+    clients:
+      - client_id: 'other-service'
+        client_secret: '$plaintext$other-secret'
+`;
+    expect(extractServicebayClientSecret(noSb)).toBeNull();
+  });
+
+  it('returns null — never throws — on empty / malformed / shapeless input', () => {
+    expect(extractServicebayClientSecret('')).toBeNull();
+    expect(extractServicebayClientSecret(null)).toBeNull();
+    expect(extractServicebayClientSecret(undefined)).toBeNull();
+    expect(extractServicebayClientSecret('identity_providers:\n  oidc:\n    clients: [ : : ::')).toBeNull();
+    expect(extractServicebayClientSecret('session:\n  secret: nope\n')).toBeNull();
+    expect(extractServicebayClientSecret('identity_providers:\n  oidc:\n    clients: not-a-list\n')).toBeNull();
+  });
+});
+
+describe('decideOidcSecretUpdate', () => {
+  const current = { enabled: true, issuer: 'https://auth.example.com', clientId: 'servicebay', clientSecret: 'oldValue' };
+
+  it('adopts the Authelia secret when it differs', () => {
+    const { result, next } = decideOidcSecretUpdate(current, 'newValue');
+    expect(result.outcome).toBe('changed');
+    expect(next!.clientSecret).toBe('newValue');
+  });
+
+  it('preserves enabled / issuer / allowedGroups while swapping the secret', () => {
+    const withGroups = { ...current, allowedGroups: ['admins'] };
+    const { next } = decideOidcSecretUpdate(withGroups, 'newValue');
+    expect(next).toEqual({
+      enabled: true,
+      issuer: 'https://auth.example.com',
+      clientId: 'servicebay',
+      clientSecret: 'newValue',
+      allowedGroups: ['admins'],
+    });
+  });
+
+  it('no-ops when the two sides already agree (idempotent re-run)', () => {
+    const { result, next } = decideOidcSecretUpdate({ ...current, clientSecret: 'same' }, 'same');
+    expect(result.outcome).toBe('aligned');
+    expect(next).toBeUndefined();
+  });
+
+  it('records the secret on a box with no oidc block, WITHOUT enabling SSO', () => {
+    const { result, next } = decideOidcSecretUpdate(undefined, 'newValue');
+    expect(result.outcome).toBe('changed');
+    expect(next!.clientSecret).toBe('newValue');
+    expect(next!.clientId).toBe('servicebay');
+    // Whether the admin panel offers SSO stays the operator's decision.
+    expect(next!.enabled).toBe(false);
+  });
+
+  it('never turns a working SSO config OFF', () => {
+    const { next } = decideOidcSecretUpdate(current, 'newValue');
+    expect(next!.enabled).toBe(true);
+  });
+
+  it('writes NOTHING when the Authelia secret is unreadable', () => {
+    // The dangerous case: an unreadable/hashed file must not clobber a value
+    // the admin panel is currently logging in with.
+    const { result, next } = decideOidcSecretUpdate(current, null);
+    expect(result.outcome).toBe('skipped');
+    expect(next).toBeUndefined();
+  });
+
+  it('keeps the secret out of every operator-facing message', () => {
+    for (const [cur, sec] of [[current, 'sup3rSecretValue'], [undefined, 'sup3rSecretValue'], [current, null]] as const) {
+      const { result } = decideOidcSecretUpdate(cur, sec);
+      expect(result.message).not.toContain('sup3rSecretValue');
+      expect(result.message).not.toContain('oldValue');
+    }
+  });
+});
+
+describe('isServicebaySecretRotation', () => {
+  it('is true when the render carries a different secret than the disk', () => {
+    expect(isServicebaySecretRotation(config('$plaintext$newOne'), config('$plaintext$oldOne'))).toBe(true);
+  });
+
+  it('is false in the steady state (same value re-rendered)', () => {
+    expect(isServicebaySecretRotation(config('$plaintext$same'), config('$plaintext$same'))).toBe(false);
+  });
+
+  it('is false on a fresh install — no working login to break', () => {
+    expect(isServicebaySecretRotation(config('$plaintext$newOne'), null)).toBe(false);
+    expect(isServicebaySecretRotation(config('$plaintext$newOne'), '')).toBe(false);
+  });
+
+  it('is false when either side is unreadable (fail-soft, never block a deploy)', () => {
+    expect(isServicebaySecretRotation(config('$plaintext$newOne'), 'garbage: [ : :')).toBe(false);
+    expect(isServicebaySecretRotation('garbage: [ : :', config('$plaintext$oldOne'))).toBe(false);
+  });
+});
+
+describe('assertBreakGlassLogin', () => {
+  it('allows the rotation when a stored admin password hash exists', () => {
+    expect(assertBreakGlassLogin('scrypt$abc', undefined)).toBeNull();
+  });
+
+  it('allows the rotation when only the SERVICEBAY_PASSWORD bootstrap is set', () => {
+    expect(assertBreakGlassLogin(undefined, 'bootstrap-pw')).toBeNull();
+  });
+
+  it('REFUSES when SSO is the only door into the admin panel', () => {
+    const reason = assertBreakGlassLogin(undefined, undefined);
+    expect(reason).toBeTruthy();
+    // The message has to be actionable — this is the operator's only clue.
+    expect(reason).toContain('SERVICEBAY_PASSWORD');
+    expect(reason).toContain('#2417');
+  });
+
+  it('treats an empty string as absent, not as a credential', () => {
+    expect(assertBreakGlassLogin('', '')).toBeTruthy();
+  });
+});

--- a/packages/backend/src/lib/capabilities/servicebayOidcSecret.ts
+++ b/packages/backend/src/lib/capabilities/servicebayOidcSecret.ts
@@ -1,0 +1,310 @@
+/**
+ * Keep ServiceBay's own `config.oidc.clientSecret` equal to the secret
+ * Authelia actually registered for the `servicebay` OIDC client (#2417).
+ *
+ * ## Why this module exists
+ *
+ * The `servicebay` client is the one guarding ServiceBay's admin panel:
+ * "Login with Authelia" sends the user to Authelia, then the callback route
+ * (`app/api/auth/oidc/callback/route.ts`) posts `client_secret` — read from
+ * `config.oidc.clientSecret` — to Authelia's token endpoint. Authelia compares
+ * it against the `client_secret` in its `configuration.yml` clients[] block.
+ *
+ * Until #2417 that block carried ONE hardcoded literal (`$plaintext$servicebay-
+ * oidc-secret`) committed to the repo, identical on every install in the world.
+ * It is now rendered from the per-install `SERVICEBAY_OIDC_SECRET` variable —
+ * which means the value CHANGES on the upgrade deploy, and the two sides must
+ * be brought back into agreement or the SSO button breaks with `invalid_client`.
+ *
+ * ## The design: follow the file, never lead it
+ *
+ * There is no transaction spanning "Authelia's configuration.yml on the box"
+ * and "ServiceBay's config.json". Two stores, two writes — a crash in between
+ * is always possible. So instead of trying to fake atomicity, this module makes
+ * the drift window *harmless and self-closing*, by fixing the DIRECTION of the
+ * dependency:
+ *
+ *   1. **Authelia's on-disk config is the authority.** We never push a secret
+ *      into it from here. We READ the `servicebay` client's `client_secret`
+ *      back out of the file that just landed and copy it into
+ *      `config.oidc.clientSecret`. ServiceBay therefore cannot end up holding
+ *      a secret Authelia has never heard of — the failure mode that produces a
+ *      dead login button.
+ *   2. **It runs AFTER the file is written and the pod restarted.** The install
+ *      path treats `writeExtraConfigFiles` as fatal, so a deploy that dies
+ *      before Authelia's config lands never reaches this reconcile: the box
+ *      keeps its old, still-consistent pair and the SSO button keeps working.
+ *      A failed deploy is a no-op, not a half-migration.
+ *   3. **It is idempotent and re-runs on every `auth` deploy.** A crash in the
+ *      window (config written, process dies before `updateConfig`) leaves a
+ *      recoverable, non-sticky mismatch: redeploy `auth` and this reconcile
+ *      re-reads the same file and converges. Nothing about the mismatch
+ *      persists across a retry.
+ *   4. **Break-glass, not lockout.** Even inside the window the operator is not
+ *      locked out: `/login` renders a local username/password form
+ *      (`/api/auth/login`, backed by `config.auth.passwordHash` or the
+ *      `SERVICEBAY_PASSWORD` bootstrap env) that is entirely independent of
+ *      OIDC. Only the SSO *button* is affected. `assertBreakGlassLogin` below
+ *      is the pre-flight that refuses to rotate when that second door is
+ *      missing.
+ *
+ * Same "reconcile, don't generate" shape as `reconcileHermesApiKey` (#1761) and
+ * `resolveOidcClientSecret` (#1738): the value already in the authoritative
+ * store wins, and we adopt it.
+ *
+ * SECURITY: the secret is read over the agent's `read_file` seam, stored under
+ * `config.oidc.clientSecret` (matched by config.ts's `SENSITIVE_KEYS`, so
+ * encrypted at rest) and is NEVER logged — only the outcome is.
+ */
+import yaml from 'js-yaml';
+
+/** Authelia's marker for a client secret stored as cleartext. */
+const PLAINTEXT_PREFIX = '$plaintext$';
+
+/** The client_id of ServiceBay's own admin-panel OIDC client. */
+export const SERVICEBAY_CLIENT_ID = 'servicebay';
+
+/**
+ * Pull the `servicebay` client's cleartext `client_secret` out of an Authelia
+ * `configuration.yml`.
+ *
+ * Returns `null` — never throws — when the document can't be parsed, the client
+ * isn't declared, or its secret is stored HASHED (`$pbkdf2…` / `$argon2…`). A
+ * hash is one-way: it cannot be replayed as the value the token endpoint
+ * expects, so there is nothing to adopt and the caller must leave
+ * `config.oidc.clientSecret` alone rather than overwrite a working value with
+ * a useless one.
+ *
+ * @param configYaml  the on-disk Authelia `configuration.yml` text.
+ * @param clientId    client_id to look up (defaults to `servicebay`).
+ */
+export function extractServicebayClientSecret(
+  configYaml: string | null | undefined,
+  clientId: string = SERVICEBAY_CLIENT_ID,
+): string | null {
+  const client = readClients(configYaml).find(
+    c => (c as Record<string, unknown>).client_id === clientId,
+  );
+  if (!client) return null;
+
+  const secret = (client as Record<string, unknown>).client_secret;
+  // A hash (`$pbkdf2…` / `$argon2…`) is one-way — nothing to adopt.
+  if (typeof secret !== 'string' || !secret.startsWith(PLAINTEXT_PREFIX)) return null;
+  return secret.slice(PLAINTEXT_PREFIX.length) || null;
+}
+
+/** `identity_providers.oidc.clients[]`, or `[]` for anything unparseable. */
+function readClients(configYaml: string | null | undefined): Record<string, unknown>[] {
+  if (!configYaml || !configYaml.trim()) return [];
+  let doc: unknown;
+  try {
+    doc = yaml.load(configYaml);
+  } catch {
+    return [];
+  }
+  const idp = asRecord(doc)?.identity_providers;
+  const oidc = asRecord(idp)?.oidc;
+  const clients = asRecord(oidc)?.clients;
+  if (!Array.isArray(clients)) return [];
+  return clients.filter((c): c is Record<string, unknown> => !!c && typeof c === 'object');
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === 'object' ? (v as Record<string, unknown>) : null;
+}
+
+/** Outcome of one reconcile pass. `secret` is deliberately NOT included. */
+export type OidcSecretOutcome = 'aligned' | 'changed' | 'skipped';
+
+export interface OidcSecretReconcileResult {
+  outcome: OidcSecretOutcome;
+  /** Operator-facing, secret-free. Safe to write to the install log. */
+  message: string;
+}
+
+/**
+ * Decide what `config.oidc` should become, given the secret Authelia holds.
+ * Pure, so the whole decision table is unit-tested without touching config.
+ *
+ * Rules:
+ *   - No secret readable from Authelia's config → `skipped`, change nothing.
+ *   - `config.oidc.clientSecret` already equals it → `aligned`, no write.
+ *   - Otherwise → `changed`, with the next `oidc` object to persist.
+ *
+ * `enabled` is NEVER flipped here. Whether the admin panel offers SSO at all is
+ * the operator's decision (the `/login` page shows the SSO button only when
+ * `oidc.enabled`); this reconcile only guarantees that IF it is enabled, the
+ * secret it posts is the one Authelia will accept. On a box where `oidc` does
+ * not exist yet we still record the secret (with `enabled: false`) so turning
+ * SSO on later is a single toggle and never a "now go find the secret" hunt.
+ */
+export function decideOidcSecretUpdate(
+  currentOidc: { enabled: boolean; issuer: string; clientId: string; clientSecret: string; allowedGroups?: string[] } | undefined,
+  autheliaSecret: string | null,
+): { result: OidcSecretReconcileResult; next?: NonNullable<typeof currentOidc> } {
+  if (!autheliaSecret) {
+    return {
+      result: {
+        outcome: 'skipped',
+        message:
+          "Could not read the `servicebay` OIDC client secret out of Authelia's configuration.yml (client absent, or its secret is hashed rather than $plaintext$). Left ServiceBay's config.oidc.clientSecret untouched — an unreadable file must never overwrite a working value.",
+      },
+    };
+  }
+
+  if (currentOidc && currentOidc.clientSecret === autheliaSecret) {
+    return {
+      result: {
+        outcome: 'aligned',
+        message: "ServiceBay's admin-panel OIDC client secret already matches Authelia's `servicebay` client.",
+      },
+    };
+  }
+
+  const next = {
+    enabled: currentOidc?.enabled ?? false,
+    issuer: currentOidc?.issuer ?? '',
+    clientId: currentOidc?.clientId || SERVICEBAY_CLIENT_ID,
+    clientSecret: autheliaSecret,
+    ...(currentOidc?.allowedGroups ? { allowedGroups: currentOidc.allowedGroups } : {}),
+  };
+
+  return {
+    result: {
+      outcome: 'changed',
+      message: currentOidc
+        ? "Adopted Authelia's `servicebay` OIDC client secret into ServiceBay's config.oidc.clientSecret — the admin panel's \"Login with Authelia\" button now posts the secret Authelia expects."
+        : "Recorded Authelia's `servicebay` OIDC client secret in config.oidc.clientSecret (admin-panel SSO stays disabled until you enable it in Settings).",
+    },
+    next,
+  };
+}
+
+/**
+ * Pre-flight for the one deliberate secret rotation this platform performs.
+ *
+ * `mergeAutheliaOidcClients` never rotates an already-registered client's
+ * secret — that stickiness is the #1559/#1738 invariant. The `servicebay`
+ * client is the deliberate exception: the fresh render owns it, so the #2417
+ * upgrade deploy replaces the hardcoded literal with the per-box value. That
+ * rotation briefly desynchronises the admin panel's SSO button.
+ *
+ * That is acceptable ONLY because a second, non-OIDC way into the admin panel
+ * exists. This asserts it. If the box has neither a stored password hash nor
+ * the `SERVICEBAY_PASSWORD` bootstrap env, SSO is the operator's ONLY door and
+ * a mid-rotation crash would be a genuine lockout — so the caller aborts the
+ * deploy BEFORE anything is written, and the box keeps its (consistent, if
+ * publicly-known) old secret until the operator sets an admin password.
+ *
+ * Pure: takes what it needs so the decision is unit-tested directly.
+ *
+ * @returns `null` when a break-glass login exists, otherwise the operator-facing
+ *          reason the rotation must not proceed.
+ */
+export function assertBreakGlassLogin(
+  passwordHash: string | undefined,
+  bootstrapPassword: string | undefined,
+): string | null {
+  if (passwordHash || bootstrapPassword) return null;
+  return (
+    'Refusing to rotate the `servicebay` Authelia OIDC client secret: this box has no local admin password ' +
+    '(config.auth.passwordHash is unset and SERVICEBAY_PASSWORD is not in the environment), so "Login with Authelia" ' +
+    'is the ONLY way into the admin panel. Rotating the secret would leave no second door if the rotation is ' +
+    'interrupted. Set an admin username + password first (Settings → Access, or SERVICEBAY_PASSWORD on the container) ' +
+    'and redeploy `auth` — the rotation will then proceed automatically (#2417).'
+  );
+}
+
+/**
+ * `true` when writing `renderedConfig` over `existingConfig` would CHANGE the
+ * `servicebay` client's secret. Pure.
+ *
+ * A fresh install (nothing on disk) is not a rotation — there is no working
+ * login to break. Neither is a redeploy that renders the same value, which is
+ * the steady state once `SERVICEBAY_OIDC_SECRET` is stored in
+ * `config.installedSecrets` and reused on every subsequent deploy.
+ */
+export function isServicebaySecretRotation(
+  renderedConfig: string,
+  existingConfig: string | null | undefined,
+): boolean {
+  const before = extractServicebayClientSecret(existingConfig);
+  if (!before) return false; // fresh install / unreadable / hashed — nothing to lose
+  const after = extractServicebayClientSecret(renderedConfig);
+  if (!after) return false; // the render doesn't own the client — merge preserves the old one
+  return before !== after;
+}
+
+/** Path of the Authelia config among a deploy's rendered `extraFiles`, if any. */
+function findAutheliaConfigPath(extraFiles: { path: string }[]): string | undefined {
+  return extraFiles.find(f => f.path.endsWith('configuration.yml'))?.path;
+}
+
+/**
+ * Deploy-time guard (#2417). Throws — aborting the `auth` deploy BEFORE any file
+ * is written — when this deploy would rotate the `servicebay` client secret on a
+ * box that has no non-OIDC way into the admin panel. See `assertBreakGlassLogin`.
+ *
+ * No-ops for every non-`auth` deploy, for fresh installs, and for the steady
+ * state where the rendered secret already matches what is on disk.
+ *
+ * @param existingConfig  the on-disk Authelia config read by the caller (so this
+ *                        costs no extra round-trip), or null on a fresh install.
+ */
+export async function assertServicebayOidcRotationSafe(
+  extraFiles: { path: string; content: string }[],
+  existingConfig: string | null,
+): Promise<void> {
+  const cf = extraFiles.find(f => f.path.endsWith('configuration.yml'));
+  if (!cf) return; // not the auth stack
+  if (!isServicebaySecretRotation(cf.content, existingConfig)) return;
+
+  const { getConfig } = await import('@/lib/config');
+  const config = await getConfig();
+  const reason = assertBreakGlassLogin(config.auth?.passwordHash, process.env.SERVICEBAY_PASSWORD);
+  if (reason) throw new Error(reason);
+}
+
+/**
+ * Post-deploy reconcile (#2417): adopt the `servicebay` client secret that is
+ * NOW on disk into `config.oidc.clientSecret`.
+ *
+ * Call this only after the deploy reported success, so a deploy that never got
+ * as far as writing Authelia's config leaves the box's (consistent) old pair
+ * alone — see the module header for why the ordering matters. No-ops for every
+ * stack other than `auth`.
+ *
+ * Best-effort by contract: never throws. A failure here is a recoverable,
+ * non-sticky mismatch (redeploy `auth` and it converges) that at worst disables
+ * the SSO button while the local password login keeps working.
+ */
+export async function reconcileServicebayOidcSecret(
+  node: string | undefined,
+  extraFiles: { path: string; content: string }[],
+): Promise<OidcSecretReconcileResult | null> {
+  const configPath = findAutheliaConfigPath(extraFiles);
+  if (!configPath) return null; // not the auth stack
+
+  try {
+    const { agentManager } = await import('@/lib/agent/manager');
+    const agent = await agentManager.ensureAgent(node || 'Local');
+    const readRes = await agent.sendCommand('read_file', { path: configPath }).catch(() => null);
+    const onDisk = readRes ? (readRes.content || readRes.stdout || '') : '';
+
+    const secret = extractServicebayClientSecret(onDisk);
+    const { getConfig, updateConfig } = await import('@/lib/config');
+    const config = await getConfig();
+    const { result, next } = decideOidcSecretUpdate(config.oidc, secret);
+    if (next) await updateConfig({ oidc: next });
+    return result;
+  } catch (e) {
+    return {
+      outcome: 'skipped',
+      message:
+        `Could not reconcile ServiceBay's admin-panel OIDC client secret against Authelia's config ` +
+        `(${e instanceof Error ? e.message : String(e)}). If "Login with Authelia" fails with an invalid-client ` +
+        `error, log in with the local admin username/password and redeploy \`auth\` — the reconcile is idempotent ` +
+        `and converges on the next run (#2417).`,
+    };
+  }
+}

--- a/packages/backend/src/lib/capabilities/servicebayOidcSecret.wiring.test.ts
+++ b/packages/backend/src/lib/capabilities/servicebayOidcSecret.wiring.test.ts
@@ -1,0 +1,217 @@
+/**
+ * #2417 — the two impure halves: the deploy-time rotation pre-flight, and the
+ * post-deploy adoption of Authelia's secret into `config.oidc.clientSecret`.
+ *
+ * The pure decisions are covered in `servicebayOidcSecret.test.ts`. What these
+ * assert is the wiring that makes "the SAME value ends up on both sides" true:
+ * that the reconcile reads the file that was just written (rather than trusting
+ * the render), that it actually persists, and that the failure paths degrade
+ * the way the design assumes — because the whole lockout argument rests on them.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const sendCommandMock = vi.fn();
+const ensureAgentMock = vi.fn();
+vi.mock('@/lib/agent/manager', () => ({
+  agentManager: { ensureAgent: (node: string) => ensureAgentMock(node) },
+}));
+
+const getConfigMock = vi.fn();
+const updateConfigMock = vi.fn();
+vi.mock('@/lib/config', () => ({
+  getConfig: () => getConfigMock(),
+  updateConfig: (patch: unknown) => updateConfigMock(patch),
+}));
+
+import {
+  reconcileServicebayOidcSecret,
+  assertServicebayOidcRotationSafe,
+} from './servicebayOidcSecret';
+
+const CONFIG_PATH = '/mnt/data/stacks/auth/authelia-config/configuration.yml';
+
+const autheliaConfig = (sbSecret: string) => `
+identity_providers:
+  oidc:
+    clients:
+      - client_id: 'servicebay'
+        client_secret: '${sbSecret}'
+`;
+
+const authFiles = (content: string) => [{ path: CONFIG_PATH, content }];
+
+beforeEach(() => {
+  sendCommandMock.mockReset();
+  ensureAgentMock.mockReset();
+  getConfigMock.mockReset();
+  updateConfigMock.mockReset();
+  ensureAgentMock.mockResolvedValue({ sendCommand: sendCommandMock });
+  updateConfigMock.mockResolvedValue(undefined);
+});
+
+describe('reconcileServicebayOidcSecret', () => {
+  it('adopts the secret from the file on disk into config.oidc.clientSecret', async () => {
+    sendCommandMock.mockResolvedValue({ content: autheliaConfig('$plaintext$perBoxValue') });
+    getConfigMock.mockResolvedValue({
+      oidc: { enabled: true, issuer: 'https://auth.example.com', clientId: 'servicebay', clientSecret: 'stale' },
+    });
+
+    const r = await reconcileServicebayOidcSecret('Local', authFiles('irrelevant'));
+
+    expect(r?.outcome).toBe('changed');
+    expect(updateConfigMock).toHaveBeenCalledWith({
+      oidc: expect.objectContaining({ clientSecret: 'perBoxValue', enabled: true }),
+    });
+  });
+
+  it('reads the ON-DISK file, not the rendered content it was handed', async () => {
+    // The whole safety argument is "ServiceBay follows the file". If this ever
+    // adopted `extraFiles[].content` instead, a write that silently failed
+    // would leave ServiceBay holding a secret Authelia never got.
+    sendCommandMock.mockResolvedValue({ content: autheliaConfig('$plaintext$whatIsActuallyOnDisk') });
+    getConfigMock.mockResolvedValue({ oidc: { enabled: true, issuer: 'i', clientId: 'servicebay', clientSecret: 'stale' } });
+
+    await reconcileServicebayOidcSecret('Local', authFiles(autheliaConfig('$plaintext$whatWeRendered')));
+
+    expect(sendCommandMock).toHaveBeenCalledWith('read_file', { path: CONFIG_PATH });
+    expect(updateConfigMock).toHaveBeenCalledWith({
+      oidc: expect.objectContaining({ clientSecret: 'whatIsActuallyOnDisk' }),
+    });
+  });
+
+  it('is a no-op on the second run (idempotent — the convergence property)', async () => {
+    sendCommandMock.mockResolvedValue({ content: autheliaConfig('$plaintext$settled') });
+    getConfigMock.mockResolvedValue({ oidc: { enabled: true, issuer: 'i', clientId: 'servicebay', clientSecret: 'settled' } });
+
+    const r = await reconcileServicebayOidcSecret('Local', authFiles('x'));
+
+    expect(r?.outcome).toBe('aligned');
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing at all for a non-auth deploy', async () => {
+    const r = await reconcileServicebayOidcSecret('Local', [{ path: '/mnt/data/stacks/immich/immich.env', content: 'X=1' }]);
+    expect(r).toBeNull();
+    expect(ensureAgentMock).not.toHaveBeenCalled();
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('defaults the node to Local', async () => {
+    sendCommandMock.mockResolvedValue({ content: autheliaConfig('$plaintext$abc12345') });
+    getConfigMock.mockResolvedValue({});
+    await reconcileServicebayOidcSecret(undefined, authFiles('x'));
+    expect(ensureAgentMock).toHaveBeenCalledWith('Local');
+  });
+
+  it('never throws, and never clobbers, when the box is unreachable', async () => {
+    // Degrading to "SSO button may be stale" is acceptable; throwing here would
+    // fail an otherwise-successful deploy, and writing would be worse still.
+    ensureAgentMock.mockRejectedValue(new Error('agent offline'));
+    const r = await reconcileServicebayOidcSecret('Local', authFiles('x'));
+    expect(r?.outcome).toBe('skipped');
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves a working secret alone when the file is unreadable', async () => {
+    sendCommandMock.mockRejectedValue(new Error('EACCES'));
+    getConfigMock.mockResolvedValue({ oidc: { enabled: true, issuer: 'i', clientId: 'servicebay', clientSecret: 'working' } });
+    const r = await reconcileServicebayOidcSecret('Local', authFiles('x'));
+    expect(r?.outcome).toBe('skipped');
+    expect(updateConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the secret out of the message on the failure path too', async () => {
+    ensureAgentMock.mockRejectedValue(new Error('agent offline'));
+    const r = await reconcileServicebayOidcSecret('Local', authFiles('x'));
+    expect(r?.message).not.toMatch(/plaintext\$/);
+    expect(r?.message).toContain('local admin username/password');
+  });
+});
+
+describe('assertServicebayOidcRotationSafe', () => {
+  const rendered = autheliaConfig('$plaintext$newPerBoxValue');
+  const onDisk = autheliaConfig('$plaintext$oldPublishedValue');
+
+  it('THROWS when rotating on a box whose only door is SSO', async () => {
+    getConfigMock.mockResolvedValue({ auth: {} });
+    delete process.env.SERVICEBAY_PASSWORD;
+    await expect(assertServicebayOidcRotationSafe(authFiles(rendered), onDisk))
+      .rejects.toThrow(/Refusing to rotate/);
+  });
+
+  it('allows the rotation when a local admin password hash exists', async () => {
+    getConfigMock.mockResolvedValue({ auth: { passwordHash: 'scrypt$abc' } });
+    await expect(assertServicebayOidcRotationSafe(authFiles(rendered), onDisk)).resolves.toBeUndefined();
+  });
+
+  it('allows the rotation when only SERVICEBAY_PASSWORD is set', async () => {
+    getConfigMock.mockResolvedValue({ auth: {} });
+    process.env.SERVICEBAY_PASSWORD = 'bootstrap';
+    try {
+      await expect(assertServicebayOidcRotationSafe(authFiles(rendered), onDisk)).resolves.toBeUndefined();
+    } finally {
+      delete process.env.SERVICEBAY_PASSWORD;
+    }
+  });
+
+  it('does not even read config on a fresh install — there is no login to break', async () => {
+    getConfigMock.mockResolvedValue({ auth: {} });
+    await expect(assertServicebayOidcRotationSafe(authFiles(rendered), null)).resolves.toBeUndefined();
+    expect(getConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fire in the steady state (same secret re-rendered)', async () => {
+    getConfigMock.mockResolvedValue({ auth: {} });
+    await expect(assertServicebayOidcRotationSafe(authFiles(rendered), rendered)).resolves.toBeUndefined();
+    expect(getConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fire for a non-auth deploy', async () => {
+    getConfigMock.mockResolvedValue({ auth: {} });
+    await expect(
+      assertServicebayOidcRotationSafe([{ path: '/mnt/data/stacks/immich/immich.env', content: 'X=1' }], onDisk),
+    ).resolves.toBeUndefined();
+    expect(getConfigMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Structural ratchet. Both halves are correct in isolation and useless if the
+ * install path stops calling them — and the symptom of that (a working SSO
+ * button that quietly still uses the published secret, or a rotation with no
+ * break-glass check) is invisible to every behavioural test above. So assert
+ * the call sites themselves, including their ORDER, which is the entire
+ * failed-deploy-is-a-no-op argument.
+ */
+describe('install-path wiring (#2417)', () => {
+  const runner = fs.readFileSync(
+    path.join(__dirname, '..', 'install', 'runner.ts'), 'utf-8',
+  );
+
+  it('runs the rotation pre-flight before the deploy is attempted', () => {
+    expect(runner).toMatch(/assertServicebayOidcRotationSafe\(extraFiles, existingAutheliaConfig\)/);
+    const preflightAt = runner.indexOf('assertServicebayOidcRotationSafe(extraFiles');
+    const attemptAt = runner.indexOf('const attemptDeploy');
+    expect(preflightAt).toBeGreaterThan(-1);
+    expect(preflightAt).toBeLessThan(attemptAt);
+  });
+
+  it('reconciles ONLY after a successful deploy, never before', () => {
+    const reconcileAt = runner.indexOf('reconcileServicebayOidcSecret(input.node, extraFiles)');
+    const awaitAttemptAt = runner.indexOf('await attemptDeploy();');
+    expect(reconcileAt).toBeGreaterThan(-1);
+    // A reconcile that ran before/around the deploy would let ServiceBay's copy
+    // lead the file — the ordering that CAN strand a box on a failed deploy.
+    expect(reconcileAt).toBeGreaterThan(awaitAttemptAt);
+  });
+
+  it('feeds the pre-flight the config preserveAutheliaOidcClients already read', () => {
+    // Not a second read_file, and not `null` — passing null would silently
+    // disable the break-glass check by making every rotation look "fresh".
+    expect(runner).toMatch(
+      /const existingAutheliaConfig = await preserveAutheliaOidcClients\(jobId, input\.node, extraFiles\)/,
+    );
+  });
+});

--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -569,9 +569,11 @@ export interface ServicePostDeployRecord {
  * `installHandlerFailures` on `AppConfig` for the keying convention.
  */
 export interface InstallHandlerFailureRecord {
-  /** What failed: a capability handler emit, or a NAS auto-restore. Drives
-   *  which retry action the diagnose probe offers. */
-  kind: 'capability' | 'restore';
+  /** What failed: a capability handler emit, a NAS auto-restore, or the
+   *  boot-time host-firewall reconcile (#2420 — box-level, not a service,
+   *  but it needs the same standing-finding + retry channel). Drives which
+   *  retry action the diagnose probe offers. */
+  kind: 'capability' | 'restore' | 'host-firewall';
   /** The service/template the failure affects (e.g. `immich`). */
   service: string;
   /** Human-readable cause (handler name + message, or the restore error). */

--- a/packages/backend/src/lib/diagnose/probes/hostFirewallRule.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/hostFirewallRule.test.ts
@@ -1,0 +1,156 @@
+/**
+ * `host_firewall_rule` probe tests (#2420).
+ *
+ * The load-bearing one is `mutation-prove`: a boot reconcile that RETURNS
+ * SUCCESS while the rule is absent must still be caught, because that is
+ * precisely what the old code trusted. Every assertion here therefore
+ * drives the probe off the fake host's ruleset, never off the return
+ * value of the reconcile.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const planMock = vi.fn();
+const inspectMock = vi.fn();
+const reconcileOnBootMock = vi.fn();
+
+vi.mock('@/lib/executor', () => ({ getExecutor: () => ({ tag: 'executor' }) }));
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('@/lib/capabilities/hostFirewall', () => ({
+  planLanBlockedPorts: () => planMock(),
+  reconcileHostFirewallOnBoot: () => reconcileOnBootMock(),
+}));
+vi.mock('@/lib/hostFirewall', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/hostFirewall')>('@/lib/hostFirewall');
+  return { ...actual, inspectHostFirewall: (...a: unknown[]) => inspectMock(...a) };
+});
+
+import { checkHostFirewallRule } from './hostFirewallRule';
+import { dispatchProbeAction } from '../actions';
+import './hostFirewallRule';
+
+/** Live-host state: rule fully loaded and persistent. */
+const loaded = (ports: number[]) => ({
+  nftAvailable: true,
+  tableLoaded: true,
+  loadedPorts: ports,
+  unitEnabled: 'enabled',
+  unitActive: 'active',
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  planMock.mockResolvedValue({ ports: [3890], skipped: [] });
+  inspectMock.mockResolvedValue(loaded([3890]));
+  reconcileOnBootMock.mockResolvedValue(undefined);
+});
+
+describe('host_firewall_rule probe (#2420)', () => {
+  it('is green when the declared port is really in the live ruleset', async () => {
+    const res = await checkHostFirewallRule();
+    expect(res.status).toBe('ok');
+    expect(res.detail).toContain('3890');
+    expect(res.items).toBeUndefined();
+  });
+
+  it('is green (nothing expected) when no template declares an on-box-only port', async () => {
+    planMock.mockResolvedValue({ ports: [], skipped: [] });
+    const res = await checkHostFirewallRule();
+    expect(res.status).toBe('ok');
+    // No host round-trip needed when nothing is desired.
+    expect(inspectMock).not.toHaveBeenCalled();
+  });
+
+  it('fails with a retry action when the nft binary is absent', async () => {
+    inspectMock.mockResolvedValue({
+      nftAvailable: false, tableLoaded: false, loadedPorts: [], unitEnabled: 'not-found', unitActive: 'inactive',
+    });
+    const res = await checkHostFirewallRule();
+    expect(res.status).toBe('fail');
+    expect(res.detail).toContain('nft is not installed');
+    expect(res.detail).toContain('3890');
+    expect(res.items?.[0].actionIds).toContain('reapply_host_firewall');
+  });
+
+  it('fails with a retry action when the table was dropped', async () => {
+    inspectMock.mockResolvedValue({
+      nftAvailable: true, tableLoaded: false, loadedPorts: [], unitEnabled: 'enabled', unitActive: 'inactive',
+    });
+    const res = await checkHostFirewallRule();
+    expect(res.status).toBe('fail');
+    expect(res.detail).toContain('servicebay_lanblock');
+    expect(res.items?.[0].actionIds).toContain('reapply_host_firewall');
+  });
+
+  it('fails when the table is loaded but is missing a declared port', async () => {
+    planMock.mockResolvedValue({ ports: [3890, 9999], skipped: [] });
+    inspectMock.mockResolvedValue(loaded([3890]));
+    const res = await checkHostFirewallRule();
+    expect(res.status).toBe('fail');
+    expect(res.detail).toContain('9999');
+    expect(res.items?.[0].actionIds).toContain('reapply_host_firewall');
+  });
+
+  it('warns when the rule is live but the boot unit will not bring it back', async () => {
+    inspectMock.mockResolvedValue({ ...loaded([3890]), unitEnabled: 'disabled', unitActive: 'active' });
+    const res = await checkHostFirewallRule();
+    expect(res.status).toBe('warn');
+    expect(res.detail).toContain('reboot');
+  });
+
+  it('warns (not "ok") when the live ruleset could not be read at all', async () => {
+    inspectMock.mockResolvedValue({
+      nftAvailable: true, tableLoaded: false, loadedPorts: [], unitEnabled: 'enabled', unitActive: 'active',
+      error: 'sudo: a password is required',
+    });
+    const res = await checkHostFirewallRule();
+    expect(res.status).toBe('warn');
+    expect(res.detail).toContain('unverified');
+  });
+
+  it('mutation-prove: a boot reconcile that RETURNS SUCCESS with the rule absent is still caught', async () => {
+    // Exactly the pre-#2420 blind spot: the call resolves happily…
+    await expect(reconcileOnBootMock()).resolves.toBeUndefined();
+    // …while the kernel holds nothing. The probe reads the host, so it fails.
+    inspectMock.mockResolvedValue({
+      nftAvailable: true, tableLoaded: false, loadedPorts: [], unitEnabled: 'enabled', unitActive: 'active',
+    });
+    const res = await checkHostFirewallRule();
+    expect(res.status).toBe('fail');
+    expect(res.detail).toContain('NOT loaded');
+  });
+});
+
+describe('reapply_host_firewall action (#2420)', () => {
+  it('re-applies and then re-reads the host before claiming success', async () => {
+    // The re-apply converged, so the post-check read finds the rule live.
+    inspectMock.mockResolvedValue(loaded([3890]));
+    const result = await dispatchProbeAction({
+      probeId: 'host_firewall_rule', actionId: 'reapply_host_firewall', node: 'Local',
+    });
+    expect(reconcileOnBootMock).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.refresh).toBe(true);
+  });
+
+  it('reports not-ok when the rule is still absent after the re-apply', async () => {
+    inspectMock.mockResolvedValue({
+      nftAvailable: true, tableLoaded: false, loadedPorts: [], unitEnabled: 'enabled', unitActive: 'active',
+    });
+    const result = await dispatchProbeAction({
+      probeId: 'host_firewall_rule', actionId: 'reapply_host_firewall', node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('still');
+  });
+
+  it('surfaces the apply error rather than swallowing it', async () => {
+    reconcileOnBootMock.mockRejectedValue(new Error('sudo: no'));
+    const result = await dispatchProbeAction({
+      probeId: 'host_firewall_rule', actionId: 'reapply_host_firewall', node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('sudo: no');
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/hostFirewallRule.ts
+++ b/packages/backend/src/lib/diagnose/probes/hostFirewallRule.ts
@@ -1,0 +1,185 @@
+/**
+ * `host_firewall_rule` probe (#2420) — does the #2388 LAN block ACTUALLY
+ * exist in the kernel right now?
+ *
+ * The rest of the host-firewall code path reports on its own return
+ * values: the capability handlers say `{ ok: false }` when a reconcile
+ * throws, and the boot reconcile records a standing failure when it does
+ * (surfaced by `install_handler_failed`). None of that catches the case
+ * this probe is for — a reconcile that returned success while the rule
+ * is **not** loaded. Which is not hypothetical: the table can be deleted
+ * by hand (it's the documented one-line rollback), the boot unit can be
+ * disabled or fail, an `nft` binary can vanish across an rpm-ostree
+ * rebase, and a box can simply never have run the boot path.
+ *
+ * So this probe compares two independently-derived facts:
+ *
+ *   - **desired** — `planLanBlockedPorts()`, the same computation the
+ *     reconcile drives off (installed templates × `blockLanAccess`), but
+ *     with no side effects;
+ *   - **actual** — `inspectHostFirewall()`, read back from
+ *     `nft list table inet servicebay_lanblock` and `systemctl` on the
+ *     host.
+ *
+ * A declared port missing from the live set is a `fail`: an on-box-only
+ * port is answering the LAN, which is exactly the exposure #2388 closed.
+ * The "loaded but the unit won't bring it back" case is a `warn` — right
+ * now it's filtered, but a reboot un-does it.
+ */
+
+import { getExecutor } from '@/lib/executor';
+import { logger } from '@/lib/logger';
+import { inspectHostFirewall, NFT_TABLE, UNIT_NAME, type HostFirewallState } from '@/lib/hostFirewall';
+import { planLanBlockedPorts } from '@/lib/capabilities/hostFirewall';
+import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
+
+export const PROBE_ID = 'host_firewall_rule';
+
+/** Single row id — the rule is box-level, so there is only ever one. */
+const ITEM_ID = 'lan_block';
+
+export interface HostFirewallRuleResult {
+  status: 'ok' | 'warn' | 'fail' | 'info';
+  detail: string;
+  hint?: string;
+  items?: ProbeItem[];
+}
+
+const list = (ports: number[]) => ports.join(', ');
+const plural = (ports: number[]) => (ports.length === 1 ? '' : 's');
+
+/** One actionable row, so the operator gets a "Re-apply" button on the finding. */
+function failingItem(label: string, detail: string, status: 'warn' | 'fail'): ProbeItem[] {
+  return [{ id: ITEM_ID, label, detail, status, actionIds: ['reapply_host_firewall'] }];
+}
+
+/**
+ * Can the host filter at all, and is our table there? Returns null when
+ * the answer is "yes, keep checking" so the caller falls through to the
+ * port-level comparison.
+ */
+function reachabilityVerdict(want: number[], state: HostFirewallState): HostFirewallRuleResult | null {
+  const wanted = `port${plural(want)} ${list(want)}`;
+
+  if (!state.nftAvailable) {
+    return {
+      status: 'fail',
+      detail:
+        `nft is not installed on this box, so the LAN block for ${wanted} cannot be applied — ` +
+        `${want.length === 1 ? 'that port answers' : 'those ports answer'} every device on the LAN.`,
+      hint: `Install nftables on the host (Fedora CoreOS: \`rpm-ostree install nftables\` + reboot), then click "Re-apply".`,
+      items: failingItem(wanted, 'nft binary not found on the host', 'fail'),
+    };
+  }
+
+  if (state.error) {
+    // Couldn't ask. Report that honestly rather than implying "loaded".
+    return {
+      status: 'warn',
+      detail: `Could not read the live nft ruleset, so the LAN block for ${wanted} is unverified — ${state.error}`,
+      hint: 'Usually the agent is down or sudo refused the read. Fix that, then re-run diagnose.',
+      items: failingItem(wanted, `ruleset query failed: ${state.error}`, 'warn'),
+    };
+  }
+
+  if (!state.tableLoaded) {
+    return {
+      status: 'fail',
+      detail:
+        `The LAN block is NOT loaded: table inet ${NFT_TABLE} is absent from the live ruleset, so ${wanted} ` +
+        `${want.length === 1 ? 'is' : 'are'} reachable from every device on the LAN.`,
+      hint: `Click "Re-apply" to re-render the rule and restart ${UNIT_NAME}.`,
+      items: failingItem(wanted, `table inet ${NFT_TABLE} not present in the live ruleset`, 'fail'),
+    };
+  }
+
+  return null;
+}
+
+/** The table is loaded — does it hold what the templates declared, and
+ *  will it still be there after a reboot? */
+function portSetVerdict(want: number[], state: HostFirewallState): HostFirewallRuleResult {
+  const wanted = `port${plural(want)} ${list(want)}`;
+  const missing = want.filter(p => !state.loadedPorts.includes(p));
+  if (missing.length > 0) {
+    return {
+      status: 'fail',
+      detail:
+        `The live ruleset filters ${state.loadedPorts.length ? `port${plural(state.loadedPorts)} ${list(state.loadedPorts)}` : 'no ports'}, ` +
+        `but port${plural(missing)} ${list(missing)} ${missing.length === 1 ? 'is' : 'are'} declared on-box-only and ` +
+        `${missing.length === 1 ? 'is' : 'are'} NOT filtered.`,
+      hint: `Click "Re-apply" to push the full desired port set back to the host.`,
+      items: failingItem(
+        `port${plural(missing)} ${list(missing)}`,
+        `declared on-box-only but not in the live inet ${NFT_TABLE} set`,
+        'fail',
+      ),
+    };
+  }
+
+  if (state.unitActive !== 'active' || state.unitEnabled !== 'enabled') {
+    return {
+      status: 'warn',
+      detail:
+        `${wanted} ${want.length === 1 ? 'is' : 'are'} filtered right now, but ${UNIT_NAME} is ` +
+        `${state.unitActive}/${state.unitEnabled} — the rule will not come back after a reboot.`,
+      hint: 'Click "Re-apply" to reinstall and enable the boot unit.',
+      items: failingItem(wanted, `${UNIT_NAME}: ${state.unitActive}, ${state.unitEnabled}`, 'warn'),
+    };
+  }
+
+  return {
+    status: 'ok',
+    detail:
+      `LAN access is refused for ${wanted} — verified against the live ruleset (table inet ${NFT_TABLE}), ` +
+      `with ${UNIT_NAME} enabled so it survives a reboot.`,
+  };
+}
+
+/** Pure verdict: desired port set vs. what the host actually reported.
+ *  Exported so the comparison can be tested without a host. */
+export function evaluateHostFirewall(want: number[], state: HostFirewallState): HostFirewallRuleResult {
+  return reachabilityVerdict(want, state) ?? portSetVerdict(want, state);
+}
+
+export async function checkHostFirewallRule(): Promise<HostFirewallRuleResult> {
+  const plan = await planLanBlockedPorts();
+  if (plan.ports.length === 0) {
+    return {
+      status: 'ok',
+      detail: 'No installed template declares an on-box-only port, so no host firewall rule is expected.',
+    };
+  }
+  return evaluateHostFirewall(plan.ports, await inspectHostFirewall(getExecutor()));
+}
+
+/** Re-render + re-apply the full desired state. Idempotent by construction
+ *  (the rendered file IS the desired state and `nft -f` swaps the table
+ *  atomically), so clicking twice is harmless. */
+async function reapplyHostFirewall(): Promise<ProbeActionResult> {
+  const { reconcileHostFirewallOnBoot } = await import('@/lib/capabilities/hostFirewall');
+  try {
+    await reconcileHostFirewallOnBoot();
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn('diagnose:host_firewall_rule', `re-apply failed: ${message}`);
+    return { ok: false, message: `Could not apply the host firewall rule: ${message}`, refresh: true };
+  }
+  // Read the host back rather than trusting the call that just returned —
+  // the whole point of this probe (#2420).
+  const after = await checkHostFirewallRule();
+  return after.status === 'ok'
+    ? { ok: true, message: after.detail, refresh: true }
+    : { ok: false, message: `Applied, but the rule still isn't right: ${after.detail}`, refresh: true };
+}
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: 'reapply_host_firewall',
+    label: 'Re-apply',
+    description:
+      'Re-renders the host firewall ruleset from the installed templates and reloads it, then re-checks the live ruleset. Only touches ServiceBay\'s own nft table — podman and the rest of the host firewall are untouched. Safe to click twice.',
+  },
+  reapplyHostFirewall,
+);

--- a/packages/backend/src/lib/diagnose/probes/installHandlerFailed.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/installHandlerFailed.test.ts
@@ -16,6 +16,13 @@ vi.mock('@/lib/config', () => ({
 vi.mock('@/lib/api/internalFetch', () => ({ internalFetch: vi.fn() }));
 vi.mock('@/lib/capabilities/authelia', () => ({ buildOidcReconcilePayload: vi.fn() }));
 
+// #2420 — the host-firewall retry path re-runs the boot reconcile; stub it
+// so the test never reaches an executor.
+const reconcileOnBootMock = vi.fn(() => Promise.resolve());
+vi.mock('@/lib/capabilities/hostFirewall', () => ({
+  reconcileHostFirewallOnBoot: () => reconcileOnBootMock(),
+}));
+
 import { checkInstallHandlerFailed } from './installHandlerFailed';
 import { dispatchProbeAction } from '../actions';
 import './installHandlerFailed';
@@ -57,6 +64,32 @@ describe('install_handler_failed probe (#2160/#2161)', () => {
     });
     expect(result.ok).toBe(true);
     expect((await checkInstallHandlerFailed()).status).toBe('ok');
+  });
+
+  it('surfaces a boot-time host-firewall failure as a standing row with a retry (#2420)', async () => {
+    await recordHandlerFailure({
+      kind: 'host-firewall',
+      service: 'host-firewall',
+      message: 'boot reconcile: sudo: a password is required',
+    });
+    const res = await checkInstallHandlerFailed();
+    expect(res.status).toBe('warn');
+    const row = res.items!.find(i => i.id === 'host-firewall:host-firewall')!;
+    expect(row.detail).toContain('host firewall reconcile (LAN block)');
+    expect(row.detail).toContain('sudo');
+    expect(row.actionIds).toContain('retry_install_handler');
+  });
+
+  it('retry on a host-firewall row re-runs the reconcile (#2420)', async () => {
+    await recordHandlerFailure({ kind: 'host-firewall', service: 'host-firewall', message: 'boot reconcile: nft gone' });
+    const result = await dispatchProbeAction({
+      probeId: 'install_handler_failed',
+      actionId: 'retry_install_handler',
+      node: 'Local',
+      itemId: 'host-firewall:host-firewall',
+    });
+    expect(reconcileOnBootMock).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
   });
 
   it('rejects an unrecognized item id', async () => {

--- a/packages/backend/src/lib/diagnose/probes/installHandlerFailed.ts
+++ b/packages/backend/src/lib/diagnose/probes/installHandlerFailed.ts
@@ -9,6 +9,9 @@
  *     proxy registration never landed → invalid_client or no route.
  *   - `restore`: a NAS auto-restore that failed, so the service came up on
  *     default config while the operator believes their state was restored.
+ *   - `host-firewall`: the boot-time LAN-block reconcile threw (#2420).
+ *     Box-level rather than per-service, but the same shape of silent
+ *     half-state: the #2388 rule did not apply and only a log line said so.
  *
  * Symmetric with `post_deploy_failed`: each standing failure is one item
  * with a retry/reconcile action so the operator can recover it long after
@@ -25,10 +28,18 @@ import {
   listHandlerFailures,
   clearHandlerFailure,
   handlerFailureKey,
+  type InstallHandlerFailureRecord,
 } from '@/lib/install/handlerFailures';
 import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
 
 export const PROBE_ID = 'install_handler_failed';
+
+/** What each record kind reads as in the row detail. */
+const KIND_LABEL: Record<InstallHandlerFailureRecord['kind'], string> = {
+  capability: 'capability registration',
+  restore: 'NAS restore',
+  'host-firewall': 'host firewall reconcile (LAN block)',
+};
 
 export interface InstallHandlerFailedResult {
   status: 'ok' | 'warn' | 'info';
@@ -48,9 +59,7 @@ export async function checkInstallHandlerFailed(): Promise<InstallHandlerFailedR
   const items: ProbeItem[] = failures.map(f => ({
     id: handlerFailureKey(f.kind, f.service),
     label: f.service,
-    detail:
-      `${f.kind === 'restore' ? 'NAS restore' : 'capability registration'} failed at ` +
-      `${new Date(f.lastFailedAt).toLocaleString()} — ${f.message}`,
+    detail: `${KIND_LABEL[f.kind]} failed at ${new Date(f.lastFailedAt).toLocaleString()} — ${f.message}`,
     status: 'warn',
     actionIds: ['retry_install_handler', 'dismiss_install_handler'],
   }));
@@ -65,13 +74,15 @@ export async function checkInstallHandlerFailed(): Promise<InstallHandlerFailedR
 }
 
 /** Parse `${kind}:${service}` back into its parts. */
-function parseItemId(itemId: string): { kind: 'capability' | 'restore'; service: string } | null {
+function parseItemId(
+  itemId: string,
+): { kind: InstallHandlerFailureRecord['kind']; service: string } | null {
   const idx = itemId.indexOf(':');
   if (idx < 0) return null;
   const kind = itemId.slice(0, idx);
   const service = itemId.slice(idx + 1);
-  if ((kind !== 'capability' && kind !== 'restore') || !service) return null;
-  return { kind, service };
+  if (!(kind in KIND_LABEL) || !service) return null;
+  return { kind: kind as InstallHandlerFailureRecord['kind'], service };
 }
 
 /** Re-run the capability registration for a service by reconciling its OIDC
@@ -148,11 +159,36 @@ async function retryRestore(service: string): Promise<ProbeActionResult> {
   return { ok: true, message: `Restored ${service} config from the NAS.`, refresh: true };
 }
 
+/** Re-run the host-firewall reconcile that failed at boot (#2420). The
+ *  reconcile is idempotent and clears its own record on success, so this
+ *  is just "try again now" — with the outcome reported either way rather
+ *  than swallowed into a log line like the boot path used to do. */
+async function retryHostFirewall(): Promise<ProbeActionResult> {
+  // Lazy import: keeps the executor/registry graph out of the probe's
+  // module load, same as the restore path above.
+  const { reconcileHostFirewallOnBoot } = await import('@/lib/capabilities/hostFirewall');
+  try {
+    await reconcileHostFirewallOnBoot();
+  } catch (e) {
+    return {
+      ok: false,
+      message: `Host firewall reconcile still failing: ${e instanceof Error ? e.message : String(e)}`,
+      refresh: true,
+    };
+  }
+  return {
+    ok: true,
+    message: 'Re-applied the host firewall rule. Run diagnose again to confirm the rule is loaded.',
+    refresh: true,
+  };
+}
+
 async function retryInstallHandler({ itemId }: { itemId?: string }): Promise<ProbeActionResult> {
   if (!itemId) return { ok: false, message: 'No service supplied.', refresh: false };
   const parsed = parseItemId(itemId);
   if (!parsed) return { ok: false, message: `Unrecognized item id: ${itemId}`, refresh: false };
   try {
+    if (parsed.kind === 'host-firewall') return await retryHostFirewall();
     return parsed.kind === 'restore'
       ? await retryRestore(parsed.service)
       : await retryCapability(parsed.service);
@@ -178,7 +214,7 @@ registerProbeAction(
     id: 'retry_install_handler',
     label: 'Retry',
     description:
-      'Re-runs the failed install step for this service — re-registers its Authelia OIDC client (fixes SSO invalid_client) or re-restores its config from the NAS. Idempotent: already-completed work is skipped. Clears the warning on success.',
+      'Re-runs the failed step for this row — re-registers the Authelia OIDC client (fixes SSO invalid_client), re-restores config from the NAS, or re-applies the host firewall LAN block. Idempotent: already-completed work is skipped. Clears the warning on success.',
   },
   retryInstallHandler,
 );

--- a/packages/backend/src/lib/diagnose/probes/register.ts
+++ b/packages/backend/src/lib/diagnose/probes/register.ts
@@ -17,6 +17,7 @@ import './routerDnsNotPointing';
 import './danglingProxy';
 import './postDeployFailed';
 import './installHandlerFailed';
+import './hostFirewallRule';
 import './crashLoop';
 import './proxyRouteMissing';
 import './nginxOnlineFailed';

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -21,6 +21,7 @@ import { checkLanIpChanged } from '@/lib/diagnose/probes/lanIpChanged';
 import { checkRouterDnsNotPointing } from '@/lib/diagnose/probes/routerDnsNotPointing';
 import { checkPostDeployFailed } from '@/lib/diagnose/probes/postDeployFailed';
 import { checkInstallHandlerFailed } from '@/lib/diagnose/probes/installHandlerFailed';
+import { checkHostFirewallRule } from '@/lib/diagnose/probes/hostFirewallRule';
 import { checkMediaLibraryAccess } from '@/lib/diagnose/probes/mediaLibraryAccess';
 import { checkProxyRouteMissing } from '@/lib/diagnose/probes/proxyRouteMissing';
 import { checkNginxOnlineFailed } from '@/lib/diagnose/probes/nginxOnlineFailed';
@@ -92,6 +93,7 @@ const PROBE_GROUP: Record<string, ProbeGroup> = {
   router_dns_not_pointing: 'dns-network',
   adguard_rewrites_missing: 'dns-network',
   domain_resolves_to_box: 'dns-network',
+  host_firewall_rule: 'dns-network',
   // TLS certificates
   cert_expiry: 'tls',
   // Login / SSO
@@ -1029,6 +1031,30 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     probes.push({
       id: 'install_handler_failed',
       label: 'Install capability/restore',
+      status: 'info',
+      detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+
+  // 15a2) Host firewall LAN block actually loaded (#2420). Every other
+  //     signal in this area reports on a return value; this one reads the
+  //     live `nft` ruleset back, so a reconcile that "succeeded" while the
+  //     rule is absent (hand-deleted table, disabled boot unit, no nft
+  //     binary) still shows up as a concrete failure with a Re-apply.
+  try {
+    const hfw = await checkHostFirewallRule();
+    probes.push({
+      id: 'host_firewall_rule',
+      label: 'On-box-only ports',
+      status: hfw.status,
+      detail: hfw.detail,
+      hint: hfw.hint,
+      _items: hfw.items,
+    });
+  } catch (e) {
+    probes.push({
+      id: 'host_firewall_rule',
+      label: 'On-box-only ports',
       status: 'info',
       detail: `Skipped: ${e instanceof Error ? e.message : String(e)}`,
     });

--- a/packages/backend/src/lib/hostFirewall.test.ts
+++ b/packages/backend/src/lib/hostFirewall.test.ts
@@ -28,11 +28,60 @@ import {
   renderUnit,
   reconcileHostFirewall,
   removeHostFirewall,
+  inspectHostFirewall,
+  parseNftPorts,
   NEVER_FILTER_PORTS,
   NFT_TABLE,
   UNIT_NAME,
 } from './hostFirewall';
 import type { Executor } from './interfaces';
+
+/** What `nft list table inet servicebay_lanblock` prints for `ports`. */
+const NFT_LISTING = (ports: number[]) => `table inet ${NFT_TABLE} {
+\tset on_box_only_ports {
+\t\ttype inet_service
+\t\tcomment "ports a template declared blockLanAccess on"
+\t\telements = { ${ports.join(', ')} }
+\t}
+
+\tchain input {
+\t\ttype filter hook input priority filter; policy accept;
+\t\ttcp dport @on_box_only_ports jump on_box_gate
+\t}
+}`;
+
+/** Executor stub for the read-back path (#2420): every host answer is a knob. */
+function inspectExecutor(opts: {
+  nftOnPath?: boolean;
+  nftAtDefault?: boolean;
+  listing?: string;
+  listError?: string;
+  isActive?: string;
+  isEnabled?: string;
+} = {}) {
+  const argvCalls: string[][] = [];
+  const executor = {
+    execArgv: vi.fn(async (argv: string[]) => {
+      argvCalls.push(argv);
+      const cmd = argv.join(' ');
+      if (cmd === 'sh -c command -v nft') {
+        if (opts.nftOnPath === false) throw new Error('command failed: exit 1');
+        return { stdout: '/usr/sbin/nft\n', stderr: '' };
+      }
+      if (cmd.includes('systemctl is-active')) return { stdout: `${opts.isActive ?? 'inactive'}\n`, stderr: '' };
+      if (cmd.includes('systemctl is-enabled')) return { stdout: `${opts.isEnabled ?? 'disabled'}\n`, stderr: '' };
+      if (cmd.includes('list table')) {
+        if (opts.listError) throw new Error(opts.listError);
+        if (opts.listing === undefined) throw new Error('No such file or directory');
+        return { stdout: opts.listing, stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    }),
+    writeFile: vi.fn(async () => undefined),
+    exists: vi.fn(async () => opts.nftAtDefault ?? false),
+  } as unknown as Executor;
+  return { executor, argvCalls };
+}
 
 /** Minimal Executor stub recording every call. */
 function fakeExecutor(opts: { failArgv?: RegExp; unitExists?: boolean; tableExists?: boolean } = {}) {
@@ -347,5 +396,71 @@ describe('removeHostFirewall (#2388)', () => {
     const { executor, argvCalls } = fakeExecutor({ unitExists: true, tableExists: true, failArgv: /systemctl disable/ });
     await expect(removeHostFirewall(executor)).resolves.toBeUndefined();
     expect(joined(argvCalls)).toContain(`sudo /usr/sbin/nft delete table inet ${NFT_TABLE}`);
+  });
+});
+
+/**
+ * Reading the host back (#2420). These cover the "we assumed instead of
+ * asking" gap: the reconcile can return success while the kernel holds
+ * nothing, so `inspectHostFirewall` must report what is actually loaded
+ * and must distinguish "no nft" / "no table" / "couldn't ask".
+ */
+describe('parseNftPorts (#2420)', () => {
+  it('reads the set elements out of a real listing', () => {
+    expect(parseNftPorts(NFT_LISTING([3890]))).toEqual([3890]);
+  });
+
+  it('handles a multi-port, line-wrapped set', () => {
+    const wrapped = `table inet ${NFT_TABLE} {
+\tset on_box_only_ports {
+\t\ttype inet_service
+\t\telements = { 3890, 9999,
+\t\t\t     10000 }
+\t}
+}`;
+    expect(parseNftPorts(wrapped)).toEqual([3890, 9999, 10000]);
+  });
+
+  it('returns nothing for a table listing with no set (never a false "loaded")', () => {
+    expect(parseNftPorts(`table inet ${NFT_TABLE} {\n\tchain input {\n\t}\n}`)).toEqual([]);
+  });
+});
+
+describe('inspectHostFirewall (#2420)', () => {
+  it('reports the ports the LIVE ruleset holds, plus the unit verdicts', async () => {
+    const { executor } = inspectExecutor({ listing: NFT_LISTING([3890]), isActive: 'active', isEnabled: 'enabled' });
+    await expect(inspectHostFirewall(executor)).resolves.toEqual({
+      nftAvailable: true,
+      tableLoaded: true,
+      loadedPorts: [3890],
+      unitEnabled: 'enabled',
+      unitActive: 'active',
+    });
+  });
+
+  it('reports table-absent as not-loaded, not as an error', async () => {
+    const { executor } = inspectExecutor({ listError: 'No such file or directory' });
+    const state = await inspectHostFirewall(executor);
+    expect(state).toMatchObject({ nftAvailable: true, tableLoaded: false, loadedPorts: [] });
+    expect(state.error).toBeUndefined();
+  });
+
+  it('flags a genuinely unanswerable query so it cannot pass as "loaded"', async () => {
+    const { executor } = inspectExecutor({ listError: 'sudo: a password is required' });
+    const state = await inspectHostFirewall(executor);
+    expect(state.tableLoaded).toBe(false);
+    expect(state.error).toContain('sudo');
+  });
+
+  it('reports nft as unavailable when it is neither on PATH nor at the default path', async () => {
+    const { executor } = inspectExecutor({ nftOnPath: false, nftAtDefault: false });
+    const state = await inspectHostFirewall(executor);
+    expect(state).toMatchObject({ nftAvailable: false, tableLoaded: false });
+  });
+
+  it('falls back to the default path when nft is off the agent PATH', async () => {
+    const { executor, argvCalls } = inspectExecutor({ nftOnPath: false, nftAtDefault: true, listing: NFT_LISTING([3890]) });
+    await expect(inspectHostFirewall(executor)).resolves.toMatchObject({ nftAvailable: true, loadedPorts: [3890] });
+    expect(joined(argvCalls).some(c => c.startsWith('sudo /usr/sbin/nft list table'))).toBe(true);
   });
 });

--- a/packages/backend/src/lib/hostFirewall.ts
+++ b/packages/backend/src/lib/hostFirewall.ts
@@ -280,16 +280,124 @@ WantedBy=multi-user.target
 `;
 }
 
-/** Resolve nft's absolute path — systemd needs one and it is not the same on every distro. */
-async function resolveNftBin(executor: Executor): Promise<string> {
+/**
+ * Locate nft, or report that the host genuinely doesn't have it.
+ *
+ * "Not on the agent's PATH" is not the same as "absent" — Fedora ships
+ * nft in `/usr/sbin`, which a non-login shell may not carry — so a
+ * missing `command -v` falls back to checking the default path itself.
+ * Returns null only when neither resolves, which is the one case where
+ * applying the rule cannot possibly work (#2420).
+ */
+async function findNftBin(executor: Executor): Promise<string | null> {
   try {
     const { stdout } = await executor.execArgv(['sh', '-c', 'command -v nft']);
     const first = stdout.trim().split('\n')[0]?.trim();
     if (first && first.startsWith('/')) return first;
   } catch {
-    /* fall through to the default */
+    /* not on PATH — fall through to the default path probe */
   }
-  return DEFAULT_NFT_BIN;
+  try {
+    if (await executor.exists(DEFAULT_NFT_BIN)) return DEFAULT_NFT_BIN;
+  } catch {
+    /* treat an unanswerable probe as absent */
+  }
+  return null;
+}
+
+/** Resolve nft's absolute path — systemd needs one and it is not the same on every distro. */
+async function resolveNftBin(executor: Executor): Promise<string> {
+  return (await findNftBin(executor)) ?? DEFAULT_NFT_BIN;
+}
+
+/**
+ * What the host's packet filter ACTUALLY looks like right now (#2420).
+ *
+ * Everything here is read back from the kernel/systemd rather than
+ * inferred from whether {@link reconcileHostFirewall} returned without
+ * throwing — a reconcile can report success and still leave the rule
+ * absent (unit masked out-of-band, table deleted by hand, a boot where
+ * the call never ran at all). A security control that is only ever
+ * "assumed applied" is the failure mode #2388 has.
+ */
+export interface HostFirewallState {
+  /** `nft` exists on the host (PATH or the distro default path). */
+  nftAvailable: boolean;
+  /** `table inet servicebay_lanblock` is present in the LIVE ruleset. */
+  tableLoaded: boolean;
+  /** Ports the live table's set actually holds. Empty when not loaded. */
+  loadedPorts: number[];
+  /** `systemctl is-enabled` verdict for the boot unit (`enabled`, `disabled`, `not-found`, …). */
+  unitEnabled: string;
+  /** `systemctl is-active` verdict (`active`, `inactive`, `failed`, …). */
+  unitActive: string;
+  /** Why the ruleset query failed, when the reason was NOT "no such table". */
+  error?: string;
+}
+
+/** nft prints an `inet_service` set as `elements = { 3890, 9999 }`, wrapping
+ *  across lines once it gets long — hence the greedy-to-`}` capture. */
+const ELEMENTS_RE = /elements\s*=\s*\{([^}]*)\}/;
+
+/**
+ * Pull the port numbers out of `nft list table` output. Exported for
+ * the diagnose probe's tests: this parse is the only thing standing
+ * between "the rule is loaded" and "we hope the rule is loaded".
+ */
+export function parseNftPorts(listing: string): number[] {
+  const match = ELEMENTS_RE.exec(listing);
+  if (!match) return [];
+  const ports = match[1]
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => /^\d+$/.test(s))
+    .map(Number);
+  return [...new Set(ports)].sort((a, b) => a - b);
+}
+
+/** Read one systemd verdict word. `is-enabled`/`is-active` exit non-zero
+ *  for every not-good answer, so the word is what we want, not the code. */
+async function systemdVerdict(executor: Executor, verb: string): Promise<string | null> {
+  try {
+    const { stdout } = await executor.execArgv([
+      'sh', '-c', `systemctl ${verb} ${UNIT_NAME} 2>/dev/null || true`,
+    ]);
+    const word = stdout.trim().split('\n').pop()?.trim();
+    return word || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ask the host what is actually loaded. Never throws — every failure
+ * becomes a field on {@link HostFirewallState} so the caller (the
+ * `host_firewall_rule` probe) can tell "no nft binary" from "table
+ * missing" from "couldn't ask" and word its finding accordingly.
+ */
+export async function inspectHostFirewall(executor: Executor): Promise<HostFirewallState> {
+  const nftBin = await findNftBin(executor);
+  const state: HostFirewallState = {
+    nftAvailable: nftBin !== null,
+    tableLoaded: false,
+    loadedPorts: [],
+    unitEnabled: (await systemdVerdict(executor, 'is-enabled')) ?? 'unknown',
+    unitActive: (await systemdVerdict(executor, 'is-active')) ?? 'unknown',
+  };
+  if (!nftBin) return state;
+
+  try {
+    const { stdout } = await executor.execArgv(['sudo', nftBin, 'list', 'table', 'inet', NFT_TABLE]);
+    state.tableLoaded = true;
+    state.loadedPorts = parseNftPorts(stdout);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    // nft says "No such file or directory" when the TABLE is absent —
+    // that's the expected negative, not an error worth quoting at the
+    // operator. Anything else (sudo refused, agent down) is.
+    if (!/no such file or directory|does not exist/i.test(message)) state.error = message;
+  }
+  return state;
 }
 
 /** Agent writes /tmp (its own user can), then `sudo install` places it root-owned. */

--- a/packages/backend/src/lib/install/manifestAssembler.test.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.test.ts
@@ -131,6 +131,45 @@ describe('assembleManifest', () => {
     expect(v.global).toBe(true);
   });
 
+  it('resolves PUBLIC_DOMAIN when NO template declares it and the global has an empty default (#2425)', async () => {
+    // Post-#2425 shape: PUBLIC_DOMAIN lives once in templates/settings.json
+    // with `default: ""` (LAN_IP's precedent), and no template's
+    // variables.json redeclares it. Both wizard paths must still land a
+    // value — the prefill (OnboardingWizard passes `stackDomain`) and the
+    // reverseProxy fallback — and neither may be a hardcoded domain.
+    getTemplateYaml.mockResolvedValue(tmplYaml('svc', [], '    # {{PUBLIC_DOMAIN}}'));
+    getTemplateVariables.mockResolvedValue({});
+    getTemplateSettingsSchema.mockResolvedValue({
+      PUBLIC_DOMAIN: { default: '', description: 'Base public domain for this box' },
+    });
+    getConfig.mockResolvedValue({ templateSettings: {} });
+
+    const prefill = await assembleManifest({
+      items: [{ name: 'svc', checked: true }],
+      prefilled: { PUBLIC_DOMAIN: 'stack.example' },
+      templateSource: 'Built-in',
+    });
+    const fromWizard = prefill.variables.find(v => v.name === 'PUBLIC_DOMAIN')!;
+    expect(fromWizard.value).toBe('stack.example');
+    expect(fromWizard.global).toBe(true);
+
+    getConfig.mockResolvedValue({ templateSettings: {}, reverseProxy: { publicDomain: 'box.example' } });
+    const fallback = await assembleManifest({
+      items: [{ name: 'svc', checked: true }],
+      templateSource: 'Built-in',
+    });
+    expect(fallback.variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value).toBe('box.example');
+
+    // Nothing configured anywhere → empty, never a leftover default. An
+    // empty PUBLIC_DOMAIN is the documented LAN-only mode (UX_PHILOSOPHY).
+    getConfig.mockResolvedValue({ templateSettings: {} });
+    const bare = await assembleManifest({
+      items: [{ name: 'svc', checked: true }],
+      templateSource: 'Built-in',
+    });
+    expect(bare.variables.find(v => v.name === 'PUBLIC_DOMAIN')?.value).toBe('');
+  });
+
   it('pre-fills PUBLIC_DOMAIN from reverseProxy.publicDomain when templateSettings is empty (#1252)', async () => {
     getTemplateYaml.mockResolvedValue(tmplYaml('svc', [], '    # {{PUBLIC_DOMAIN}}'));
     getTemplateVariables.mockResolvedValue({ PUBLIC_DOMAIN: { type: 'text' } });

--- a/packages/backend/src/lib/install/manifestAssembler.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.ts
@@ -190,7 +190,7 @@ async function hostHasNvidiaCdi(): Promise<boolean> {
  */
 const GLOBAL_VAR_HELP: Record<string, string> = {
   PUBLIC_DOMAIN:
-    'Base public domain for this box (e.g. dopp.cloud). Services are ' +
+    'Base public domain for this box (e.g. example.com). Services are ' +
     'exposed at <service>.<this domain>. Enter the bare domain, not a ' +
     'subdomain.',
 };

--- a/packages/backend/src/lib/install/preserveAutheliaOidcClients.test.ts
+++ b/packages/backend/src/lib/install/preserveAutheliaOidcClients.test.ts
@@ -94,10 +94,31 @@ describe('preserveAutheliaOidcClients (#1724)', () => {
   it('is fail-soft: an agent error leaves the fresh render unchanged (never throws)', async () => {
     ensureAgentMock.mockRejectedValue(new Error('agent offline'));
     const extraFiles = [{ path: '/mnt/data/stacks/auth/configuration.yml', content: RENDERED }];
+    // Resolves to null, not the on-disk text: the caller's #2417 rotation
+    // pre-flight must treat "couldn't read it" as "nothing known on disk"
+    // rather than mistaking an unreadable box for a rotation.
     await expect(
       preserveAutheliaOidcClients('job-1', 'Local', extraFiles),
-    ).resolves.toBeUndefined();
+    ).resolves.toBeNull();
     expect(extraFiles[0].content).toBe(RENDERED);
+  });
+
+  it('returns the on-disk text it read, for the caller to reuse (#2417)', async () => {
+    // Saves a second read_file round-trip: the rotation pre-flight compares
+    // this against the fresh render to decide whether the servicebay client's
+    // secret is actually changing on this deploy.
+    sendCommandMock.mockResolvedValue({ content: EXISTING_WITH_IMMICH });
+    const extraFiles = [{ path: '/mnt/data/stacks/auth/configuration.yml', content: RENDERED }];
+    await expect(
+      preserveAutheliaOidcClients('job-1', 'Local', extraFiles),
+    ).resolves.toBe(EXISTING_WITH_IMMICH);
+  });
+
+  it('returns null for a non-auth deploy (no configuration.yml in extraFiles)', async () => {
+    const extraFiles = [{ path: '/mnt/data/stacks/immich/immich.env', content: 'X=1' }];
+    await expect(
+      preserveAutheliaOidcClients('job-1', 'Local', extraFiles),
+    ).resolves.toBeNull();
   });
 
   it('tolerates a read_file rejection (uses empty existing, no merge)', async () => {

--- a/packages/backend/src/lib/install/runner.ts
+++ b/packages/backend/src/lib/install/runner.ts
@@ -528,22 +528,26 @@ export function buildRenderedSentinelError(itemName: string, sentinelSecrets: st
  * Mutates the matching `extraFiles` entry in place. Best-effort: any failure
  * to read the existing config leaves the fresh render untouched (the
  * post-deploy `ensureOidcClients` reconcile is the backstop) — never throws.
+ *
+ * Returns the on-disk config text it read (or null when there is none / it
+ * couldn't be read), so the caller can run the #2417 rotation pre-flight
+ * against it without paying for a second `read_file` round-trip.
  */
 export async function preserveAutheliaOidcClients(
   jobId: string,
   node: string | undefined,
   extraFiles: { path: string; content: string }[],
-): Promise<void> {
+): Promise<string | null> {
   // Authelia's config is the only `configuration.yml` the auth stack writes.
   const cf = extraFiles.find(f => f.path.endsWith('/configuration.yml') || f.path.endsWith('configuration.yml'));
-  if (!cf) return;
+  if (!cf) return null;
 
   try {
     const { agentManager } = await import('@/lib/agent/manager');
     const agent = await agentManager.ensureAgent(node || 'Local');
     const readRes = await agent.sendCommand('read_file', { path: cf.path }).catch(() => null);
     const existing = readRes ? (readRes.content || readRes.stdout || '') : '';
-    if (!existing) return; // fresh install — nothing on disk to preserve
+    if (!existing) return null; // fresh install — nothing on disk to preserve
 
     const { mergeAutheliaOidcClients } = await import('@/lib/capabilities/autheliaClientMerge');
     const merged = mergeAutheliaOidcClients(cf.content, existing);
@@ -551,8 +555,10 @@ export async function preserveAutheliaOidcClients(
       cf.content = merged;
       await log(jobId, 'ℹ️ Preserved existing Authelia OIDC client registrations across the auth redeploy (#1724).');
     }
+    return existing;
   } catch (e) {
     await log(jobId, `⚠️ Could not preserve existing Authelia OIDC clients (${e instanceof Error ? e.message : String(e)}); the post-deploy reconcile will re-register this install's clients.`);
+    return null;
   }
 }
 
@@ -724,7 +730,19 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
   // each stack is individually redeployed. Before writing the auth config, read
   // the current on-disk `configuration.yml` and merge back any clients the
   // fresh render doesn't own — preserving each client's secret (no rotation).
-  await preserveAutheliaOidcClients(jobId, input.node, extraFiles);
+  const existingAutheliaConfig = await preserveAutheliaOidcClients(jobId, input.node, extraFiles);
+
+  // #2417 — the `servicebay` OIDC client (the admin panel's own "Login with
+  // Authelia") is the ONE client whose secret this deploy is allowed to
+  // rotate: it is owned by the fresh render, so the upgrade off the old
+  // hardcoded literal replaces it. That rotation briefly desynchronises the
+  // SSO button, which is only tolerable because the local admin
+  // username/password login is a second, non-OIDC door. Assert that door
+  // exists BEFORE anything is written — a throw here aborts the deploy with
+  // the box untouched, which is strictly safer than rotating the only
+  // credential the operator has.
+  const { assertServicebayOidcRotationSafe } = await import('@/lib/capabilities/servicebayOidcSecret');
+  await assertServicebayOidcRotationSafe(extraFiles, existingAutheliaConfig);
 
   // Optional per-template post-deploy.py — server runs it after the unit
   // starts; output streams back via `progress` events. Parsed below for
@@ -887,6 +905,20 @@ async function deployItem(ctx: DeployContext, item: JobInputItem): Promise<boole
       await log(jobId, attempt > 1
         ? `✅ ${item.name} deployed on attempt ${attempt}/${MAX_DEPLOY_ATTEMPTS}.`
         : `✅ ${item.name} deployed (containers may still be starting in background).`);
+
+      // #2417 — now that Authelia's configuration.yml is actually on disk,
+      // copy the `servicebay` client secret it holds into ServiceBay's own
+      // `config.oidc.clientSecret`, so the admin panel posts the value the
+      // token endpoint will accept. Deliberately AFTER the deploy succeeded:
+      // a deploy that died before the config landed must leave the box's
+      // existing (consistent) pair alone rather than half-migrate it.
+      // No-op for every stack other than `auth`; never throws.
+      {
+        const { reconcileServicebayOidcSecret } = await import('@/lib/capabilities/servicebayOidcSecret');
+        const r = await reconcileServicebayOidcSecret(input.node, extraFiles);
+        if (r?.outcome === 'changed') await log(jobId, `🔑 ${r.message}`);
+        else if (r?.outcome === 'skipped') await log(jobId, `⚠️ ${r.message}`);
+      }
       return true;
     } catch (e) {
       lastErr = e instanceof Error ? e : new Error(String(e));

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -661,6 +661,11 @@ app.prepare().then(() => {
           const { reconcileHostFirewallOnBoot } = await import('./lib/capabilities/hostFirewall');
           await reconcileHostFirewallOnBoot();
         } catch (err) {
+          // Log only — `reconcileHostFirewallOnBoot` has already persisted
+          // the failure into `config.installHandlerFailures`, so diagnose
+          // shows a standing finding with a Retry instead of this line
+          // being the only trace (#2420). The `host_firewall_rule` probe
+          // independently re-checks the live ruleset either way.
           logger.warn('Server', `Host firewall reconcile failed: ${err instanceof Error ? err.message : String(err)}`);
         }
       })();

--- a/packages/disk-import-worker/src/cli/hashMemory.test.ts
+++ b/packages/disk-import-worker/src/cli/hashMemory.test.ts
@@ -1,0 +1,144 @@
+/**
+ * #2423 — the planning-phase full hash must be O(chunk) memory, not O(filesize).
+ *
+ * `hashFileContent` is the `hashOf` resolver for planning, and planning runs
+ * inside the `--memory=1g` worker container. A re-plan over an already-cataloged
+ * multi-GB movie takes that full hash, so an eager whole-file read OOM-kills the
+ * container (a SIGKILL, so no terminal status is ever written).
+ *
+ * These tests prove the READ PATTERN, not only the digest: the fs seam is
+ * instrumented so every `readSync` is recorded, and a virtual file LARGER THAN
+ * THE 1g CAP is hashed without a byte of whole-file materialization. The
+ * digest-identity side (same sha256 as the eager implementation, across chunk
+ * boundaries) is pinned in `main.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { createReadStream, openSync, ftruncateSync, closeSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+import { hashFileContent, HASH_CHUNK_BYTES, type HashFileIO } from './main';
+import type { ImportRecord } from '../engine/types';
+
+const rec = (sourcePath: string, size: number): ImportRecord =>
+  ({ sourcePath, size, mtimeMs: 0 }) as ImportRecord;
+
+/** A file of `size` bytes that never exists — reads are served from nothing and
+ *  recorded, so a 1.25 GiB "file" costs no disk and no whole-file buffer. */
+function virtualFile(size: number): {
+  io: HashFileIO;
+  reads: { requested: number; returned: number; buffer: Buffer }[];
+  closed: number;
+} {
+  let remaining = size;
+  const reads: { requested: number; returned: number; buffer: Buffer }[] = [];
+  const state = { closed: 0 };
+  const io: HashFileIO = {
+    openSync: () => 7,
+    readSync: (_fd, buffer, offset, length) => {
+      const returned = Math.min(length, remaining);
+      remaining -= returned;
+      buffer.fill(0, offset, offset + returned); // deterministic bytes
+      reads.push({ requested: length, returned, buffer });
+      return returned;
+    },
+    closeSync: () => {
+      state.closed += 1;
+    },
+  };
+  return {
+    io,
+    reads,
+    get closed() {
+      return state.closed;
+    },
+  };
+}
+
+describe('hashFileContent memory profile (#2423)', () => {
+  it('hashes a file bigger than the container 1g cap through ONE reusable 1MB buffer', () => {
+    // 1.25 GiB — larger than the worker's `--memory=1g`, so the eager
+    // implementation could not have survived this file at all.
+    const size = 1280 * 1024 * 1024;
+    const vf = virtualFile(size);
+
+    const digest = hashFileContent(rec('/mnt/src/movies/huge.mkv', size), vf.io);
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+
+    // (a) The whole file was consumed — this is a full hash, not a prefix hash.
+    expect(vf.reads.reduce((n, r) => n + r.returned, 0)).toBe(size);
+
+    // (b) No read ever asked for more than one chunk …
+    expect(Math.max(...vf.reads.map(r => r.requested))).toBe(HASH_CHUNK_BYTES);
+    // … and it took one read per chunk plus the final 0-byte EOF read.
+    expect(vf.reads).toHaveLength(size / HASH_CHUNK_BYTES + 1);
+
+    // (c) THE memory claim: a single buffer, one chunk wide, reused for all 1281
+    // reads. Peak resident bytes are O(chunk) and independent of `size`.
+    const buffers = new Set(vf.reads.map(r => r.buffer));
+    expect(buffers.size).toBe(1);
+    expect([...buffers][0].byteLength).toBe(HASH_CHUNK_BYTES);
+    expect(HASH_CHUNK_BYTES).toBeLessThanOrEqual(1024 * 1024);
+
+    // (d) The descriptor is closed even on this long loop.
+    expect(vf.closed).toBe(1);
+  }, 60_000);
+
+  it('read count scales with the file while the buffer does not', () => {
+    const small = 4 * HASH_CHUNK_BYTES;
+    const big = 64 * HASH_CHUNK_BYTES;
+    const vs = virtualFile(small);
+    const vb = virtualFile(big);
+    hashFileContent(rec('/mnt/src/small.bin', small), vs.io);
+    hashFileContent(rec('/mnt/src/big.bin', big), vb.io);
+
+    expect(vb.reads.length - vs.reads.length).toBe((big - small) / HASH_CHUNK_BYTES);
+    // 16x the file, identical peak allocation.
+    expect(Math.max(...vb.reads.map(r => r.buffer.byteLength))).toBe(
+      Math.max(...vs.reads.map(r => r.buffer.byteLength)),
+    );
+  }, 60_000);
+
+  it('closes the descriptor when a read fails mid-file', () => {
+    const vf = virtualFile(8 * HASH_CHUNK_BYTES);
+    const failing: HashFileIO = {
+      ...vf.io,
+      readSync: (fd, buffer, offset, length, position) => {
+        if (vf.reads.length >= 3) throw new Error('EIO: bad sector');
+        return vf.io.readSync(fd, buffer, offset, length, position);
+      },
+    };
+    expect(() => hashFileContent(rec('/mnt/src/flaky.mkv', 8 * HASH_CHUNK_BYTES), failing)).toThrow(
+      'EIO: bad sector',
+    );
+    expect(vf.closed).toBe(1);
+  });
+
+  it('on a REAL 256MB file: same digest as a streaming hash, ~no extra memory held', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'sb-hash-big-'));
+    const p = path.join(dir, 'sparse.bin');
+    try {
+      const size = 256 * 1024 * 1024;
+      const fd = openSync(p, 'w');
+      ftruncateSync(fd, size); // sparse: costs no real disk, reads as zeros
+      closeSync(fd);
+
+      // Independent oracle: node's own streaming hash over the same file.
+      const oracleHash = createHash('sha256');
+      await pipeline(createReadStream(p), oracleHash);
+      const oracle = oracleHash.digest('hex');
+
+      const before = process.memoryUsage().arrayBuffers;
+      const digest = hashFileContent(rec(p, size));
+      const held = process.memoryUsage().arrayBuffers - before;
+
+      expect(digest).toBe(oracle);
+      // The eager whole-file read showed a ~256MB spike right here.
+      expect(held).toBeLessThan(32 * 1024 * 1024);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/packages/disk-import-worker/src/cli/main.test.ts
+++ b/packages/disk-import-worker/src/cli/main.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { writeFileSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -7,6 +8,8 @@ import {
   parseWorkerArgs,
   runWorker,
   fingerprintFileContent,
+  hashFileContent,
+  HASH_CHUNK_BYTES,
   WorkerArgError,
   type WorkerIO,
   type WorkerOptions,
@@ -203,6 +206,61 @@ describe('fingerprintFileContent (#1995)', () => {
       const fM = fingerprintFileContent(rec(path.join(dir, 'bigM'), size));
       expect(f1).toBe(f2);
       expect(f1).not.toBe(fM); // middle sample catches a mid-file difference
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('hashFileContent (#2423 — chunked, digest-identical)', () => {
+  const rec = (sourcePath: string, size: number): ImportRecord =>
+    ({ sourcePath, size, mtimeMs: 0 }) as ImportRecord;
+
+  /** The implementation this replaced: one eager readFileSync into one update(). */
+  const eagerHash = (p: string): string =>
+    createHash('sha256').update(readFileSync(p)).digest('hex');
+
+  it('matches the eager readFileSync digest across every chunk boundary', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'sb-hash-'));
+    try {
+      // Empty, sub-chunk, exactly-a-chunk, chunk±1 and multi-chunk-with-remainder:
+      // a byte-identical digest at each of these pins the chunk-boundary handling.
+      const sizes = [
+        0,
+        1,
+        4096,
+        HASH_CHUNK_BYTES - 1,
+        HASH_CHUNK_BYTES,
+        HASH_CHUNK_BYTES + 1,
+        2 * HASH_CHUNK_BYTES,
+        2 * HASH_CHUNK_BYTES + 12345,
+      ];
+      for (const size of sizes) {
+        const p = path.join(dir, `f-${size}`);
+        // Non-uniform bytes: a chunk mixed up (or dropped) would change the digest.
+        const bytes = Buffer.allocUnsafe(size);
+        for (let i = 0; i < size; i += 1) bytes[i] = (i * 31 + (i >> 13)) & 0xff;
+        writeFileSync(p, bytes);
+        expect(hashFileContent(rec(p, size)), `size ${size}`).toBe(eagerHash(p));
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('is order-sensitive: one flipped byte in the last partial chunk changes the digest', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'sb-hash-'));
+    try {
+      const size = HASH_CHUNK_BYTES + 17;
+      const base = Buffer.alloc(size, 0x41);
+      const tweaked = Buffer.from(base);
+      tweaked[size - 1] = 0x42;
+      writeFileSync(path.join(dir, 'a'), base);
+      writeFileSync(path.join(dir, 'b'), tweaked);
+      const ha = hashFileContent(rec(path.join(dir, 'a'), size));
+      const hb = hashFileContent(rec(path.join(dir, 'b'), size));
+      expect(ha).toBe(eagerHash(path.join(dir, 'a')));
+      expect(ha).not.toBe(hb);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/disk-import-worker/src/cli/main.ts
+++ b/packages/disk-import-worker/src/cli/main.ts
@@ -211,10 +211,55 @@ export async function walkMount(mount: string, fsImpl: typeof fs = fs): Promise<
   return out;
 }
 
-/** Lazy sha256 of a file's bytes — the full hash, used only to CONFIRM a
- *  fingerprint collision (so a real backup disk is never read whole). */
-export function hashFileContent(record: ImportRecord): string {
-  return createHash('sha256').update(readFileSync(record.sourcePath)).digest('hex');
+/** Bytes held in memory at a time by the full hash. The peak allocation of
+ *  `hashFileContent` is this buffer, whatever the file's size (#2423). */
+export const HASH_CHUNK_BYTES = 1024 * 1024;
+
+/** The fs seam `hashFileContent` reads through — injectable like `walkMount`'s
+ *  `fsImpl`, so a test can prove the READ PATTERN (chunk-sized, one buffer) on a
+ *  file far larger than anything it could put on disk. */
+export interface HashFileIO {
+  openSync: (path: string, flags: string) => number;
+  readSync: (
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number | null,
+  ) => number;
+  closeSync: (fd: number) => void;
+}
+
+const realHashFileIO: HashFileIO = { openSync, readSync, closeSync };
+
+/**
+ * Lazy sha256 of a file's bytes — the full hash, taken only for a record whose
+ * target is already in the catalog (a delta/re-plan), never to confirm a
+ * fingerprint collision (so a real backup disk is never read whole).
+ *
+ * Read in fixed `HASH_CHUNK_BYTES` chunks through ONE reusable buffer: peak
+ * memory is O(chunk), not O(filesize). The eager `readFileSync` this replaced
+ * pulled the whole file in, so a re-plan over an already-cataloged multi-GB
+ * movie OOM-killed the `--memory=1g` worker — a SIGKILL, which skips
+ * `runWorker`'s catch, so the run vanished with no terminal status (#2423).
+ * sha256 is a streaming hash, so the digest is byte-identical to hashing the
+ * whole buffer in one `update()`.
+ */
+export function hashFileContent(record: ImportRecord, fsImpl: HashFileIO = realHashFileIO): string {
+  const h = createHash('sha256');
+  const buf = Buffer.allocUnsafe(HASH_CHUNK_BYTES);
+  const fd = fsImpl.openSync(record.sourcePath, 'r');
+  try {
+    for (;;) {
+      // position `null` ⇒ read from (and advance) the file's own offset.
+      const read = fsImpl.readSync(fd, buf, 0, HASH_CHUNK_BYTES, null);
+      if (read === 0) break;
+      h.update(read === HASH_CHUNK_BYTES ? buf : buf.subarray(0, read));
+    }
+  } finally {
+    fsImpl.closeSync(fd);
+  }
+  return h.digest('hex');
 }
 
 /** Bytes read from each end for the cheap dedup fingerprint (#1995). */

--- a/packages/disk-import-worker/src/engine/dedup.ts
+++ b/packages/disk-import-worker/src/engine/dedup.ts
@@ -280,7 +280,9 @@ interface KeyInfo {
  *    false match is one file not COPIED (still safe on the disk), never data loss.
  *  - the ONLY full hash is for a record whose target is already in the catalog
  *    (a delta/re-run), because the catalog stores full sha256 (`h:` key). A first
- *    import has an empty catalog, so it does ZERO full reads.
+ *    import has an empty catalog, so it does ZERO full reads. That full read is
+ *    CHUNKED by the resolver (`hashFileContent`, O(1MB) peak), so even a
+ *    multi-GB cataloged movie cannot OOM the `--memory=1g` worker (#2423).
  * Progress is reported across the fingerprint pass (the dominant I/O) so a large
  * plan shows live progress and never looks hung.
  */

--- a/packages/frontend/src/app/portal/PortalUnavailableNotice.tsx
+++ b/packages/frontend/src/app/portal/PortalUnavailableNotice.tsx
@@ -1,0 +1,37 @@
+import ServiceBayLogo from '@/components/ServiceBayLogo';
+
+/**
+ * Shown instead of the portal when the page can't build itself — today that
+ * means `getConfig()` threw `ConfigReadError` (#2421), i.e. the config read
+ * failed its retries and the page can't tell whether the LAN-only gate is on
+ * or which services to list.
+ *
+ * `/portal` and `/portal/requests` are the two anonymous, pre-auth,
+ * family-facing surfaces. The app-root `error.tsx` ("Something went wrong",
+ * "Run diagnostics", ref digest) is written for an operator with admin
+ * recourse; a household member has none, so these pages degrade to this
+ * reassuring, transient-sounding notice instead — same shell and wording
+ * shape as `PortalLanOnlyNotice`.
+ *
+ * `children` is the action slot: the server-rendered pages leave it empty
+ * (a plain reload is the only recourse), the client `portal/error.tsx`
+ * boundary fills it with its `reset()` button.
+ */
+export default function PortalUnavailableNotice({ children }: { children?: React.ReactNode }) {
+  return (
+    <main className="relative max-w-2xl mx-auto px-space-5 py-space-8 text-center">
+      <div className="flex items-center justify-center gap-space-3 mb-space-5">
+        <ServiceBayLogo size={36} className="text-accent shrink-0" />
+        <h1 className="text-3xl font-bold text-text">Home</h1>
+      </div>
+      <p className="text-lg text-text">
+        Home is temporarily unavailable.
+      </p>
+      <p className="mt-space-3 text-sm text-text-muted">
+        This is usually brief. Wait a moment and reload — nothing you did caused it,
+        and there is nothing you need to fix.
+      </p>
+      {children}
+    </main>
+  );
+}

--- a/packages/frontend/src/app/portal/error.tsx
+++ b/packages/frontend/src/app/portal/error.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui';
+import PortalUnavailableNotice from './PortalUnavailableNotice';
+
+/**
+ * Route-segment error boundary for `/portal` and everything under it
+ * (`/portal/requests`, …) — #2421.
+ *
+ * Without it the nearest boundary is the app-root `app/error.tsx`, whose
+ * "Something went wrong" / "Run diagnostics" / `ref: <digest>` framing is
+ * aimed at the operator. The portal segment is anonymous and family-facing:
+ * a visitor there has no admin recourse, so any throw below `/portal`
+ * renders the portal's own temporarily-unavailable notice instead.
+ *
+ * The pages catch `ConfigReadError` themselves (server-rendered, no client
+ * flash); this is the backstop for everything else that can throw in the
+ * segment.
+ */
+export default function PortalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Portal route error:', error);
+  }, [error]);
+
+  return (
+    <PortalUnavailableNotice>
+      <div className="mt-space-6 flex justify-center">
+        <Button onClick={() => reset()}>Try again</Button>
+      </div>
+    </PortalUnavailableNotice>
+  );
+}

--- a/packages/frontend/src/app/portal/page.test.tsx
+++ b/packages/frontend/src/app/portal/page.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * The anonymous portal degrades instead of exploding (#2421).
+ *
+ * #2399 turned `getConfig()` from "never throws, returns defaults" into
+ * "retry 3×, then throw `ConfigReadError`". `/portal` and `/portal/requests`
+ * are the two pre-auth, family-facing routes; before this, a transient read
+ * blip bubbled to the app-root `error.tsx` — an operator screen ("Something
+ * went wrong", "Run diagnostics") shown to a household member with no admin
+ * recourse.
+ *
+ * What these tests pin, for BOTH routes: a throwing config read renders the
+ * portal shell with a temporarily-unavailable message; a readable config
+ * leaves both routes exactly as they were; and anything else that throws in
+ * the segment lands on the portal-scoped boundary, not the app-root one.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ConfigReadError } from '@/lib/config';
+
+const { getConfig, verifyAutheliaSession, headersMock, buildPortalCards, redirect } = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  verifyAutheliaSession: vi.fn(),
+  headersMock: vi.fn(),
+  buildPortalCards: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock('next/headers', () => ({ headers: headersMock }));
+// `ConfigReadError` is the REAL class from the real module — the pages branch
+// on `instanceof`, so a stand-in would prove nothing about production.
+vi.mock('@/lib/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/config')>()),
+  getConfig,
+  getAdminBaseUrl: () => null,
+}));
+vi.mock('@/lib/portal/auth', () => ({ verifyAutheliaSession }));
+vi.mock('@/lib/portal/services', () => ({ buildPortalCards }));
+
+/** Anonymous, LAN-shaped visit (X-Real-IP set by NPM). */
+const lanHeaders = () => new Headers({ 'x-real-ip': '192.168.1.42' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  getConfig.mockResolvedValue({ portalLanOnly: false });
+  verifyAutheliaSession.mockResolvedValue({ user: null, name: null });
+  buildPortalCards.mockResolvedValue([]);
+  headersMock.mockResolvedValue(lanHeaders());
+});
+
+const renderPortal = async () => {
+  const { default: Page } = await import('./page');
+  render(await Page());
+};
+const renderRequests = async () => {
+  const { default: Page } = await import('./requests/page');
+  render(await Page());
+};
+
+const routes: [string, () => Promise<void>][] = [
+  ['/portal', renderPortal],
+  ['/portal/requests', renderRequests],
+];
+
+describe.each(routes)('%s — config read fails', (_route, renderRoute) => {
+  beforeEach(() => {
+    getConfig.mockRejectedValue(new ConfigReadError('Failed to read config.json after 3 attempts'));
+  });
+
+  it('renders the portal shell with a temporarily-unavailable message', async () => {
+    await renderRoute();
+    expect(screen.getByRole('heading', { name: 'Home' })).toBeTruthy();
+    expect(screen.getByText(/temporarily unavailable/i)).toBeTruthy();
+  });
+
+  it('does not show the operator-facing app-root error screen', async () => {
+    await renderRoute();
+    expect(screen.queryByText(/Something went wrong/i)).toBeNull();
+    expect(screen.queryByText(/Run diagnostics/i)).toBeNull();
+  });
+
+  it('shows no service grid and no request form behind the unknown LAN gate', async () => {
+    await renderRoute();
+    expect(screen.queryByRole('button', { name: /Send request/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /have an account/i })).toBeNull();
+  });
+
+  it('still propagates a non-ConfigReadError to the boundary', async () => {
+    getConfig.mockRejectedValue(new Error('boom'));
+    await expect(renderRoute()).rejects.toThrow('boom');
+  });
+});
+
+describe('config readable — both routes unchanged', () => {
+  it('/portal still renders the hero and the request-access CTA', async () => {
+    await renderPortal();
+    expect(screen.getByRole('heading', { name: /Home/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /have an account/i })).toBeTruthy();
+    expect(screen.queryByText(/temporarily unavailable/i)).toBeNull();
+  });
+
+  it('/portal/requests still opens the form', async () => {
+    await renderRequests();
+    expect(screen.getByRole('button', { name: /Send request/i })).toBeTruthy();
+    expect(screen.queryByText(/temporarily unavailable/i)).toBeNull();
+  });
+});
+
+describe('portal-scoped error boundary', () => {
+  it('renders the portal notice, not the app-root screen, and offers a retry', async () => {
+    const reset = vi.fn();
+    const { default: PortalError } = await import('./error');
+    render(<PortalError error={Object.assign(new Error('boom'), { digest: 'abc123' })} reset={reset} />);
+
+    expect(screen.getByText(/temporarily unavailable/i)).toBeTruthy();
+    expect(screen.queryByText(/Something went wrong/i)).toBeNull();
+    expect(screen.queryByText(/abc123/)).toBeNull();
+    screen.getByRole('button', { name: /Try again/i }).click();
+    expect(reset).toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/app/portal/page.tsx
+++ b/packages/frontend/src/app/portal/page.tsx
@@ -1,12 +1,13 @@
 import { headers } from 'next/headers';
 import { Settings } from 'lucide-react';
 import ServiceBayLogo from '@/components/ServiceBayLogo';
-import { getConfig, getAdminBaseUrl } from '@/lib/config';
+import { getConfig, getAdminBaseUrl, ConfigReadError, type AppConfig } from '@/lib/config';
 import { buildPortalCards } from '@/lib/portal/services';
 import { isPortalBlockedForRequest } from '@/lib/portal/lanGate';
 import { verifyAutheliaSession } from '@/lib/portal/auth';
 import PortalGrid from './PortalGrid';
 import PortalLanOnlyNotice from './PortalLanOnlyNotice';
+import PortalUnavailableNotice from './PortalUnavailableNotice';
 import PortalLogoutLink from './PortalLogoutLink';
 import PortalUserChip from './PortalUserChip';
 import AccessRequestStatusCTA from './AccessRequestStatusCTA';
@@ -41,7 +42,20 @@ export const dynamic = 'force-dynamic';
  */
 export default async function PortalPage() {
   const hdrs = await headers();
-  const config = await getConfig();
+
+  // #2399 made `getConfig()` throw `ConfigReadError` instead of quietly
+  // returning defaults. This page is anonymous and family-facing, so a
+  // transient read blip must not bubble to the operator-facing app-root
+  // error screen (#2421) — and it must not fall through to rendering the
+  // grid either: without the config we can't tell whether `portalLanOnly`
+  // is on, so listing services would leak them past a closed gate.
+  let config: AppConfig;
+  try {
+    config = await getConfig();
+  } catch (error) {
+    if (!(error instanceof ConfigReadError)) throw error;
+    return <PortalUnavailableNotice />;
+  }
 
   // LAN-only gate (#1456): behind NPM the RSC's TCP peer is always
   // loopback, so passing '127.0.0.1' makes the resolver trust the

--- a/packages/frontend/src/app/portal/requests/page.test.tsx
+++ b/packages/frontend/src/app/portal/requests/page.test.tsx
@@ -26,7 +26,13 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
 }));
 vi.mock('next/headers', () => ({ headers: headersMock }));
-vi.mock('@/lib/config', () => ({ getConfig, getAdminBaseUrl: () => null }));
+// Spread the real module so `ConfigReadError` (which both pages branch on
+// since #2421) stays the genuine class; only the reads are stubbed.
+vi.mock('@/lib/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/config')>()),
+  getConfig,
+  getAdminBaseUrl: () => null,
+}));
 vi.mock('@/lib/portal/auth', () => ({ verifyAutheliaSession }));
 vi.mock('@/lib/portal/services', () => ({ buildPortalCards }));
 // The LAN gate itself is NOT mocked — both routes must run the real

--- a/packages/frontend/src/app/portal/requests/page.tsx
+++ b/packages/frontend/src/app/portal/requests/page.tsx
@@ -1,11 +1,12 @@
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import ServiceBayLogo from '@/components/ServiceBayLogo';
-import { getConfig } from '@/lib/config';
+import { getConfig, ConfigReadError, type AppConfig } from '@/lib/config';
 import { isPortalBlockedForRequest } from '@/lib/portal/lanGate';
 import { verifyAutheliaSession } from '@/lib/portal/auth';
 import AccessRequestStatusCTA from '../AccessRequestStatusCTA';
 import PortalLanOnlyNotice from '../PortalLanOnlyNotice';
+import PortalUnavailableNotice from '../PortalUnavailableNotice';
 import RequestAccessDeepLink from './RequestAccessDeepLink';
 
 export const revalidate = 0;
@@ -34,7 +35,18 @@ export const dynamic = 'force-dynamic';
  */
 export default async function PortalRequestAccessPage() {
   const hdrs = await headers();
-  const config = await getConfig();
+
+  // Same degrade as `/portal` (#2421): `getConfig()` throws `ConfigReadError`
+  // since #2399, and this route is anonymous too — show the portal's
+  // temporarily-unavailable notice rather than the operator-facing app-root
+  // error screen, and never open the form behind an unknown LAN gate.
+  let config: AppConfig;
+  try {
+    config = await getConfig();
+  } catch (error) {
+    if (!(error instanceof ConfigReadError)) throw error;
+    return <PortalUnavailableNotice />;
+  }
 
   // LAN-only gate (#1456): behind NPM the RSC's TCP peer is always
   // loopback, so passing '127.0.0.1' makes the resolver trust the

--- a/scripts/maintenance/repair-admin-proxy-hosts.sh
+++ b/scripts/maintenance/repair-admin-proxy-hosts.sh
@@ -16,21 +16,41 @@
 # only patched when its current shape differs from the target. A
 # host that's already correct logs `(no change)` and skips.
 #
+# TARGET — there is no default box (#2426). This script mutates proxy
+# hosts on YOUR install; it resolves host + domain in this order:
+#   1. --host / --domain flags
+#   2. SB_HOST / SB_DOMAIN environment variables
+#   3. STATIC_IP / PUBLIC_DOMAIN from build/fcos/install-settings.env
+#      (written by `sb build`; the same file scripts/fcos-diagnose.sh reads)
+# If neither resolves, the script exits 2 with a usage error rather than
+# aiming a PUT at somebody else's LAN address.
+#
 # Usage:
-#   scripts/maintenance/repair-admin-proxy-hosts.sh                    # heal & report
+#   SB_HOST=10.0.0.42 SB_DOMAIN=example.com scripts/maintenance/repair-admin-proxy-hosts.sh
+#   scripts/maintenance/repair-admin-proxy-hosts.sh --host 10.0.0.42 --domain example.com
 #   scripts/maintenance/repair-admin-proxy-hosts.sh --dry-run          # what would change
-#   scripts/maintenance/repair-admin-proxy-hosts.sh --host 10.0.0.42   # different box
 #   scripts/maintenance/repair-admin-proxy-hosts.sh --no-cert          # forward-auth only
 #
 # Requires: SSH access to the box (build/fcos/servicebay-ssh/id_rsa)
 # + curl + python3.
 set -euo pipefail
 
-HOST="${SB_HOST:-192.168.178.100}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+SETTINGS_FILE="${SB_SETTINGS_FILE:-$REPO_ROOT/build/fcos/install-settings.env}"
+
+# Pull a KEY=value out of install-settings.env (quoted or bare), empty if absent.
+settings_value() {
+  [[ -f "$SETTINGS_FILE" ]] || { echo ""; return 0; }
+  sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*[\"']\\?\\([^\"'[:space:]#]*\\).*/\\1/p" \
+    "$SETTINGS_FILE" | head -1
+}
+
+HOST="${SB_HOST:-$(settings_value STATIC_IP)}"
+DOMAIN="${SB_DOMAIN:-$(settings_value PUBLIC_DOMAIN)}"
 SB_PORT="${SB_PORT:-5888}"
 SB_ADMIN_USER="${SB_ADMIN_USER:-admin}"
 SB_ADMIN_PASS="${SB_ADMIN_PASS:-}"
-DOMAIN="${SB_DOMAIN:-dopp.cloud}"
 SSH_KEY="${SB_SSH_KEY:-build/fcos/servicebay-ssh/id_rsa}"
 SSH_USER="${SB_SSH_USER:-core}"
 DRY_RUN=0
@@ -42,10 +62,22 @@ while [[ $# -gt 0 ]]; do
     --no-cert) NO_CERT=1; shift ;;
     --host) HOST="$2"; shift 2 ;;
     --domain) DOMAIN="$2"; shift 2 ;;
-    --help|-h) sed -n '2,25p' "$0"; exit 0 ;;
+    --help|-h) sed -n '2,37p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+# No silent fallback to one particular deployment (#2426) — this script
+# writes to NPM, so a bad default would reconfigure a stranger's proxy.
+usage_error() {
+  echo "✗ $1" >&2
+  echo "  Set it via the flag, the env var, or $SETTINGS_FILE:" >&2
+  echo "    SB_HOST=<box-ip> SB_DOMAIN=<your-domain> $0" >&2
+  echo "    $0 --host <box-ip> --domain <your-domain>" >&2
+  exit 2
+}
+[[ -n "$HOST" ]] || usage_error "no target host — set SB_HOST, pass --host, or build an ISO first so $SETTINGS_FILE exists."
+[[ -n "$DOMAIN" ]] || usage_error "no public domain — set SB_DOMAIN, pass --domain, or build an ISO first so $SETTINGS_FILE exists."
 
 RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; CYAN=$'\033[36m'; OFF=$'\033[0m'
 ssh_cmd() { ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no -o ConnectTimeout=10 "$SSH_USER@$HOST" "$@"; }

--- a/scripts/smoke/sso-verify.sh
+++ b/scripts/smoke/sso-verify.sh
@@ -15,28 +15,48 @@
 #                    expect HTTP 2xx/3xx and (where it's a stable string)
 #                    a recognisable HTML title or content signature.
 #   6. Access ctl  — confirm the `family` user is REJECTED by admin-only
-#                    domains (admin.dopp.cloud, nginx.dopp.cloud, ...).
+#                    domains (admin.<domain>, nginx.<domain>, ...).
 #   7. Cleanup     — delete the test user (always, even on failure).
 #
 # Exit 0 ⇔ every check passed. Exit 1 with a per-step PASS/FAIL summary
 # otherwise.
 #
+# TARGET — there is no default box (#2426). This script points at YOUR
+# install; it resolves host + domain in this order:
+#   1. --host / --domain flags
+#   2. SB_HOST / SB_DOMAIN environment variables
+#   3. STATIC_IP / PUBLIC_DOMAIN from build/fcos/install-settings.env
+#      (written by `sb build`; the same file scripts/fcos-diagnose.sh reads)
+# If neither resolves, the script exits 2 with a usage error rather than
+# probing somebody else's LAN address.
+#
 # Usage:
-#   scripts/smoke/sso-verify.sh                    # uses defaults below
+#   SB_HOST=10.0.0.42 SB_DOMAIN=example.com scripts/smoke/sso-verify.sh
+#   scripts/smoke/sso-verify.sh --host 10.0.0.42 --domain example.com
 #   scripts/smoke/sso-verify.sh --keep-user        # leaves the test user
 #                                                    in place for poking
-#   scripts/smoke/sso-verify.sh --host 10.0.0.42   # different host
 #   scripts/smoke/sso-verify.sh --verbose          # log every curl
 #
 # Requires: ssh key at build/fcos/servicebay-ssh/id_rsa (the same one the
 # rest of the repo's tooling uses), bash, curl, openssl, python3.
 set -euo pipefail
 
-# -------------------- defaults --------------------
-HOST="${SB_HOST:-192.168.178.100}"
+# -------------------- target resolution --------------------
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+SETTINGS_FILE="${SB_SETTINGS_FILE:-$REPO_ROOT/build/fcos/install-settings.env}"
+
+# Pull a KEY=value out of install-settings.env (quoted or bare), empty if absent.
+settings_value() {
+  [[ -f "$SETTINGS_FILE" ]] || { echo ""; return 0; }
+  sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*[\"']\\?\\([^\"'[:space:]#]*\\).*/\\1/p" \
+    "$SETTINGS_FILE" | head -1
+}
+
+HOST="${SB_HOST:-$(settings_value STATIC_IP)}"
+DOMAIN="${SB_DOMAIN:-$(settings_value PUBLIC_DOMAIN)}"
 SB_PORT="${SB_PORT:-5888}"
 LLDAP_PORT="${LLDAP_PORT:-17170}"
-DOMAIN="${SB_DOMAIN:-dopp.cloud}"
 SSH_KEY="${SB_SSH_KEY:-build/fcos/servicebay-ssh/id_rsa}"
 SSH_USER="${SB_SSH_USER:-core}"
 KEEP_USER=0
@@ -50,10 +70,22 @@ while [[ $# -gt 0 ]]; do
     --host) HOST="$2"; shift 2 ;;
     --domain) DOMAIN="$2"; shift 2 ;;
     --help|-h)
-      sed -n '2,30p' "$0"; exit 0 ;;
+      sed -n '2,40p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+# No silent fallback to one particular deployment (#2426) — a contributor
+# running this must aim it at their own box, not a stranger's LAN address.
+usage_error() {
+  echo "✗ $1" >&2
+  echo "  Set it via the flag, the env var, or $SETTINGS_FILE:" >&2
+  echo "    SB_HOST=<box-ip> SB_DOMAIN=<your-domain> $0" >&2
+  echo "    $0 --host <box-ip> --domain <your-domain>" >&2
+  exit 2
+}
+[[ -n "$HOST" ]] || usage_error "no target host — set SB_HOST, pass --host, or build an ISO first so $SETTINGS_FILE exists."
+[[ -n "$DOMAIN" ]] || usage_error "no public domain — set SB_DOMAIN, pass --domain, or build an ISO first so $SETTINGS_FILE exists."
 
 # -------------------- helpers --------------------
 RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; CYAN=$'\033[36m'; OFF=$'\033[0m'
@@ -101,7 +133,7 @@ lldap_api_quiet() {
 }
 
 # Curl wrapper that pins SNI to the box's IP via --resolve, since the
-# operator running this from outside the LAN may not have *.dopp.cloud
+# operator running this from outside the LAN may not have *.<domain>
 # in their resolver.
 RESOLVE_FLAGS=""
 build_resolve_flags() {
@@ -351,15 +383,15 @@ declare -A USER_APPS=(
   # Hermes' dashboard is uvicorn-backed and rejects requests whose Host
   # header doesn't match its bind address — caught here as HTTP 400 with
   # `{"detail":"Invalid Host header. ..."}` when NPM forwards
-  # `Host: hermes.dopp.cloud` without the `proxy_set_header Host
+  # `Host: hermes.<domain>` without the `proxy_set_header Host
   # 127.0.0.1:9119;` rewrite from the template's advanced_config. Signature
   # is the literal dashboard title so the test also catches a "200 with
   # wrong content" regression (proxy half-broken).
   [hermes]="Hermes Agent"
-  # ollama.dopp.cloud intentionally not checked: the ollama template
+  # ollama.<domain> intentionally not checked: the ollama template
   # ships no auth of its own and the wizard requires explicit opt-in
   # to expose it via NPM. Bare default installs have no proxy host
-  # for ollama.dopp.cloud, so probing it would false-fail. See #1180.
+  # for ollama.<domain>, so probing it would false-fail. See #1180.
 )
 
 for h in "${!USER_APPS[@]}"; do
@@ -394,17 +426,17 @@ section "6/8 · Access control — family user MUST NOT reach admin domains"
 # user should get redirected back to /auth (302) or refused (403 from
 # Authelia's verify endpoint), NOT 200 from the upstream app.
 #
-# `admin.dopp.cloud` is intentionally NOT in this list: ServiceBay
+# `admin.<domain>` is intentionally NOT in this list: ServiceBay
 # has its own login on the application layer, and stacking Authelia
 # forward-auth on top would double-login the operator whose recovery
 # path goes through this UI. The HTML shell at `/` is reachable on
-# admin.dopp.cloud but every API call returns 401 without a
+# admin.<domain> but every API call returns 401 without a
 # ServiceBay session — covered by integration tests on the
 # ServiceBay app itself, not by this smoke test.
 for h in nginx dns ldap; do
   body=$(mktemp -t sb-smoke-svc.XXXXXX)
   # Single follow-on response — don't chase redirects, so a 302 back
-  # to auth.dopp.cloud is the SUCCESS signal here.
+  # to auth.<domain> is the SUCCESS signal here.
   set +e
   code=$(curl -ks $RESOLVE_FLAGS -b "$COOKIE_JAR" \
               --max-redirs 0 \

--- a/templates/auth/CHANGELOG.md
+++ b/templates/auth/CHANGELOG.md
@@ -1,5 +1,55 @@
 # auth template changelog
 
+## v4 (breaking)
+
+**The `servicebay` OIDC client secret is now generated per install (#2417).**
+
+Required action: **re-deploy** the `auth` service. The rotation happens during
+that deploy; nothing on disk moves.
+
+Authelia's `servicebay` OIDC client — the one behind ServiceBay's own
+"Login with Authelia" button — shipped a **hardcoded** `client_secret` baked
+into `configuration.yml.mustache`. Every install in the world had the same
+value, and anyone could read it out of the public repository. That client is
+`authorization_policy: two_factor` and redirects to the admin panel, so the
+secret guarding the box's control plane was a published constant. Every other
+SSO-wired template (`HA_OIDC_SECRET`, `IMMICH_SSO_SECRET`,
+`VAULTWARDEN_SSO_SECRET`) already did this correctly; this one was the outlier.
+
+v4 adds `SERVICEBAY_OIDC_SECRET`, a `type: "secret"` variable generated once
+per box, stored encrypted in `config.installedSecrets`, and reused verbatim on
+every later deploy.
+
+**How the two sides stay in agreement.** The secret has to match in two places
+or the SSO button fails with `invalid_client`: Authelia's `configuration.yml`,
+and ServiceBay's own `config.oidc.clientSecret` (the value the callback route
+posts to the token endpoint). There is no transaction spanning both, so the
+ordering is chosen so that no failure can lock anyone out:
+
+1. The fresh render owns the `servicebay` client, so the new value replaces the
+   old literal in `configuration.yml`. (`mergeAutheliaOidcClients` never rotates
+   an *incrementally registered* client's secret — the #1559 invariant — and
+   `servicebay` is the one deliberate exception, because this template declares
+   it.) Other services' clients are preserved untouched, secrets included.
+2. **Only after** that file has landed and the pod is back does ServiceBay read
+   the secret back out of it and copy it into `config.oidc.clientSecret`.
+
+ServiceBay follows the file; it never leads it. So a deploy that fails before
+the config lands changes nothing — the box keeps its old, still-consistent pair
+and SSO keeps working. A crash in the narrow window between the two steps leaves
+a mismatch that is recoverable, not sticky: the copy is idempotent and re-runs
+on every `auth` deploy.
+
+**Break-glass.** `/login` also offers a local admin username/password form that
+has nothing to do with OIDC — that is the second door, and it is unaffected by
+this change. ServiceBay refuses to start the rotation at all (aborting the
+deploy before writing anything) on a box that has neither a stored admin
+password hash nor `SERVICEBAY_PASSWORD` set, since SSO would then be the only
+way in.
+
+Existing browser sessions stay valid; only new SSO logins use the new secret.
+Other services' users are unaffected.
+
 ## v3 (breaking)
 
 **LLDAP's admin web UI bound to loopback — no longer LAN-exposed (#2380).**

--- a/templates/auth/configuration.yml.mustache
+++ b/templates/auth/configuration.yml.mustache
@@ -104,7 +104,7 @@ identity_providers:
     clients:
       - client_id: 'servicebay'
         client_name: 'ServiceBay'
-        client_secret: '$plaintext$servicebay-oidc-secret'
+        client_secret: '$plaintext${{SERVICEBAY_OIDC_SECRET}}'
         public: false
         authorization_policy: 'two_factor'
         redirect_uris:

--- a/templates/auth/migrations/v3-to-v4.py
+++ b/templates/auth/migrations/v3-to-v4.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Migration: auth v3 → v4 (#2417).
+
+What changed between v3 and v4
+------------------------------
+Authelia's `servicebay` OIDC client — the one guarding ServiceBay's own
+admin panel behind the "Login with Authelia" button — used to ship a
+**hardcoded** `client_secret` baked into
+`templates/auth/configuration.yml.mustache`. Every ServiceBay install in
+the world therefore shared one secret that anybody could read out of the
+public repository.
+
+From v4 that secret is a per-install `type: "secret"` variable
+(`SERVICEBAY_OIDC_SECRET`), generated once per box by the wizard, stored
+encrypted in `config.installedSecrets`, and reused verbatim on every
+later deploy — exactly like `HA_OIDC_SECRET`, `IMMICH_SSO_SECRET` and
+`VAULTWARDEN_SSO_SECRET` already were.
+
+How the rotation happens (this script does NOT perform it)
+----------------------------------------------------------
+The rotation is structural, and deliberately lives in ServiceBay's
+install path rather than here, because it spans two stores that a
+Python script on the box cannot write atomically:
+
+  1. `mergeAutheliaOidcClients` preserves every *incrementally registered*
+     client's secret across an auth redeploy, and never rotates one — the
+     #1559 invariant. `servicebay` is the ONE deliberate exception: that
+     client is declared by this template's mustache, so the fresh render
+     owns it and the newly generated value replaces the old literal in
+     `configuration.yml`.
+  2. After that file has actually landed on disk and the pod has come
+     back, ServiceBay READS the `servicebay` client's secret back out of
+     it and copies it into its own `config.oidc.clientSecret` — the value
+     the admin panel posts to Authelia's token endpoint.
+
+The direction matters. ServiceBay follows the file; it never leads it.
+So ServiceBay cannot end up holding a secret Authelia has never seen —
+the mismatch that produces a dead login button. And because the copy
+happens only after a *successful* write, a deploy that fails earlier
+leaves the old, still-consistent pair in place: a failed deploy is a
+no-op, not a half-migration.
+
+If the process dies in the narrow window between the two (config written,
+copy not yet done), the result is a recoverable mismatch, never a
+lockout:
+
+  - The `/login` page also renders a **local admin username/password**
+    form (`/api/auth/login`) that has nothing to do with OIDC. That is
+    the break-glass door, and ServiceBay refuses to start this rotation
+    at all on a box that does not have one (it aborts the deploy before
+    writing anything).
+  - The copy is idempotent and re-runs on every `auth` deploy, so simply
+    redeploying `auth` converges the two sides again. Nothing about the
+    mismatch is sticky.
+
+What this script does
+---------------------
+It transforms nothing — there is nothing on disk to move, and doing the
+rotation here would be the unsafe ordering (ServiceBay's copy would lead
+the file instead of following it). It exists to tell the operator, at the
+moment it matters, what is about to change and how to recover, and it
+exits 0 so the deploy continues.
+
+Environment available (set by ServiceManager.runMigrationScript):
+  - OLD_SCHEMA_VERSION = 3
+  - NEW_SCHEMA_VERSION = 4
+  - OLD_DATA_DIR, NEW_DATA_DIR (defaults to DATA_DIR for both)
+  - Every wizard variable (PUBLIC_DOMAIN, AUTHELIA_SUBDOMAIN, …)
+  - SB_NODE, SB_API_URL, SB_API_TOKEN (for callbacks into ServiceBay)
+
+NOTE: this script never prints, reads or handles the secret value itself.
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    domain = os.environ.get("PUBLIC_DOMAIN", "<your-domain>")
+    print("Auth v3 → v4: rotating the `servicebay` Authelia OIDC client secret (#2417).")
+    print("  Until now that secret was a constant committed to the ServiceBay")
+    print("  repository — identical on every install. This deploy replaces it")
+    print("  with a value generated for this box alone.")
+    print("  Both sides are updated by this deploy: Authelia's configuration.yml")
+    print("  gets the new client_secret, and ServiceBay then copies that same")
+    print("  value into its own config.oidc.clientSecret. Nothing moves on disk;")
+    print("  Authelia's db.sqlite3 and LLDAP's users.db are untouched.")
+    print("  Other services' SSO is unaffected — only the `servicebay` client")
+    print("  rotates; immich/vaultwarden/home-assistant keep their own secrets.")
+    print("  IF \"Login with Authelia\" on the admin panel fails after this deploy:")
+    print(f"    1. Log in at https://admin.{domain}/login with the LOCAL admin")
+    print("       username + password (the form below the SSO button). It does not")
+    print("       use OIDC and is unaffected by this change.")
+    print("    2. Re-deploy `auth`. The copy step is idempotent and re-syncs the")
+    print("       two sides on every run.")
+    print("  Existing browser sessions stay valid; only NEW SSO logins use the")
+    print("  new secret. Users of other services do not need to log in again.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/auth/post-deploy.py
+++ b/templates/auth/post-deploy.py
@@ -397,17 +397,46 @@ def main() -> int:
 # these helpers do one job (read ServiceBay's email config, rewrite
 # the notifier block on disk, signal reload) and nothing else.
 
-# Path conventions:
-#   - ServiceBay's config.json lives on host at /mnt/data/servicebay/config.json
-#     (DATA_ROOT in install-fedora-coreos.sh). Post-deploy runs on the host
-#     as the user that owns this script; that's root on Fedora CoreOS.
-#   - Authelia's configuration.yml is at
-#     /mnt/data/stacks/auth/authelia-config/configuration.yml — written by the
-#     mustache rendering step before this script runs.
+# Path conventions (#2424 — resolved from DATA_DIR, never hardcoded, same as
+# `authelia_db_path()` above and every sibling template's post-deploy):
+#   - Authelia's configuration.yml sits under the `authelia-config` hostPath
+#     mount declared in template.yml (the auth/authelia-config dir under
+#     DATA_DIR) —
+#     written by the mustache rendering step before this script runs.
+#   - ServiceBay's own config.json is NOT under DATA_DIR: the box layout is
+#     `<DATA_ROOT>/servicebay` and `<DATA_ROOT>/stacks` as SIBLINGS, and the
+#     baked config points the DATA_DIR template variable at `<DATA_ROOT>/stacks`
+#     (see tools/sb/internal/build/assets/fedora-coreos.bu). So the ServiceBay
+#     root is DATA_DIR's parent when DATA_DIR is the `stacks` dir, else DATA_DIR
+#     itself (the bare `/mnt/data` default used in dev). Both candidates are
+#     probed so neither layout silently no-ops.
 #   - Authelia hot-reloads SIGHUP, but with podman quadlet the cleanest
 #     reload signal is `systemctl --user restart auth` (the pod) — sub-second.
-SB_CONFIG_PATH = "/mnt/data/servicebay/config.json"
-AUTHELIA_CONFIG_PATH = "/mnt/data/stacks/auth/authelia-config/configuration.yml"
+
+
+def data_dir() -> str:
+    """The operator's template data root, as the install runner exports it."""
+    return env("DATA_DIR", "/mnt/data")
+
+
+def authelia_config_path() -> str:
+    """Host path of Authelia's rendered configuration.yml. Must track the
+    `authelia-config` hostPath mount in template.yml
+    (`{{DATA_DIR}}/auth/authelia-config`)."""
+    return os.path.join(data_dir(), "auth", "authelia-config", "configuration.yml")
+
+
+def sb_config_path_candidates() -> list[str]:
+    """Host paths where ServiceBay's own config.json may live, most likely
+    first. `<DATA_ROOT>/servicebay` is a sibling of the stacks dir DATA_DIR
+    points at, so the parent is tried before DATA_DIR itself."""
+    base = data_dir()
+    roots = [os.path.dirname(base.rstrip("/")), base]
+    seen: list[str] = []
+    for root in roots:
+        if root and root not in seen:
+            seen.append(root)
+    return [os.path.join(root, "servicebay", "config.json") for root in seen]
 
 
 def _sb_email_config(sb_api: str):
@@ -440,14 +469,15 @@ def _sb_email_config(sb_api: str):
             pass
 
     # Path 2: read config.json directly off disk.
-    try:
-        with open(SB_CONFIG_PATH, "r", encoding="utf-8") as f:
-            cfg = json.load(f)
-        em = (cfg.get("notifications") or {}).get("email") or {}
-        if em.get("host") and em.get("user") and em.get("pass") and em.get("from"):
-            return em
-    except Exception:
-        pass
+    for path in sb_config_path_candidates():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            em = (cfg.get("notifications") or {}).get("email") or {}
+            if em.get("host") and em.get("user") and em.get("pass") and em.get("from"):
+                return em
+        except Exception:
+            continue
 
     return None
 
@@ -520,14 +550,15 @@ def rewrite_authelia_smtp_notifier(sb_api: str) -> None:
         log("ℹ️ No SMTP config found in ServiceBay settings — leaving Authelia's filesystem notifier in place. Configure email in Settings → Notifications + redeploy auth to enable Authelia email.")
         return
 
+    config_path = authelia_config_path()
     try:
-        with open(AUTHELIA_CONFIG_PATH, "r", encoding="utf-8") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             current = f.read()
     except FileNotFoundError:
-        log(f"⚠️ Authelia config not at {AUTHELIA_CONFIG_PATH} — skipping notifier rewrite.")
+        log(f"⚠️ Authelia config not at {config_path} — skipping notifier rewrite.")
         return
     except Exception as e:
-        log(f"⚠️ Couldn't read {AUTHELIA_CONFIG_PATH}: {e} — skipping notifier rewrite.")
+        log(f"⚠️ Couldn't read {config_path}: {e} — skipping notifier rewrite.")
         return
 
     new_block = _smtp_notifier_block(em)
@@ -543,7 +574,7 @@ def rewrite_authelia_smtp_notifier(sb_api: str) -> None:
             start = i
             break
     if start is None:
-        log(f"⚠️ No `notifier:` block found in {AUTHELIA_CONFIG_PATH} — appending one. Authelia config may need manual review.")
+        log(f"⚠️ No `notifier:` block found in {config_path} — appending one. Authelia config may need manual review.")
         new_content = current.rstrip("\n") + "\n\n" + new_block
     else:
         end = len(lines)
@@ -560,11 +591,11 @@ def rewrite_authelia_smtp_notifier(sb_api: str) -> None:
 
     # Atomic write (temp + rename) so a partial write can't leave Authelia
     # with malformed YAML that crashes the pod.
-    tmp_path = AUTHELIA_CONFIG_PATH + ".tmp"
+    tmp_path = config_path + ".tmp"
     try:
         with open(tmp_path, "w", encoding="utf-8") as f:
             f.write(new_content)
-        os.replace(tmp_path, AUTHELIA_CONFIG_PATH)
+        os.replace(tmp_path, config_path)
     except Exception as e:
         log(f"⚠️ Failed to write updated Authelia config: {e} — leaving original in place.")
         try: os.unlink(tmp_path)

--- a/templates/auth/template.yml
+++ b/templates/auth/template.yml
@@ -11,7 +11,11 @@ metadata:
     # v3 (#2380): LLDAP's HTTP port (admin web UI + GraphQL API) is bound to
     # the host loopback instead of 0.0.0.0. No data move; requires a re-deploy
     # so podman recreates the pod from this manifest.
-    servicebay.schema-version: "3"
+    # v4 (#2417): the `servicebay` OIDC client's client_secret is generated per
+    # install (SERVICEBAY_OIDC_SECRET) instead of the hardcoded literal every
+    # box shipped. The deploy rotates it and ServiceBay adopts the new value
+    # into config.oidc.clientSecret. No data move.
+    servicebay.schema-version: "4"
     servicebay.tier: "infrastructure"
     # post-deploy.py calls /api/system/lldap/* and /api/system/authelia/*.
     # Pin the API versions (#588) so core refuses to invoke this script if

--- a/templates/auth/variables.json
+++ b/templates/auth/variables.json
@@ -81,11 +81,6 @@
     "description": "LLDAP host — always localhost when bundled with Authelia in the auth pod.",
     "default": "localhost"
   },
-  "PUBLIC_DOMAIN": {
-    "type": "text",
-    "description": "Public domain for access rules (e.g. dopp.cloud)",
-    "default": "dopp.cloud"
-  },
   "LLDAP_FORCE_LDAP_USER_PASS_RESET": {
     "type": "text",
     "description": "Dynamic self-healing flag for resetting admin password during install-time drift",

--- a/templates/auth/variables.json
+++ b/templates/auth/variables.json
@@ -68,6 +68,10 @@
     "type": "rsa-private",
     "description": "RSA private key (PEM) for OIDC token signing — Authelia 4.39+ requires a real key, no longer auto-generates one. Server-generated 2048-bit at install time."
   },
+  "SERVICEBAY_OIDC_SECRET": {
+    "type": "secret",
+    "description": "OIDC client secret for the `servicebay` client — the one Authelia checks when you press \"Login with Authelia\" on ServiceBay's own admin panel. Auto-generated per box (template v4, #2417); before that the client shipped one hardcoded literal identical on every install. This variable is the SINGLE source of truth: it is rendered into Authelia's `configuration.yml` clients[] block, and after that file lands ServiceBay copies the value it finds on disk into its own `config.oidc.clientSecret`. Both sides must hold the same value or the SSO button fails with `invalid_client` — the local admin username/password login on the same page is the break-glass path if they ever drift."
+  },
   "AUTHELIA_STORAGE_ENCRYPTION_KEY": {
     "type": "secret",
     "description": "Encryption key for Authelia SQLite storage (min 20 chars)"

--- a/templates/claude-dev/docker-entrypoint.sh
+++ b/templates/claude-dev/docker-entrypoint.sh
@@ -11,6 +11,89 @@ SSH_PORT="${CLAUDE_DEV_SSH_PORT:-2222}"
 DEV_HOME=/workspace
 HOSTKEY_DIR="$DEV_HOME/.ssh/host_keys"
 
+# ---------------------------------------------------------------------------
+# Helpers. Everything below the sourcing guard is the boot sequence, which is
+# root-only and ends in `exec sshd`; these three functions hold the parts that
+# handle UNTRUSTED input (shared-workspace directory names) or a SECRET (the
+# LLDAP bind password), so they are defined up here and exercised directly by
+# tests/templates/claude_dev_entrypoint_test.sh.
+# ---------------------------------------------------------------------------
+
+# Run `su` as the `dev` user with an explicit argv vector.
+#
+# The `--` before the user name is LOAD-BEARING, not decoration: util-linux
+# `su` parses its arguments with a PERMUTING getopt, so options are still
+# recognised *after* the user operand. Without the `--`, a checkout named
+# `-c` would be re-read as su's own `--command` and replace the command su
+# runs; `-s` would pick the shell. `--` stops option parsing, so every
+# following word is a plain positional the su'd shell sees as "$0", "$1", …
+# and never re-parses (#2418).
+su_dev() {
+  local script="$1"; shift
+  su -s /bin/bash -c "$script" -- dev claude-dev "$@"
+}
+
+# Discover git checkouts under $DEV_HOME into the global `repos` array.
+#
+# A checkout is a top-level dir holding a `.git` entry. The `*/` glob skips
+# hidden dirs (~/.ssh, ~/.claude) and the per-user homes (home/ has no .git),
+# so only real project checkouts are picked up.
+#
+# /workspace is group-writable by `devshare` (see the chown below), so these
+# basenames are ATTACKER-CONTROLLED: a filename may hold any byte but `/` and
+# NUL. They are therefore only ever handled as array elements — never spliced
+# into a string that a second shell re-parses.
+discover_repos() {
+  local d
+  repos=()
+  for d in "$DEV_HOME"/*/; do
+    [ -e "${d}.git" ] || continue
+    repos+=("$(basename -- "$d")")
+  done
+}
+
+# Hand the discovered repo list to `start-claude` as an argv array.
+# $DEV_HOME and every repo name cross the su boundary as positional
+# parameters; the only shell source here is the literal single-quoted script,
+# which contains no interpolation at all.
+autostart_claude() {
+  su_dev '
+    if [ "$#" -lt 2 ]; then
+      echo "claude-dev: autostart received no arguments across the su boundary." >&2
+      exit 1
+    fi
+    dev_home="$1"; shift
+    cd "$dev_home" || exit 1
+    export HOME="$dev_home" CLAUDE_START_NO_ATTACH=1
+    exec start-claude --continue --allow-dangerously-skip-permissions -- "$@"
+  ' "$DEV_HOME" "$@"
+}
+
+# List the uids of the LLDAP group members allowed to log in.
+#
+# The bind password goes to ldapsearch through a mode-0600 file (`-y`), never
+# on the command line (`-w`), where any user on the box could read it out of
+# /proc/<pid>/cmdline. `printf '%s'`, not `echo`: ldapsearch takes the file's
+# ENTIRE contents as the password, a trailing newline included.
+ldap_group_members() {
+  local pwfile
+  pwfile="$(mktemp)"
+  chmod 600 "$pwfile"
+  printf '%s' "$LLDAP_ADMIN_PASSWORD" > "$pwfile"
+  ldapsearch -x -LLL -o ldif-wrap=no \
+    -H "$ldap_uri" -D "$admin_dn" -y "$pwfile" \
+    -b "$group_dn" '(objectClass=*)' member 2>/dev/null \
+    | sed -n 's/^member: uid=\([^,]*\),.*/\1/p' | sort -u
+  rm -f "$pwfile"
+}
+
+# Sourcing guard: `CLAUDE_DEV_ENTRYPOINT_LIB=1 source docker-entrypoint.sh`
+# stops here with the helpers defined, so the regression test can exercise
+# them without the root-only boot sequence below.
+if [ -n "${CLAUDE_DEV_ENTRYPOINT_LIB:-}" ]; then
+  return 0
+fi
+
 # /workspace is a fresh, root-owned bind mount on first install. It's a
 # SHARED working area: the `dev` break-glass user plus every provisioned LDAP
 # user (e.g. mdopp) collaborate on the same checkouts here. Own it
@@ -100,10 +183,7 @@ EOF
     # the persistent /workspace volume.
     install -d -o root -g root -m 0755 "$DEV_HOME/home"
     groupadd -f ldapusers
-    members="$(ldapsearch -x -LLL -o ldif-wrap=no \
-                 -H "$ldap_uri" -D "$admin_dn" -w "$LLDAP_ADMIN_PASSWORD" \
-                 -b "$group_dn" '(objectClass=*)' member 2>/dev/null \
-               | sed -n 's/^member: uid=\([^,]*\),.*/\1/p' | sort -u)"
+    members="$(ldap_group_members)"
     provisioned=0
     for u in $members; do
       case "$u" in admin|root|dev|''|*[!a-z0-9_-]*) continue;; esac
@@ -148,26 +228,22 @@ fi
 # daemonizes, so sshd stays PID 1 — do NOT regress that. CLAUDE_START_NO_ATTACH
 # stops start-claude from trying to attach a terminal we don't have here.
 #
-# A git checkout is a top-level dir under /workspace holding a `.git` entry.
-# The `*/` glob skips the hidden dirs (~/.ssh, ~/.claude) and per-user homes
-# (home/ has no .git), so only real project checkouts are picked up.
-repos=()
-for d in "$DEV_HOME"/*/; do
-  [ -e "${d}.git" ] && repos+=("$(basename "$d")")
-done
+# Repo discovery + the su hand-off live in `discover_repos` / `autostart_claude`
+# at the top of this file — the directory names are shared-workspace-writable,
+# so they must reach `start-claude` as argv, never as shell source (#2418).
+discover_repos
 
 if [ "${#repos[@]}" -gt 0 ]; then
-  su -s /bin/bash dev -c "cd '$DEV_HOME' && HOME='$DEV_HOME' CLAUDE_START_NO_ATTACH=1 \
-      start-claude --continue --allow-dangerously-skip-permissions -- ${repos[*]}" \
+  autostart_claude "${repos[@]}" \
     || echo "claude-dev: WARNING — autostart of Claude sessions reported an error." >&2
   echo "claude-dev: auto-started Claude in ${#repos[@]} git repo(s): ${repos[*]}"
 else
   # Fresh volume with no checkouts yet — still start an empty `claude` tmux
   # session so interactive logins have something to attach to.
-  if su -s /bin/bash dev -c 'tmux has-session -t claude' 2>/dev/null; then
+  if su_dev 'tmux has-session -t claude' 2>/dev/null; then
     echo "claude-dev: tmux session 'claude' already running."
   else
-    su -s /bin/bash dev -c "cd '$DEV_HOME' && HOME='$DEV_HOME' tmux new-session -d -s claude"
+    su_dev 'cd "$1" && HOME="$1" tmux new-session -d -s claude' "$DEV_HOME"
     echo "claude-dev: no git repos under $DEV_HOME yet — started empty tmux session 'claude' for user 'dev'."
   fi
 fi

--- a/templates/claude-dev/start-claude.sh
+++ b/templates/claude-dev/start-claude.sh
@@ -57,7 +57,10 @@ done
 started=()
 for d in "${dirs[@]}"; do
   if [ -d "$d" ]; then
-    path="$(cd "$d" && pwd)"
+    # `cd -- ` so a directory whose name starts with a dash (the boot-time
+    # autostart feeds this loop shared-workspace-writable basenames) is a
+    # path, not an option to `cd`.
+    path="$(cd -- "$d" && pwd)"
   else
     echo "start-claude: skipping '$d' — not a directory (looked under $PWD)" >&2
     continue

--- a/templates/home-assistant/CHANGELOG.md
+++ b/templates/home-assistant/CHANGELOG.md
@@ -10,6 +10,73 @@ operator's installed schema-version and the current one and surfaces
 them in the re-deploy dialog. Each `(breaking)` section needs an
 explicit acknowledgement before the deploy can proceed.
 
+## v7 (breaking) — #2416
+
+**Z-Wave and Matter admin/control ports bound to loopback — no longer
+LAN-exposed.**
+
+Required action: **re-deploy** the `home-assistant` service so podman
+recreates the pod from the v7 manifest. Existing installs keep the old
+every-interface binds until the pod is recreated — the running containers
+were started from the v6 manifest and do not auto-rebind.
+
+This pod runs `hostNetwork: true`, so an app that binds `0.0.0.0` binds
+every host interface, and Fedora CoreOS ships with no firewall enabled.
+Three ports in this pod did exactly that, and none of them carries usable
+authentication of its own:
+
+* **8091 — Z-Wave JS UI.** The admin panel: include/exclude nodes, read
+  the network security keys, actuate any paired device. `zwave.<domain>`
+  is gated by Authelia forward-auth, but that only gates the *nginx*
+  path — nothing made nginx the only path, so any LAN device could open
+  `http://<box-lan-ip>:8091/` directly. Same bypass as LLDAP's #2380.
+* **3001 — the raw Z-Wave JS server protocol.** No subdomain, no
+  healthcheck, no SSO gate, and it was not declared anywhere: an
+  unauthenticated websocket giving direct control of every paired Z-Wave
+  device, door locks included.
+* **5580 — python-matter-server's control websocket.** Same shape for
+  Matter devices, and it was missing from `servicebay.ports` entirely, so
+  the network map never showed it.
+
+v7 binds all three to `127.0.0.1`: `HOST=127.0.0.1` on the zwave-js
+container, `--listen-address 127.0.0.1` on matter-server, and
+`serverHost: "127.0.0.1"` in the Z-Wave WS server settings that
+`post-deploy.py` seeds. 5580 is now declared in `servicebay.ports`
+alongside the other two.
+
+Home Assistant's own port **8123 is unchanged** — it keeps its own login
+plus the Authelia OIDC provider, and is published at `home.<domain>`.
+
+Nothing you use breaks:
+
+* `zwave.<domain>` keeps working. nginx also runs on `hostNetwork`, so it
+  still reaches 8091 over the loopback, and `ZWAVE_JS_SUBDOMAIN` now
+  carries `loopbackOnly: true` so the proxy host forwards to
+  `127.0.0.1:8091`. An existing `zwave.<domain>` host is re-pointed
+  automatically on this deploy by ServiceBay's core reconcile (#2364) —
+  no manual proxy edit, and exposure, forward-auth and the cert are
+  preserved.
+* Home Assistant is a container in this same pod, so it shares the host
+  netns. Its Z-Wave JS integration already connects to
+  `ws://localhost:3001` and its Matter integration to
+  `ws://localhost:5580/ws`. No re-pairing, no reconfiguration.
+* Matter commissioning and device traffic are untouched:
+  `--listen-address` binds only the websocket API server, never the
+  CHIP/Matter stack.
+
+Port 3001's bind address lives on disk (in the WS server settings the
+post-deploy seeds), not in the pod manifest, and the seeder only writes
+that file when it is missing. So `migrations/v6-to-v7.py` rewrites the
+stored `serverHost` in place — an install predating the fix is closed by
+this deploy with no manual edit. A `serverHost` you deliberately pinned to
+a specific address is left alone (the migration warns instead of
+overriding it).
+
+After the re-deploy, `curl http://<box-lan-ip>:8091/` and a websocket
+connect to `<box-lan-ip>:3001` / `<box-lan-ip>:5580` are all refused from
+another LAN host, while `https://zwave.<domain>/` still serves normally
+and HA's Z-Wave and Matter integrations stay connected.
+
 ## v6
 
 **Z-Wave JS WS server pinned via `ZWAVE_EXTERNAL_SETTINGS`.**

--- a/templates/home-assistant/README.md
+++ b/templates/home-assistant/README.md
@@ -18,8 +18,27 @@ This stack combines the core smart-home components into a single pod:
 *   **ZWAVE_DEVICE**: Absolute path to the USB device (e.g., `/dev/serial/by-id/usb-0658_0200-if00`)
 
 ## Ports
-*   Home Assistant: `http://<server-ip>:8123`
-*   Z-Wave JS UI: `http://<server-ip>:8091`
+
+The pod runs on the host network, so an app that binds `0.0.0.0` is reachable
+from every LAN device with no proxy and no SSO in front of it. Since template
+**v7 (#2416)** only Home Assistant itself is exposed that way — it has its own
+login. Everything else is bound to the host loopback and reached either through
+the reverse proxy or from inside the pod:
+
+| Port | Service | Bind | How you reach it |
+|------|---------|------|------------------|
+| 8123 | Home Assistant | all interfaces | `https://home.<domain>` (or `http://<server-ip>:8123`); HA's own login + Authelia OIDC |
+| 8091 | Z-Wave JS UI | `127.0.0.1` (`HOST` env) | `https://zwave.<domain>` — LAN-only proxy host, Authelia forward-auth |
+| 3001 | Z-Wave JS control websocket | `127.0.0.1` (`serverHost` setting) | Home Assistant only, over `ws://localhost:3001` |
+| 5580 | Matter server websocket | `127.0.0.1` (`--listen-address`) | Home Assistant only, over `ws://localhost:5580/ws` |
+
+Ports 3001 and 5580 are unauthenticated control channels — anything that can
+open them can actuate every paired Z-Wave/Matter device — which is why they are
+loopback-only. Binding the Matter websocket to the loopback does **not** affect
+Matter commissioning or device traffic: `--listen-address` binds only the
+websocket API server, never the CHIP/Matter stack (that is
+`--primary-interface`). mDNS/UPnP/Thread discovery keeps using the real
+interfaces.
 
 ## SSO (Authelia)
 

--- a/templates/home-assistant/migrations/v6-to-v7.py
+++ b/templates/home-assistant/migrations/v6-to-v7.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Migration: home-assistant v6 → v7 (#2416).
+
+What changed between v6 and v7: every admin/control port this pod exposes
+except Home Assistant's own 8123 is now bound to the host **loopback**.
+The pod runs `hostNetwork: true`, so before v7 each of them answered on
+every host interface:
+
+  - **8091** — the Z-Wave JS UI admin panel (include/exclude nodes, read
+    the network security keys). Now bound via `HOST=127.0.0.1` on the
+    zwave-js container.
+  - **3001** — the raw Z-Wave JS server protocol, which carries no
+    authentication at all: anything that can open the socket can actuate
+    every paired device, door locks included. Now bound via `serverHost`
+    in zwave-js-ui's settings — that is the one piece of on-disk state
+    this script has to fix, see below.
+  - **5580** — python-matter-server's control websocket, likewise
+    unauthenticated. Now bound via `--listen-address 127.0.0.1` on the
+    matter-server container, and declared in `servicebay.ports` for the
+    first time (it was invisible to the network map before).
+
+The pod-level rebinds are structural: `podman play kube` recreates the pod
+from the v7 manifest, which carries the new env var / args. Nothing moves
+on disk — HA's `/config`, the zwave-js store and the matter-server data
+directory are untouched.
+
+The existing `zwave.<domain>` NPM host is retargeted AUTOMATICALLY by
+ServiceBay's core reconcile — this migration does NOT touch the proxy
+itself (#2364). On every deploy the install runner runs `ensureProxyHosts`,
+which walks the stack variables through `buildProxyHosts`:
+ZWAVE_JS_SUBDOMAIN's new `loopbackOnly: true` makes it emit
+`forwardHost: 127.0.0.1`, and the proxy-hosts endpoint's existing-host
+branch (`reconcileProxyHostUpstream` / `decideUpstreamReconcile`) re-points
+the live host's forward target from the old LAN IP (now closed) to
+`127.0.0.1:8091`. That reconcile PUTs ONLY the forward target, so exposure
+(internal), the Authelia forward-auth advanced_config and the bound cert
+survive, and it is idempotent.
+
+Everything that legitimately talks to these ports keeps working:
+  - nginx runs on `hostNetwork`, so `127.0.0.1` IS the loopback the
+    Z-Wave UI listens on.
+  - Home Assistant is a container in THIS pod, so it shares the host
+    netns; its `zwave_js` config entry connects to `ws://localhost:3001`
+    and its `matter` entry to `ws://localhost:5580/ws`. Both are loopback
+    already — no HA-side reconfiguration, no re-pairing.
+  - `post-deploy.py` and this script run in the HOST netns (ADR 0007),
+    so their localhost probes are unaffected.
+  - Matter commissioning and device traffic are unaffected:
+    `--listen-address` binds only the websocket API server, never the
+    CHIP/Matter stack (that knob is `--primary-interface`).
+
+WHY THIS HOP IS NOT PURELY INFORMATIONAL. Port 3001's bind address is not
+in the pod manifest — it lives in zwave-js-ui's on-disk settings, seeded
+by `post-deploy.py` as `sb-external-settings.json`. That seeder writes the
+file only when it is MISSING, so on every v6 install the file already
+exists carrying `"serverHost": "0.0.0.0"` and would keep the port
+LAN-reachable forever. This script rewrites that value in place so an
+install predating the fix is closed by the deploy itself, with no manual
+edit and no redeploy dance.
+
+What this script does:
+  - Re-pin `serverHost` to 127.0.0.1 in whichever settings file governs
+    the WS server: `sb-external-settings.json` when ServiceBay seeded it,
+    otherwise zwave-js-ui's own `settings.json` (the install shape where
+    the operator pinned `zwave.serverPort` in the UI). Both are JSON
+    objects; only that one key is touched.
+  - Leave a DELIBERATE non-wildcard `serverHost` alone and warn instead —
+    an operator who pinned a specific address made a choice, and silently
+    overriding it would break their setup. Everything else (absent,
+    `0.0.0.0`, `::`) is rewritten.
+  - Print what changed and exit 0. Migration scripts MUST exit 0 to let
+    the deploy continue; a non-zero exit aborts it before the new yaml
+    lands. A settings file we cannot read/write is reported loudly but is
+    not fatal — the pod-level 8091/5580 binds still land, and the next
+    deploy's post-deploy retries the 3001 pin.
+
+Idempotent by contract: re-running finds `serverHost` already 127.0.0.1
+and reports "already pinned" without writing.
+
+Environment available (set by ServiceManager.runMigrationScript):
+  - OLD_SCHEMA_VERSION = 6
+  - NEW_SCHEMA_VERSION = 7
+  - OLD_DATA_DIR, NEW_DATA_DIR (defaults to DATA_DIR for both)
+  - Every wizard variable (DATA_DIR, ZWAVE_DEVICE, PUBLIC_DOMAIN, …)
+  - SB_NODE, SB_API_URL, SB_API_TOKEN (for callbacks into ServiceBay)
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# Must stay in sync with post-deploy.py's ZWAVEJS_WS_* constants.
+ZWAVEJS_WS_PORT = 3001
+ZWAVEJS_WS_HOST = "127.0.0.1"
+WILDCARD_HOSTS = ("", "0.0.0.0", "::", "[::]", "*")
+
+
+def _store_dir() -> str:
+    """Host-side path of the zwave-js container's /usr/src/app/store mount.
+    Must stay in sync with the volume declaration in template.yml and with
+    post-deploy.py's `_zwave_store_dir`."""
+    base = os.environ.get("DATA_DIR") or "/mnt/data"
+    return os.path.join(base, "home-assistant", "zwave-js")
+
+
+def _load(path: str) -> dict | None:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"  ⚠️ Could not read {path}: {exc} — leaving it untouched.")
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _save(path: str, data: dict) -> bool:
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+            fh.write("\n")
+    except OSError as exc:
+        print(f"  ⚠️ Could not rewrite {path}: {exc}")
+        print(f"     Port {ZWAVEJS_WS_PORT} stays LAN-reachable until this is fixed;")
+        print("     post-deploy retries the pin on the next deploy.")
+        return False
+    return True
+
+
+def _pin(container: dict, label: str) -> bool:
+    """Pin `serverHost` inside `container` (mutated in place). Returns True
+    iff the caller should write the file back out."""
+    host = container.get("serverHost")
+    if host == ZWAVEJS_WS_HOST:
+        print(f"  {label}: serverHost already pinned to {ZWAVEJS_WS_HOST} — nothing to do.")
+        return False
+    if host is not None and str(host).strip() not in WILDCARD_HOSTS:
+        print(f"  ⚠️ {label}: serverHost is pinned to {host!r}, not a wildcard — leaving it alone.")
+        print(f"     Set it to {ZWAVEJS_WS_HOST} yourself to keep port {ZWAVEJS_WS_PORT} off the LAN.")
+        return False
+    container["serverHost"] = ZWAVEJS_WS_HOST
+    print(f"  {label}: serverHost {host!r} → {ZWAVEJS_WS_HOST}")
+    return True
+
+
+def migrate_zwave_ws_bind() -> None:
+    """Close port 3001 on the LAN for an install seeded under v6."""
+    external = os.path.join(_store_dir(), "sb-external-settings.json")
+    settings = os.path.join(_store_dir(), "settings.json")
+
+    data = _load(external)
+    if data is not None:
+        if _pin(data, "sb-external-settings.json"):
+            _save(external, data)
+        return
+
+    data = _load(settings)
+    if data is not None and isinstance(data.get("zwave"), dict):
+        if _pin(data["zwave"], "settings.json (zwave)"):
+            _save(settings, data)
+        return
+
+    print("  No zwave-js settings file on disk yet — post-deploy seeds it with")
+    print(f"  serverHost={ZWAVEJS_WS_HOST} later in this same deploy.")
+
+
+def main() -> int:
+    print("Home Assistant v6 → v7: admin/control ports moved to the loopback (#2416).")
+    print("  8091 (Z-Wave JS UI) and 5580 (Matter websocket) rebind when podman")
+    print("  recreates the pod from the v7 manifest — no action needed.")
+    print("  zwave.<domain> is retargeted to 127.0.0.1:8091 automatically by the")
+    print("  core reconcile (#2364) — no manual proxy edit; exposure, forward-auth")
+    print("  config and the cert are preserved.")
+    print(f"  Port {ZWAVEJS_WS_PORT} (raw Z-Wave control websocket) is stored on disk, so:")
+    migrate_zwave_ws_bind()
+    print("  Home Assistant already reaches all three over localhost — nothing to")
+    print("  re-pair. Nothing moves on disk; /config, the zwave-js store and the")
+    print("  matter-server data directory are untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -20,7 +20,12 @@ Responsibilities:
      same container only exposes 80/443/81 externally. The external-settings
      file is read by zwave-js-ui on every boot; we only write it when it's
      missing AND the operator has not already configured a serverPort via
-     the UI (stored in settings.json under `zwave.serverPort`).
+     the UI (stored in settings.json under `zwave.serverPort`). Since
+     template v7 (#2416) the server is also pinned to `serverHost`
+     127.0.0.1 — the protocol is unauthenticated and this pod is
+     `hostNetwork: true`, so a wildcard bind handed every LAN device raw
+     control of the Z-Wave mesh. An existing settings file carrying the old
+     wildcard bind is re-pinned in place on every deploy.
 
   3. **auth_oidc custom component** — downloads the pinned release tarball
      of the `auth_oidc` HA custom component (#493) and drops it into
@@ -50,7 +55,16 @@ UDEV_RULE_DIR = "/etc/udev/rules.d"
 UDEV_RULE_FILE = "99-zwave.rules"
 
 ZWAVEJS_WS_PORT = 3001
-ZWAVEJS_WS_HOST = "0.0.0.0"
+# Loopback since template v7 (#2416). The Z-Wave JS control websocket speaks
+# the raw zwave-js server protocol with NO authentication of its own — anything
+# that can open it can actuate every paired device, door locks included. Under
+# `hostNetwork: true` a 0.0.0.0 bind meant every LAN host could. Home Assistant
+# shares this pod and its zwave_js config entry connects to
+# `ws://localhost:3001`, so nothing legitimate loses reach.
+ZWAVEJS_WS_HOST = "127.0.0.1"
+# Wildcard binds we will rewrite in place on an existing settings file. An
+# operator who deliberately pinned some OTHER address is left alone (warned).
+ZWAVEJS_WS_WILDCARD_HOSTS = ("", "0.0.0.0", "::", "[::]", "*")
 ZWAVE_CONTAINER_NAME = "home-assistant-zwave-js"
 REQUEST_TIMEOUT = 10.0
 
@@ -190,6 +204,102 @@ def _zwave_ui_has_serverport() -> bool:
     return bool(stored.get("zwave", {}).get("serverPort"))
 
 
+def _ws_host_verdict(host: object) -> str:
+    """Classify a stored zwave-js `serverHost` value: 'pinned' (already the
+    loopback), 'wildcard' (absent or an every-interface bind — rewrite it), or
+    'operator' (a deliberate specific address — leave it, warn)."""
+    if host == ZWAVEJS_WS_HOST:
+        return "pinned"
+    if host is None or str(host).strip() in ZWAVEJS_WS_WILDCARD_HOSTS:
+        return "wildcard"
+    return "operator"
+
+
+def _warn_operator_ws_host(where: str, host: object) -> None:
+    log(f"   ⚠️ {where} pins serverHost={host!r} (not a wildcard) — leaving it alone.")
+    log(f"      Set it to {ZWAVEJS_WS_HOST} to keep port {ZWAVEJS_WS_PORT} off the LAN (#2416).")
+
+
+def repair_zwave_external_settings_host(path: str) -> bool:
+    """Re-pin `serverHost` to the loopback in an EXISTING external-settings
+    file (#2416).
+
+    The v6-to-v7 migration does this once for installs that predate the
+    loopback bind, but a file carrying the old wildcard bind can also arrive
+    later — a restored backup, a hand-edited store, a v7 install rolled back
+    and forward again. This runs on every deploy so the pin converges instead
+    of depending on a one-shot hop. Returns True iff the file changed (caller
+    restarts zwave-js)."""
+    name = os.path.basename(path)
+    try:
+        with open(path, encoding="utf-8") as fh:
+            current = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        log(f"   ⚠️ Could not read {path}: {exc}. Leaving it untouched.")
+        return False
+    if not isinstance(current, dict):
+        log(f"   ⚠️ {name} is not a JSON object — leaving it untouched.")
+        return False
+
+    host = current.get("serverHost")
+    verdict = _ws_host_verdict(host)
+    if verdict == "pinned":
+        log(f"   {name} already in place — serverHost={host}.")
+        return False
+    if verdict == "operator":
+        _warn_operator_ws_host(name, host)
+        return False
+
+    current["serverHost"] = ZWAVEJS_WS_HOST
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(current, fh, indent=2)
+            fh.write("\n")
+    except OSError as exc:
+        log(f"   ⚠️ Could not rewrite {path}: {exc}. Port {ZWAVEJS_WS_PORT} stays LAN-reachable.")
+        return False
+    log(f"   re-pinned {name}: serverHost {host!r} → {ZWAVEJS_WS_HOST} (#2416)")
+    return True
+
+
+def repair_zwave_ui_settings_host() -> bool:
+    """Same loopback pin for the OTHER authoritative file (#2416).
+
+    When the operator pinned `zwave.serverPort` in the UI, ServiceBay leaves
+    the external-settings file unwritten and zwave-js-ui's own settings.json
+    governs the WS server — including its bind address, which the UI has no
+    field for and therefore leaves unset (= every interface). Merge the
+    loopback in so that install shape is covered too. Returns True iff the
+    file changed."""
+    path = _zwave_settings_path()
+    try:
+        with open(path, encoding="utf-8") as fh:
+            settings = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(settings, dict) or not isinstance(settings.get("zwave"), dict):
+        return False
+
+    host = settings["zwave"].get("serverHost")
+    verdict = _ws_host_verdict(host)
+    if verdict == "pinned":
+        return False
+    if verdict == "operator":
+        _warn_operator_ws_host("settings.json", host)
+        return False
+
+    settings["zwave"]["serverHost"] = ZWAVEJS_WS_HOST
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(settings, fh, indent=2)
+            fh.write("\n")
+    except OSError as exc:
+        log(f"   ⚠️ Could not rewrite {path}: {exc}. Port {ZWAVEJS_WS_PORT} stays LAN-reachable.")
+        return False
+    log(f"   re-pinned settings.json: zwave.serverHost {host!r} → {ZWAVEJS_WS_HOST} (#2416)")
+    return True
+
+
 def ensure_zwave_external_settings() -> bool:
     """Seed the JSON file zwave-js-ui reads via ZWAVE_EXTERNAL_SETTINGS.
     Returns True iff a file was just written (caller restarts the
@@ -198,11 +308,10 @@ def ensure_zwave_external_settings() -> bool:
     reboot)."""
     path = _zwave_external_settings_path()
     if os.path.isfile(path):
-        log(f"   {os.path.basename(path)} already in place — leaving untouched.")
-        return False
+        return repair_zwave_external_settings_host(path)
     if _zwave_ui_has_serverport():
         log("   Existing UI-configured serverPort found in settings.json — not overriding.")
-        return False
+        return repair_zwave_ui_settings_host()
 
     desired = {
         "serverEnabled": True,

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -6,12 +6,22 @@ metadata:
     app: home-assistant
   annotations:
     servicebay.label: "Smart Home (Home Assistant)"
-    servicebay.schema-version: "6"
+    # v7 (#2416): every admin/control port in this pod except Home
+    # Assistant's own 8123 is bound to the host loopback. No data move;
+    # requires a re-deploy so podman recreates the pod from this manifest.
+    servicebay.schema-version: "7"
     # Home Assistant is reached at home.<domain> via nginx and
     # authenticates via Authelia.
     servicebay.dependencies: "nginx,auth"
     servicebay.config-mount: "/config"
-    servicebay.ports: "8123/tcp,8091/tcp,3001/tcp"
+    # 8123 = Home Assistant (own login + OIDC, public via home.<domain>).
+    # 8091 = Z-Wave JS UI, 3001 = the raw Z-Wave JS control websocket,
+    # 5580 = python-matter-server's control websocket. Those three carry no
+    # usable auth of their own and are loopback-bound since v7 (#2416); 5580
+    # was previously undeclared here entirely, which hid it from the network
+    # map. See tests/backend/template_consistency.test.ts § "hostNetwork
+    # templates expose no unguarded admin/control port".
+    servicebay.ports: "8123/tcp,8091/tcp,3001/tcp,5580/tcp"
     # Continuous health probe (#628). `/manifest.json` is the PWA
     # manifest — unauthenticated, served once HA's HTTP listener is up.
     # Avoids the /api token requirement of the regular /api endpoint.
@@ -61,6 +71,26 @@ spec:
     # tab, so deleting the file is the escape hatch for manual control.
     - name: ZWAVE_EXTERNAL_SETTINGS
       value: "/usr/src/app/store/sb-external-settings.json"
+    # Bind zwave-js-ui's web UI + REST API to the host LOOPBACK only
+    # (#2416). zwave-js-ui's `HOST` env var defaults to empty, which its
+    # express server reads as "every IPv4 and IPv6 interface" — and because
+    # this pod is `hostNetwork: true` that means every host interface. The
+    # Z-Wave admin panel (include/exclude nodes, read the network security
+    # keys, actuate any paired device — door locks included) therefore
+    # answered directly at <lan-ip>:8091, never touching nginx and so never
+    # touching the Authelia forward-auth on zwave.<domain>. FCoS ships no
+    # firewall.
+    #
+    # Same shape as LLDAP's LLDAP_HTTP_HOST (#2380) and the hostNetwork
+    # equivalent of radicale's `hostIP: 127.0.0.1` publish (#2357): a
+    # hostNetwork pod publishes no ports, so the bind address has to come
+    # from the app's own config. nginx also runs on hostNetwork, so it still
+    # reaches this port over the loopback, and `loopbackOnly: true` on
+    # ZWAVE_JS_SUBDOMAIN (variables.json) points zwave.<domain>'s forward
+    # target at 127.0.0.1:8091 — re-pointing an EXISTING host off the now
+    # closed LAN address on redeploy via the core reconcile (#2364).
+    - name: HOST
+      value: "127.0.0.1"
     volumeMounts:
     - mountPath: /usr/src/app/store
       name: zwave-config
@@ -74,6 +104,34 @@ spec:
   # 3. Matter Server
   - name: matter-server
     image: ghcr.io/home-assistant-libs/python-matter-server:stable
+    # Bind the Matter control websocket (5580) to the host LOOPBACK only
+    # (#2416). python-matter-server's `--listen-address` defaults to None,
+    # which aiohttp reads as "any IPv4 and IPv6 address" — under
+    # `hostNetwork: true` that is every host interface, and the websocket
+    # carries NO authentication: anything that can open it can commission,
+    # read and actuate every paired Matter device.
+    #
+    # `--listen-address` binds ONLY the websocket API server
+    # (`MultiHostTCPSite(host=self.listen_addresses, port=self.port)`); it is
+    # never passed to the CHIP/Matter stack, whose own operational sockets and
+    # mDNS discovery keep using the real interfaces. So Matter commissioning
+    # and device traffic are unaffected — see `--primary-interface` for the
+    # knob that *would* touch the SDK. Home Assistant lives in this same pod
+    # and its matter config entry connects to `ws://localhost:5580/ws`, so it
+    # is unaffected too.
+    #
+    # `args` REPLACES the image's CMD (the ENTRYPOINT stays `matter-server`),
+    # so the image's own default arguments have to be repeated verbatim here.
+    # Upstream CMD as of this bump:
+    #   ["--storage-path", "/data", "--paa-root-cert-dir", "/data/credentials"]
+    # If a future :stable changes them, mirror the change here.
+    args:
+    - "--storage-path"
+    - "/data"
+    - "--paa-root-cert-dir"
+    - "/data/credentials"
+    - "--listen-address"
+    - "127.0.0.1"
     env:
     - name: TZ
       value: "{{TZ}}"

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -15,10 +15,11 @@
   },
   "ZWAVE_JS_SUBDOMAIN": {
     "type": "subdomain",
-    "description": "Subdomain for the Z-Wave JS UI. Internal exposure — gets a real LE cert (Authelia forward-auth needs https) but NPM binds the LAN-only access list, so it's not reachable from outside the LAN.",
+    "description": "Subdomain for the Z-Wave JS UI. Internal exposure — gets a real LE cert (Authelia forward-auth needs https) but NPM binds the LAN-only access list, so it's not reachable from outside the LAN. The forward-auth block only gates the nginx path; until template v7 nothing made nginx the only path, so the Z-Wave admin panel also answered directly at <box-lan-ip>:8091 and skipped Authelia entirely (#2416, same shape as LLDAP's #2380). v7 binds zwave-js-ui's web server to 127.0.0.1 via the HOST env var in template.yml, and the loopbackOnly flag below points this proxy host's forward target at 127.0.0.1:8091 so the proxied route keeps working.",
     "default": "zwave",
     "exposure": "internal",
     "proxyPort": "8091",
+    "loopbackOnly": true,
     "proxyConfig": {
       "allow_websocket_upgrade": true,
       "block_exploits": true,

--- a/templates/immich/variables.json
+++ b/templates/immich/variables.json
@@ -32,11 +32,6 @@
     "type": "secret",
     "description": "OIDC client secret for Immich ↔ Authelia. Auto-generated; the wizard wires the same value into Authelia's clients[] entry and the Immich system-config OAuth section via post-deploy."
   },
-  "PUBLIC_DOMAIN": {
-    "type": "text",
-    "description": "Public domain (used to build the SSO authority URL https://auth.<domain>)",
-    "default": "dopp.cloud"
-  },
   "IMMICH_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Immich",

--- a/templates/media/migrations/v3-to-v4.py
+++ b/templates/media/migrations/v3-to-v4.py
@@ -27,7 +27,7 @@ After deploy:
   - Old `${DATA_DIR}/media/navidrome` is renamed to
     `${DATA_DIR}/media/navidrome.bak`. Operator deletes when ready.
   - Jellyfin starts on JELLYFIN_PORT (default 8096); the
-    `music.dopp.cloud` proxy host now forwards there.
+    `music.<PUBLIC_DOMAIN>` proxy host now forwards there.
   - Symfonium users need to re-pair (delete old connection, add new
     via Quick Connect; Jellyfin backend, not Subsonic). Plays /
     favorites from Navidrome are NOT carried over.

--- a/templates/media/variables.json
+++ b/templates/media/variables.json
@@ -36,11 +36,6 @@
     "description": "Host path mounted at /media (read-only). Defaults to the file-share volume so Music/, Movies/, TV/ etc. dropped into the Samba share appear in Jellyfin's library scan.",
     "default": "/mnt/data/stacks/file-share/data"
   },
-  "PUBLIC_DOMAIN": {
-    "type": "text",
-    "description": "Public domain (used to build the JELLYFIN_PublishedServerUrl env that mobile apps probe for backend URLs).",
-    "default": "dopp.cloud"
-  },
   "LLDAP_LDAP_PORT": {
     "type": "text",
     "description": "LLDAP LDAP-protocol port — Jellyfin's LDAP-Auth plugin binds LLDAP here for SSO (#1718). Inherited from the auth template.",

--- a/templates/nginx/variables.json
+++ b/templates/nginx/variables.json
@@ -23,11 +23,6 @@
     "description": "Admin UI port",
     "default": "81"
   },
-  "PUBLIC_DOMAIN": {
-    "type": "text",
-    "description": "Public domain for all services (e.g. dopp.cloud)",
-    "default": "dopp.cloud"
-  },
   "NPM_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Nginx Proxy Manager admin. Internal exposure — gets a real LE cert (without it nginx serves the default cert and the SNI handshake fails with 'unrecognized name'), NPM binds the LAN-only access list so it isn't reachable from outside the LAN, and Authelia forward-auth gates it on top because NPM exposes proxy-host edit (#878).",

--- a/templates/radicale/migrations/v1-to-v2.py
+++ b/templates/radicale/migrations/v1-to-v2.py
@@ -25,7 +25,7 @@ runs `ensureProxyHosts`, which walks the stack variables through
 emit `forwardHost: 127.0.0.1`, and the proxy-hosts endpoint's
 existing-host branch (`reconcileProxyHostUpstream` /
 `decideUpstreamReconcile`) re-points the live host's forward target
-from the old LAN IP (`192.168.178.100:{{RADICALE_PORT}}`, now closed)
+from the old LAN IP (`<LAN_IP>:{{RADICALE_PORT}}`, now closed)
 to `127.0.0.1:{{RADICALE_PORT}}`. That reconcile PUTs ONLY the forward
 target, so exposure (public), auth (Radicale Basic — no Authelia) and
 the bound cert are untouched, and it is idempotent (a no-op once the

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -14,8 +14,12 @@
       "description": "LLDAP LDAP protocol port"
     },
     "LLDAP_BASE_DN": {
-      "default": "dc=dopp,dc=cloud",
-      "description": "LDAP base distinguished name"
+      "default": "",
+      "description": "LDAP base distinguished name, e.g. dc=example,dc=com. No default — it must match the DN your LLDAP was initialised with."
+    },
+    "PUBLIC_DOMAIN": {
+      "default": "",
+      "description": "Base public domain for this box, e.g. example.com. Services are exposed at <service>.<this domain>; enter the bare domain, not a subdomain. Declared ONCE here rather than per-template (#2425) — templates just reference {{PUBLIC_DOMAIN}}. No default: the wizard prefills it from the domain you enter during onboarding, and the install runner falls back to config.reverseProxy.publicDomain."
     },
     "LAN_IP": {
       "default": "",

--- a/templates/vaultwarden/variables.json
+++ b/templates/vaultwarden/variables.json
@@ -26,11 +26,6 @@
     "type": "secret",
     "description": "OIDC client secret for Vaultwarden ↔ Authelia. Auto-generated; the wizard wires it into both the SSO_CLIENT_SECRET env and Authelia's clients[] entry."
   },
-  "PUBLIC_DOMAIN": {
-    "type": "text",
-    "description": "Public domain (used to build the SSO authority URL https://auth.<domain>)",
-    "default": "dopp.cloud"
-  },
   "VAULTWARDEN_SUBDOMAIN": {
     "type": "subdomain",
     "description": "Subdomain for Vaultwarden",

--- a/tests/backend/claude_dev_entrypoint.test.ts
+++ b/tests/backend/claude_dev_entrypoint.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Runtime regression tests for templates/claude-dev/docker-entrypoint.sh.
+ *
+ * The actual cases live in tests/templates/claude_dev_entrypoint_test.sh
+ * (bash, since the subject is bash: the suite sources the entrypoint with
+ * CLAUDE_DEV_ENTRYPOINT_LIB=1 and drives its helpers against a fake
+ * /workspace full of hostile directory names, with su/start-claude/ldapsearch
+ * stubbed on PATH — far cleaner than re-implementing shell word-splitting in
+ * JS).
+ *
+ * This vitest wrapper executes that suite and surfaces its output as a vitest
+ * assertion, so `npm test` gives the same green/red signal (same pattern as
+ * post_deploy_runtime.test.ts wrapping the Python post-deploy suite).
+ *
+ * What it guards (#2418): /workspace is group-writable by every `devshare`
+ * member, so a checkout's basename is attacker-controlled. It must reach
+ * `start-claude` as one literal argv element and never be re-parsed as shell
+ * by the `su` the entrypoint runs — including via util-linux su's PERMUTING
+ * getopt, which is why the `--` before the user name is load-bearing.
+ * Skipped if bash isn't available on the runner.
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SH_TEST = path.join(REPO_ROOT, 'tests', 'templates', 'claude_dev_entrypoint_test.sh');
+
+function bashAvailable(): boolean {
+  try {
+    execSync('bash --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('claude-dev docker-entrypoint.sh', () => {
+  const testFn = bashAvailable() ? it : it.skip;
+
+  // 30 s like the Python wrapper: the suite runs in well under a second, but
+  // it spawns a few dozen short-lived processes (stubs, mktemp, find), which
+  // a cold GHA runner can drag past vitest's 5 s default.
+  testFn('passes its shell-injection + secret-hygiene regression suite', () => {
+    const result = spawnSync('bash', [SH_TEST], { cwd: REPO_ROOT, encoding: 'utf-8' });
+    if (result.status !== 0) {
+      throw new Error(
+        `claude-dev entrypoint regression suite failed (exit ${result.status}):\n\n` +
+        `--- stdout ---\n${result.stdout}\n` +
+        `--- stderr ---\n${result.stderr}\n`,
+      );
+    }
+    expect(result.stdout).toMatch(/checks passed/);
+    expect(result.stdout).not.toMatch(/^FAIL/m);
+  }, 30_000);
+});

--- a/tests/backend/dockerfile_workspace_deps.test.ts
+++ b/tests/backend/dockerfile_workspace_deps.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Workspace manifests must be COPY'd before every `npm ci` in the images
+ * (#2422).
+ *
+ * `npm ci` against a workspace root resolves `workspaces: ["packages/*"]` from
+ * the on-disk tree, not from the lockfile. If a Dockerfile stage copies only
+ * the ROOT package.json + package-lock.json, the glob matches nothing, npm
+ * installs the root deps only and exits 0 — no warning. Everything declared in
+ * packages/backend/package.json (ssh2, better-sqlite3, node-pty, nodemailer)
+ * silently vanishes, and the pre-bundled server dies on first import with
+ * "Cannot find module 'ssh2'".
+ *
+ * The production Dockerfile has carried that fix since #767; Dockerfile.dev
+ * never got it and the dev container was unbootable until #2422. This test is
+ * the guard for both — and for the next workspace member somebody adds under
+ * packages/ without touching the images.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DOCKERFILES = ['Dockerfile', 'Dockerfile.dev'];
+
+/** Workspace members on disk — every `packages/<name>/package.json`. */
+function workspaceMembers(): string[] {
+  const dir = path.join(REPO_ROOT, 'packages');
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && fs.existsSync(path.join(dir, e.name, 'package.json')))
+    .map((e) => e.name)
+    .sort();
+}
+
+/** Split a Dockerfile into build stages; each `FROM` starts a new one. */
+function stages(text: string): string[][] {
+  const out: string[][] = [];
+  let current: string[] | null = null;
+  for (const line of text.split('\n')) {
+    if (/^\s*FROM\s/i.test(line)) {
+      current = [];
+      out.push(current);
+    }
+    if (current) current.push(line);
+  }
+  return out;
+}
+
+describe('Dockerfile workspace dependency install (#2422)', () => {
+  it('copies every workspace package.json before each `npm ci`', () => {
+    const members = workspaceMembers();
+    expect(members.length, 'expected workspace members under packages/').toBeGreaterThan(0);
+
+    const problems: string[] = [];
+
+    for (const file of DOCKERFILES) {
+      const text = fs.readFileSync(path.join(REPO_ROOT, file), 'utf-8');
+      for (const stage of stages(text)) {
+        const npmCi = stage.findIndex((l) => /^\s*RUN\s.*\bnpm ci\b/.test(l));
+        if (npmCi === -1) continue;
+        const before = stage.slice(0, npmCi);
+        for (const m of members) {
+          const copied = before.some((l) =>
+            new RegExp(`^\\s*COPY\\s.*\\bpackages/${m}/package\\.json\\b`).test(l),
+          );
+          if (!copied) problems.push(`${file}: packages/${m}/package.json not copied before \`npm ci\``);
+        }
+      }
+    }
+
+    expect(
+      problems,
+      `Workspace manifests missing before \`npm ci\`:\n  ${problems.join('\n  ')}\n\n` +
+        'Without them the workspaces glob resolves to nothing, npm ci installs only root deps ' +
+        '(exit 0, no warning), and the image ships without ssh2/better-sqlite3/node-pty/nodemailer.',
+    ).toEqual([]);
+  });
+
+  it('Dockerfile.dev merges workspace-scoped node_modules into the root', () => {
+    // npm deoptimizes hoisting for some packages (nodemailer today) and leaves
+    // them in packages/backend/node_modules. dist-server/server.cjs require()s
+    // them as externals and node resolves those from /app/node_modules only.
+    const text = fs.readFileSync(path.join(REPO_ROOT, 'Dockerfile.dev'), 'utf-8');
+    expect(
+      /packages\/\*\/node_modules/.test(text),
+      'Dockerfile.dev must merge packages/*/node_modules into the root node_modules — ' +
+        'otherwise a non-hoisted runtime dep (nodemailer) is unreachable from dist-server/server.cjs.',
+    ).toBe(true);
+  });
+});

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -456,6 +456,333 @@ describe('Auth template: LLDAP HTTP port is loopback-bound (#2380)', () => {
   });
 });
 
+// ─── 3b2a. hostNetwork templates expose no unguarded admin/control port ─────
+describe('hostNetwork templates: every declared TCP port is guarded (#2416)', () => {
+  // A `hostNetwork: true` pod publishes no ports — whatever its containers
+  // bind, they bind on EVERY host interface, and Fedora CoreOS ships no
+  // firewall. So every TCP port such a template declares in
+  // `servicebay.ports` is LAN-reachable by default, with nginx (and with it
+  // Authelia) bypassed entirely. That is one bug class hit three times on
+  // three templates: #2380 (LLDAP web UI), #2388 (raw LDAP port), #2416
+  // (Z-Wave JS UI + its raw control websocket + the Matter websocket).
+  //
+  // This test turns the class into a structural rule. A declared TCP port
+  // passes only if it is:
+  //   (a) covered by a `loopbackOnly: true` subdomain variable — nginx also
+  //       runs on hostNetwork, so it forwards to 127.0.0.1 and the app is
+  //       expected to bind the loopback (we check the template ships such a
+  //       bind, which is exactly the half #2380 was missing); or
+  //   (b) covered by a `blockLanAccess: true` port variable — the host
+  //       nftables rule for ports that CANNOT be loopback-bound (#2388); or
+  //   (c) listed in HOST_NETWORK_PORT_POLICY below with a written reason,
+  //       and — for a port claimed loopback-bound without a proxy host — a
+  //       `bind` proof pointing at the config that actually binds it.
+  //
+  // Adding a port to a hostNetwork template without doing one of those three
+  // fails this suite. Deleting the guard from an existing one does too.
+  interface PortPolicy {
+    policy: 'loopback-bound' | 'lan-exposed';
+    why: string;
+    /** `loopback-bound` only: file (relative to the template dir) + pattern
+     *  proving the bind is actually configured, not just asserted here. */
+    bind?: { file: string; pattern: RegExp };
+  }
+
+  const HOST_NETWORK_PORT_POLICY: Record<string, PortPolicy> = {
+    // — Ports that are meant to answer on the LAN, each with its own auth —
+    'adguard:8083': {
+      policy: 'lan-exposed',
+      why: 'AdGuard Home admin UI. Its own login (post-deploy sets the admin '
+        + 'password) and it is the console for the box DNS server, which has to '
+        + 'stay reachable when the proxy is down.',
+    },
+    'adguard:53': {
+      policy: 'lan-exposed',
+      why: 'DNS over TCP. Serving the LAN is the entire job of the service — '
+        + 'every device on the network resolves through it.',
+    },
+    'auth:9091': {
+      policy: 'lan-exposed',
+      why: 'The Authelia portal itself — it IS the login surface, so gating it '
+        + 'behind itself is circular. Every app redirects here.',
+    },
+    'claude-dev:2222': {
+      policy: 'lan-exposed',
+      why: 'sshd. Authenticated by SSH key / LLDAP bind, not by the proxy; '
+        + 'nginx cannot proxy raw SSH.',
+    },
+    'file-share:22000': {
+      policy: 'lan-exposed',
+      why: 'Syncthing sync protocol. Peers connect device-to-device over TLS '
+        + 'with device-ID authentication; loopback would break every peer.',
+    },
+    'file-share:139': {
+      policy: 'lan-exposed',
+      why: 'SMB (NetBIOS session). LAN file sharing is the point of the '
+        + 'service; Samba authenticates users itself.',
+    },
+    'file-share:445': {
+      policy: 'lan-exposed',
+      why: 'SMB. Same as 139 — LAN by design, Samba-authenticated.',
+    },
+    'file-share:8088': {
+      policy: 'lan-exposed',
+      why: 'FileBrowser. Runs in proxy-auth mode (auth.method=proxy with '
+        + 'Remote-User), so a direct LAN request without the forward-auth header '
+        + 'is rejected 403. It cannot be loopback-bound because NPM reaches it '
+        + 'from its own pod netns.',
+    },
+    'home-assistant:8123': {
+      policy: 'lan-exposed',
+      why: 'Home Assistant itself. Has its own login plus the Authelia OIDC '
+        + 'provider, is published at home.<domain>, and the companion apps talk '
+        + 'to it directly on the LAN.',
+    },
+    'nginx:80': { policy: 'lan-exposed', why: 'The reverse proxy — this is the front door.' },
+    'nginx:443': { policy: 'lan-exposed', why: 'The reverse proxy — this is the front door.' },
+    'nginx:81': {
+      policy: 'lan-exposed',
+      why: "NPM's admin UI. Own login, and it is the recovery console for the "
+        + 'proxy itself, so it must survive a broken proxy config.',
+    },
+
+    // — Loopback-bound ports with no proxy host of their own (#2416) —
+    'home-assistant:3001': {
+      policy: 'loopback-bound',
+      why: 'Raw Z-Wave JS server protocol — no authentication of any kind, so '
+        + 'LAN reach means LAN control of every paired device, door locks '
+        + 'included. Home Assistant shares this pod and connects over '
+        + 'ws://localhost:3001, so nothing legitimate needs the LAN path.',
+      bind: { file: 'post-deploy.py', pattern: /^ZWAVEJS_WS_HOST = "127\.0\.0\.1"$/m },
+    },
+    'home-assistant:5580': {
+      policy: 'loopback-bound',
+      why: "python-matter-server's control websocket — likewise unauthenticated. "
+        + 'Home Assistant connects over ws://localhost:5580/ws. --listen-address '
+        + 'binds only the websocket API server, never the CHIP/Matter stack, so '
+        + 'commissioning and device traffic are unaffected.',
+      bind: { file: 'template.yml', pattern: /- "--listen-address"\n\s*- "127\.0\.0\.1"/ },
+    },
+  };
+
+  /** A YAML *value* (not a comment) binding something to the loopback. */
+  const LOOPBACK_BIND = /(value:\s*"127\.0\.0\.1|^\s*-\s*"127\.0\.0\.1)/m;
+
+  /** Render a template with variable defaults, like the sibling suites do. */
+  const renderPod = (t: TemplateInfo): // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any => {
+    const view: Record<string, string> = {};
+    for (const v of catalogVars) view[v] = `stub-${v.toLowerCase()}`;
+    for (const [name, meta] of Object.entries(t.variables)) {
+      if (meta && typeof meta === 'object' && 'default' in meta && typeof meta.default === 'string') {
+        view[name] = meta.default;
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return yaml.loadAll(Mustache.render(t.yamlContent, view)).find((d: any) => d?.kind === 'Pod');
+  };
+
+  /** Resolve a subdomain's proxyPort to a number (literal or via variable). */
+  const resolvePort = (t: TemplateInfo, proxyPort: string | undefined): number | null => {
+    if (!proxyPort) return null;
+    if (/^\d+$/.test(proxyPort)) return parseInt(proxyPort, 10);
+    const local = t.variables[proxyPort];
+    const fromLocal = local && typeof local === 'object' ? local.default : undefined;
+    if (typeof fromLocal === 'string' && /^\d+$/.test(fromLocal)) return parseInt(fromLocal, 10);
+    for (const other of templates) {
+      const meta = other.variables[proxyPort];
+      const d = meta && typeof meta === 'object' ? meta.default : undefined;
+      if (typeof d === 'string' && /^\d+$/.test(d)) return parseInt(d, 10);
+    }
+    return null;
+  };
+
+  const hostNetworkTemplates = templates.filter(t => renderPod(t)?.spec?.hostNetwork === true);
+
+  it('there is at least one hostNetwork template to check', () => {
+    // Guards against the rule silently becoming a no-op if rendering breaks.
+    expect(hostNetworkTemplates.length).toBeGreaterThan(0);
+  });
+
+  for (const t of hostNetworkTemplates) {
+    it(`${t.name}: every declared TCP port is loopback-bound, firewalled, or reasoned`, () => {
+      const pod = renderPod(t);
+      const declared: string = pod?.metadata?.annotations?.['servicebay.ports'] ?? '';
+      const tcpPorts = declared.split(',')
+        .map(p => p.trim())
+        .filter(p => p.toLowerCase().endsWith('/tcp'))
+        .map(p => parseInt(p.split('/')[0], 10))
+        .filter(p => Number.isFinite(p));
+
+      // Ports a `loopbackOnly` subdomain or a `blockLanAccess` variable covers.
+      const loopbackPorts = new Set<number>();
+      const firewalledPorts = new Set<number>();
+      for (const meta of Object.values(t.variables)) {
+        if (!meta || typeof meta !== 'object') continue;
+        if (meta.loopbackOnly) {
+          const p = resolvePort(t, meta.proxyPort);
+          if (p !== null) loopbackPorts.add(p);
+        }
+        if (meta.blockLanAccess && typeof meta.default === 'string' && /^\d+$/.test(meta.default)) {
+          firewalledPorts.add(parseInt(meta.default, 10));
+        }
+      }
+
+      const offenders: string[] = [];
+      for (const port of tcpPorts) {
+        if (firewalledPorts.has(port)) continue;
+        if (loopbackPorts.has(port)) {
+          // The proxy half is declared; assert the app-bind half exists too —
+          // that is precisely the half #2380 shipped without.
+          expect(
+            t.yamlContent,
+            `${t.name}: a subdomain declares loopbackOnly for port ${port}, but `
+            + `${t.name}/template.yml never binds anything to 127.0.0.1. The proxy `
+            + `would forward to a loopback nothing listens on, and the LAN path `
+            + `would still be open.`,
+          ).toMatch(LOOPBACK_BIND);
+          continue;
+        }
+        const policy = HOST_NETWORK_PORT_POLICY[`${t.name}:${port}`];
+        if (!policy) {
+          offenders.push(
+            `${t.name}:${port} — hostNetwork pod, so this port answers on every `
+            + `host interface with no proxy and no SSO in front of it.`,
+          );
+          continue;
+        }
+        expect(policy.why.length, `${t.name}:${port} policy needs a written reason`).toBeGreaterThan(20);
+        if (policy.policy === 'loopback-bound') {
+          expect(
+            policy.bind,
+            `${t.name}:${port} claims loopback-bound — give it a bind proof so the `
+            + `claim is checked rather than asserted.`,
+          ).toBeTruthy();
+          const proof = fs.readFileSync(path.join(TEMPLATES_DIR, t.name, policy.bind!.file), 'utf-8');
+          expect(
+            proof,
+            `${t.name}:${port} is declared loopback-bound but `
+            + `templates/${t.name}/${policy.bind!.file} no longer configures that bind `
+            + `(${policy.bind!.pattern}). The port is LAN-reachable again.`,
+          ).toMatch(policy.bind!.pattern);
+        }
+      }
+
+      expect(
+        offenders,
+        `${t.name}: unguarded admin/control port(s) on a hostNetwork pod:\n  `
+        + `${offenders.join('\n  ')}\n\n`
+        + `Close it one of three ways:\n`
+        + `  1. Bind the app to 127.0.0.1 in template.yml and add \`loopbackOnly: true\`\n`
+        + `     to the subdomain variable that proxies it (prior art: auth #2380,\n`
+        + `     home-assistant #2416).\n`
+        + `  2. If it cannot be loopback-bound, add \`blockLanAccess: true\` to the port\n`
+        + `     variable so ServiceBay installs the host nftables rule (prior art: #2388).\n`
+        + `  3. If it genuinely has to answer on the LAN, add an entry to\n`
+        + `     HOST_NETWORK_PORT_POLICY in this file saying why, and what authenticates it.`,
+      ).toEqual([]);
+    });
+  }
+});
+
+// ─── 3b2b. Home Assistant: Z-Wave + Matter control ports loopback (#2416) ───
+describe('Home Assistant template: Z-Wave and Matter ports are loopback-bound (#2416)', () => {
+  const ha = templates.find(t => t.name === 'home-assistant')!;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const container = (name: string): any => {
+    const view: Record<string, string> = {};
+    for (const v of catalogVars) view[v] = `stub-${v.toLowerCase()}`;
+    for (const [n, meta] of Object.entries(ha.variables)) {
+      if (meta && typeof meta === 'object' && 'default' in meta && typeof meta.default === 'string') {
+        view[n] = meta.default;
+      }
+    }
+    const rendered = Mustache.render(ha.yamlContent, view);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pod = yaml.loadAll(rendered).find((d: any) => d?.kind === 'Pod') as any;
+    return (pod?.spec?.containers ?? []).find((c: { name: string }) => c.name === name);
+  };
+
+  const postDeploy = (): string =>
+    fs.readFileSync(path.join(TEMPLATES_DIR, 'home-assistant', 'post-deploy.py'), 'utf-8');
+
+  it('binds the Z-Wave JS UI web server to 127.0.0.1 via HOST', () => {
+    // The pod is hostNetwork: true and zwave-js-ui reads an empty HOST as
+    // "every IPv4 and IPv6 interface", so the admin panel — add/remove nodes,
+    // read the network security keys — answered at <lan-ip>:8091 without ever
+    // passing through nginx, and therefore without Authelia's forward-auth.
+    const env: { name: string; value: string }[] = container('zwave-js')?.env ?? [];
+    expect(env.find(e => e.name === 'HOST')?.value).toBe('127.0.0.1');
+  });
+
+  it('points zwave.<domain> at the loopback while keeping forward-auth', () => {
+    // nginx runs on hostNetwork, so `loopbackOnly` (forwardHost 127.0.0.1) is
+    // what keeps the proxied route working — and re-points an EXISTING host
+    // off the now-closed LAN address on redeploy (#2364). The forward-auth
+    // sentinel must survive: it is the only gate left.
+    expect(ha.variables.ZWAVE_JS_SUBDOMAIN.loopbackOnly).toBe(true);
+    expect(ha.variables.ZWAVE_JS_SUBDOMAIN.proxyPort).toBe('8091');
+    expect(ha.variables.ZWAVE_JS_SUBDOMAIN.proxyConfig.advanced_config)
+      .toBe('__authelia_forward_auth__');
+  });
+
+  it('seeds the raw Z-Wave control websocket on 127.0.0.1, not 0.0.0.0', () => {
+    // Port 3001 speaks the zwave-js server protocol with no auth at all — LAN
+    // reach is LAN control of every paired device. HA lives in this same pod
+    // and connects over ws://localhost:3001, so the loopback bind costs it
+    // nothing. The bind lives in post-deploy's seeded settings file, not in
+    // the pod manifest, which is why it needs its own assertion.
+    expect(postDeploy()).toMatch(/^ZWAVEJS_WS_HOST = "127\.0\.0\.1"$/m);
+    expect(postDeploy()).toMatch(/ws:\/\/localhost:\{ZWAVEJS_WS_PORT\}/);
+  });
+
+  it('re-pins an existing settings file that still carries a wildcard bind', () => {
+    // The seeder only writes the external-settings file when it is MISSING, so
+    // every pre-v7 install already has one saying 0.0.0.0. Without an in-place
+    // repair the bind constant above would never reach those boxes.
+    const src = postDeploy();
+    expect(src).toMatch(/def repair_zwave_external_settings_host\(/);
+    expect(src).toMatch(/def repair_zwave_ui_settings_host\(/);
+    expect(src).toMatch(/ZWAVEJS_WS_WILDCARD_HOSTS/);
+  });
+
+  it('binds the Matter websocket to 127.0.0.1 without touching the CHIP stack', () => {
+    // `args` REPLACES the image CMD, so the image's own defaults have to be
+    // repeated — dropping them would start matter-server with no storage path.
+    const args: string[] = container('matter-server')?.args ?? [];
+    expect(args).toEqual([
+      '--storage-path', '/data',
+      '--paa-root-cert-dir', '/data/credentials',
+      '--listen-address', '127.0.0.1',
+    ]);
+  });
+
+  it('declares the Matter websocket port so the network map can see it', () => {
+    // 5580 was bound on every interface AND undeclared, so it was invisible.
+    expect(ha.yamlContent).toMatch(/servicebay\.ports:\s*"8123\/tcp,8091\/tcp,3001\/tcp,5580\/tcp"/);
+  });
+
+  it('schema-version is bumped to 7 with a CHANGELOG section and a v6-to-v7 migration', () => {
+    expect(ha.yamlContent).toMatch(/servicebay\.schema-version:\s*"7"/);
+    const changelog = fs.readFileSync(
+      path.join(TEMPLATES_DIR, 'home-assistant', 'CHANGELOG.md'), 'utf-8',
+    );
+    expect(changelog).toMatch(/##\s*v7\b.*\(breaking\)/);
+    const mig = fs.readFileSync(
+      path.join(TEMPLATES_DIR, 'home-assistant', 'migrations', 'v6-to-v7.py'), 'utf-8',
+    );
+    // Config-only hop: it rewrites one JSON key and must not move or delete
+    // anything on disk (HA's /config, the zwave-js store, matter-server data).
+    expect(mig).not.toMatch(/shutil\.(move|rmtree)|os\.remove|\.unlink\(|\.rename\(/);
+    expect(mig).toMatch(/untouched/i);
+    // Unlike auth's v2-to-v3 this hop is NOT informational — 3001's bind is
+    // on-disk state the seeder will not rewrite, so the migration must.
+    expect(mig).toMatch(/serverHost/);
+    expect(mig).toMatch(/def migrate_zwave_ws_bind\(/);
+  });
+});
+
 // ─── 3b3. Radicale template: rights ruleset is baked in (#2411) ─────────────
 describe('Radicale template: rights ruleset (#2411)', () => {
   const radicale = templates.find(t => t.name === 'radicale')!;

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -428,8 +428,7 @@ describe('Auth template: LLDAP HTTP port is loopback-bound (#2380)', () => {
       .toBe('__authelia_forward_auth__');
   });
 
-  it('schema-version is bumped to 3 with a CHANGELOG section and a v2-to-v3 migration', () => {
-    expect(auth.yamlContent).toMatch(/servicebay\.schema-version:\s*"3"/);
+  it('ships a CHANGELOG section and a v2-to-v3 migration for the loopback bind', () => {
     const changelog = fs.readFileSync(path.join(TEMPLATES_DIR, 'auth', 'CHANGELOG.md'), 'utf-8');
     expect(changelog).toMatch(/##\s*v3\b.*\(breaking\)/);
     const mig = fs.readFileSync(
@@ -453,6 +452,49 @@ describe('Auth template: LLDAP HTTP port is loopback-bound (#2380)', () => {
     expect(smoke).toMatch(/http:\/\/127\.0\.0\.1:\$\{LLDAP_PORT\}/);
     // No `curl ... "http://$HOST:$LLDAP_PORT/api/..."`-style API call left.
     expect(smoke).not.toMatch(/\$HOST:\$LLDAP_PORT\/(api|auth)\b/);
+  });
+
+  // ─── #2417: the servicebay OIDC client's secret is per-install ──────────
+  //
+  // This client guards the admin panel itself. A literal here is a credential
+  // every box on earth shares, and `mergeAutheliaOidcClients`'s no-rotate rule
+  // means it never self-heals. These assertions are the ratchet: the literal
+  // cannot come back, and the variable that replaced it cannot be quietly
+  // dropped or downgraded to a non-secret.
+  it('renders the servicebay OIDC client_secret from a per-install secret variable', () => {
+    const mustache = fs.readFileSync(
+      path.join(TEMPLATES_DIR, 'auth', 'configuration.yml.mustache'), 'utf-8',
+    );
+    // The client is still declared…
+    expect(mustache).toMatch(/client_id:\s*'servicebay'/);
+    // …but its secret is a placeholder, not a value.
+    expect(mustache).toMatch(/client_secret:\s*'\$plaintext\$\{\{SERVICEBAY_OIDC_SECRET\}\}'/);
+    // No `$plaintext$<literal>` anywhere in the rendered config.
+    expect(mustache).not.toMatch(/\$plaintext\$[A-Za-z0-9_-]/);
+
+    // Declared as a generated secret, like every sibling SSO template's.
+    expect(auth.variables.SERVICEBAY_OIDC_SECRET?.type).toBe('secret');
+    // `noAutoGenerate` would leave it EMPTY, rendering an empty client_secret
+    // — Authelia would then accept any secret for this client.
+    expect(auth.variables.SERVICEBAY_OIDC_SECRET?.noAutoGenerate).toBeFalsy();
+    expect(auth.variables.SERVICEBAY_OIDC_SECRET?.default).toBeUndefined();
+  });
+
+  it('schema-version is bumped to 4 with a CHANGELOG section and a v3-to-v4 migration', () => {
+    // Without the bump, an existing box never re-renders configuration.yml and
+    // keeps the published secret forever.
+    expect(auth.yamlContent).toMatch(/servicebay\.schema-version:\s*"4"/);
+    const changelog = fs.readFileSync(path.join(TEMPLATES_DIR, 'auth', 'CHANGELOG.md'), 'utf-8');
+    expect(changelog).toMatch(/##\s*v4\b.*\(breaking\)/);
+    const mig = fs.readFileSync(
+      path.join(TEMPLATES_DIR, 'auth', 'migrations', 'v3-to-v4.py'), 'utf-8',
+    );
+    // Informational hop: the rotation is structural (the re-render owns it),
+    // so this script must not move data or try to write either side itself —
+    // a script that flipped ServiceBay's copy here would lead the file instead
+    // of following it, which is the ordering that CAN strand a box.
+    expect(mig).not.toMatch(/shutil\.(move|rmtree)|os\.remove|\.unlink\(|\.rename\(/);
+    expect(mig).toMatch(/break-glass|LOCAL admin/i);
   });
 });
 

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -252,6 +252,60 @@ describe('Template variables are declared', () => {
   }
 });
 
+// ─── 2b. …and every declared variable is actually used ──────────────────────
+//
+// The mirror image of rule 2, and the guard #2425 asked for. A template that
+// DECLARES a variable it never renders makes the wizard collect a value that
+// goes nowhere — `templates/nginx/variables.json`'s PUBLIC_DOMAIN was exactly
+// that (declared, referenced in no nginx file, deleted in #2425), and the
+// orphaned `ABS_*` variables of #2381 were the same shape one release earlier.
+// Without an assertion, an orphan reappears silently on the next edit.
+describe('Declared template variables are used', () => {
+  /** Files inside a template dir that can legitimately consume a variable:
+   *  the pod manifest, companion mustache configs, and the host-side
+   *  post-deploy / entrypoint scripts (which read them as env vars, not as
+   *  `{{...}}`). Deliberately EXCLUDES `variables.json` itself (the
+   *  declaration is not a use) and the `migrations/` + `*.md` files (a
+   *  historical note naming a retired variable must not keep it alive). */
+  const USE_BEARING_EXT = /\.(ya?ml|mustache|py|sh|conf|json)$/;
+
+  function usageBlob(templateName: string): string {
+    const dir = path.join(TEMPLATES_DIR, templateName);
+    const parts: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      if (entry.name === 'variables.json') continue;
+      if (!USE_BEARING_EXT.test(entry.name)) continue;
+      parts.push(fs.readFileSync(path.join(dir, entry.name), 'utf-8'));
+    }
+    return parts.join('\n');
+  }
+
+  for (const t of templates) {
+    it(`${t.name}: every declared variable is rendered or read somewhere`, () => {
+      const blob = usageBlob(t.name);
+      const orphans = Object.entries(t.variables)
+        // `type: subdomain` vars are consumed STRUCTURALLY by the platform
+        // (buildProxyHosts turns them into NPM proxy hosts) rather than by a
+        // `{{...}}` reference, so absence from the template's own files is
+        // expected and correct — see media's ABS_SUBDOMAIN (#2381).
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .filter(([, spec]) => (spec as any)?.type !== 'subdomain')
+        .map(([name]) => name)
+        .filter(name => !blob.includes(name));
+
+      expect(
+        orphans,
+        `${t.name}: ${orphans.length} declared-but-unused variable(s):\n  ${orphans.join(', ')}\n\n` +
+        `The wizard would collect a value that nothing consumes. Either reference it in ` +
+        `${t.name}/template.yml, a *.mustache config or post-deploy.py — or delete the ` +
+        `declaration from ${t.name}/variables.json. If it is a shared global (PUBLIC_DOMAIN, ` +
+        `DATA_DIR, LLDAP_*), declare it ONCE in templates/settings.json instead (#2425).`,
+      ).toEqual([]);
+    });
+  }
+});
+
 // ─── 3. Each template renders to a valid Pod ────────────────────────────────
 describe('Templates render to valid Pod manifests', () => {
   /** Build a Mustache view that supplies a value for every variable referenced

--- a/tests/scripts/box-target-resolution.test.ts
+++ b/tests/scripts/box-target-resolution.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * #2426 — neither operator script may default to one particular deployment.
+ *
+ * `scripts/smoke/sso-verify.sh` and `scripts/maintenance/repair-admin-proxy-hosts.sh`
+ * used to fall back to the maintainer's own box IP and domain, so a contributor
+ * running either one aimed it at a stranger's LAN address (the maintenance
+ * script *writes* to that box's NPM). Both now resolve the target the way
+ * `scripts/fcos-diagnose.sh` and `tools/sb`'s ResolveTarget already do —
+ * flag → env → build/fcos/install-settings.env — and exit 2 with a usage
+ * error when nothing resolves.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPTS = [
+  'scripts/smoke/sso-verify.sh',
+  'scripts/maintenance/repair-admin-proxy-hosts.sh',
+] as const;
+
+/** Run a script with a controlled env; return {code, stdout, stderr}. */
+function run(script: string, env: Record<string, string>) {
+  try {
+    const stdout = execFileSync('bash', [path.join(REPO_ROOT, script)], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      // A clean env: no inherited SB_* from the developer's shell, and a
+      // settings file that does not exist unless the case provides one.
+      // A clean env — no inherited SB_* from the developer's shell. NODE_ENV
+      // is declared non-optional on this repo's ProcessEnv, so it's passed
+      // through explicitly rather than cast away.
+      env: { NODE_ENV: process.env.NODE_ENV ?? 'test', PATH: process.env.PATH ?? '/usr/bin:/bin', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 20_000,
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return { code: err.status ?? -1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+describe.each(SCRIPTS)('%s: box target must be supplied', (script) => {
+  const noSettings = { SB_SETTINGS_FILE: '/nonexistent/install-settings.env' };
+
+  it('exits 2 with a usage error when neither host nor domain is set', () => {
+    const r = run(script, noSettings);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toMatch(/no target host/i);
+    // The error names all three ways to supply it, so the operator isn't
+    // left guessing.
+    expect(r.stderr).toContain('SB_HOST');
+    expect(r.stderr).toContain('--host');
+    expect(r.stderr).toContain('install-settings.env');
+  });
+
+  it('exits 2 when the host resolves but the domain does not', () => {
+    const r = run(script, { ...noSettings, SB_HOST: '10.0.0.42' });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toMatch(/no public domain/i);
+    expect(r.stderr).toContain('SB_DOMAIN');
+  });
+
+  it('never falls back to a hardcoded host or domain', () => {
+    const body = fs.readFileSync(path.join(REPO_ROOT, script), 'utf-8');
+    // No `${SB_HOST:-<literal>}` / `${SB_DOMAIN:-<literal>}` shape at all:
+    // the only permitted fallback is a settings_value lookup.
+    const badDefault = /\$\{SB_(HOST|DOMAIN):-(?!\$\()/;
+    expect(badDefault.test(body), `${script} still has a literal SB_HOST/SB_DOMAIN default`).toBe(false);
+    // And the two values #2426 was filed over are gone from the file
+    // entirely — including the prose comments, which named them too.
+    expect(body).not.toContain('192.168.178.100');
+    expect(body).not.toContain('dopp.cloud');
+    // No real LAN address anywhere. Loopback is fine (it's the box's own
+    // interface, not an identity), and `10.0.0.x` is the placeholder the
+    // usage examples tell the operator to replace.
+    const leaked = (body.match(/\b\d{1,3}(?:\.\d{1,3}){3}\b/g) ?? []).filter(
+      a => !a.startsWith('127.') && !a.startsWith('10.0.0.') && a !== '0.0.0.0',
+    );
+    expect(leaked, `unexpected IP literal(s) in ${script}`).toEqual([]);
+  });
+
+  it('resolves host + domain from install-settings.env when the env vars are unset', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-target-'));
+    const settings = path.join(dir, 'install-settings.env');
+    // Loopback so the run past the resolution gate fails fast (connection
+    // refused) instead of burning an ssh connect timeout.
+    fs.writeFileSync(settings, 'STATIC_IP=127.0.0.1\nPUBLIC_DOMAIN="example.test"\n');
+    try {
+      const r = run(script, { SB_SETTINGS_FILE: settings });
+      // Both values resolved, so neither usage error fires. The run then
+      // proceeds and fails on the *next* real dependency (no reachable box)
+      // — a different, non-2 failure.
+      expect(r.stderr).not.toMatch(/no target host|no public domain/i);
+      expect(r.code).not.toBe(2);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/templates/claude_dev_entrypoint_test.sh
+++ b/tests/templates/claude_dev_entrypoint_test.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+# Regression test for templates/claude-dev/docker-entrypoint.sh (#2418).
+#
+# The entrypoint's boot autostart discovers git checkouts under /workspace —
+# a directory that is group-writable by every `devshare` member, i.e. by every
+# non-admin LDAP collaborator — and hands the basenames to `start-claude`
+# through `su`. It used to splice them into a string `su -c` re-parsed as
+# shell, so a directory named `$(...)` executed as the shared `dev` account on
+# the next container start.
+#
+# This suite sources the entrypoint with CLAUDE_DEV_ENTRYPOINT_LIB=1 (which
+# stops before the root-only boot sequence, leaving the helpers defined) and
+# exercises those helpers against a fake workspace full of hostile directory
+# names, with `su` / `start-claude` / `ldapsearch` stubbed on PATH.
+#
+# Run directly:  bash tests/templates/claude_dev_entrypoint_test.sh
+# Run via CI:    npm test  (wrapped by tests/backend/claude_dev_entrypoint.test.ts)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENTRYPOINT="$REPO_ROOT/templates/claude-dev/docker-entrypoint.sh"
+
+FAILURES=0
+CASES=0
+
+pass() { CASES=$((CASES + 1)); echo "ok   - $1"; }
+fail() {
+  CASES=$((CASES + 1))
+  FAILURES=$((FAILURES + 1))
+  echo "FAIL - $1"
+  [ $# -gt 1 ] && printf '       %s\n' "${@:2}"
+  return 0
+}
+check() { # check <desc> <cond-result 0/1> [detail...]
+  local desc="$1" rc="$2"; shift 2
+  if [ "$rc" -eq 0 ]; then pass "$desc"; else fail "$desc" "$@"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+STUB_BIN="$WORK/bin"
+RECORD="$WORK/record"
+MARKERS="$WORK/markers"
+mkdir -p "$STUB_BIN" "$RECORD" "$MARKERS"
+
+# --- the fake shared workspace -------------------------------------------
+# Hostile names first. Each payload writes into $MARKERS; if any of these
+# files exists at the end of a case, some shell evaluated a directory name.
+DEV_HOME_FAKE="$WORK/workspace"
+mkdir -p "$DEV_HOME_FAKE"
+
+# A filename cannot contain `/`, so the payloads are relative `touch`es. The
+# test process cds into $MARKERS and the su'd shell cds into $DEV_HOME, so an
+# evaluated payload lands in one of those two — both under $WORK, which the
+# leak check sweeps.
+MAL_CMDSUB='$(touch pwned-cmdsub)'
+MAL_BACKTICK='`touch pwned-backtick`'
+MAL_SEMI='repo; touch pwned-semi'
+MAL_SUOPT='-c'                       # su's own --command, via permuting getopt
+MAL_SUOPT_VAL='touch pwned-suopt'    # …and the value it would swallow
+
+REPO_NAMES=(
+  "$MAL_CMDSUB"
+  "$MAL_BACKTICK"
+  "$MAL_SEMI"
+  "$MAL_SUOPT"
+  "$MAL_SUOPT_VAL"
+  'normal-repo'
+  'another repo with spaces'
+)
+for name in "${REPO_NAMES[@]}"; do
+  mkdir -p "$DEV_HOME_FAKE/$name"
+  : > "$DEV_HOME_FAKE/$name/.git"
+done
+# Decoys that must NOT be picked up.
+mkdir -p "$DEV_HOME_FAKE/not-a-repo" "$DEV_HOME_FAKE/home/someuser" "$DEV_HOME_FAKE/.claude"
+: > "$DEV_HOME_FAKE/.claude/.git"    # hidden — skipped by the */ glob
+
+# --- stubs ----------------------------------------------------------------
+# `su` stub. It deliberately MODELS util-linux su: a permuting getopt (options
+# are still recognised after the user operand, until `--`), then
+# `<shell> -c <command> <remaining args...>`. Modelling the re-parse is the
+# whole point — a stub that just recorded argv would pass on the vulnerable
+# code too. The `real su permutes` case below pins this model against the
+# actual su binary so it cannot drift.
+cat > "$STUB_BIN/su" <<'STUB'
+#!/usr/bin/env bash
+shell=/bin/bash
+command=
+user=
+args=()
+end_of_opts=0
+while [ $# -gt 0 ]; do
+  if [ "$end_of_opts" -eq 0 ]; then
+    case "$1" in
+      --) end_of_opts=1; shift; continue;;
+      -c|--command) command="$2"; shift 2; continue;;
+      -s|--shell)   shell="$2";   shift 2; continue;;
+      -*) shift; continue;;
+    esac
+  fi
+  if [ -z "$user" ]; then user="$1"; else args+=("$1"); fi
+  shift
+done
+printf '%s\0' "SU_USER=$user" "SU_SHELL=$shell" "SU_COMMAND=$command" >> "$SU_RECORD"
+printf '%s\0' "${args[@]}" >> "$SU_ARGS_RECORD"
+exec "$shell" -c "$command" "${args[@]}"
+STUB
+
+# `start-claude` stub — records the argv it was handed, NUL-delimited, so a
+# name containing a newline or a space is still one unambiguous element.
+cat > "$STUB_BIN/start-claude" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\0' "$@" >> "$SC_ARGS_RECORD"
+printf '%s\0' "PWD=$PWD" "HOME=$HOME" "NO_ATTACH=${CLAUDE_START_NO_ATTACH:-}" >> "$SC_ENV_RECORD"
+STUB
+
+# `ldapsearch` stub — records argv plus, for a `-y` file, its mode and
+# contents at the moment of the call (the entrypoint deletes it afterwards).
+cat > "$STUB_BIN/ldapsearch" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\0' "$@" >> "$LS_ARGS_RECORD"
+prev=
+for a in "$@"; do
+  if [ "$prev" = "-y" ]; then
+    printf '%s\0' "PWFILE=$a" "PWMODE=$(stat -c '%a' "$a" 2>/dev/null)" \
+                  "PWCONTENT=$(cat "$a" 2>/dev/null)" >> "$LS_PWFILE_RECORD"
+  fi
+  prev="$a"
+done
+cat <<'LDIF'
+dn: cn=devs,ou=groups,dc=example,dc=test
+member: uid=alice,ou=people,dc=example,dc=test
+member: uid=bob,ou=people,dc=example,dc=test
+LDIF
+STUB
+
+chmod +x "$STUB_BIN/su" "$STUB_BIN/start-claude" "$STUB_BIN/ldapsearch"
+
+export SU_RECORD="$RECORD/su.txt"
+export SU_ARGS_RECORD="$RECORD/su-args.txt"
+export SC_ARGS_RECORD="$RECORD/start-claude-args.txt"
+export SC_ENV_RECORD="$RECORD/start-claude-env.txt"
+export LS_ARGS_RECORD="$RECORD/ldapsearch-args.txt"
+export LS_PWFILE_RECORD="$RECORD/ldapsearch-pwfile.txt"
+
+read_nul() { # read_nul <file> -> lines on stdout, one record per line
+  [ -f "$1" ] || return 0
+  tr '\0' '\n' < "$1"
+}
+
+# --- source the entrypoint as a library -----------------------------------
+CLAUDE_DEV_ENTRYPOINT_LIB=1
+export CLAUDE_DEV_ENTRYPOINT_LIB
+# shellcheck source=../../templates/claude-dev/docker-entrypoint.sh
+# shellcheck disable=SC1090
+source "$ENTRYPOINT"
+set +e   # the entrypoint sets -euo pipefail; assertions need to keep going
+
+check "sourcing guard leaves the helpers defined without running the boot sequence" \
+  "$( { declare -F discover_repos autostart_claude su_dev ldap_group_members >/dev/null; } && echo 0 || echo 1)"
+
+DEV_HOME="$DEV_HOME_FAKE"
+PATH="$STUB_BIN:$PATH"
+cd "$MARKERS" || exit 1   # any payload evaluated by THIS shell lands under $WORK
+
+# =========================================================================
+# 1. discover_repos picks up exactly the real checkouts, names intact
+# =========================================================================
+repos=()
+discover_repos
+
+expected="$(printf '%s\n' "${REPO_NAMES[@]}" | LC_ALL=C sort)"
+actual="$(printf '%s\n' "${repos[@]}" | LC_ALL=C sort)"
+check "discover_repos finds every .git checkout and nothing else" \
+  "$([ "$expected" = "$actual" ] && echo 0 || echo 1)" \
+  "expected: $(printf '%s' "$expected" | tr '\n' '|')" \
+  "actual:   $(printf '%s' "$actual" | tr '\n' '|')"
+
+# =========================================================================
+# 2. THE FIX: a hostile checkout name reaches start-claude as ONE literal
+#    argv element and no shell ever evaluates it.
+# =========================================================================
+autostart_claude "${repos[@]}"
+autostart_rc=$?
+
+check "autostart_claude exits 0 on a normal boot" \
+  "$([ "$autostart_rc" -eq 0 ] && echo 0 || echo 1)" "exit=$autostart_rc"
+
+leaked="$(find "$WORK" -name 'pwned-*' 2>/dev/null | tr '\n' ' ')"
+check "no payload from a directory name ever executed" \
+  "$([ -z "$leaked" ] && echo 0 || echo 1)" \
+  "marker files created: $leaked"
+
+sc_args="$(read_nul "$SC_ARGS_RECORD")"
+check "start-claude was invoked" \
+  "$([ -n "$sc_args" ] && echo 0 || echo 1)"
+
+for name in "${REPO_NAMES[@]}"; do
+  check "repo name is one literal argv element: [$name]" \
+    "$(grep -Fqx -- "$name" <<<"$sc_args" && echo 0 || echo 1)" \
+    "recorded argv: $(printf '%s' "$sc_args" | tr '\n' '|')"
+done
+
+# The count must match exactly — a re-parse would split one name into several
+# words, or drop one into su's option slot.
+sc_repo_count="$(sed -n '/^--$/,$p' <<<"$sc_args" | tail -n +2 | grep -c '')"
+check "start-claude got exactly ${#REPO_NAMES[@]} repo arguments after the -- separator" \
+  "$([ "$sc_repo_count" -eq "${#REPO_NAMES[@]}" ] && echo 0 || echo 1)" \
+  "got $sc_repo_count"
+
+check "the pass-through claude flags survived" \
+  "$(grep -Fqx -- '--continue' <<<"$sc_args" \
+     && grep -Fqx -- '--allow-dangerously-skip-permissions' <<<"$sc_args" \
+     && grep -Fqx -- '--' <<<"$sc_args" && echo 0 || echo 1)"
+
+sc_env="$(read_nul "$SC_ENV_RECORD")"
+check "start-claude ran in \$DEV_HOME with HOME=\$DEV_HOME and no-attach set" \
+  "$(grep -Fqx -- "PWD=$DEV_HOME" <<<"$sc_env" \
+     && grep -Fqx -- "HOME=$DEV_HOME" <<<"$sc_env" \
+     && grep -Fqx -- 'NO_ATTACH=1' <<<"$sc_env" && echo 0 || echo 1)" \
+  "recorded: $(printf '%s' "$sc_env" | tr '\n' '|')"
+
+# The su command string itself must carry no interpolated repo name — that is
+# the string that gets re-parsed, so nothing untrusted may reach it.
+su_rec="$(read_nul "$SU_RECORD")"
+su_cmd="$(grep -m1 '^SU_COMMAND=' <<<"$su_rec" | sed 's/^SU_COMMAND=//')"
+untrusted_in_cmd=0
+for name in "${REPO_NAMES[@]}"; do
+  case "$su_cmd" in *"$name"*) untrusted_in_cmd=1;; esac
+done
+check "the su -c command string contains no interpolated directory name" \
+  "$untrusted_in_cmd"
+check "su ran as the dev user" \
+  "$(grep -Fqx -- 'SU_USER=dev' <<<"$su_rec" && echo 0 || echo 1)" \
+  "recorded: $(printf '%s' "$su_rec" | tr '\n' '|')"
+
+# =========================================================================
+# 3. The `--` before the user name is load-bearing — pin the su model
+#    against the REAL su binary (argument parsing happens before auth, so
+#    this needs no privileges).
+# =========================================================================
+if command -v /bin/su >/dev/null 2>&1 || command -v su >/dev/null 2>&1; then
+  real_su="$(PATH="/usr/bin:/bin" command -v su)"
+  if [ -n "$real_su" ]; then
+    permuted="$("$real_su" -c 'echo x' nosuchuser_sb2418 --help 2>&1)"
+    guarded="$("$real_su" -c 'echo x' -- nosuchuser_sb2418 --help 2>&1)"
+    check "real su DOES permute post-user options (so the -- is required)" \
+      "$(grep -qi 'usage' <<<"$permuted" && echo 0 || echo 1)" \
+      "output: $(head -c 120 <<<"$permuted")"
+    check "real su with -- before the user stops option parsing" \
+      "$(grep -qi 'usage' <<<"$guarded" && echo 1 || echo 0)" \
+      "output: $(head -c 120 <<<"$guarded")"
+  fi
+fi
+
+# Structural guard: every su call in the entrypoint must use the `--` form,
+# so a future edit cannot quietly reintroduce the permuting-getopt hole.
+bad_su="$(grep -nE '^[[:space:]]*(if[[:space:]]+)?su[[:space:]]' "$ENTRYPOINT" \
+          | grep -v -- '-- dev' || true)"
+check "every raw su invocation in the entrypoint puts -- before the user" \
+  "$([ -z "$bad_su" ] && echo 0 || echo 1)" "offending lines: $bad_su"
+
+su_lines_with_repos="$(grep -nE '^[[:space:]]*(if[[:space:]]+)?su' "$ENTRYPOINT" \
+                       | grep -F '${repos' || true)"
+check "no repo array is interpolated into a su command string" \
+  "$([ -z "$su_lines_with_repos" ] && echo 0 || echo 1)" \
+  "offending lines: $su_lines_with_repos"
+
+# =========================================================================
+# 4. The LLDAP bind password never appears on a command line.
+# =========================================================================
+LLDAP_ADMIN_PASSWORD='sup3r-s3cret-bind-pw'
+ldap_uri='ldap://localhost:3890'
+admin_dn='uid=admin,ou=people,dc=example,dc=test'
+group_dn='cn=devs,ou=groups,dc=example,dc=test'
+
+members="$(ldap_group_members)"
+
+ls_args="$(read_nul "$LS_ARGS_RECORD")"
+check "ldapsearch argv carries no -w flag" \
+  "$(grep -Fqx -- '-w' <<<"$ls_args" && echo 1 || echo 0)" \
+  "argv: $(printf '%s' "$ls_args" | tr '\n' '|')"
+check "the bind password appears nowhere in ldapsearch's argv (/proc/<pid>/cmdline)" \
+  "$(grep -Fq -- "$LLDAP_ADMIN_PASSWORD" <<<"$ls_args" && echo 1 || echo 0)"
+check "ldapsearch reads the password from a file (-y)" \
+  "$(grep -Fqx -- '-y' <<<"$ls_args" && echo 0 || echo 1)"
+
+pw_rec="$(read_nul "$LS_PWFILE_RECORD")"
+check "the password file was mode 0600 at call time" \
+  "$(grep -Fqx -- 'PWMODE=600' <<<"$pw_rec" && echo 0 || echo 1)" \
+  "recorded: $(printf '%s' "$pw_rec" | tr '\n' '|')"
+check "the password file held the password with NO trailing newline" \
+  "$(grep -Fqx -- "PWCONTENT=$LLDAP_ADMIN_PASSWORD" <<<"$pw_rec" && echo 0 || echo 1)"
+
+pwfile="$(grep -m1 '^PWFILE=' <<<"$pw_rec" | sed 's/^PWFILE=//')"
+check "the password file is deleted once ldapsearch returns" \
+  "$([ -n "$pwfile" ] && [ ! -e "$pwfile" ] && echo 0 || echo 1)" "file: $pwfile"
+
+check "member uids are still parsed out of the LDIF" \
+  "$([ "$members" = "$(printf 'alice\nbob')" ] && echo 0 || echo 1)" \
+  "got: $(printf '%s' "$members" | tr '\n' '|')"
+
+check "the entrypoint no longer passes the bind password with -w" \
+  "$(grep -q -- '-w "\$LLDAP_ADMIN_PASSWORD"' "$ENTRYPOINT" && echo 1 || echo 0)"
+
+# =========================================================================
+echo
+echo "claude-dev entrypoint: $((CASES - FAILURES))/$CASES checks passed"
+[ "$FAILURES" -eq 0 ] || exit 1

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -1527,7 +1527,11 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertTrue(os.path.isfile(seeded), f"expected file at {seeded}")
             with open(seeded) as fh:
                 data = json.load(fh)
-            self.assertEqual(data, {"serverEnabled": True, "serverPort": 3001, "serverHost": "0.0.0.0"})
+            # serverHost is the LOOPBACK since template v7 (#2416): port 3001
+            # speaks the raw zwave-js protocol with no auth, and this pod is
+            # hostNetwork, so 0.0.0.0 handed every LAN device direct control of
+            # the mesh. HA is in the same pod and uses ws://localhost:3001.
+            self.assertEqual(data, {"serverEnabled": True, "serverPort": 3001, "serverHost": "127.0.0.1"})
 
             # Second run: file exists, must not be touched + must log skip.
             mtime_before = os.path.getmtime(seeded)
@@ -1541,9 +1545,50 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertIn("already in place", out2)
             self.assertEqual(os.path.getmtime(seeded), mtime_before)
 
+    def test_repins_wildcard_ws_host_on_a_pre_v7_install(self):
+        """#2416: the seeder only writes sb-external-settings.json when it is
+        MISSING, so every pre-v7 install already has one saying 0.0.0.0 and
+        would keep port 3001 LAN-reachable forever. An existing file carrying
+        a wildcard bind must be re-pinned in place (the migration does it once
+        at the hop; this is the every-deploy convergence for a restored
+        backup). A DELIBERATE non-wildcard address is left alone."""
+        import tempfile
+
+        m = load_script("home-assistant")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            zwave_dir = os.path.join(tmp, "home-assistant", "zwave-js")
+            os.makedirs(zwave_dir, exist_ok=True)
+            path = os.path.join(zwave_dir, "sb-external-settings.json")
+            with open(path, "w") as fh:
+                json.dump({"serverEnabled": True, "serverPort": 3001, "serverHost": "0.0.0.0"}, fh)
+
+            with run_with_env({"DATA_DIR": tmp}):
+                changed = m.ensure_zwave_external_settings()
+            # True → the caller restarts zwave-js so the new bind takes effect
+            # on this deploy rather than at the next reboot.
+            self.assertTrue(changed)
+            with open(path) as fh:
+                self.assertEqual(json.load(fh)["serverHost"], "127.0.0.1")
+
+            # Idempotent: a second pass finds it pinned and writes nothing.
+            with run_with_env({"DATA_DIR": tmp}):
+                self.assertFalse(m.ensure_zwave_external_settings())
+
+            # Operator-chosen address survives (warned, not overridden).
+            with open(path, "w") as fh:
+                json.dump({"serverEnabled": True, "serverPort": 3001, "serverHost": "10.1.2.3"}, fh)
+            with run_with_env({"DATA_DIR": tmp}):
+                self.assertFalse(m.ensure_zwave_external_settings())
+            with open(path) as fh:
+                self.assertEqual(json.load(fh)["serverHost"], "10.1.2.3")
+
     def test_skips_external_settings_when_ui_serverport_already_set(self):
         """If settings.json already has a `zwave.serverPort`, the operator
-        chose it via the UI — don't override silently."""
+        chose it via the UI — don't override silently. The loopback bind is
+        still merged in, because in that install shape settings.json is what
+        governs the WS server and the UI has no field for its bind address
+        (#2416)."""
         import tempfile
         import urllib.error
         import urllib.request
@@ -1553,7 +1598,8 @@ class HomeAssistantScript(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             zwave_dir = os.path.join(tmp, "home-assistant", "zwave-js")
             os.makedirs(zwave_dir, exist_ok=True)
-            with open(os.path.join(zwave_dir, "settings.json"), "w") as fh:
+            settings_path = os.path.join(zwave_dir, "settings.json")
+            with open(settings_path, "w") as fh:
                 json.dump({"zwave": {"serverPort": 8888}}, fh)
 
             env = {"HA_OIDC_AUTH_VERSION": "v0.6.0", "DATA_DIR": tmp}
@@ -1566,6 +1612,11 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertIn("UI-configured serverPort", out)
             self.assertFalse(os.path.isfile(os.path.join(zwave_dir, "sb-external-settings.json")))
+            with open(settings_path) as fh:
+                stored = json.load(fh)
+            # The operator's port is untouched; only the bind address is pinned.
+            self.assertEqual(stored["zwave"]["serverPort"], 8888)
+            self.assertEqual(stored["zwave"]["serverHost"], "127.0.0.1")
 
     def test_zwave_port_settings_written_on_fresh_store(self):
         """`ensure_zwave_port_settings` must seed zwave.port and default

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -464,6 +464,88 @@ class AuthScript(unittest.TestCase):
         self.assertIn("disable_startup_check: true", block)
         self.assertNotIn("disable_startup_check: false", block)
 
+    def test_config_paths_track_data_dir_instead_of_a_hardcoded_root(self):
+        """#2424: the two notifier paths were module-level literals pinned to
+        one deployment's `/mnt/data...` root, so on any install with a
+        non-default DATA_DIR the SMTP wiring silently no-opped. They must now
+        derive from DATA_DIR, like `authelia_db_path()` in the same file."""
+        m = load_script("auth")
+        with run_with_env({"DATA_DIR": "/srv/pool/stacks"}):
+            self.assertEqual(
+                m.authelia_config_path(),
+                "/srv/pool/stacks/auth/authelia-config/configuration.yml",
+            )
+            # ServiceBay's own config.json is a SIBLING of the stacks dir, so
+            # the parent is probed first, then DATA_DIR itself (bare-/mnt/data
+            # dev layout). Neither candidate is a hardcoded literal.
+            self.assertEqual(
+                m.sb_config_path_candidates(),
+                ["/srv/pool/servicebay/config.json", "/srv/pool/stacks/servicebay/config.json"],
+            )
+        src = (TEMPLATES_DIR / "auth" / "post-deploy.py").read_text()
+        self.assertNotIn('"/mnt/data/servicebay/config.json"', src)
+        self.assertNotIn('"/mnt/data/stacks/auth/authelia-config/configuration.yml"', src)
+
+    def test_smtp_notifier_is_wired_on_a_non_default_data_dir(self):
+        """End-to-end for #2424: with DATA_DIR pointed somewhere other than the
+        default, `rewrite_authelia_smtp_notifier` must FIND ServiceBay's email
+        config on disk and REWRITE Authelia's filesystem notifier to smtp.
+        Before the fix this printed 'Authelia config not at ...' and did
+        nothing while the UI reported email as configured."""
+        import tempfile
+        m = load_script("auth")
+        with tempfile.TemporaryDirectory() as root:
+            # Box layout: <root>/servicebay (ServiceBay) + <root>/stacks (DATA_DIR).
+            data_dir = os.path.join(root, "stacks")
+            sb_dir = os.path.join(root, "servicebay")
+            authelia_dir = os.path.join(data_dir, "auth", "authelia-config")
+            os.makedirs(sb_dir)
+            os.makedirs(authelia_dir)
+            with open(os.path.join(sb_dir, "config.json"), "w", encoding="utf-8") as fh:
+                json.dump({"notifications": {"email": {
+                    "host": "smtp.example.com", "port": 587, "secure": False,
+                    "user": "box@example.com", "pass": "s3cret", "from": "box@example.com",
+                }}}, fh)
+            cfg = os.path.join(authelia_dir, "configuration.yml")
+            with open(cfg, "w", encoding="utf-8") as fh:
+                fh.write("theme: light\n\nnotifier:\n  filesystem:\n    filename: /data/notification.txt\n\nserver:\n  address: 'tcp://:9091'\n")
+
+            # No SB_API_TOKEN → the API path is skipped and the on-disk
+            # fallback (the half that #2424 broke) is what runs.
+            with run_with_env({"DATA_DIR": data_dir}):
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    m.rewrite_authelia_smtp_notifier("http://127.0.0.1:5888")
+                out = buf.getvalue()
+
+            self.assertNotIn("skipping notifier rewrite", out)
+            self.assertIn("Rewrote Authelia notifier", out)
+            with open(cfg, encoding="utf-8") as fh:
+                written = fh.read()
+            self.assertIn("submission://smtp.example.com:587", written)
+            self.assertIn("username: 'box@example.com'", written)
+            self.assertNotIn("filesystem:", written)
+            # The surrounding config survives the splice untouched.
+            self.assertIn("theme: light", written)
+            self.assertIn("address: 'tcp://:9091'", written)
+
+    def test_smtp_notifier_finds_config_on_a_bare_data_dir_layout(self):
+        """The dev/default layout has no `stacks` level: DATA_DIR and the
+        servicebay dir share a parent. The second candidate covers it."""
+        import tempfile
+        m = load_script("auth")
+        with tempfile.TemporaryDirectory() as data_dir:
+            os.makedirs(os.path.join(data_dir, "servicebay"))
+            with open(os.path.join(data_dir, "servicebay", "config.json"), "w", encoding="utf-8") as fh:
+                json.dump({"notifications": {"email": {
+                    "host": "smtp.example.com", "port": 465, "secure": True,
+                    "user": "box@example.com", "pass": "s3cret", "from": "box@example.com",
+                }}}, fh)
+            with run_with_env({"DATA_DIR": data_dir}):
+                em = m._sb_email_config("http://127.0.0.1:5888")
+            self.assertIsNotNone(em)
+            self.assertEqual(em["host"], "smtp.example.com")
+
 
 class FileShareScript(unittest.TestCase):
     def test_samba_credential_emitted_when_password_set(self):
@@ -2577,10 +2659,11 @@ class VerbatimScriptBodies(unittest.TestCase):
     quietly start depending on a render pass that no longer happens.
     """
 
-    # The seven `{{…}}` sites across templates/*/post-deploy.py, and the
+    # The eight `{{…}}` sites across templates/*/post-deploy.py, and the
     # env var that actually carries the value (None = prose only).
     SITES = [
         ("auth", "DATA_DIR"),            # authelia_db_path() docstring
+        ("auth", "DATA_DIR"),            # authelia_config_path() docstring (#2424)
         ("auth", None),                  # f-string escape: subject "[Authelia] {title}"
         ("nginx", "DATA_DIR"),           # npm_db_path() docstring
         ("file-share", "DATA_DIR"),      # _notes_dir() docstring
@@ -2589,7 +2672,7 @@ class VerbatimScriptBodies(unittest.TestCase):
         ("immich", None),                # comment: podman --format '{{.State}}'
     ]
 
-    def test_all_seven_sites_are_accounted_for(self):
+    def test_all_sites_are_accounted_for(self):
         """Guard the inventory: if a new `{{…}}` appears in a post-deploy
         script, this fails until someone confirms it doesn't need a render."""
         found = []
@@ -2604,10 +2687,11 @@ class VerbatimScriptBodies(unittest.TestCase):
         )
 
     def test_data_dir_paths_resolve_from_the_environment(self):
-        """The four DATA_DIR docstring sites: the path helper next to each
+        """The DATA_DIR docstring sites: the path helper next to each
         docstring reads DATA_DIR from os.environ, with a sane default."""
         cases = [
             ("auth", "authelia_db_path", ("auth", "authelia-data", "db.sqlite3")),
+            ("auth", "authelia_config_path", ("auth", "authelia-config", "configuration.yml")),
             ("nginx", "npm_db_path", ("nginx-proxy-manager", "data", "database.sqlite")),
             ("file-share", "_notes_dir", ("file-share", "data", "notes")),
             ("home-assistant", "_ha_config_dir", ("home-assistant", "homeassistant")),


### PR DESCRIPTION
Autoloop batch `batch/2026-07-28a` — 8 units, 10 issues closed. Deep codebase eval follow-through, security-first.

- **Z-Wave admin UI + control websocket closed off the LAN** (#2416, security) — reaches physical door locks. Both loopback-bound now (mirroring #2380's LLDAP fix), schema v6→v7 with a real (not informational) migration since existing installs would otherwise keep the LAN-exposed default forever, plus a class-level regression guard: any hostNetwork template declaring an unguarded admin/control port now fails CI. matter-server's port 5580 resolved and bound.
- **Two RCE vectors closed in claude-dev's boot autostart** (#2418, security): a checkout directory name could execute as shell via the `su -c` string-splice, and — found during this fix, not in the original report — a directory literally named `-c` could hijack `su`'s command entirely via option permutation (proven against the real `/usr/bin/su` binary and util-linux source). Both fixed by passing repo names as argv, never re-parsed. LLDAP bind password also removed from process argv (was visible via `/proc/<pid>/cmdline`).
- **The admin panel's own SSO login secret is no longer a hardcoded plaintext value** (#2417, security) — every install shipped the identical Authelia OIDC client secret. Now per-install random, with a migration that rotates both sides (Authelia's config + ServiceBay's own stored copy) in the only safe order (ServiceBay reads the secret back out of what Authelia actually persisted, never the reverse), a hard precondition check that aborts before rotating if no break-glass local-admin login exists, and a new secret-scanner pattern to catch a future literal.
- **Boot-time firewall reconcile failures are no longer invisible** (#2420) — a failed `#2388` LAN-block apply now surfaces via the existing failure-probe channel, and a new diagnose probe asserts the real `nft` ruleset state instead of trusting the boot call's return value.
- **Anonymous portal pages degrade instead of crashing** (#2421) — `/portal` and `/portal/requests` (today's #2399 config-read hardening made `getConfig()` throw on failure) now show a family-facing "temporarily unavailable" message instead of the operator-facing generic error screen.
- **The dev container image can build again** (#2422) — `Dockerfile.dev` was missing the workspace-manifest copy the production Dockerfile has, so `npm ci` silently produced a `node_modules` missing `ssh2`/`node-pty`/`nodemailer`/`better-sqlite3`; fixed, and CI now builds it so this can't rot silently again.
- **disk-import's planning-phase file hashing is constant-memory** (#2423) — was `readFileSync`-ing whole files, OOM-killing the 1G worker on large files. Now streamed, byte-identical digest proven against the prior implementation, and proven O(chunk) against a 1.25GB virtual file. A sibling instance of the same bug in `scripts/disk-import.ts` filed as #2438.
- **No committed file hardcodes one deployment's paths/host/domain anymore** (#2424, #2425, #2426) — a real privacy concern in this public repo. `PUBLIC_DOMAIN` collapsed from 5 duplicate declarations to one, dead defaults dropped, an orphan variable deleted, a regression guard added; two smoke/maintenance scripts now require the host/domain explicitly instead of silently defaulting to the maintainer's real home IP and domain. `grep -r 'dopp.cloud'` / `192.168.178.100'` over templates/ and scripts/ now return nothing. LLDAP_BASE_DN's per-template defaults deliberately left alone (different risk — blanking could re-root an existing box's LDAP tree) and filed as #2439 for a considered fix.

Closes #2416
Closes #2418
Closes #2417
Closes #2420
Closes #2421
Closes #2422
Closes #2423
Closes #2424
Closes #2425
Closes #2426

Local safety-net gate green: lint, typecheck, check:arch, npm test (500 files, 4562 passed / 2 skipped).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
