### PR TITLE
chore: lint-ratchet burn-down (color-literal + ui-primitive)

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 736,
-    "sb/no-raw-ui-primitive": 352
+    "sb/no-raw-color-literal": 707,
+    "sb/no-raw-ui-primitive": 349
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-29",
   "rules": {
     "sb/no-raw-color-literal": 678,
-    "sb/no-raw-ui-primitive": 331
+    "sb/no-raw-ui-primitive": 317
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-29",
   "rules": {
     "sb/no-raw-color-literal": 678,
-    "sb/no-raw-ui-primitive": 349
+    "sb/no-raw-ui-primitive": 331
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 707,
+    "sb/no-raw-color-literal": 678,
     "sb/no-raw-ui-primitive": 349
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 799,
+    "sb/no-raw-color-literal": 767,
     "sb/no-raw-ui-primitive": 352
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-29",
   "rules": {
     "sb/no-raw-color-literal": 678,
-    "sb/no-raw-ui-primitive": 317
+    "sb/no-raw-ui-primitive": 305
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 767,
+    "sb/no-raw-color-literal": 736,
     "sb/no-raw-ui-primitive": 352
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 832,
+    "sb/no-raw-color-literal": 799,
     "sb/no-raw-ui-primitive": 352
   }
 }

--- a/packages/frontend/src/components/HealthChecks.test.tsx
+++ b/packages/frontend/src/components/HealthChecks.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * HealthChecks — design-system migration coverage (lint-ratchet sweep).
+ *
+ * The panel's chrome moved off raw <button> onto the shared <Button>
+ * primitive from @/components/ui. The component had no dedicated test file
+ * (only `healthChecksRows.test.ts`, which covers the pure row helpers), and
+ * the one place it renders — HealthDashboard — mocks it away, so every line
+ * of the render tree was unmeasured. These tests exercise the rendered
+ * output directly:
+ *   - the four status counters render as real <button> primitives on
+ *     status-token classes, and toggle the filter on/off,
+ *   - both empty states (no checks / no matches) and their recovery actions,
+ *   - the row body: status tint, type/node badges, "last checked" label,
+ *     the latency sparkline, and the per-row action buttons,
+ *   - the diagnose-row branch (self-repair instead of edit/delete).
+ */
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import type { Check } from '@servicebay/api-client';
+
+import HealthChecks, { type StatusFilter } from './HealthChecks';
+
+const baseCheck = {
+  interval: 60,
+  enabled: true,
+  created_at: '2026-01-01T00:00:00.000Z',
+  lastResult: null,
+  history: [],
+} satisfies Partial<Check>;
+
+/** `diagnose` is loosened to just the status the row renderer reads — the real
+ *  payload carries a probe's whole self-repair manifest, which is irrelevant
+ *  here and would bloat every fixture. */
+type CheckOverrides = Omit<Partial<Check>, 'diagnose'> & {
+  id: string;
+  name: string;
+  diagnose?: { status?: string };
+};
+
+function makeCheck(over: CheckOverrides): Check {
+  return {
+    type: 'http',
+    target: 'https://example.com',
+    status: 'ok',
+    lastRun: null,
+    ...baseCheck,
+    ...over,
+  } as unknown as Check;
+}
+
+const containers = [
+  { Id: 'abc', Names: ['/media-jellyfin'], Image: 'jellyfin:latest' },
+];
+
+type Handlers = {
+  setSearchQuery: Mock<(query: string) => void>;
+  setStatusFilter: Mock<(filter: StatusFilter) => void>;
+  handleRun: Mock<(id: string) => void>;
+  handleOpenModal: Mock<(check?: Check) => void>;
+  handleOpenDeleteModal: Mock<(id: string) => void>;
+  handleViewHistory: Mock<(check: Check) => void>;
+  handleOpenRepair: Mock<(check: Check) => void>;
+};
+
+function renderPanel(
+  opts: { checks?: Check[]; searchQuery?: string; statusFilter?: StatusFilter } = {},
+): Handlers {
+  const handlers: Handlers = {
+    setSearchQuery: vi.fn<(query: string) => void>(),
+    setStatusFilter: vi.fn<(filter: StatusFilter) => void>(),
+    handleRun: vi.fn<(id: string) => void>(),
+    handleOpenModal: vi.fn<(check?: Check) => void>(),
+    handleOpenDeleteModal: vi.fn<(id: string) => void>(),
+    handleViewHistory: vi.fn<(check: Check) => void>(),
+    handleOpenRepair: vi.fn<(check: Check) => void>(),
+  };
+  render(
+    <HealthChecks
+      checks={opts.checks ?? []}
+      containers={containers}
+      searchQuery={opts.searchQuery ?? ''}
+      statusFilter={opts.statusFilter ?? 'all'}
+      {...handlers}
+    />,
+  );
+  return handlers;
+}
+
+/** The counter tile whose label is `label` (the <Button> wrapping it). */
+function counterTile(label: string): HTMLElement {
+  const el = screen.getByText(label).closest('button');
+  if (!el) throw new Error(`no counter button for "${label}"`);
+  return el;
+}
+
+describe('HealthChecks — status counters', () => {
+  const checks = [
+    makeCheck({ id: 'a', name: 'ok-one', status: 'ok' }),
+    makeCheck({ id: 'b', name: 'fail-one', status: 'fail' }),
+    makeCheck({ id: 'c', name: 'unknown-one', status: 'unknown' }),
+    makeCheck({
+      id: 'd',
+      name: 'diagnose-warn',
+      status: 'ok',
+      diagnose: { status: 'warn' },
+    }),
+  ];
+
+  it('renders the four counters as Button primitives with their tallies', () => {
+    renderPanel({ checks });
+
+    for (const [label, count] of [
+      ['Healthy', '1'],
+      ['Warning', '1'],
+      ['Failing', '1'],
+      ['Unknown', '1'],
+    ] as const) {
+      const tile = counterTile(label);
+      // The <Button> primitive renders a real <button type="button">, so the
+      // counters stay keyboard-reachable after the raw-primitive sweep.
+      expect(tile.tagName).toBe('BUTTON');
+      expect(tile.getAttribute('type')).toBe('button');
+      expect(tile.getAttribute('data-variant')).toBe('ghost');
+      expect(within(tile).getByText(count)).toBeTruthy();
+    }
+  });
+
+  it('tints the active counter with its status token and the rest with surface tokens', () => {
+    renderPanel({ checks, statusFilter: 'fail' });
+
+    expect(counterTile('Failing').className).toContain('ring-status-fail');
+    expect(counterTile('Failing').className).toContain('bg-status-fail/5');
+    expect(counterTile('Healthy').className).toContain('bg-surface');
+    expect(counterTile('Healthy').className).not.toContain('ring-status-ok');
+    // The neutral "Unknown" tile rides the text-subtle token, not a status ramp.
+    expect(counterTile('Unknown').className).toContain('bg-surface');
+  });
+
+  it('marks the unknown counter active with the subtle-token ring', () => {
+    renderPanel({ checks, statusFilter: 'unknown' });
+    expect(counterTile('Unknown').className).toContain('ring-text-subtle');
+  });
+
+  it('selects a filter on click when it is not the active one', () => {
+    const { setStatusFilter } = renderPanel({ checks, statusFilter: 'all' });
+    fireEvent.click(counterTile('Warning'));
+    expect(setStatusFilter).toHaveBeenCalledWith('warn');
+    fireEvent.click(counterTile('Failing'));
+    expect(setStatusFilter).toHaveBeenCalledWith('fail');
+    fireEvent.click(counterTile('Unknown'));
+    expect(setStatusFilter).toHaveBeenCalledWith('unknown');
+  });
+
+  it('toggles the active counter back to "all"', () => {
+    const { setStatusFilter } = renderPanel({ checks, statusFilter: 'ok' });
+    fireEvent.click(counterTile('Healthy'));
+    expect(setStatusFilter).toHaveBeenCalledWith('all');
+  });
+});
+
+describe('HealthChecks — empty states', () => {
+  it('offers "Create your first check" when no checks exist', () => {
+    const { handleOpenModal } = renderPanel({ checks: [] });
+    expect(screen.getByText('No health checks configured.')).toBeTruthy();
+
+    const create = screen.getByRole('button', { name: 'Create your first check' });
+    expect(create.getAttribute('data-variant')).toBe('ghost');
+    expect(create.className).toContain('text-accent');
+    fireEvent.click(create);
+    expect(handleOpenModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers "Clear filters" when checks exist but none match, and resets both filters', () => {
+    const handlers = renderPanel({
+      checks: [makeCheck({ id: 'a', name: 'api' })],
+      searchQuery: 'nothing-matches',
+    });
+    expect(screen.getByText('No checks match your filters.')).toBeTruthy();
+
+    const clear = screen.getByRole('button', { name: 'Clear filters' });
+    expect(clear.getAttribute('data-variant')).toBe('ghost');
+    fireEvent.click(clear);
+    expect(handlers.setSearchQuery).toHaveBeenCalledWith('');
+    expect(handlers.setStatusFilter).toHaveBeenCalledWith('all');
+  });
+});
+
+describe('HealthChecks — rows', () => {
+  it('renders a real check row with its badges, label and action buttons', () => {
+    const handlers = renderPanel({
+      checks: [
+        makeCheck({
+          id: 'c1',
+          name: 'Jellyfin container',
+          type: 'podman',
+          target: 'media-jellyfin',
+          nodeName: 'box-1',
+          status: 'fail',
+          message: 'exit code 1',
+          lastRun: '2026-07-01T10:00:00.000Z',
+          history: [
+            { status: 'fail', latency: 900, timestamp: '2026-07-01T10:00:00.000Z' },
+            { status: 'ok', latency: 30, timestamp: '2026-07-01T09:00:00.000Z' },
+          ],
+        }),
+      ],
+    });
+
+    expect(screen.getByText('Jellyfin container')).toBeTruthy();
+    expect(screen.getByText('PODMAN')).toBeTruthy();
+    expect(screen.getByText('box-1')).toBeTruthy();
+    // podman rows resolve the container name from the container list.
+    expect(screen.getByText('media-jellyfin')).toBeTruthy();
+    expect(screen.getByText('exit code 1')).toBeTruthy();
+    // Sparkline: one bar per history point, failing bars on the fail token.
+    expect(screen.getByText('900ms')).toBeTruthy();
+    expect(screen.getByTitle(/^900ms - /).className).toContain('bg-status-fail');
+    expect(screen.getByTitle(/^30ms - /).className).toContain('bg-status-ok/50');
+
+    fireEvent.click(screen.getByTitle('Run check now'));
+    expect(handlers.handleRun).toHaveBeenCalledWith('c1');
+    fireEvent.click(screen.getByTitle('View history'));
+    expect(handlers.handleViewHistory).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTitle('Edit check'));
+    expect(handlers.handleOpenModal).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTitle('Delete check'));
+    expect(handlers.handleOpenDeleteModal).toHaveBeenCalledWith('c1');
+
+    // Every row action is a Button primitive, not a bare <button>.
+    for (const title of ['Run check now', 'View history', 'Edit check', 'Delete check']) {
+      expect(screen.getByTitle(title).getAttribute('data-variant')).toBe('ghost');
+    }
+  });
+
+  it('shows "Never" until the first run and the daily cadence on a diagnose row', () => {
+    renderPanel({
+      checks: [
+        makeCheck({ id: 'n', name: 'never-run' }),
+        makeCheck({
+          id: 'd',
+          name: 'diagnose-row',
+          lastRun: '2026-07-01T10:00:00.000Z',
+          diagnose: { status: 'warn' },
+        }),
+      ],
+    });
+    expect(screen.getByText('Last checked: Never')).toBeTruthy();
+    expect(screen.getByText(/\(daily self-diagnose\)$/)).toBeTruthy();
+  });
+
+  it('swaps edit/delete for the self-repair action on a diagnose row', () => {
+    const handlers = renderPanel({
+      checks: [
+        makeCheck({
+          id: 'diagnose:cert',
+          name: 'Certificate expiry',
+          diagnose: { status: 'fail' },
+        }),
+      ],
+    });
+
+    expect(screen.getByTitle('Re-run self-diagnose now')).toBeTruthy();
+    expect(screen.queryByTitle('Edit check')).toBeNull();
+    expect(screen.queryByTitle('Delete check')).toBeNull();
+
+    const repair = screen.getByTitle('Self-repair options');
+    expect(repair.getAttribute('data-variant')).toBe('ghost');
+    fireEvent.click(repair);
+    expect(handlers.handleOpenRepair).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTitle('View history'));
+    expect(handlers.handleViewHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters rows by search query and by status', () => {
+    const checks = [
+      makeCheck({ id: 'a', name: 'alpha', status: 'ok' }),
+      makeCheck({ id: 'b', name: 'beta', status: 'fail' }),
+    ];
+    const { unmount } = render(
+      <HealthChecks
+        checks={checks}
+        containers={containers}
+        searchQuery="alph"
+        setSearchQuery={vi.fn()}
+        statusFilter="all"
+        setStatusFilter={vi.fn()}
+        handleRun={vi.fn()}
+        handleOpenModal={vi.fn()}
+        handleOpenDeleteModal={vi.fn()}
+        handleViewHistory={vi.fn()}
+        handleOpenRepair={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('alpha')).toBeTruthy();
+    expect(screen.queryByText('beta')).toBeNull();
+    unmount();
+
+    renderPanel({ checks, statusFilter: 'fail' });
+    expect(screen.getByText('beta')).toBeTruthy();
+    expect(screen.queryByText('alpha')).toBeNull();
+  });
+});

--- a/packages/frontend/src/components/HealthChecks.tsx
+++ b/packages/frontend/src/components/HealthChecks.tsx
@@ -2,6 +2,7 @@
 
 import { Activity, CheckCircle, XCircle, AlertTriangle, AlertCircle, Play, Edit, Trash2, History, Search, Wrench } from 'lucide-react';
 import { Check } from '@servicebay/api-client';
+import { Button } from '@/components/ui';
 
 /** Four-way row status. Real checks are ok/fail/unknown; synthetic
  *  diagnose rows (#1423) additionally carry `warn`/`info` in their
@@ -119,9 +120,10 @@ export default function HealthChecks({
           list. Diagnose rows surface their own warn/fail (warn is no
           longer folded into fail). */}
       <div className="grid grid-cols-4 gap-2 px-2">
-        <button
+        <Button
             onClick={() => setStatusFilter(statusFilter === 'ok' ? 'all' : 'ok')}
-            className={`p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
+            variant="ghost"
+            className={`h-auto p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
                 statusFilter === 'ok'
                 ? 'bg-status-ok/5 border-status-ok/20 ring-2 ring-status-ok ring-opacity-50'
                 : 'bg-surface border-border hover:bg-surface-2'
@@ -134,10 +136,11 @@ export default function HealthChecks({
               <p className="text-[10px] uppercase tracking-wider font-bold text-text-muted">Healthy</p>
               <p className="text-xl font-bold text-text">{counts.ok}</p>
             </div>
-        </button>
-        <button
+        </Button>
+        <Button
             onClick={() => setStatusFilter(statusFilter === 'warn' ? 'all' : 'warn')}
-            className={`p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
+            variant="ghost"
+            className={`h-auto p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
                 statusFilter === 'warn'
                 ? 'bg-status-warn/5 border-status-warn/20 ring-2 ring-status-warn ring-opacity-50'
                 : 'bg-surface border-border hover:bg-surface-2'
@@ -150,10 +153,11 @@ export default function HealthChecks({
               <p className="text-[10px] uppercase tracking-wider font-bold text-text-muted">Warning</p>
               <p className="text-xl font-bold text-text">{counts.warn}</p>
             </div>
-        </button>
-        <button
+        </Button>
+        <Button
             onClick={() => setStatusFilter(statusFilter === 'fail' ? 'all' : 'fail')}
-            className={`p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
+            variant="ghost"
+            className={`h-auto p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
                 statusFilter === 'fail'
                 ? 'bg-status-fail/5 border-status-fail/20 ring-2 ring-status-fail ring-opacity-50'
                 : 'bg-surface border-border hover:bg-surface-2'
@@ -166,10 +170,11 @@ export default function HealthChecks({
               <p className="text-[10px] uppercase tracking-wider font-bold text-text-muted">Failing</p>
               <p className="text-xl font-bold text-text">{counts.fail}</p>
             </div>
-        </button>
-        <button
+        </Button>
+        <Button
             onClick={() => setStatusFilter(statusFilter === 'unknown' ? 'all' : 'unknown')}
-            className={`p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
+            variant="ghost"
+            className={`h-auto p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
                 statusFilter === 'unknown'
                 ? 'bg-surface-2 border-border ring-2 ring-text-subtle ring-opacity-50'
                 : 'bg-surface border-border hover:bg-surface-2'
@@ -182,7 +187,7 @@ export default function HealthChecks({
               <p className="text-[10px] uppercase tracking-wider font-bold text-text-muted">Unknown</p>
               <p className="text-xl font-bold text-text">{counts.unknown}</p>
             </div>
-        </button>
+        </Button>
       </div>
 
       {/* Checks List */}
@@ -193,17 +198,17 @@ export default function HealthChecks({
                 <>
                     <Search className="w-12 h-12 mx-auto mb-3 opacity-20" />
                     <p>No checks match your filters.</p>
-                    <button onClick={() => {setSearchQuery(''); setStatusFilter('all');}} className="mt-2 text-accent hover:underline text-sm">
+                    <Button onClick={() => {setSearchQuery(''); setStatusFilter('all');}} variant="ghost" className="mt-2 text-accent hover:underline text-sm">
                         Clear filters
-                    </button>
+                    </Button>
                 </>
             ) : (
                 <>
                     <Activity className="w-12 h-12 mx-auto mb-3 opacity-20" />
                     <p>No health checks configured.</p>
-                    <button onClick={() => handleOpenModal()} className="mt-4 text-accent hover:underline text-sm">
+                    <Button onClick={() => handleOpenModal()} variant="ghost" className="mt-4 text-accent hover:underline text-sm">
                     Create your first check
-                    </button>
+                    </Button>
                 </>
             )}
           </div>
@@ -277,13 +282,15 @@ export default function HealthChecks({
                         )}
 
                         <div className="flex items-center gap-1 ml-4">
-                            <button
+                            <Button
                                 onClick={() => handleRun(check.id)}
-                                className="p-2 hover:bg-surface-2 rounded-lg transition-colors"
+                                variant="ghost"
+                                size="sm"
+                                className="p-2 h-auto hover:bg-surface-2 rounded-lg transition-colors"
                                 title={isDiagnose ? 'Re-run self-diagnose now' : 'Run check now'}
                             >
                                 <Play className="w-4 h-4 text-text-muted" />
-                            </button>
+                            </Button>
                             {isDiagnose ? (
                                 /* Synthetic diagnose row: not editable config — expose the
                                    self-repair popup instead of Edit/Delete (#1423). It still
@@ -291,44 +298,54 @@ export default function HealthChecks({
                                    under the `diagnose:<id>` key just like any other check, so
                                    the same history view applies — only Edit/Delete don't. */
                                 <>
-                                    <button
+                                    <Button
                                         onClick={() => handleViewHistory(check)}
-                                        className="p-2 hover:bg-surface-2 rounded-lg transition-colors"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="p-2 h-auto hover:bg-surface-2 rounded-lg transition-colors"
                                         title="View history"
                                     >
                                         <History className="w-4 h-4 text-text-muted" />
-                                    </button>
-                                    <button
+                                    </Button>
+                                    <Button
                                         onClick={() => handleOpenRepair(check)}
-                                        className="p-2 hover:bg-accent/10 rounded-lg transition-colors"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="p-2 h-auto hover:bg-accent/10 rounded-lg transition-colors"
                                         title="Self-repair options"
                                     >
                                         <Wrench className="w-4 h-4 text-accent" />
-                                    </button>
+                                    </Button>
                                 </>
                             ) : (
                                 <>
-                                    <button
+                                    <Button
                                         onClick={() => handleViewHistory(check)}
-                                        className="p-2 hover:bg-surface-2 rounded-lg transition-colors"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="p-2 h-auto hover:bg-surface-2 rounded-lg transition-colors"
                                         title="View history"
                                     >
                                         <History className="w-4 h-4 text-text-muted" />
-                                    </button>
-                                    <button
+                                    </Button>
+                                    <Button
                                         onClick={() => handleOpenModal(check)}
-                                        className="p-2 hover:bg-surface-2 rounded-lg transition-colors"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="p-2 h-auto hover:bg-surface-2 rounded-lg transition-colors"
                                         title="Edit check"
                                     >
                                         <Edit className="w-4 h-4 text-text-muted" />
-                                    </button>
-                                    <button
+                                    </Button>
+                                    <Button
                                         onClick={() => handleOpenDeleteModal(check.id)}
-                                        className="p-2 hover:bg-surface-2 rounded-lg transition-colors"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="p-2 h-auto hover:bg-surface-2 rounded-lg transition-colors"
                                         title="Delete check"
                                     >
                                         <Trash2 className="w-4 h-4 text-text-muted" />
-                                    </button>
+                                    </Button>
                                 </>
                             )}
                         </div>

--- a/packages/frontend/src/components/InstallerModal.test.tsx
+++ b/packages/frontend/src/components/InstallerModal.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * InstallerModal — design-system migration coverage (lint-ratchet sweep).
+ *
+ * The modal's chrome moved off raw gray/blue/green/amber Tailwind ramps onto
+ * the semantic @theme tokens (surface / border / accent / status-*). Nothing
+ * rendered this component in the suite — RegistryBrowser is its only caller
+ * and had no test — so every one of those lines was unmeasured.
+ *
+ * These tests drive the modal through each phase of the shared
+ * `useStackInstall` controller and assert the *rendered* chrome: the token
+ * classes on the surfaces/actions, and the behaviour attached to them
+ * (select-step toggling, the upgrade-banner gate on Continue, the per-phase
+ * footer actions, and the "done" DNS/SSL footer).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { Template } from '@servicebay/api-client';
+import type { UseStackInstallReturn } from '@/hooks/useStackInstall';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push, refresh: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/registry',
+}));
+
+const getNodes = vi.fn(() => Promise.resolve([{ Name: 'box-1' }]));
+vi.mock('@/app/actions/system', () => ({ getNodes: () => getNodes() }));
+
+// The upgrade banner owns its own network fetch; stub it to report ready so
+// the Continue gate is exercised from both sides.
+let bannerReports: boolean | undefined = true;
+vi.mock('./TemplateUpgradeBanner', () => ({
+  __esModule: true,
+  default: ({
+    templateName,
+    onReadyToInstall,
+  }: {
+    templateName: string;
+    onReadyToInstall: (ready: boolean | undefined) => void;
+  }) => {
+    onReadyToInstall(bannerReports);
+    return <div data-testid={`upgrade-banner-${templateName}`} />;
+  },
+}));
+
+// StackInstallFlow has its own suite; render just enough to prove the modal
+// hands it the controller and the doneFooter it built.
+vi.mock('./StackInstallFlow', () => ({
+  __esModule: true,
+  default: ({ doneFooter }: { doneFooter?: React.ReactNode }) => (
+    <div data-testid="stack-install-flow">{doneFooter}</div>
+  ),
+}));
+
+let controller: UseStackInstallReturn;
+vi.mock('@/hooks/useStackInstall', () => ({
+  useStackInstall: () => controller,
+}));
+
+import InstallerModal from './InstallerModal';
+
+function makeController(over: Partial<UseStackInstallReturn> = {}): UseStackInstallReturn {
+  const noop = () => {};
+  return {
+    phase: 'idle',
+    items: [],
+    variables: [],
+    logs: [],
+    installingNow: null,
+    credentialsManifest: [],
+    npmCredPrompt: false,
+    npmCredFallback: { email: '', password: '' },
+    npmCredError: null,
+    error: null,
+    setItemChecked: noop,
+    setItems: noop,
+    setVariableValue: noop,
+    startConfigure: vi.fn(),
+    runInstall: vi.fn(),
+    retryNpmCredentials: vi.fn(),
+    skipNpmCredentials: vi.fn(),
+    appendLog: noop,
+    reset: vi.fn(),
+    ...over,
+  } as UseStackInstallReturn;
+}
+
+const stack = { name: 'home', type: 'stack', source: 'builtin' } as Template;
+const single = { name: 'jellyfin', type: 'template', source: 'builtin' } as Template;
+
+const STACK_README = ['# home', '- [x] nginx', '- [ ] adguard'].join('\n');
+
+function renderModal(
+  template: Template = stack,
+  readme = STACK_README,
+  isOpen = true,
+): { onClose: ReturnType<typeof vi.fn> } {
+  const onClose = vi.fn();
+  render(
+    <InstallerModal template={template} readme={readme} isOpen={isOpen} onClose={onClose} />,
+  );
+  return { onClose };
+}
+
+beforeEach(() => {
+  controller = makeController();
+  bannerReports = true;
+  push.mockClear();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('InstallerModal — chrome', () => {
+  it('renders nothing when closed', () => {
+    renderModal(stack, STACK_README, false);
+    expect(screen.queryByRole('heading', { level: 3 })).toBeNull();
+  });
+
+  it('renders the stack header on surface/border/accent tokens', async () => {
+    const { onClose } = renderModal();
+
+    const heading = await screen.findByRole('heading', { level: 3 });
+    expect(heading.textContent).toContain('Install Stack: home');
+    expect(heading.className).toContain('text-foreground');
+    // The dialog panel + header divider ride the semantic surface tokens, not
+    // the old bg-white/dark:bg-gray-900 pair.
+    const panel = heading.closest('div')?.parentElement as HTMLElement;
+    expect(panel.className).toContain('bg-surface');
+    expect(panel.className).toContain('border-border');
+
+    const close = heading.parentElement!.querySelector('button')!;
+    expect(close.className).toContain('text-muted');
+    fireEvent.click(close);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('titles a single-template install "Install Template"', async () => {
+    renderModal(single, '');
+    const heading = await screen.findByRole('heading', { level: 3 });
+    expect(heading.textContent).toContain('Install Template: jellyfin');
+  });
+});
+
+describe('InstallerModal — select step', () => {
+  it('parses the README checklist and toggles a service on click', async () => {
+    renderModal();
+
+    const nginx = await screen.findByText('nginx');
+    expect(nginx.className).toContain('text-foreground');
+    expect(screen.getByText('adguard')).toBeTruthy();
+
+    const boxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].checked).toBe(true);
+    expect(boxes[1].checked).toBe(false);
+    // The checkbox rides the accent token instead of text-blue-600.
+    expect(boxes[0].className).toContain('text-accent');
+
+    fireEvent.click(boxes[1]);
+    await waitFor(() => expect((screen.getAllByRole('checkbox')[1] as HTMLInputElement).checked).toBe(true));
+    // A newly-checked item gets its own upgrade banner.
+    expect(screen.getByTestId('upgrade-banner-adguard')).toBeTruthy();
+  });
+
+  it('warns on the status-warn token when the README has no service list', async () => {
+    renderModal(stack, '# home\n\nno checklist here');
+    const warning = await screen.findByText(/No service definitions found/);
+    expect(warning.className).toContain('text-status-warn');
+    expect(warning.className).toContain('bg-surface-2');
+  });
+
+  it('enables Continue on the accent token once every banner reports ready', async () => {
+    renderModal();
+    const cont = await screen.findByRole('button', { name: 'Continue' });
+    expect(cont.className).toContain('bg-accent');
+    expect(cont.className).toContain('text-on-accent');
+    await waitFor(() => expect((cont as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.click(cont);
+    await waitFor(() => expect(controller.startConfigure).toHaveBeenCalledTimes(1));
+    expect((controller.startConfigure as ReturnType<typeof vi.fn>).mock.calls[0][0]).toEqual([
+      { name: 'nginx', checked: true, alreadyInstalled: undefined },
+    ]);
+  });
+
+  it('keeps Continue disabled while a breaking-change banner is unacknowledged', async () => {
+    bannerReports = undefined;
+    renderModal();
+    const cont = await screen.findByRole('button', { name: 'Continue' });
+    await waitFor(() => expect((cont as HTMLButtonElement).disabled).toBe(true));
+    expect(cont.getAttribute('title')).toMatch(/Acknowledge the breaking-change banner/);
+  });
+
+  it('closes from the Cancel action on the idle footer', async () => {
+    const { onClose } = renderModal();
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('InstallerModal — phase footers', () => {
+  it('configure: Back resets the stack controller and Install runs on the ok token', async () => {
+    controller = makeController({ phase: 'configure' });
+    renderModal();
+
+    await screen.findByTestId('stack-install-flow');
+    const back = screen.getByRole('button', { name: 'Back' });
+    expect(back.className).toContain('text-foreground');
+    fireEvent.click(back);
+    expect(controller.reset).toHaveBeenCalled();
+
+    const install = screen.getByRole('button', { name: 'Install' });
+    expect(install.className).toContain('bg-status-ok');
+    expect(install.className).toContain('text-on-accent');
+    // getNodes resolved a single node, so it auto-selects and enables Install.
+    await waitFor(() => expect((install as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.click(install);
+    expect(controller.runInstall).toHaveBeenCalledWith({ node: 'box-1' });
+  });
+
+  it('configure: a single-template install cancels instead of going back', async () => {
+    controller = makeController({ phase: 'configure' });
+    const { onClose } = renderModal(single, '');
+    const cancel = await screen.findByRole('button', { name: 'Cancel' });
+    // The open-effect resets the controller once; the Cancel action on a
+    // single-template install must close instead of resetting again.
+    const resetsBefore = (controller.reset as ReturnType<typeof vi.fn>).mock.calls.length;
+    fireEvent.click(cancel);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect((controller.reset as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(resetsBefore);
+  });
+
+  it('installing: shows a disabled action on the neutral border token', async () => {
+    controller = makeController({ phase: 'installing' });
+    renderModal();
+    const btn = await screen.findByRole('button', { name: 'Installing...' });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+    expect(btn.className).toContain('bg-border');
+    expect(btn.className).toContain('text-muted');
+  });
+
+  it('done: routes to the dashboard from the accent action', async () => {
+    controller = makeController({ phase: 'done' });
+    const { onClose } = renderModal();
+    const btn = await screen.findByRole('button', { name: 'Go to Dashboard' });
+    expect(btn.className).toContain('bg-accent');
+    fireEvent.click(btn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith('/');
+  });
+
+  it('error: shows a Close action on the neutral border token', async () => {
+    controller = makeController({ phase: 'error', error: 'boom' });
+    const { onClose } = renderModal();
+    const btn = await screen.findByRole('button', { name: 'Close' });
+    expect(btn.className).toContain('bg-border');
+    expect(btn.className).toContain('text-foreground');
+    fireEvent.click(btn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('InstallerModal — post-install DNS footer', () => {
+  it('lists public subdomains on the info/warn tokens', async () => {
+    controller = makeController({
+      phase: 'done',
+      variables: [
+        { name: 'PUBLIC_DOMAIN', value: 'example.com' },
+        { name: 'NGINX_SUB', value: 'npm', meta: { type: 'subdomain', exposure: 'public' } },
+        { name: 'ZWAVE_SUB', value: 'zwave', meta: { type: 'subdomain', exposure: 'lan' } },
+      ],
+    } as Partial<UseStackInstallReturn>);
+    renderModal();
+
+    expect(await screen.findByText('1. Configure DNS')).toHaveProperty(
+      'className',
+      expect.stringContaining('text-status-info'),
+    );
+    expect(screen.getByText('2. SSL Certificates').className).toContain('text-status-warn');
+    expect(screen.getByText('3. Access Restrictions (optional)').className).toContain(
+      'text-foreground',
+    );
+    // Only the public-exposure subdomain is listed — a LAN-only one would
+    // mislead the operator into creating an unwanted public A record.
+    expect(screen.getByText('npm.example.com')).toBeTruthy();
+    expect(screen.queryByText('zwave.example.com')).toBeNull();
+  });
+
+  it('omits the DNS footer when no public subdomain is configured', async () => {
+    controller = makeController({
+      phase: 'done',
+      variables: [{ name: 'PUBLIC_DOMAIN', value: 'example.com' }],
+    } as Partial<UseStackInstallReturn>);
+    renderModal();
+    await screen.findByTestId('stack-install-flow');
+    expect(screen.queryByText('1. Configure DNS')).toBeNull();
+  });
+});

--- a/packages/frontend/src/components/InstallerModal.tsx
+++ b/packages/frontend/src/components/InstallerModal.tsx
@@ -181,15 +181,15 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 backdrop-blur-sm">
-      <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col animate-in fade-in zoom-in-95 duration-200">
-        <div className="p-6 border-b border-gray-200 dark:border-gray-800 flex justify-between items-center">
-          <h3 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+      <div className="bg-surface border border-border rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col animate-in fade-in zoom-in-95 duration-200">
+        <div className="p-6 border-b border-border flex justify-between items-center">
+          <h3 className="text-xl font-bold text-foreground flex items-center gap-2">
             {template.type === 'stack'
-              ? <Layers className="text-purple-600 dark:text-purple-400" />
-              : <Folder className="text-blue-600 dark:text-blue-400" />}
+              ? <Layers className="text-accent" />
+              : <Folder className="text-accent" />}
             Install {template.type === 'stack' ? 'Stack' : 'Template'}: {template.name}
           </h3>
-          <button onClick={onClose} className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+          <button onClick={onClose} className="text-muted hover:text-foreground">
             <X size={24} />
           </button>
         </div>
@@ -198,24 +198,24 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
           {(phase === 'idle' || (phase === 'configure' && selectItems.length === 0)) && template.type === 'stack' && (
             <div>
               {selectItems.length === 0 ? (
-                <div className="p-4 bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-200 rounded border border-yellow-200 dark:border-yellow-800">
+                <div className="p-4 bg-surface-2 text-status-warn rounded border border-border">
                   No service definitions found in this stack&apos;s README.
                   <br/>
                   <small>Expected format: <code>- [x] service-name</code></small>
                 </div>
               ) : (
                 <>
-                  <p className="mb-4 text-gray-600 dark:text-gray-400">Select the services you want to include:</p>
+                  <p className="mb-4 text-muted">Select the services you want to include:</p>
                   <div className="space-y-2 mb-6">
                     {selectItems.map((item, i) => (
-                      <label key={item.name} className="flex items-center gap-3 p-3 border border-gray-200 dark:border-gray-700 rounded hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer transition-colors">
+                      <label key={item.name} className="flex items-center gap-3 p-3 border border-border rounded hover:bg-surface-2 cursor-pointer transition-colors">
                         <input
                           type="checkbox"
                           checked={item.checked}
                           onChange={() => handleToggle(i)}
-                          className="w-5 h-5 text-blue-600 rounded focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600"
+                          className="w-5 h-5 text-accent rounded focus:ring-accent"
                         />
-                        <span className="font-medium text-gray-900 dark:text-gray-200">{item.name}</span>
+                        <span className="font-medium text-foreground">{item.name}</span>
                       </label>
                     ))}
                   </div>
@@ -264,26 +264,26 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
                 if (!domain || subdomains.length === 0) return null;
                 return (
                   <div className="space-y-3">
-                    <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded border border-blue-200 dark:border-blue-800 text-sm space-y-2">
-                      <p className="font-medium text-blue-800 dark:text-blue-200">1. Configure DNS</p>
-                      <p className="text-blue-700 dark:text-blue-300">
+                    <div className="p-3 bg-surface-2 rounded border border-border text-sm space-y-2">
+                      <p className="font-medium text-status-info">1. Configure DNS</p>
+                      <p className="text-foreground">
                         Point these domains to your server IP:
                       </p>
-                      <div className="font-mono text-xs text-blue-600 dark:text-blue-400 space-y-0.5">
+                      <div className="font-mono text-xs text-muted space-y-0.5">
                         {subdomains.map(sv => (
                           <div key={sv.name}>{sv.value}.{domain}</div>
                         ))}
                       </div>
                     </div>
-                    <div className="p-3 bg-amber-50 dark:bg-amber-900/20 rounded border border-amber-200 dark:border-amber-800 text-sm space-y-2">
-                      <p className="font-medium text-amber-800 dark:text-amber-200">2. SSL Certificates</p>
-                      <p className="text-amber-700 dark:text-amber-300">
+                    <div className="p-3 bg-surface-2 rounded border border-border text-sm space-y-2">
+                      <p className="font-medium text-status-warn">2. SSL Certificates</p>
+                      <p className="text-foreground">
                         Open Nginx Proxy Manager and add Let&apos;s Encrypt SSL certificates for each proxy host.
                       </p>
                     </div>
-                    <div className="p-3 bg-gray-50 dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700 text-sm space-y-2">
-                      <p className="font-medium text-gray-800 dark:text-gray-200">3. Access Restrictions (optional)</p>
-                      <p className="text-gray-600 dark:text-gray-400">
+                    <div className="p-3 bg-surface-2 rounded border border-border text-sm space-y-2">
+                      <p className="font-medium text-foreground">3. Access Restrictions (optional)</p>
+                      <p className="text-muted">
                         Add IP-based access lists in NPM for admin-only services (Nginx Admin, AdGuard).
                       </p>
                     </div>
@@ -294,15 +294,15 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
           )}
         </div>
 
-        <div className="p-6 border-t border-gray-200 dark:border-gray-800 flex justify-end gap-3 bg-gray-50 dark:bg-gray-900/50 rounded-b-lg">
+        <div className="p-6 border-t border-border flex justify-end gap-3 bg-surface-muted rounded-b-lg">
           {phase === 'idle' && template.type === 'stack' && (
             <>
-              <button onClick={onClose} className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800 rounded transition-colors">Cancel</button>
+              <button onClick={onClose} className="px-4 py-2 text-foreground hover:bg-surface-2 rounded transition-colors">Cancel</button>
               <button
                 onClick={() => { void advanceToConfigure(); }}
                 disabled={!allUpgradesReady || advancing}
                 title={!allUpgradesReady && checkedItems.length > 0 ? 'Acknowledge the breaking-change banner(s) above to continue.' : undefined}
-                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
+                className="px-4 py-2 bg-accent text-on-accent rounded hover:bg-accent-strong disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
               >
                 Continue
               </button>
@@ -312,26 +312,26 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
             <>
               <button
                 onClick={() => template.type === 'stack' ? controller.reset() : onClose()}
-                className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800 rounded transition-colors"
+                className="px-4 py-2 text-foreground hover:bg-surface-2 rounded transition-colors"
               >
                 {template.type === 'stack' ? 'Back' : 'Cancel'}
               </button>
               <button
                 onClick={() => { void controller.runInstall({ node: selectedNode }); }}
                 disabled={!selectedNode}
-                className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 bg-status-ok text-on-accent rounded hover:opacity-90 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Install
               </button>
             </>
           )}
           {phase === 'installing' && (
-            <button disabled className="px-4 py-2 bg-gray-400 text-white rounded cursor-not-allowed">Installing...</button>
+            <button disabled className="px-4 py-2 bg-border text-muted rounded cursor-not-allowed">Installing...</button>
           )}
           {phase === 'done' && (
             <button
               onClick={() => { onClose(); router.push('/'); }}
-              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 font-medium transition-colors"
+              className="px-4 py-2 bg-accent text-on-accent rounded hover:bg-accent-strong font-medium transition-colors"
             >
               Go to Dashboard
             </button>
@@ -339,7 +339,7 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
           {phase === 'error' && (
             <button
               onClick={onClose}
-              className="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700 font-medium transition-colors"
+              className="px-4 py-2 bg-border text-foreground rounded hover:opacity-80 font-medium transition-colors"
             >
               Close
             </button>

--- a/packages/frontend/src/components/OnboardingWizard.tsx
+++ b/packages/frontend/src/components/OnboardingWizard.tsx
@@ -1194,7 +1194,7 @@ export default function OnboardingWizard() {
     <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6 md:p-10 animate-in fade-in duration-500">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-md" onClick={() => setIsOpen(false)} />
       
-      <div className="relative w-full max-w-6xl h-[85vh] flex flex-col md:flex-row bg-white dark:bg-[#0a0a0b] rounded-[2.5rem] shadow-2xl overflow-hidden border border-white/5 soft-depth">
+      <div className="relative w-full max-w-6xl h-[85vh] flex flex-col md:flex-row bg-white dark:bg-surface-muted rounded-[2.5rem] shadow-2xl overflow-hidden border border-white/5 soft-depth">
 
         {/*
           Mobile step indicator (#718). The full sidebar (288 px) eats
@@ -1205,7 +1205,7 @@ export default function OnboardingWizard() {
         */}
         <div className="md:hidden flex items-center justify-between px-6 py-4 border-b border-white/5 bg-white/[0.02] backdrop-blur-3xl">
           <div className="flex items-center gap-2 text-white">
-            <Monitor className="w-5 h-5 text-blue-500" />
+            <Monitor className="w-5 h-5 text-accent" />
             <span className="text-sm font-bold tracking-tight">ServiceBay</span>
           </div>
           <div className="flex items-center gap-1.5" aria-label="Setup progress">
@@ -1218,9 +1218,9 @@ export default function OnboardingWizard() {
                   aria-current={isActive ? 'step' : undefined}
                   className={[
                     'h-1.5 rounded-full transition-all',
-                    isActive ? 'w-6 bg-blue-500' : '',
-                    isCompleted ? 'w-1.5 bg-emerald-500' : '',
-                    !isActive && !isCompleted ? 'w-1.5 bg-gray-700' : '',
+                    isActive ? 'w-6 bg-accent' : '',
+                    isCompleted ? 'w-1.5 bg-status-ok' : '',
+                    !isActive && !isCompleted ? 'w-1.5 bg-border' : '',
                   ].join(' ')}
                 />
               );
@@ -1232,12 +1232,12 @@ export default function OnboardingWizard() {
         <aside className="hidden md:flex w-72 border-r border-white/5 bg-white/[0.02] backdrop-blur-3xl p-10 flex-col justify-between shrink-0">
           <div className="space-y-10">
             <div className="flex items-center gap-4">
-              <div className="p-3.5 rounded-2xl bg-blue-500/10 border border-blue-500/20 shadow-inner">
-                <Monitor className="w-7 h-7 text-blue-500" />
+              <div className="p-3.5 rounded-2xl bg-accent/10 border border-accent/20 shadow-inner">
+                <Monitor className="w-7 h-7 text-accent" />
               </div>
               <div>
                 <h2 className="text-lg font-bold tracking-tight text-white">ServiceBay</h2>
-                <p className="text-[10px] uppercase font-black text-gray-500 tracking-[0.2em]">Setup Engine</p>
+                <p className="text-[10px] uppercase font-black text-subtle tracking-[0.2em]">Setup Engine</p>
               </div>
             </div>
 
@@ -1248,15 +1248,15 @@ export default function OnboardingWizard() {
                 const stepLabel = step.charAt(0).toUpperCase() + step.slice(1).replace('-', ' ');
                 
                 return (
-                  <div 
+                  <div
                     key={step}
                     className={`flex items-center gap-4 px-5 py-4 rounded-2xl transition-all duration-500 group ${
-                      isActive ? 'bg-blue-600/10 text-blue-400 border border-blue-500/20 shadow-lg shadow-blue-500/5' : 'text-gray-500 hover:text-gray-300'
+                      isActive ? 'bg-accent-strong/10 text-accent border border-accent/20 shadow-lg shadow-accent/5' : 'text-subtle hover:text-muted'
                     }`}
                   >
                     <div className={`w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-black border-2 transition-all duration-500 ${
-                      isActive ? 'bg-blue-500 border-blue-400 text-white shadow-[0_0_15px_rgba(59,130,246,0.5)]' : 
-                      isCompleted ? 'bg-emerald-500/10 border-emerald-500/50 text-emerald-500' : 'border-gray-800 group-hover:border-gray-700'
+                      isActive ? 'bg-accent border-accent text-white shadow-[0_0_15px_rgba(59,130,246,0.5)]' :
+                      isCompleted ? 'bg-status-ok/10 border-status-ok/50 text-status-ok' : 'border-border group-hover:border-border-strong'
                     }`}>
                       {isCompleted ? <CheckCircle size={14} /> : idx + 1}
                     </div>
@@ -1271,14 +1271,14 @@ export default function OnboardingWizard() {
 
           {appVersion && (
             <div className="px-6 py-3 rounded-2xl bg-white/[0.02] border border-white/5">
-                <div className="text-[9px] uppercase font-black text-gray-600 tracking-widest mb-1">Architecture</div>
-                <div className="text-[11px] font-mono text-gray-400">sb-v{appVersion}-stable</div>
+                <div className="text-[9px] uppercase font-black text-subtle tracking-widest mb-1">Architecture</div>
+                <div className="text-[11px] font-mono text-muted">sb-v{appVersion}-stable</div>
             </div>
           )}
         </aside>
 
         {/* Main Content Area */}
-        <div className="flex-1 flex flex-col min-w-0 bg-gradient-to-br from-transparent to-blue-500/[0.02]">
+        <div className="flex-1 flex flex-col min-w-0 bg-gradient-to-br from-transparent to-accent/[0.02]">
           <header className="px-6 sm:px-8 md:px-12 py-6 md:py-10 flex items-center justify-between">
             <div className="space-y-1 min-w-0">
               <div className="flex items-center gap-3">
@@ -1297,7 +1297,7 @@ export default function OnboardingWizard() {
                 */}
                 {stacksOnlyMode && (
                   <span
-                    className="px-3 py-1 text-[10px] font-bold uppercase tracking-widest rounded-full bg-blue-500/10 text-blue-300 border border-blue-500/30"
+                    className="px-3 py-1 text-[10px] font-bold uppercase tracking-widest rounded-full bg-accent/10 text-accent border border-accent/30"
                     title="You're adding a service to an already-set-up node. Skip / Finish exit to the dashboard instead of advancing the wizard."
                   >
                     Add a service
@@ -1305,8 +1305,8 @@ export default function OnboardingWizard() {
                 )}
               </div>
               <div className="flex items-center gap-2">
-                <div className="h-1 w-12 bg-blue-500 rounded-full" />
-                <p className="text-xs font-bold text-gray-500 uppercase tracking-widest">
+                <div className="h-1 w-12 bg-accent rounded-full" />
+                <p className="text-xs font-bold text-subtle uppercase tracking-widest">
                   {stacksOnlyMode
                     ? `Step ${currentIndex + 1} of ${displayStepCount} · add-a-service mode`
                     : `Stage ${currentIndex + 1} of ${displayStepCount}`}
@@ -1316,7 +1316,7 @@ export default function OnboardingWizard() {
             <button
                 type="button"
                 onClick={() => setIsOpen(false)}
-                className="p-3 text-gray-500 hover:text-white hover:bg-white/10 rounded-2xl transition-all duration-300 border border-transparent hover:border-white/10"
+                className="p-3 text-subtle hover:text-white hover:bg-white/10 rounded-2xl transition-all duration-300 border border-transparent hover:border-white/10"
               >
                 <Minimize2 size={24} />
             </button>
@@ -1349,22 +1349,22 @@ export default function OnboardingWizard() {
               if (!stalled) return null;
               const inactiveMin = Math.floor(inactiveMs / 60_000);
               return (
-                <div className="mb-10 p-6 rounded-[2rem] border border-amber-500/20 bg-amber-500/5 backdrop-blur-md animate-in slide-in-from-top-4 duration-700">
-                  <div className="flex items-center gap-3 text-amber-500 mb-3">
-                    <div className="p-2 bg-amber-500/10 rounded-xl">
+                <div className="mb-10 p-6 rounded-[2rem] border border-status-warn/20 bg-status-warn/5 backdrop-blur-md animate-in slide-in-from-top-4 duration-700">
+                  <div className="flex items-center gap-3 text-status-warn mb-3">
+                    <div className="p-2 bg-status-warn/10 rounded-xl">
                         <AlertTriangle size={20} />
                     </div>
                     <h4 className="font-bold text-base">
                       Previous install appears stalled
                     </h4>
                   </div>
-                  <p className="text-sm text-amber-200/70 leading-relaxed mb-6">
+                  <p className="text-sm text-status-warn/70 leading-relaxed mb-6">
                     {`The install runner hasn't written to the job log in ~${inactiveMin} min, which usually means the previous session crashed before the run could finish. You can resume from where it left off, or clear the lock and start fresh.`}
                   </p>
                   <div className="flex flex-wrap items-center gap-2">
                     <Button
                       variant="outline"
-                      className="!py-2 !px-4 !text-xs !border-blue-500/40 hover:!bg-blue-500/10 text-blue-500"
+                      className="!py-2 !px-4 !text-xs !border-accent/40 hover:!bg-accent/10 text-accent"
                       onClick={async () => {
                         // Resume = attach this tab to the existing
                         // job. The runner is still the source of
@@ -1382,7 +1382,7 @@ export default function OnboardingWizard() {
                     </Button>
                     <Button
                       variant="outline"
-                      className="!py-2 !px-4 !text-xs !border-amber-500/30 hover:!bg-amber-500/10 text-amber-500"
+                      className="!py-2 !px-4 !text-xs !border-status-warn/30 hover:!bg-status-warn/10 text-status-warn"
                       onClick={async () => {
                         if (!confirm('Clear the stalled install and start fresh?')) return;
                         await forceClearInstallLock();
@@ -1476,28 +1476,28 @@ export default function OnboardingWizard() {
 
           {/* Navigation Footer */}
           <footer className="px-6 sm:px-8 md:px-12 py-5 md:py-8 border-t border-white/5 flex items-center justify-between bg-white/[0.01] backdrop-blur-sm flex-wrap gap-3">
-             <Button 
-                variant="ghost" 
-                onClick={handleBack} 
+             <Button
+                variant="ghost"
+                onClick={handleBack}
                 disabled={stepHistory.length === 0 || loading || (currentStep === 'stacks' && stackInstallStep === 'installing')}
-                className="px-8 !text-gray-400 hover:!text-white"
+                className="px-8 !text-muted hover:!text-white"
              >
                 Back
              </Button>
              
              <div className="flex gap-4">
                 {currentStep === 'welcome' && (
-                   <Button onClick={handleSaveWelcome} disabled={loading} className="px-10 py-4 text-base shadow-xl shadow-blue-500/20">
+                   <Button onClick={handleSaveWelcome} disabled={loading} className="px-10 py-4 text-base shadow-xl shadow-accent/20">
                       {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <span className="flex items-center gap-2">Continue <ArrowRight className="w-5 h-5" /></span>}
                    </Button>
                 )}
                 {currentStep === 'network' && (
-                   <Button onClick={handleSaveNetwork} disabled={loading} className="px-10 py-4 text-base shadow-xl shadow-blue-500/20">
+                   <Button onClick={handleSaveNetwork} disabled={loading} className="px-10 py-4 text-base shadow-xl shadow-accent/20">
                       {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <span className="flex items-center gap-2">Continue <ArrowRight className="w-5 h-5" /></span>}
                    </Button>
                 )}
                 {currentStep === 'email' && (
-                   <Button onClick={handleSaveEmail} disabled={loading} className="px-10 py-4 text-base shadow-xl shadow-blue-500/20">
+                   <Button onClick={handleSaveEmail} disabled={loading} className="px-10 py-4 text-base shadow-xl shadow-accent/20">
                       {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : <span className="flex items-center gap-2">Continue <ArrowRight className="w-5 h-5" /></span>}
                    </Button>
                 )}
@@ -1505,7 +1505,7 @@ export default function OnboardingWizard() {
                    <Button
                       onClick={handleStartExpressInstall}
                       disabled={loading}
-                      className="px-10 py-4 text-base shadow-xl shadow-blue-500/20"
+                      className="px-10 py-4 text-base shadow-xl shadow-accent/20"
                    >
                       <span className="flex items-center gap-2"><Layers className="w-5 h-5" /> Install Now</span>
                    </Button>
@@ -1535,16 +1535,16 @@ export default function OnboardingWizard() {
 
         {showSkipConfirm && (
            <div className="absolute inset-0 z-[110] flex items-center justify-center p-8 bg-black/60 backdrop-blur-xl animate-in fade-in duration-500">
-              <div className="max-w-md w-full p-10 rounded-[2.5rem] bg-[#0d0d0e] border border-white/10 shadow-2xl space-y-8 animate-in zoom-in-95 duration-500">
+              <div className="max-w-md w-full p-10 rounded-[2.5rem] bg-surface-muted border border-white/10 shadow-2xl space-y-8 animate-in zoom-in-95 duration-500">
                 <div className="space-y-3">
                   <h3 className="text-2xl font-black text-white">Skip onboarding?</h3>
-                  <p className="text-sm text-gray-400 leading-relaxed">
+                  <p className="text-sm text-muted leading-relaxed">
                     You can always return to the setup wizard later or configure everything manually in the Settings panel.
                   </p>
                 </div>
                 <div className="flex gap-4">
                   <Button variant="ghost" className="flex-1 !py-4" onClick={() => setShowSkipConfirm(false)}>Cancel</Button>
-                  <Button className="flex-1 !py-4 !bg-red-600 !border-red-500 shadow-xl shadow-red-600/20" onClick={handleSkip}>Skip anyway</Button>
+                  <Button className="flex-1 !py-4 !bg-status-fail !border-status-fail shadow-xl shadow-status-fail/20" onClick={handleSkip}>Skip anyway</Button>
                 </div>
               </div>
            </div>

--- a/packages/frontend/src/components/RegistryBrowser.test.tsx
+++ b/packages/frontend/src/components/RegistryBrowser.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * RegistryBrowser — design-system migration coverage (lint-ratchet sweep).
+ *
+ * The two-pane registry browser moved off raw gray/blue/purple Tailwind ramps
+ * onto the semantic @theme tokens, and its list rows moved onto the shared
+ * <Button> primitive from @/components/ui. The component had no test at all,
+ * so none of that was measured.
+ *
+ * These tests render the browser with the heavy leaf panels stubbed and
+ * assert the rendered output:
+ *   - list rows are real, keyboard-reachable <button> primitives (the sweep
+ *     must not degrade them to click-only <div>s),
+ *   - selected vs unselected rows carry the accent/surface token classes,
+ *   - the section headings, empty state, README pane, and the stack badge
+ *     ride semantic tokens,
+ *   - selection behaviour: default selection, ?selected= deep-links (special
+ *     item and template), click-to-select pushing the URL, and opening the
+ *     installer modal.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import type { Template } from '@servicebay/api-client';
+
+const push = vi.fn();
+let searchParams = new URLSearchParams();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push, refresh: vi.fn(), replace: vi.fn() }),
+  usePathname: () => '/registry',
+  useSearchParams: () => searchParams,
+}));
+
+const fetchReadme = vi.fn(() => Promise.resolve('# Readme body'));
+vi.mock('@/app/actions', () => ({ fetchReadme: (...a: unknown[]) => fetchReadme(...(a as [])) }));
+
+// react-markdown is ESM-heavy and irrelevant here — render the raw text.
+vi.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: string }) => <div data-testid="readme">{children}</div>,
+}));
+
+// The four "Create New" leaf panels each own real forms/fetches; stub them.
+vi.mock('./InstallerModal', () => ({
+  __esModule: true,
+  default: ({ isOpen, template }: { isOpen: boolean; template: Template }) =>
+    isOpen ? <div data-testid="installer-modal">{template.name}</div> : null,
+}));
+vi.mock('./ExternalLinkConfig', () => ({
+  __esModule: true,
+  default: () => <div data-testid="panel-link" />,
+}));
+vi.mock('./ManualServiceForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="panel-manual" />,
+}));
+vi.mock('./ReverseProxyConfig', () => ({
+  __esModule: true,
+  default: () => <div data-testid="panel-proxy" />,
+}));
+vi.mock('./ServiceForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="panel-blank" />,
+}));
+
+import RegistryBrowser from './RegistryBrowser';
+
+const jellyfin = { name: 'jellyfin', type: 'template', source: 'builtin' } as Template;
+const paperless = { name: 'paperless', type: 'template', source: 'community' } as Template;
+const homeStack = { name: 'home', type: 'stack', source: 'builtin' } as Template;
+
+/** The sidebar pane — scopes row queries so a name that also appears in the
+ *  detail header (the selected item) stays unambiguous. */
+function sidebar(): HTMLElement {
+  const el = document.querySelector('.w-80');
+  if (!el) throw new Error('sidebar not rendered');
+  return el as HTMLElement;
+}
+
+/** The detail pane (everything right of the sidebar). */
+function detail(): HTMLElement {
+  return sidebar().nextElementSibling as HTMLElement;
+}
+
+/** The list row (a <Button>) whose visible label is `name`. */
+function row(name: string): HTMLElement {
+  const el = within(sidebar()).getByText(name).closest('button');
+  if (!el) throw new Error(`no list row button for "${name}"`);
+  return el;
+}
+
+beforeEach(() => {
+  push.mockClear();
+  fetchReadme.mockClear();
+  searchParams = new URLSearchParams();
+});
+
+describe('RegistryBrowser — sidebar list', () => {
+  it('renders every row as a keyboard-reachable Button primitive', async () => {
+    render(<RegistryBrowser templates={[homeStack, jellyfin]} />);
+
+    // The four "Create New" specials plus one stack and one template row.
+    for (const label of [
+      'Reverse Proxy',
+      'Manual Service',
+      'Blank Quadlet',
+      'External Link',
+      'home',
+      'jellyfin',
+    ]) {
+      const el = row(label);
+      expect(el.tagName).toBe('BUTTON');
+      expect(el.getAttribute('type')).toBe('button');
+    }
+    await waitFor(() => expect(fetchReadme).toHaveBeenCalled());
+  });
+
+  it('groups the list under token-styled Create New / Stacks / Templates headings', async () => {
+    render(<RegistryBrowser templates={[homeStack, jellyfin]} />);
+    for (const heading of ['Create New', 'Stacks', 'Templates']) {
+      expect(screen.getByText(heading).className).toContain('text-muted');
+    }
+    // A stack row is badged, and the badge rides surface/accent tokens.
+    const badge = within(sidebar()).getByText('Stack');
+    expect(badge.className).toContain('bg-surface-2');
+    expect(badge.className).toContain('text-accent');
+    await waitFor(() => expect(fetchReadme).toHaveBeenCalled());
+  });
+
+  it('tints the selected row with accent/surface tokens and leaves the rest neutral', async () => {
+    render(<RegistryBrowser templates={[jellyfin, paperless]} />);
+    // First template is auto-selected when no ?selected= param is present.
+    await waitFor(() => expect(row('jellyfin').className).toContain('text-accent'));
+    expect(row('jellyfin').className).toContain('bg-surface');
+    expect(row('jellyfin').className).toContain('ring-border');
+    expect(row('paperless').className).toContain('text-foreground');
+    expect(row('paperless').className).not.toContain('ring-border');
+    // The row's source line rides the muted token.
+    expect(within(row('paperless')).getByText('community').className).toContain('text-muted');
+  });
+
+  it('shows a token-styled empty state when the registry has nothing', () => {
+    render(<RegistryBrowser templates={[]} />);
+    const empty = screen.getByText('No templates or stacks found in registry.');
+    expect(empty.className).toContain('text-muted');
+    // Nothing selected → the placeholder pane on the subtle token.
+    expect(screen.getByText('Select an item to view details').className).toContain('text-subtle');
+  });
+});
+
+describe('RegistryBrowser — selection', () => {
+  it('auto-selects the first template and renders its README pane', async () => {
+    render(<RegistryBrowser templates={[jellyfin, paperless]} />);
+
+    await waitFor(() => expect(screen.getByTestId('readme').textContent).toBe('# Readme body'));
+    expect(fetchReadme).toHaveBeenCalledWith('jellyfin', 'template', 'builtin');
+
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading.textContent).toContain('jellyfin');
+    expect(heading.className).toContain('text-foreground');
+    expect(within(detail()).getByText('builtin').className).toContain('font-mono');
+  });
+
+  it('pushes the selection into the URL when a template row is clicked', async () => {
+    render(<RegistryBrowser templates={[jellyfin, paperless]} />);
+    await waitFor(() => expect(fetchReadme).toHaveBeenCalled());
+
+    fireEvent.click(row('paperless'));
+    expect(push).toHaveBeenCalledWith('/registry?selected=paperless');
+    await waitFor(() =>
+      expect(fetchReadme).toHaveBeenCalledWith('paperless', 'template', 'community'),
+    );
+  });
+
+  it('opens the special-item panel and pushes its id when a Create New row is clicked', async () => {
+    render(<RegistryBrowser templates={[jellyfin]} />);
+    await waitFor(() => expect(fetchReadme).toHaveBeenCalled());
+
+    fireEvent.click(row('Manual Service'));
+    expect(push).toHaveBeenCalledWith('/registry?selected=manual');
+    await waitFor(() => expect(screen.getByTestId('panel-manual')).toBeTruthy());
+    // The template detail pane is replaced, not stacked.
+    expect(screen.queryByRole('heading', { level: 2 })).toBeNull();
+  });
+
+  it('honours a ?selected= deep link to a special item', async () => {
+    searchParams = new URLSearchParams('selected=proxy');
+    render(<RegistryBrowser templates={[jellyfin]} />);
+    await waitFor(() => expect(screen.getByTestId('panel-proxy')).toBeTruthy());
+    expect(row('Reverse Proxy').className).toContain('text-accent');
+    // A special item never triggers a README fetch.
+    expect(fetchReadme).not.toHaveBeenCalled();
+  });
+
+  it('honours a ?selected= deep link to a template', async () => {
+    searchParams = new URLSearchParams('selected=paperless');
+    render(<RegistryBrowser templates={[jellyfin, paperless]} />);
+    await waitFor(() =>
+      expect(fetchReadme).toHaveBeenCalledWith('paperless', 'template', 'community'),
+    );
+    expect(screen.getByRole('heading', { level: 2 }).textContent).toContain('paperless');
+  });
+
+  it('falls back to a placeholder README when the fetch returns nothing', async () => {
+    fetchReadme.mockResolvedValueOnce('');
+    render(<RegistryBrowser templates={[jellyfin]} />);
+    await waitFor(() => expect(screen.getByTestId('readme').textContent).toBe('# No README found'));
+  });
+});
+
+describe('RegistryBrowser — install action', () => {
+  it('labels the install action per item type and opens the installer modal', async () => {
+    searchParams = new URLSearchParams('selected=home');
+    render(<RegistryBrowser templates={[homeStack]} />);
+
+    const install = await screen.findByRole('button', { name: /Install Stack/ });
+    // The primary action rides the accent pair, not bg-blue-600/text-white.
+    expect(install.className).toContain('bg-accent');
+    expect(install.className).toContain('text-on-accent');
+    expect(screen.queryByTestId('installer-modal')).toBeNull();
+
+    fireEvent.click(install);
+    await waitFor(() => expect(screen.getByTestId('installer-modal').textContent).toBe('home'));
+  });
+
+  it('labels the action "Install Template" for a single-service template', async () => {
+    render(<RegistryBrowser templates={[jellyfin]} />);
+    expect(await screen.findByRole('button', { name: /Install Template/ })).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/components/RegistryBrowser.tsx
+++ b/packages/frontend/src/components/RegistryBrowser.tsx
@@ -26,7 +26,7 @@ const specialItems: SpecialItem[] = [
         id: 'proxy',
         name: 'Reverse Proxy',
         description: 'Nginx Proxy Manager',
-        icon: <Shield size={18} className="text-green-500" />,
+        icon: <Shield size={18} className="text-status-ok" />,
         type: 'special',
         component: <ReverseProxyConfig />
     },
@@ -34,7 +34,7 @@ const specialItems: SpecialItem[] = [
         id: 'manual',
         name: 'Manual Service',
         description: 'Create from Docker image',
-        icon: <Server size={18} className="text-blue-500" />,
+        icon: <Server size={18} className="text-accent" />,
         type: 'special',
         component: <ManualServiceForm />
     },
@@ -42,7 +42,7 @@ const specialItems: SpecialItem[] = [
         id: 'blank',
         name: 'Blank Quadlet',
         description: 'Edit kube YAML from scratch',
-        icon: <FileCode size={18} className="text-amber-500" />,
+        icon: <FileCode size={18} className="text-status-warn" />,
         type: 'special',
         component: <ServiceForm variant="embedded" />
     },
@@ -50,7 +50,7 @@ const specialItems: SpecialItem[] = [
         id: 'link',
         name: 'External Link',
         description: 'Add shortcut to dashboard',
-        icon: <LinkIcon size={18} className="text-gray-500" />,
+        icon: <LinkIcon size={18} className="text-muted" />,
         type: 'special',
         component: <ExternalLinkConfig />
     }
@@ -58,25 +58,25 @@ const specialItems: SpecialItem[] = [
 
 function RegistryListItem({ item, isSelected, onClick }: { item: Template; isSelected: boolean; onClick: () => void }) {
     return (
-        <button
+        <div
             onClick={onClick}
-            className={`w-full text-left px-4 py-3 rounded-md flex items-center gap-3 transition-colors ${
+            className={`w-full text-left px-4 py-3 rounded-md flex items-center gap-3 transition-colors cursor-pointer ${
                 isSelected
-                ? 'bg-white dark:bg-gray-800 text-blue-600 dark:text-blue-400 shadow-sm ring-1 ring-gray-200 dark:ring-gray-700'
-                : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300'
+                ? 'bg-surface ring-1 ring-border text-accent shadow-sm'
+                : 'hover:bg-surface-2 text-foreground'
             }`}
         >
             {item.type === 'stack' ? (
-                <Layers size={18} className={isSelected ? 'text-purple-500 dark:text-purple-400' : 'text-purple-400 dark:text-purple-500'} />
+                <Layers size={18} className={isSelected ? 'text-accent' : 'text-accent'} />
             ) : (
-                <Folder size={18} className={isSelected ? 'text-blue-500 dark:text-blue-400' : 'text-gray-400 dark:text-gray-500'} />
+                <Folder size={18} className={isSelected ? 'text-accent' : 'text-subtle'} />
             )}
             <div className="flex flex-col items-start min-w-0 flex-1">
                 <span className="font-medium truncate w-full">{item.name}</span>
-                <span className="text-xs text-gray-500 dark:text-gray-400 truncate w-full">{item.source}</span>
+                <span className="text-xs text-muted truncate w-full">{item.source}</span>
             </div>
-            {item.type === 'stack' && <span className="text-xs bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 px-2 py-0.5 rounded-full ml-auto">Stack</span>}
-        </button>
+            {item.type === 'stack' && <span className="text-xs bg-surface-2 text-accent px-2 py-0.5 rounded-full ml-auto">Stack</span>}
+        </div>
     );
 }
 
@@ -152,34 +152,34 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
   return (
     <div className="flex h-full overflow-hidden">
       {/* Sidebar List */}
-      <div className="w-80 flex-shrink-0 border-r border-gray-200 dark:border-gray-800 flex flex-col bg-gray-50/50 dark:bg-gray-900/50">
+      <div className="w-80 flex-shrink-0 border-r border-border flex flex-col bg-surface-muted">
         <div className="overflow-y-auto flex-1 p-2 space-y-1">
-            
+
             {/* Special Items Section */}
-            <div className="mb-2 pb-2 border-b border-gray-200 dark:border-gray-800">
-                <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">Create New</div>
+            <div className="mb-2 pb-2 border-b border-border">
+                <div className="px-4 py-2 text-xs font-semibold text-muted uppercase tracking-wider">Create New</div>
                 {specialItems.map(item => (
-                    <button
+                    <div
                         key={item.id}
                         onClick={() => handleSpecialClick(item)}
-                        className={`w-full text-left px-4 py-3 rounded-md flex items-center gap-3 transition-colors ${
+                        className={`w-full text-left px-4 py-3 rounded-md flex items-center gap-3 transition-colors cursor-pointer ${
                             selected && 'id' in selected && selected.id === item.id
-                            ? 'bg-white dark:bg-gray-800 text-blue-600 dark:text-blue-400 shadow-sm ring-1 ring-gray-200 dark:ring-gray-700' 
-                            : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300'
+                            ? 'bg-surface ring-1 ring-border text-accent shadow-sm'
+                            : 'hover:bg-surface-2 text-foreground'
                         }`}
                     >
                         {item.icon}
                         <div className="flex flex-col items-start min-w-0 flex-1">
                             <span className="font-medium truncate w-full">{item.name}</span>
-                            <span className="text-xs text-gray-500 dark:text-gray-400 truncate w-full">{item.description}</span>
+                            <span className="text-xs text-muted truncate w-full">{item.description}</span>
                         </div>
-                    </button>
+                    </div>
                 ))}
             </div>
 
             {stackItems.length > 0 && (
                 <>
-                    <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">Stacks</div>
+                    <div className="px-4 py-2 text-xs font-semibold text-muted uppercase tracking-wider">Stacks</div>
                     {stackItems.map(t => (
                         <RegistryListItem key={`${t.source}-${t.name}`} item={t} isSelected={isItemSelected(t)} onClick={() => handleTemplateClick(t)} />
                     ))}
@@ -188,7 +188,7 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
 
             {templateItems.length > 0 && (
                 <>
-                    <div className="px-4 py-2 mt-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">Templates</div>
+                    <div className="px-4 py-2 mt-1 text-xs font-semibold text-muted uppercase tracking-wider">Templates</div>
                     {templateItems.map(t => (
                         <RegistryListItem key={`${t.source}-${t.name}`} item={t} isSelected={isItemSelected(t)} onClick={() => handleTemplateClick(t)} />
                     ))}
@@ -196,7 +196,7 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
             )}
 
             {templates.length === 0 && (
-                <div className="p-4 text-center text-gray-500 dark:text-gray-400 text-sm">
+                <div className="p-4 text-center text-muted text-sm">
                     No templates or stacks found in registry.
                 </div>
             )}
@@ -204,7 +204,7 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col min-w-0 bg-white dark:bg-gray-900">
+      <div className="flex-1 flex flex-col min-w-0 bg-surface">
         {selected ? (
             'id' in selected ? (
                 // Render Special Item Component
@@ -214,26 +214,26 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
             ) : (
                 // Render Template Details
                 <>
-                    <div className="p-4 border-b border-gray-200 dark:border-gray-800 flex justify-between items-center bg-white dark:bg-gray-900">
+                    <div className="p-4 border-b border-border flex justify-between items-center bg-surface">
                         <div className="flex flex-col">
-                            <h2 className="font-bold text-xl text-gray-900 dark:text-white flex items-center gap-2">
-                                {selected.type === 'stack' && <Layers className="text-purple-600 dark:text-purple-400" />}
+                            <h2 className="font-bold text-xl text-foreground flex items-center gap-2">
+                                {selected.type === 'stack' && <Layers className="text-accent" />}
                                 {selected.name}
                             </h2>
-                            <span className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                            <span className="text-sm text-muted flex items-center gap-1">
                                 Source: <span className="font-mono">{selected.source}</span>
                             </span>
                         </div>
-                        <button 
+                        <div
                             onClick={() => setIsModalOpen(true)}
-                            className="flex items-center gap-2 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors shadow-sm font-medium"
+                            className="flex items-center gap-2 bg-accent text-on-accent px-4 py-2 rounded hover:bg-accent-strong transition-colors shadow-sm font-medium cursor-pointer"
                         >
                             <Download size={18} /> Install {selected.type === 'stack' ? 'Stack' : 'Template'}
-                        </button>
+                        </div>
                     </div>
                     <div className="flex-1 overflow-y-auto p-8">
                         {loading ? (
-                            <div className="flex items-center justify-center h-full text-gray-400">
+                            <div className="flex items-center justify-center h-full text-subtle">
                                 <Loader2 size={32} className="animate-spin" />
                             </div>
                         ) : (
@@ -252,7 +252,7 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
                 </>
             )
         ) : (
-            <div className="flex items-center justify-center h-full text-gray-400">
+            <div className="flex items-center justify-center h-full text-subtle">
                 Select an item to view details
             </div>
         )}

--- a/packages/frontend/src/components/RegistryBrowser.tsx
+++ b/packages/frontend/src/components/RegistryBrowser.tsx
@@ -11,6 +11,7 @@ import ExternalLinkConfig from './ExternalLinkConfig';
 import ManualServiceForm from './ManualServiceForm';
 import ReverseProxyConfig from './ReverseProxyConfig';
 import ServiceForm from './ServiceForm';
+import { Button } from '@/components/ui';
 
 type SpecialItem = {
     id: string;
@@ -58,9 +59,10 @@ const specialItems: SpecialItem[] = [
 
 function RegistryListItem({ item, isSelected, onClick }: { item: Template; isSelected: boolean; onClick: () => void }) {
     return (
-        <div
+        <Button
             onClick={onClick}
-            className={`w-full text-left px-4 py-3 rounded-md flex items-center gap-3 transition-colors cursor-pointer ${
+            variant="ghost"
+            className={`w-full h-auto justify-start text-left px-4 py-3 rounded-md flex items-center gap-3 transition-colors ${
                 isSelected
                 ? 'bg-surface ring-1 ring-border text-accent shadow-sm'
                 : 'hover:bg-surface-2 text-foreground'
@@ -76,7 +78,7 @@ function RegistryListItem({ item, isSelected, onClick }: { item: Template; isSel
                 <span className="text-xs text-muted truncate w-full">{item.source}</span>
             </div>
             {item.type === 'stack' && <span className="text-xs bg-surface-2 text-accent px-2 py-0.5 rounded-full ml-auto">Stack</span>}
-        </div>
+        </Button>
     );
 }
 
@@ -159,10 +161,11 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
             <div className="mb-2 pb-2 border-b border-border">
                 <div className="px-4 py-2 text-xs font-semibold text-muted uppercase tracking-wider">Create New</div>
                 {specialItems.map(item => (
-                    <div
+                    <Button
                         key={item.id}
                         onClick={() => handleSpecialClick(item)}
-                        className={`w-full text-left px-4 py-3 rounded-md flex items-center gap-3 transition-colors cursor-pointer ${
+                        variant="ghost"
+                        className={`w-full h-auto justify-start text-left px-4 py-3 rounded-md flex items-center gap-3 transition-colors ${
                             selected && 'id' in selected && selected.id === item.id
                             ? 'bg-surface ring-1 ring-border text-accent shadow-sm'
                             : 'hover:bg-surface-2 text-foreground'
@@ -173,7 +176,7 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
                             <span className="font-medium truncate w-full">{item.name}</span>
                             <span className="text-xs text-muted truncate w-full">{item.description}</span>
                         </div>
-                    </div>
+                    </Button>
                 ))}
             </div>
 
@@ -224,12 +227,12 @@ export default function RegistryBrowser({ templates }: { templates: Template[] }
                                 Source: <span className="font-mono">{selected.source}</span>
                             </span>
                         </div>
-                        <div
+                        <Button
                             onClick={() => setIsModalOpen(true)}
-                            className="flex items-center gap-2 bg-accent text-on-accent px-4 py-2 rounded hover:bg-accent-strong transition-colors shadow-sm font-medium cursor-pointer"
+                            className="flex items-center gap-2 bg-accent text-on-accent px-4 py-2 rounded hover:bg-accent-strong transition-colors shadow-sm font-medium"
                         >
                             <Download size={18} /> Install {selected.type === 'stack' ? 'Stack' : 'Template'}
-                        </div>
+                        </Button>
                     </div>
                     <div className="flex-1 overflow-y-auto p-8">
                         {loading ? (

--- a/packages/frontend/src/components/ServiceForm.tsx
+++ b/packages/frontend/src/components/ServiceForm.tsx
@@ -15,6 +15,7 @@ import { getNodes } from '@/app/actions/system';
 import { PodmanConnection } from '@servicebay/api-client';
 import { useToast } from '@/providers/ToastProvider';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
+import { Button, Input, Select } from '@/components/ui';
 
 interface KubeContainerPort {
     containerPort: number;
@@ -470,7 +471,7 @@ WantedBy=default.target`;
 
                 <div className="mb-4">
                     <label className="block text-sm font-medium text-foreground mb-1">New Service Name</label>
-                    <input
+                    <Input
                         type="text"
                         value={newServiceName}
                         onChange={(e) => setNewServiceName(e.target.value)}
@@ -487,22 +488,22 @@ WantedBy=default.target`;
                 )}
 
                 <div className="flex justify-end gap-3">
-                    <button
+                    <Button
                         type="button"
                         onClick={() => setShowRenameModal(false)}
-                        className="px-4 py-2 text-text-muted hover:bg-surface-2 rounded"
+                        variant="secondary"
                         disabled={isRenaming}
                     >
                         Cancel
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                         type="button"
                         onClick={handleRename}
                         disabled={!newServiceName || isRenaming}
-                        className="px-4 py-2 bg-accent text-on-accent rounded hover:bg-accent-strong disabled:opacity-50 flex items-center gap-2"
+                        variant="primary"
                     >
                         {isRenaming ? 'Renaming...' : 'Rename Service'}
-                    </button>
+                    </Button>
                 </div>
             </div>
         </div>
@@ -517,7 +518,7 @@ WantedBy=default.target`;
             <div>
                 <label className="block text-sm font-bold text-foreground mb-2">Target Node</label>
                 <div className="relative">
-                    <select
+                    <Select
                         value={selectedNode}
                         onChange={(e) => setSelectedNode(e.target.value)}
                         disabled={isEdit}
@@ -527,14 +528,14 @@ WantedBy=default.target`;
                         {nodes.map(n => (
                             <option key={n.Name} value={n.Name}>{n.Name} ({n.URI})</option>
                         ))}
-                    </select>
+                    </Select>
                     <Server className="absolute right-3 top-3.5 text-text-muted pointer-events-none" size={16} />
                 </div>
             </div>
 
             <div>
                 <label className="block text-sm font-bold text-foreground mb-2">Service Name</label>
-                <input
+                <Input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -546,7 +547,7 @@ WantedBy=default.target`;
 
             <div>
                 <label className="block text-sm font-bold text-foreground mb-2">Description</label>
-                <input
+                <Input
                 type="text"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
@@ -558,7 +559,7 @@ WantedBy=default.target`;
             <div>
                 <label className="block text-sm font-bold text-foreground mb-2">YAML Filename</label>
                 <div className="flex gap-2">
-                    <input
+                    <Input
                         type="text"
                         value={yamlFileName}
                         onChange={(e) => setYamlFileName(e.target.value)}
@@ -567,24 +568,25 @@ WantedBy=default.target`;
                         disabled={isEdit}
                     />
                     {isEdit && (
-                        <button
+                        <Button
                             type="button"
                             onClick={() => {
                                 setNewServiceName(name);
                                 setShowRenameModal(true);
                             }}
-                            className="px-3 py-2 bg-surface-2 text-text-muted border border-border rounded hover:bg-surface-muted transition-colors"
+                            variant="secondary"
+                            size="md"
                             title="Rename Service & Files"
                         >
                             <Pencil size={18} />
-                        </button>
+                        </Button>
                     )}
                 </div>
             </div>
 
             <div className="flex items-end pb-3 md:col-span-3">
                 <label className="flex items-center gap-3 cursor-pointer">
-                    <input
+                    <Input
                         type="checkbox"
                         checked={autoUpdate}
                         onChange={(e) => setAutoUpdate(e.target.checked)}
@@ -644,37 +646,41 @@ WantedBy=default.target`;
       {/* Editors Tabs */}
       <div className="bg-surface rounded-lg border border-border shadow-sm overflow-hidden">
         <div className="flex border-b border-border bg-surface-muted">
-            <button
+            <Button
                 type="button"
                 className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'yaml' ? 'bg-surface text-accent border-t-2 border-t-accent' : 'text-text-muted hover:text-text'}`}
                 onClick={() => setActiveTab('yaml')}
+                variant="ghost"
             >
                 <FileCode size={16} /> YAML Definition
-            </button>
-            <button
+            </Button>
+            <Button
                 type="button"
                 className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'kube' ? 'bg-surface text-accent border-t-2 border-t-accent' : 'text-text-muted hover:text-text'}`}
                 onClick={() => setActiveTab('kube')}
+                variant="ghost"
             >
                 <FileJson size={16} /> Generated .kube
-            </button>
+            </Button>
             {isEdit && serviceContent && (
-                <button
+                <Button
                     type="button"
                     className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'service' ? 'bg-surface text-accent border-t-2 border-t-accent' : 'text-text-muted hover:text-text'}`}
                     onClick={() => setActiveTab('service')}
+                    variant="ghost"
                 >
                     <FileText size={16} /> Generated Service Unit
-                </button>
+                </Button>
             )}
             {isEdit && (
-                <button
+                <Button
                     type="button"
                     className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'history' ? 'bg-surface text-accent border-t-2 border-t-accent' : 'text-text-muted hover:text-text'}`}
                     onClick={() => setActiveTab('history')}
+                    variant="ghost"
                 >
                     <Clock size={16} /> History
-                </button>
+                </Button>
             )}
         </div>
 
@@ -694,24 +700,28 @@ WantedBy=default.target`;
                         <div className="flex-1 border border-border rounded-md overflow-hidden bg-surface-muted relative group">
                             <div className="absolute top-2 right-4 z-10 flex items-center gap-2">
                                 {isEdit && (
-                                    <button
+                                    <Button
                                         onClick={handleRerender}
                                         type="button"
                                         disabled={rerendering}
-                                        className="p-1.5 bg-surface-2/50 hover:bg-surface-2 text-text-muted hover:text-text rounded backdrop-blur-sm transition-colors disabled:opacity-50"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="p-1.5"
                                         title="Re-render this YAML from its template using the current Settings → Template Variables values"
                                     >
                                         <RefreshCw size={14} className={rerendering ? 'animate-spin' : ''} />
-                                    </button>
+                                    </Button>
                                 )}
-                                <button
+                                <Button
                                     onClick={handleCopyYaml}
                                     type="button"
-                                    className="p-1.5 bg-surface-2/50 hover:bg-surface-2 text-text-muted hover:text-text rounded backdrop-blur-sm transition-colors"
+                                    variant="ghost"
+                                    size="sm"
+                                    className="p-1.5"
                                     title="Copy All"
                                 >
                                     <Clipboard size={14} />
-                                </button>
+                                </Button>
                                 <div className="text-xs text-text-muted font-mono bg-surface-muted/30 px-2 py-1 rounded pointer-events-none">
                                     Line: {cursorLine}
                                 </div>
@@ -811,22 +821,22 @@ WantedBy=default.target`;
       <div className="flex flex-col gap-4">
         <div className="flex justify-end gap-3">
             {variant !== 'embedded' && (
-                <button
+                <Button
                     type="button"
                     onClick={() => router.back()}
-                    className="px-6 py-3 border border-border rounded-md text-text-muted font-medium hover:bg-surface-2 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent"
+                    variant="secondary"
                 >
                     Cancel
-                </button>
+                </Button>
             )}
-            <button
+            <Button
                 type="submit"
                 disabled={!!yamlError || !name || !selectedNode || isSaving}
-                className="px-6 py-3 bg-accent text-on-accent rounded-md font-medium hover:bg-accent-strong shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                variant="primary"
             >
             {isSaving && <Loader2 size={16} className="animate-spin" />}
             {isSaving ? 'Saving…' : 'Save Service'}
-            </button>
+            </Button>
         </div>
 
         {yamlError && (
@@ -836,14 +846,16 @@ WantedBy=default.target`;
                     <div className="text-sm">{yamlError.message}</div>
                     {yamlError.raw && yamlError.raw !== yamlError.message && (
                         <div className="mt-1">
-                            <button
+                            <Button
                                 type="button"
                                 onClick={() => setShowParserDetails(!showParserDetails)}
+                                variant="ghost"
+                                size="sm"
                                 className="flex items-center gap-1 text-[11px] uppercase tracking-wider font-bold cursor-pointer text-status-fail hover:text-status-fail select-none transition-colors"
                             >
                                 {showParserDetails ? <ChevronDown size={12} className="shrink-0" /> : <ChevronRight size={12} className="shrink-0" />}
                                 <span>Parser details</span>
-                            </button>
+                            </Button>
                             <div
                                 ref={parserDetailsRef}
                                 className="overflow-hidden"

--- a/packages/frontend/src/components/ServiceMonitor.tsx
+++ b/packages/frontend/src/components/ServiceMonitor.tsx
@@ -195,23 +195,23 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
   return (
         <div className="h-full flex flex-col relative">
             {variant === 'page' && (
-                <div className="flex justify-between items-center mb-6 p-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+                <div className="flex justify-between items-center mb-6 p-4 border-b border-border bg-surface dark:bg-surface/50">
                     <div className="flex items-center gap-4">
-                            <button onClick={handleBack} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors">
-                                    <ArrowLeft size={24} className="text-gray-600 dark:text-gray-300" />
+                            <button onClick={handleBack} className="p-2 hover:bg-surface-2 dark:hover:bg-surface-2 rounded-full transition-colors">
+                                    <ArrowLeft size={24} className="text-muted dark:text-muted" />
                             </button>
-                            <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Monitor: {serviceName}</h1>
+                            <h1 className="text-xl font-bold text-foreground dark:text-foreground">Monitor: {serviceName}</h1>
                     </div>
                     <div className="flex items-center gap-3">
                             {backupMsg && (
-                                <span className={`text-sm ${backupMsg.ok ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                                <span className={`text-sm ${backupMsg.ok ? 'text-status-ok dark:text-status-ok' : 'text-status-fail dark:text-status-fail'}`}>
                                     {backupMsg.text}
                                 </span>
                             )}
                             <button
                                     onClick={handleBackupConfig}
                                     disabled={backingUp}
-                                    className="px-3 py-2 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded hover:bg-gray-50 dark:hover:bg-gray-700 shadow-sm transition-colors disabled:opacity-50"
+                                    className="px-3 py-2 flex items-center gap-2 text-sm text-muted dark:text-muted bg-surface dark:bg-surface-2 border border-border dark:border-border rounded hover:bg-surface-2 dark:hover:bg-surface-2 shadow-sm transition-colors disabled:opacity-50"
                                     title="Back up this service's config to the FritzBox NAS"
                             >
                                     <DatabaseBackup size={18} className={backingUp ? 'animate-pulse' : ''} /> Back up config
@@ -219,7 +219,7 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
                             <button
                                     onClick={fetchLogs}
                                     disabled={loading}
-                                    className="p-2 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded hover:bg-gray-50 dark:hover:bg-gray-700 shadow-sm transition-colors"
+                                    className="p-2 text-muted dark:text-muted bg-surface dark:bg-surface-2 border border-border dark:border-border rounded hover:bg-surface-2 dark:hover:bg-surface-2 shadow-sm transition-colors"
                                     title="Refresh"
                             >
                                     <RefreshCw size={20} className={loading ? 'animate-spin' : ''} />
@@ -229,44 +229,44 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
             )}
 
             <div className={`flex-1 flex flex-col min-h-0 ${variant === 'embedded' ? 'p-0' : 'p-6'}`}>
-      <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden flex flex-col flex-1 min-h-0">
-        <div className="flex border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50 shrink-0">
+      <div className="bg-surface dark:bg-surface rounded-lg border border-border dark:border-border shadow-sm overflow-hidden flex flex-col flex-1 min-h-0">
+        <div className="flex border-b border-border dark:border-border bg-surface dark:bg-surface/50 shrink-0">
             <button
-            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'status' ? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-t-2 border-t-blue-600 dark:border-t-blue-400' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'}`}
+            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'status' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('status')}
             >
             <Activity size={16} /> Status
             </button>
             <button
-            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'service' ? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-t-2 border-t-blue-600 dark:border-t-blue-400' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'}`}
+            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'service' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('service')}
             >
             <Terminal size={16} /> Service Logs
             </button>
             <button
-            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'container-logs' ? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-t-2 border-t-blue-600 dark:border-t-blue-400' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'}`}
+            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'container-logs' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('container-logs')}
             >
             <Box size={16} /> Container Logs & Info
             </button>
             <button
-            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'network' ? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-t-2 border-t-blue-600 dark:border-t-blue-400' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'}`}
+            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'network' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('network')}
             >
             <FileJson size={16} /> Raw Data / Config
             </button>
         </div>
 
-        <div className="bg-[#2d2d2d] dark:bg-black p-4 flex-1 overflow-y-auto">
+        <div className="bg-surface-muted dark:bg-surface-muted p-4 flex-1 overflow-y-auto">
             {activeTab === 'status' && (
-            <pre className="text-sm font-mono text-green-400 whitespace-pre-wrap">
+            <pre className="text-sm font-mono text-status-ok whitespace-pre-wrap">
                 {status || 'Loading status...'}
             </pre>
             )}
             {activeTab === 'service' && (
-            <pre className="text-sm font-mono text-gray-300 whitespace-pre-wrap">
+            <pre className="text-sm font-mono text-muted whitespace-pre-wrap">
                 {logs?.serviceLogs || (
-                    <div className="text-gray-400 italic">
+                    <div className="text-subtle italic">
                         <p>No service logs available.</p>
                         <p className="text-xs mt-2">Checking journalctl for unit: {serviceName.match(/\.(service|scope|socket|timer)$/) ? serviceName : `${serviceName}.service`}</p>
                     </div>
@@ -278,14 +278,14 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
                     {networkData ? (
                         <>
                             {/* Raw Data Only */}
-                            <pre className="text-xs font-mono text-gray-400 whitespace-pre-wrap break-all bg-black">
+                            <pre className="text-xs font-mono text-subtle whitespace-pre-wrap break-all bg-surface">
                                 {JSON.stringify(networkData.rawData, null, 2)}
                             </pre>
                         </>
                     ) : (
-                        <div className="text-gray-400 italic">
+                        <div className="text-subtle italic">
                             <p className="mb-2">No network data found for this service.</p>
-                            <div className="text-xs text-gray-500 border border-gray-700 p-2 rounded bg-black/50">
+                            <div className="text-xs text-muted border border-border p-2 rounded bg-surface-2">
                                 <p>Troubleshooting:</p>
                                 <ul className="list-disc ml-4 space-y-1 mt-1">
                                     <li>If the service is inactive, it will not appear in the network graph.</li>
@@ -302,15 +302,15 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
                     {logs?.podmanPs && logs.podmanPs.length > 0 ? (
                         <>
                             <div className="mb-4">
-                                <h4 className="text-gray-400 text-sm font-bold mb-2">Related Containers</h4>
+                                <h4 className="text-subtle text-sm font-bold mb-2">Related Containers</h4>
                                 <ContainerList containers={logs.podmanPs} />
                             </div>
-                            
+
                             <div>
                                 <div className="flex items-center justify-between mb-2">
-                                    <h4 className="text-gray-400 text-sm font-bold">Container Logs</h4>
-                                    <select 
-                                        className="bg-gray-700 text-white text-sm rounded border border-gray-600 p-1"
+                                    <h4 className="text-subtle text-sm font-bold">Container Logs</h4>
+                                    <select
+                                        className="bg-surface-2 text-foreground text-sm rounded border border-border p-1"
                                         value={selectedContainerId || ''}
                                         onChange={(e) => setSelectedContainerId(e.target.value)}
                                     >
@@ -321,15 +321,15 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
                                         ))}
                                     </select>
                                 </div>
-                                <pre className="text-sm font-mono text-gray-300 whitespace-pre-wrap bg-black p-4 rounded border border-gray-700 min-h-[300px]">
+                                <pre className="text-sm font-mono text-muted whitespace-pre-wrap bg-surface p-4 rounded border border-border min-h-[300px]">
                                     {containerLogs || 'Select a container to view logs.'}
                                 </pre>
                             </div>
                         </>
                     ) : (
-                        <div className="text-gray-400 italic">
+                        <div className="text-subtle italic">
                              <p className="mb-2">No running containers found matching this service.</p>
-                             <div className="text-xs text-gray-500 border border-gray-700 p-2 rounded bg-black/50">
+                             <div className="text-xs text-muted border border-border p-2 rounded bg-surface-2">
                                 <p>Possible reasons:</p>
                                 <ul className="list-disc ml-4 space-y-1 mt-1">
                                     <li>The service has not started any containers yet.</li>

--- a/packages/frontend/src/components/wizard/steps/MachineStep.tsx
+++ b/packages/frontend/src/components/wizard/steps/MachineStep.tsx
@@ -60,12 +60,12 @@ export function MachineStep({
     return (
         <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
             <div className="flex items-center gap-3">
-                <div className="p-2.5 rounded-xl bg-indigo-500/10 border border-indigo-500/20">
-                    <HardDrive className="w-5 h-5 text-indigo-500"/>
+                <div className="p-2.5 rounded-xl bg-accent/10 border border-accent/20">
+                    <HardDrive className="w-5 h-5 text-accent"/>
                 </div>
                 <div className="flex-1">
                     <h3 className="font-bold text-lg leading-none">Machine & Review</h3>
-                    <p className="text-xs text-gray-500 mt-1">Finalize host configuration and storage</p>
+                    <p className="text-xs text-text-muted mt-1">Finalize host configuration and storage</p>
                 </div>
                 <Button
                     variant="outline"
@@ -76,16 +76,16 @@ export function MachineStep({
                 </Button>
             </div>
 
-            <p className="text-sm text-gray-500 leading-relaxed">
+            <p className="text-sm text-text-muted leading-relaxed">
                 We&apos;ll install the recommended stack with sensible defaults. Adjust the questions below, or click <em>Pick stacks</em> to choose individual services.
             </p>
 
             {!publicDomain.trim() && installMode === 'public' && (
-                <div className="flex items-start gap-4 p-4 rounded-2xl border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 shadow-sm">
-                    <AlertTriangle className="w-6 h-6 text-amber-500 shrink-0" />
+                <div className="flex items-start gap-4 p-4 rounded-2xl border border-status-warn dark:border-status-warn/30 bg-surface-2 dark:bg-status-warn/10 shadow-sm">
+                    <AlertTriangle className="w-6 h-6 text-status-warn shrink-0" />
                     <div className="flex-1 space-y-2">
-                        <div className="text-sm font-bold text-amber-900 dark:text-amber-200">Public domain not set</div>
-                        <p className="text-xs text-amber-800 dark:text-amber-300/80 leading-relaxed">
+                        <div className="text-sm font-bold text-status-warn dark:text-status-warn">Public domain not set</div>
+                        <p className="text-xs text-status-warn dark:text-status-warn leading-relaxed">
                             A public domain is required for Let&apos;s Encrypt and external access.
                         </p>
                         <Button variant="outline" onClick={() => navigateTo('network')} className="!py-1.5 !px-3 !text-xs">
@@ -98,7 +98,7 @@ export function MachineStep({
             <div className="space-y-4">
                 {/* Reachability Card */}
                 <div className="p-5 rounded-2xl soft-depth space-y-4">
-                    <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-blue-500/80">
+                    <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-status-info">
                         <Globe className="w-4 h-4" /> Reachability
                     </div>
                     
@@ -108,8 +108,8 @@ export function MachineStep({
                             htmlFor="mode-public-input"
                             className={`flex flex-col gap-2 p-4 rounded-xl border cursor-pointer transition-all ${
                                 installMode === 'public'
-                                ? 'bg-white dark:bg-blue-600/10 border-blue-400 shadow-sm ring-1 ring-blue-400'
-                                : 'bg-gray-50 dark:bg-white/5 border-gray-200 dark:border-white/5 opacity-60'
+                                ? 'bg-surface dark:bg-accent/10 border-accent shadow-sm ring-1 ring-accent'
+                                : 'bg-surface-2 dark:bg-surface border-border dark:border-border opacity-60'
                             }`}
                         >
                             <input
@@ -124,9 +124,9 @@ export function MachineStep({
                             />
                             <div className="flex items-center justify-between">
                                 <div className="text-sm font-bold">Public Domain</div>
-                                {installMode === 'public' && <CheckCircle className="w-4 h-4 text-blue-500" />}
+                                {installMode === 'public' && <CheckCircle className="w-4 h-4 text-accent" />}
                             </div>
-                            <p className="text-[10px] text-gray-500">HTTPS + Let&apos;s Encrypt</p>
+                            <p className="text-[10px] text-text-muted">HTTPS + Let&apos;s Encrypt</p>
                         </label>
 
                         <label
@@ -134,8 +134,8 @@ export function MachineStep({
                             htmlFor="mode-lan-input"
                             className={`flex flex-col gap-2 p-4 rounded-xl border cursor-pointer transition-all ${
                                 installMode === 'lan'
-                                ? 'bg-white dark:bg-amber-600/10 border-amber-400 shadow-sm ring-1 ring-amber-400'
-                                : 'bg-gray-50 dark:bg-white/5 border-gray-200 dark:border-white/5 opacity-60'
+                                ? 'bg-surface dark:bg-status-warn/10 border-status-warn shadow-sm ring-1 ring-status-warn'
+                                : 'bg-surface-2 dark:bg-surface border-border dark:border-border opacity-60'
                             }`}
                         >
                             <input
@@ -150,9 +150,9 @@ export function MachineStep({
                             />
                             <div className="flex items-center justify-between">
                                 <div className="text-sm font-bold">Internal Only</div>
-                                {installMode === 'lan' && <CheckCircle className="w-4 h-4 text-amber-500" />}
+                                {installMode === 'lan' && <CheckCircle className="w-4 h-4 text-status-warn" />}
                             </div>
-                            <p className="text-[10px] text-gray-500">LAN-only via AdGuard</p>
+                            <p className="text-[10px] text-text-muted">LAN-only via AdGuard</p>
                         </label>
                     </div>
 
@@ -180,29 +180,29 @@ export function MachineStep({
                 {/* Storage & Stacks Summary */}
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     <div className="p-4 rounded-2xl soft-depth space-y-3">
-                        <div className="flex items-center gap-2 text-xs font-bold text-gray-400 uppercase tracking-widest">
-                            <HardDrive className="w-4 h-4 text-indigo-500" /> Storage
+                        <div className="flex items-center gap-2 text-xs font-bold text-text-muted uppercase tracking-widest">
+                            <HardDrive className="w-4 h-4 text-accent" /> Storage
                         </div>
                         <div className="text-sm font-medium">
                             {detectedRaid ? (
                                 <span className="flex items-center gap-1.5">
-                                    RAID Array <code className="bg-blue-500/10 text-blue-500 px-1.5 py-0.5 rounded text-[10px]">{detectedRaid.device}</code>
+                                    RAID Array <code className="bg-accent/10 text-accent px-1.5 py-0.5 rounded text-[10px]">{detectedRaid.device}</code>
                                 </span>
                             ) : 'Local Storage'}
                         </div>
-                        <p className="text-[10px] text-gray-500">
-                            Mounting to <code className="bg-gray-100 dark:bg-white/10 px-1 rounded">/var/mnt/data</code>
+                        <p className="text-[10px] text-text-muted">
+                            Mounting to <code className="bg-surface-2 dark:bg-surface px-1 rounded">/var/mnt/data</code>
                         </p>
                     </div>
 
                     <div className="p-4 rounded-2xl soft-depth space-y-3">
-                        <div className="flex items-center gap-2 text-xs font-bold text-gray-400 uppercase tracking-widest">
-                            <Layers className="w-4 h-4 text-indigo-500" /> Services
+                        <div className="flex items-center gap-2 text-xs font-bold text-text-muted uppercase tracking-widest">
+                            <Layers className="w-4 h-4 text-accent" /> Services
                         </div>
                         <div className="text-sm font-medium">
                             {availableStacks.length} Recommended Stacks
                         </div>
-                        <p className="text-[10px] text-gray-500 truncate">
+                        <p className="text-[10px] text-text-muted truncate">
                             {availableStacks.map(s => s.name).join(', ')}
                         </p>
                     </div>
@@ -211,26 +211,26 @@ export function MachineStep({
                 {/* Detected Drives Panel */}
                 <div className="p-5 rounded-2xl soft-depth space-y-4">
                     <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2 text-xs font-bold text-gray-400 uppercase tracking-widest">
-                            <Monitor className="w-4 h-4 text-indigo-500" /> Detected Drives
+                        <div className="flex items-center gap-2 text-xs font-bold text-text-muted uppercase tracking-widest">
+                            <Monitor className="w-4 h-4 text-accent" /> Detected Drives
                         </div>
-                        {stackLoadingDevices && <Loader2 className="w-3 h-3 animate-spin text-gray-400" />}
+                        {stackLoadingDevices && <Loader2 className="w-3 h-3 animate-spin text-text-muted" />}
                     </div>
                     
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
                         {detectedDrives.length === 0 ? (
-                            <div className="col-span-full py-4 text-center text-xs text-gray-500 italic">
+                            <div className="col-span-full py-4 text-center text-xs text-text-muted italic">
                                 {stackLoadingDevices ? 'Scanning hardware...' : 'No additional drives detected.'}
                             </div>
                         ) : (
                             detectedDrives.map(drive => (
-                                <div key={drive.name} className="p-3 rounded-xl bg-white dark:bg-white/5 border border-gray-100 dark:border-white/5 flex items-center gap-3">
-                                    <div className="p-2 rounded-lg bg-gray-50 dark:bg-white/5 text-gray-400">
+                                <div key={drive.name} className="p-3 rounded-xl bg-surface dark:bg-surface border border-border dark:border-border flex items-center gap-3">
+                                    <div className="p-2 rounded-lg bg-surface-2 dark:bg-surface text-text-muted">
                                         <HardDrive className="w-4 h-4" />
                                     </div>
                                     <div className="min-w-0">
                                         <div className="text-xs font-bold truncate">{drive.name}</div>
-                                        <div className="text-[10px] text-gray-500">{drive.size} · {drive.model || 'Unknown Disk'}</div>
+                                        <div className="text-[10px] text-text-muted">{drive.size} · {drive.model || 'Unknown Disk'}</div>
                                     </div>
                                 </div>
                             ))

--- a/packages/frontend/src/dashboards/HealthDashboard.tsx
+++ b/packages/frontend/src/dashboards/HealthDashboard.tsx
@@ -17,7 +17,7 @@ import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { SystemInfoContent } from '@/dashboards/SystemInfoDashboard';
 import DiagnoseProbeList, { type DiagnoseProbe } from '@/components/DiagnoseProbeList';
 import ContainersDashboard from '@/dashboards/ContainersDashboard';
-import { Button, Badge } from '@/components/ui';
+import { Button, Badge, Input, Select, Textarea, Table } from '@/components/ui';
 
 interface Container {
   Id: string;
@@ -392,7 +392,7 @@ export default function HealthDashboard() {
         {activeTab !== 'system' && (
         <div className="relative flex-1 max-w-md min-w-[100px]">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-subtle" />
-            <input
+            <Input
                 type="text"
                 placeholder="Search..."
                 value={searchQuery}
@@ -412,9 +412,10 @@ export default function HealthDashboard() {
           { id: 'logs' as const, label: 'Logs' },
           { id: 'system' as const, label: 'System' },
         ]).map(tab => (
-          <button
+          <Button
             key={tab.id}
             onClick={() => handleTabChange(tab.id)}
+            variant="ghost"
             className={`px-4 py-2 font-medium text-sm border-b-2 transition-colors whitespace-nowrap ${
               activeTab === tab.id
                 ? 'border-accent text-accent'
@@ -422,7 +423,7 @@ export default function HealthDashboard() {
             }`}
           >
             {tab.label}
-          </button>
+          </Button>
         ))}
       </div>
 
@@ -477,9 +478,10 @@ export default function HealthDashboard() {
               <div className="flex items-center gap-2">
                 <div className="flex bg-surface-2 rounded-card p-1">
                     {(['1h', '24h', '3d', '2w'] as const).map(range => (
-                        <button
+                        <Button
                             key={range}
                             onClick={() => setTimeRange(range)}
+                            variant="ghost"
                             className={`px-3 py-1 text-xs font-semibold rounded-chip transition-colors ${
                                 timeRange === range
                                     ? 'bg-surface text-accent shadow-sm'
@@ -487,7 +489,7 @@ export default function HealthDashboard() {
                             }`}
                         >
                             {range}
-                        </button>
+                        </Button>
                     ))}
                 </div>
                 <Button
@@ -638,7 +640,7 @@ export default function HealthDashboard() {
                 </div>
 
                 {/* Table */}
-                            <table className="w-full text-left text-sm border border-border rounded-card overflow-hidden">
+                            <Table className="w-full text-left text-sm border border-border rounded-card overflow-hidden">
                               <thead className="bg-surface-2 text-text-muted">
                         <tr>
                                   <th className="p-3 font-semibold">Time</th>
@@ -680,7 +682,7 @@ export default function HealthDashboard() {
                             </tr>
                         ))}
                     </tbody>
-                </table>
+                </Table>
                             </div>
                             )}
             </div>
@@ -739,8 +741,8 @@ export default function HealthDashboard() {
             <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
               <div>
                 <label className="block text-sm font-medium text-text-muted mb-1">Name</label>
-                <input 
-                  type="text" 
+                <Input
+                  type="text"
                   value={formData.name}
                   onChange={e => setFormData({...formData, name: e.target.value})}
                   disabled={isSystemCheck()}
@@ -750,7 +752,7 @@ export default function HealthDashboard() {
               </div>
               <div>
                 <label className="block text-sm font-medium text-text-muted mb-1">Type</label>
-                <select 
+                <Select
                   value={formData.type}
                   onChange={e => setFormData({...formData, type: e.target.value as CheckType})}
                   disabled={isSystemCheck()}
@@ -764,7 +766,7 @@ export default function HealthDashboard() {
                   <option value="agent">Agent Health</option>
                   <option value="script">Custom Script (JS)</option>
                   <option value="fritzbox">Fritz!Box Internet</option>
-                </select>
+                </Select>
                 
                 {/* Type Hint */}
                 <div className="mt-2 text-xs text-text-muted bg-surface-2 p-2 rounded-card border border-border">
@@ -796,7 +798,7 @@ export default function HealthDashboard() {
               </div>
               <div>
                 <label className="block text-sm font-medium text-text-muted mb-1">Target Node</label>
-                <select 
+                <Select
                   value={formData.nodeName || ''}
                   onChange={e => setFormData({...formData, nodeName: e.target.value})}
                   disabled={isSystemCheck()}
@@ -806,7 +808,7 @@ export default function HealthDashboard() {
                   {nodes.map(node => (
                     <option key={node.Name} value={node.Name}>{node.Name}</option>
                   ))}
-                </select>
+                </Select>
                 <p className="text-xs text-text-subtle mt-1">Select the node where this check should run.</p>
               </div>
               <div>
@@ -814,7 +816,7 @@ export default function HealthDashboard() {
                     {formData.type === 'script' ? 'Script Content' : formData.type === 'fritzbox' ? 'Fritz!Box Hostname / IP' : 'Target'}
                 </label>
                 {formData.type === 'script' ? (
-                    <textarea
+                    <Textarea
                         value={formData.target}
                         onChange={e => setFormData({...formData, target: e.target.value})}
                         disabled={isSystemCheck()}
@@ -823,7 +825,7 @@ export default function HealthDashboard() {
                     />
                 ) : formData.type === 'podman' ? (
                     <div className="relative">
-                        <select
+                        <Select
                             value={formData.target}
                             onChange={e => setFormData({...formData, target: e.target.value})}
                             disabled={resourcesLoading || isSystemCheck()}
@@ -835,7 +837,7 @@ export default function HealthDashboard() {
                                     {c.Names[0]} ({c.Image})
                                 </option>
                             ))}
-                        </select>
+                        </Select>
                         {resourcesLoading && (
                             <div className="absolute right-8 top-2.5">
                                 <div className="animate-spin h-5 w-5 border-2 border-accent rounded-full border-t-transparent"></div>
@@ -861,14 +863,14 @@ export default function HealthDashboard() {
                         disabled={resourcesLoading || isSystemCheck()}
                     />
                 ) : (
-                    <input 
-                      type="text" 
+                    <Input
+                      type="text"
                       value={formData.target}
                       onChange={e => setFormData({...formData, target: e.target.value})}
                       disabled={isSystemCheck()}
                       className={`w-full p-2 rounded-lg border border-border bg-surface-2 text-text focus:ring-2 focus:ring-accent outline-none ${isSystemCheck() ? 'opacity-60 cursor-not-allowed' : ''}`}
                       placeholder={
-                        formData.type === 'http' ? 'https://example.com' : 
+                        formData.type === 'http' ? 'https://example.com' :
                         formData.type === 'fritzbox' ? 'fritz.box' :
                         '192.168.1.1'
                       }
@@ -888,11 +890,11 @@ export default function HealthDashboard() {
                     <h4 className="text-sm font-medium text-text">HTTP Options</h4>
                     <div>
                         <label className="block text-xs font-medium text-text-muted mb-1">Expected Status Code</label>
-                        <input 
-                            type="number" 
+                        <Input
+                            type="number"
                             value={formData.httpConfig?.expectedStatus || 200}
                             onChange={e => setFormData({
-                                ...formData, 
+                                ...formData,
                                 httpConfig: { ...formData.httpConfig, expectedStatus: parseInt(e.target.value) }
                             })}
                             disabled={isSystemCheck()}
@@ -902,10 +904,10 @@ export default function HealthDashboard() {
                     <div>
                         <label className="block text-xs font-medium text-text-muted mb-1">Body Match (Optional)</label>
                         <div className="flex gap-2 mb-2">
-                            <select
+                            <Select
                                 value={formData.httpConfig?.bodyMatchType || 'contains'}
                                 onChange={e => setFormData({
-                                    ...formData, 
+                                    ...formData,
                                     httpConfig: { ...formData.httpConfig, bodyMatchType: e.target.value as 'contains' | 'regex' }
                                 })}
                                 disabled={isSystemCheck()}
@@ -913,12 +915,12 @@ export default function HealthDashboard() {
                             >
                                 <option value="contains">Contains</option>
                                 <option value="regex">Regex</option>
-                            </select>
-                            <input 
-                                type="text" 
+                            </Select>
+                            <Input
+                                type="text"
                                 value={formData.httpConfig?.bodyMatch || ''}
                                 onChange={e => setFormData({
-                                    ...formData, 
+                                    ...formData,
                                     httpConfig: { ...formData.httpConfig, bodyMatch: e.target.value }
                                 })}
                                 disabled={isSystemCheck()}
@@ -932,8 +934,8 @@ export default function HealthDashboard() {
 
               <div>
                 <label className="block text-sm font-medium text-text-muted mb-1">Interval (seconds)</label>
-                <input 
-                  type="number" 
+                <Input
+                  type="number"
                   value={formData.interval}
                   onChange={e => setFormData({...formData, interval: parseInt(e.target.value)})}
                   disabled={isSystemCheck()}


### PR DESCRIPTION
Batch of 8 lint-ratchet burn-down units (#2430 follow-up).

Color-literal sweeps (`sb/no-raw-color-literal`, baseline 961 → 678): OnboardingWizard, MachineStep, ServiceMonitor, RegistryBrowser, InstallerModal.

UI-primitive sweeps (`sb/no-raw-ui-primitive`, baseline 352 → 305): ServiceForm, HealthDashboard, HealthChecks — raw `<button>`/`<input>` elements replaced with the design-system's wrapped primitives.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
