### PR TITLE
fix: silent-failure toasts, quality-gate blind spots, lint-ratchet continuation

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 592,
+    "sb/no-raw-color-literal": 566,
     "sb/no-raw-ui-primitive": 294
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-29",
   "rules": {
-    "sb/no-raw-color-literal": 670,
+    "sb/no-raw-color-literal": 592,
     "sb/no-raw-ui-primitive": 294
   }
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.test.tsx
@@ -129,5 +129,73 @@ describe('ApiTokensSection (#2100 settings migration)', () => {
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith('/api/system/api-tokens?id=t1', { method: 'DELETE' }),
     );
+    // A successful revoke closes the dialog.
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
+  // #2461: `setRevokeTarget(null)` used to run in `finally`, so a failed DELETE
+  // closed the modal with no error — the operator believed a still-live token
+  // had been locked out.
+  it('keeps the confirm modal open and shows an error when the revoke call fails', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/system/mcp-bootstrap') {
+        return Promise.resolve(new Response(JSON.stringify({ active: false }), { status: 200 }));
+      }
+      if (url.startsWith('/api/system/api-tokens')) {
+        if (init?.method === 'DELETE') {
+          return Promise.resolve(new Response(JSON.stringify({ error: 'token store is read-only' }), { status: 500 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ tokens: [TOKEN] }), { status: 200 }));
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ApiTokensSection />);
+    await waitFor(() => expect(screen.getByText('workstation')).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /revoke workstation/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    const input = dialog.querySelector('input[type="text"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'workstation' } });
+    fireEvent.click(screen.getByRole('button', { name: /revoke token/i }));
+
+    // The server's reason is surfaced, in the dialog, which stays open.
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/token store is read-only/);
+    expect(alert.textContent).toMatch(/still active/i);
+    expect(screen.getByRole('dialog')).toBeDefined();
+    // The token is still listed — nothing was optimistically removed.
+    expect(screen.getByRole('button', { name: /revoke workstation/i })).toBeDefined();
+    // Not stuck mid-flight either: the retry path is live again.
+    await waitFor(() => expect(screen.getByRole('button', { name: /^revoke token$/i })).toBeDefined());
+  });
+
+  it('surfaces a network failure on revoke without closing the modal', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/api/system/mcp-bootstrap') {
+        return Promise.resolve(new Response(JSON.stringify({ active: false }), { status: 200 }));
+      }
+      if (url.startsWith('/api/system/api-tokens')) {
+        if (init?.method === 'DELETE') return Promise.reject(new Error('network down'));
+        return Promise.resolve(new Response(JSON.stringify({ tokens: [TOKEN] }), { status: 200 }));
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ApiTokensSection />);
+    await waitFor(() => expect(screen.getByText('workstation')).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /revoke workstation/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    fireEvent.change(dialog.querySelector('input[type="text"]') as HTMLInputElement, {
+      target: { value: 'workstation' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /revoke token/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/network down/);
+    expect(screen.getByRole('dialog')).toBeDefined();
   });
 });

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
@@ -250,6 +250,7 @@ export default function ApiTokensSection() {
   // factory-reset — never a bare browser confirm() (#2164).
   const [revokeTarget, setRevokeTarget] = useState<{ id: string; name: string } | null>(null);
   const [revoking, setRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState<string | null>(null);
 
   // The hash is set by the install script; this UI just reflects status +
   // offers a manual revoke. Auto-revoked when the operator mints their first
@@ -327,16 +328,28 @@ export default function ApiTokensSection() {
   };
 
   const revokeOneToken = (id: string, name: string) => {
+    setRevokeError(null);
     setRevokeTarget({ id, name });
   };
 
   const confirmRevoke = async () => {
     if (!revokeTarget || revoking) return;
     setRevoking(true);
+    setRevokeError(null);
     try {
       const res = await fetch(`/api/system/api-tokens?id=${revokeTarget.id}`, { method: 'DELETE' });
-      if (res.ok) loadTokens();
+      // Close the dialog only when the token is actually gone. Closing
+      // unconditionally made a failed revoke look like a success, so the
+      // operator believed a live token was locked out (#2461).
+      if (!res.ok) {
+        const detail = await res.json().then(d => d?.error).catch(() => null);
+        setRevokeError(detail || `Revoke failed — HTTP ${res.status}`);
+        return;
+      }
+      loadTokens();
       setRevokeTarget(null);
+    } catch (e) {
+      setRevokeError(e instanceof Error ? e.message : String(e));
     } finally {
       setRevoking(false);
     }
@@ -418,10 +431,20 @@ export default function ApiTokensSection() {
         resourceName={revokeTarget?.name ?? ''}
         isLoading={revoking}
         confirmText={revoking ? 'Revoking…' : 'Revoke token'}
-        message="Any client using this token — an MCP assistant, the ServiceBay TUI, or a script — is locked out immediately. This cannot be undone."
+        message={
+          <>
+            Any client using this token — an MCP assistant, the ServiceBay TUI, or a script — is locked out immediately. This cannot be undone.
+            {revokeError && (
+              <span role="alert" className="mt-2 block text-status-fail">
+                {revokeError} — the token is still active.
+              </span>
+            )}
+          </>
+        }
         onConfirm={confirmRevoke}
         onCancel={() => {
           if (revoking) return;
+          setRevokeError(null);
           setRevokeTarget(null);
         }}
       />

--- a/packages/frontend/src/app/(dashboard)/setup/page.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/setup/page.test.tsx
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 import SetupPage from './page';
+import { completeStackSetup } from '@/app/actions/onboarding';
 
-vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
+const { push, refresh } = vi.hoisted(() => ({ push: vi.fn(), refresh: vi.fn() }));
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push, refresh }) }));
 vi.mock('@/app/actions/onboarding', () => ({ completeStackSetup: vi.fn(async () => undefined) }));
 vi.mock('@/components/DoneStepDnsCheck', () => ({ DoneStepDnsCheck: () => <div>dns</div> }));
 vi.mock('@/components/DiagnoseProbeList', () => ({ default: () => <div>probes</div> }));
@@ -26,6 +29,9 @@ function jobResponse(over: Record<string, unknown> = {}) {
 
 describe('SetupPage — design-system tokens (#2100)', () => {
   beforeEach(() => {
+    push.mockClear();
+    refresh.mockClear();
+    vi.mocked(completeStackSetup).mockReset().mockResolvedValue(undefined);
     vi.stubGlobal('fetch', vi.fn(async (u: RequestInfo | URL) => {
       if (String(u).includes('/api/install/status')) {
         return new Response(JSON.stringify(jobResponse()), { headers: { 'Content-Type': 'application/json' } });
@@ -52,5 +58,54 @@ describe('SetupPage — design-system tokens (#2100)', () => {
     await waitFor(() => expect(screen.getByText('Service status')).toBeTruthy());
     expect(screen.getByText('Install log')).toBeTruthy();
     expect(screen.getByText('1/1 deployed')).toBeTruthy();
+  });
+});
+
+/**
+ * #2460 — a throwing completeStackSetup() used to stop the Finish spinner via
+ * `finally` and do nothing else: no error, no navigation, no way for the
+ * operator to tell whether setup completed.
+ */
+describe('SetupPage — Finish failure is visible (#2460)', () => {
+  beforeEach(() => {
+    push.mockClear();
+    refresh.mockClear();
+    vi.mocked(completeStackSetup).mockReset().mockResolvedValue(undefined);
+    vi.stubGlobal('fetch', vi.fn(async (u: RequestInfo | URL) => {
+      if (String(u).includes('/api/install/status')) {
+        return new Response(JSON.stringify(jobResponse()), { headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ probes: [] }), { headers: { 'Content-Type': 'application/json' } });
+    }));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('shows an error alert and does not navigate when completeStackSetup throws', async () => {
+    vi.mocked(completeStackSetup).mockRejectedValue(new Error('config write failed'));
+    render(<SetupPage />);
+    const finish = await waitFor(() => screen.getByRole('button', { name: /Finish/i }));
+    fireEvent.click(finish);
+
+    const alert = await waitFor(() => screen.getByRole('alert'));
+    expect(alert.textContent).toMatch(/Couldn't finish setup/i);
+    expect(alert.textContent).toMatch(/config write failed/);
+    expect(alert.textContent).toMatch(/still pending/i);
+    // The spinner stopped, but not silently: no navigation happened and the
+    // button is clickable again for a retry.
+    expect(push).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    expect((finish as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('navigates with no error banner when Finish succeeds', async () => {
+    render(<SetupPage />);
+    const finish = await waitFor(() => screen.getByRole('button', { name: /Finish/i }));
+    fireEvent.click(finish);
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/services'));
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 });

--- a/packages/frontend/src/app/(dashboard)/setup/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/setup/page.tsx
@@ -327,6 +327,7 @@ export default function SetupPage() {
   const [logs, setLogs] = useState('');
   const [loading, setLoading] = useState(true);
   const [finishing, setFinishing] = useState(false);
+  const [finishError, setFinishError] = useState<string | null>(null);
   const [logsCollapsed, setLogsCollapsed] = useState(false);
   const logsOffsetRef = useRef(0);
   const logViewRef = useRef<HTMLPreElement>(null);
@@ -388,10 +389,15 @@ export default function SetupPage() {
 
   const handleFinish = async () => {
     setFinishing(true);
+    setFinishError(null);
     try {
       await completeStackSetup();
       router.push('/services');
       router.refresh();
+    } catch (e) {
+      // Without this the spinner just stopped: no error, no navigation, and no
+      // way for the operator to tell whether setup completed (#2460).
+      setFinishError(e instanceof Error ? e.message : String(e));
     } finally {
       setFinishing(false);
     }
@@ -468,6 +474,12 @@ export default function SetupPage() {
       </header>
 
       <div className="flex-1 overflow-auto p-6 space-y-4">
+        {finishError && (
+          <div role="alert" className="p-3 rounded-card border border-status-fail/20 bg-status-fail/10 text-sm text-status-fail">
+            Couldn&apos;t finish setup: {finishError}. Setup is still pending — try Finish again.
+          </div>
+        )}
+
         {job.error && (
           <div className="p-3 rounded-card border border-status-fail/20 bg-status-fail/10 text-sm text-status-fail">
             {job.error}

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -50,6 +50,35 @@
   --accent-strong: #2563eb;    /* blue-600 — hover/active */
   --on-accent: #ffffff;        /* text/icon on an accent fill */
 
+  /* --- Network topology visualization (#2430) --- */
+  --edge-default: rgba(148, 163, 184, 0.2);  /* faint slate for default edges */
+  --edge-down: #ef4444;                       /* red-500 for down edges */
+  --edge-declared: #64748b;                   /* slate-600 for declared edges */
+  --edge-observed: #3b82f6;                   /* blue-500 for observed edges */
+  --edge-inferred: #a855f7;                   /* violet-500 for inferred edges */
+  --minimap-container: #60a5fa;               /* blue-400 */
+  --minimap-service: #c084fc;                 /* purple-400 */
+  --minimap-unmanaged-service: #fbbf24;       /* amber-400 */
+  --minimap-pod: #f472b6;                     /* pink-400 */
+  --minimap-proxy: #34d399;                   /* emerald-400 */
+  --minimap-router: #fb923c;                  /* orange-400 */
+  --minimap-gateway: #fb923c;                 /* orange-400 */
+  --minimap-internet: #9ca3af;                /* gray-400 */
+  --minimap-link: #22d3ee;                    /* cyan-400 */
+  --minimap-device: #818cf8;                  /* indigo-400 */
+  --minimap-group: transparent;
+  --minimap-container-stroke: #2563eb;        /* blue-600 */
+  --minimap-service-stroke: #9333ea;          /* purple-600 */
+  --minimap-unmanaged-service-stroke: #d97706; /* amber-600 */
+  --minimap-pod-stroke: #db2777;              /* pink-600 */
+  --minimap-router-stroke: #ea580c;           /* orange-600 */
+  --minimap-gateway-stroke: #ea580c;          /* orange-600 */
+  --minimap-internet-stroke: #4b5563;         /* slate-700 */
+  --minimap-proxy-stroke: #059669;            /* emerald-600 */
+  --minimap-link-stroke: #0891b2;             /* cyan-600 */
+  --minimap-device-stroke: #4f46e5;           /* indigo-600 */
+  --minimap-group-stroke: #d1d5db;            /* gray-300 */
+
   /* --- Radius: ONE canonical semantic scale (was rounded-lg vs -xl ad-hoc).
      Named distinctly (chip/card/panel) so primitives standardize on these and
      the existing numeric rounded-sm/-lg utilities keep their defaults. --- */

--- a/packages/frontend/src/dashboards/NetworkDashboard.tsx
+++ b/packages/frontend/src/dashboards/NetworkDashboard.tsx
@@ -163,7 +163,7 @@ function getNodeTypeInfo(data: GraphNodeData) {
 export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
     const isCollapsed = data.collapsed;
     const onToggle = data.onToggle;
-    const { isGroup, isExpandable, effectiveType, isManagedService, isUnmanagedService, isServiceType, isMissing, isGateway } = getNodeTypeInfo(data);
+    const { isGroup, isExpandable, effectiveType, isManagedService, isUnmanagedService, isServiceType, isMissing } = getNodeTypeInfo(data);
 
   // Decide whether to render as the "Opened Group Frame" or the "Node Card"
   const renderAsExpandedGroup = isExpandable && !isCollapsed;
@@ -177,16 +177,16 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
   const usesDns = data.metadata?.usesDns === true;
 
   const getTypeColors = (): Record<string, string> => ({
-    container: 'border-blue-400 dark:border-blue-600 bg-blue-100 dark:bg-blue-900/40',
-    service: 'border-purple-400 dark:border-purple-600 bg-purple-100 dark:bg-purple-900/40',
-    'unmanaged-service': 'border-amber-400 dark:border-amber-500 bg-amber-50 dark:bg-amber-900/30',
-    pod: 'border-pink-400 dark:border-pink-600 bg-pink-100 dark:bg-pink-900/40',
-    router: 'border-orange-400 dark:border-orange-600 bg-orange-100 dark:bg-orange-600/60',
-    internet: 'border-gray-400 dark:border-gray-600 bg-gray-100 dark:bg-gray-800/60',
-    proxy: 'border-emerald-400 dark:border-emerald-600 bg-emerald-100 dark:bg-emerald-900/40',
-    gateway: 'border-orange-400 dark:border-orange-600 bg-orange-100 dark:bg-orange-800/50',
-    link: 'border-cyan-400 dark:border-cyan-600 bg-cyan-100 dark:bg-cyan-900/40',
-    device: 'border-indigo-400 dark:border-indigo-600 bg-indigo-100 dark:bg-indigo-900/40',
+    container: 'border-border bg-surface-2',
+    service: 'border-border bg-surface-2',
+    'unmanaged-service': 'border-border bg-surface-2',
+    pod: 'border-border bg-surface-2',
+    router: 'border-border bg-surface-2',
+    internet: 'border-border bg-surface-2',
+    proxy: 'border-border bg-surface-2',
+    gateway: 'border-border bg-surface-2',
+    link: 'border-border bg-surface-2',
+    device: 'border-border bg-surface-2',
   });
 
   const typeLabels: Record<string, string> = {
@@ -203,8 +203,8 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
 
   const typeColors = getTypeColors();
   const nodeColor = isMissing
-      ? 'border-red-400 dark:border-red-600 bg-red-50 dark:bg-red-900/20 border-dashed'
-      : (typeColors[effectiveType] || 'border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900');
+      ? 'border-border bg-surface-muted border-dashed'
+      : (typeColors[effectiveType] || 'border-border bg-surface');
 
       // Pre-calculate effective ports to use in IP extraction if data.ports is empty
       // (e.g. Pod Nodes which inherit ports from children)
@@ -363,10 +363,10 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
 
   if (data.type === 'internet') {
       return (
-        <div className="flex flex-col items-center justify-center w-32 h-32 rounded-full bg-blue-50 dark:bg-blue-900/20 border-4 border-blue-200 dark:border-blue-800 shadow-lg relative group">
-            <Handle type="source" position={Position.Right} className="!w-3 !h-3 !bg-blue-400 !-right-1.5" />
-            <Globe className="w-12 h-12 text-blue-500 dark:text-blue-400 mb-1" />
-            <span className="font-bold text-sm text-blue-700 dark:text-blue-300 uppercase tracking-wider">Internet</span>
+        <div className="flex flex-col items-center justify-center w-32 h-32 rounded-full bg-surface-2 border-4 border-border shadow-lg relative group">
+            <Handle type="source" position={Position.Right} className="!w-3 !h-3 !bg-accent !-right-1.5" />
+            <Globe className="w-12 h-12 text-accent mb-1" />
+            <span className="font-bold text-sm text-accent uppercase tracking-wider">Internet</span>
         </div>
       );
   }
@@ -389,57 +389,33 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
           : 'min-w-[320px] h-auto'
     }`}>
       {/* Handles for connecting */}
-      <Handle type="target" position={targetPos} className="!w-3 !h-3 !bg-blue-400" />
-      <Handle type="source" position={sourcePos} className="!w-3 !h-3 !bg-blue-400" />
+      <Handle type="target" position={targetPos} className="!w-3 !h-3 !bg-accent" />
+      <Handle type="source" position={sourcePos} className="!w-3 !h-3 !bg-accent" />
       
       {renderAsExpandedGroup ? (
           /* Render as "Expanded Group Frame" */
-         <div className={`w-full h-full rounded-xl border-2 flex flex-col justify-between p-2 pl-2 transition-all group-border ${
-             // Explicit Group Stylings to ensure visibility
-             isServiceType
-                 ? (isUnmanagedService
-                     ? 'border-amber-400/50 dark:border-amber-500/50 bg-amber-50/50 dark:bg-amber-900/10'
-                     : 'border-purple-400/50 dark:border-purple-500/50 bg-purple-50/50 dark:bg-purple-900/10')
-                 : effectiveType === 'pod' ? 'border-pink-400/50 dark:border-pink-500/50 bg-pink-50/50 dark:bg-pink-900/10'
-                 : effectiveType === 'proxy' ? 'border-emerald-400/50 dark:border-emerald-500/50 bg-emerald-50/50 dark:bg-emerald-900/10'
-                 : 'border-gray-300 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/10'
-         }`}>
+         <div className={`w-full h-full rounded-xl border-2 flex flex-col justify-between p-2 pl-2 transition-all group-border border-border/50 bg-surface-2/30`}>
             <div className="flex justify-between items-start w-full pointer-events-none">
-                <div className={`self-start px-3 py-1.5 rounded-md text-sm font-bold uppercase tracking-wider border shadow-sm flex items-center gap-2 pointer-events-auto ${
-                    isGateway 
-                        ? 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900 dark:text-emerald-300 dark:border-emerald-800' 
-                        : (effectiveType !== 'group' && typeColors[effectiveType] 
-                            ? typeColors[effectiveType].replace('bg-', 'bg-opacity-20 bg-').replace('border-', 'border-opacity-50 border-') 
-                            : 'bg-white text-gray-600 border-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700')
-                } ${
-                    // Ensure text color is set for specific types if not already
-                    isServiceType
-                        ? (isUnmanagedService
-                            ? 'text-amber-700 dark:text-amber-300'
-                            : 'text-purple-700 dark:text-purple-300')
-                        : effectiveType === 'pod' ? 'text-pink-700 dark:text-pink-300'
-                        : effectiveType === 'proxy' ? 'text-emerald-700 dark:text-emerald-300'
-                        : ''
-                }`}>
+                <div className={`self-start px-3 py-1.5 rounded-md text-sm font-bold uppercase tracking-wider border shadow-sm flex items-center gap-2 pointer-events-auto bg-surface-2 text-text border-border`}>
                     <button
                         onClick={(e) => { e.stopPropagation(); onToggle?.(id); }}
-                        className="mr-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded p-0.5 text-gray-500"
+                        className="mr-1 hover:bg-border rounded p-0.5 text-muted"
                         title="Collapse Group"
                     >
-                        <LayoutGrid size={14} /> 
+                        <LayoutGrid size={14} />
                     </button>
                     {data.status && (
-                        <div className={`w-2.5 h-2.5 rounded-full ${data.status === 'up' ? 'bg-green-500' : 'bg-red-500'}`} />
+                        <div className={`w-2.5 h-2.5 rounded-full ${data.status === 'up' ? 'bg-status-ok' : 'bg-status-fail'}`} />
                     )}
                     {data.label}
                     {/* Visual Tag for Pod/Service */}
                     {(isServiceType || effectiveType === 'pod') ? (
-                        <span className="ml-1 px-1.5 py-0.5 rounded text-[9px] bg-white/50 dark:bg-black/20 border border-black/10 dark:border-white/10 uppercase tracking-wider font-extrabold opacity-80">
+                        <span className="ml-1 px-1.5 py-0.5 rounded text-[9px] bg-surface border border-border uppercase tracking-wider font-extrabold opacity-80">
                             {effectiveType === 'pod' ? 'Pod' : (isUnmanagedService ? 'Bundle' : 'Service')}
                         </span>
                     ) : null}
                     {data.node && data.node !== 'local' && (
-                        <span className="ml-1 px-1.5 py-0.5 rounded text-[9px] bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-800">
+                        <span className="ml-1 px-1.5 py-0.5 rounded text-[9px] bg-surface-2 text-text border border-border">
                             {data.node}
                         </span>
                     )}
@@ -449,7 +425,7 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                 {portMap.length > 0 && !['service', 'pod', 'proxy', 'unmanaged-service'].includes(effectiveType) && (
                     <div className="flex flex-col gap-1 items-end">
                         {globalIp && (
-                             <div className="text-[10px] font-mono text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 px-1.5 py-0.5 rounded border border-gray-100 dark:border-gray-800 mb-0.5 self-end" title="Host IP">
+                             <div className="text-[10px] font-mono text-muted bg-surface-2 px-1.5 py-0.5 rounded border border-border mb-0.5 self-end" title="Host IP">
                                 {globalIp}
                              </div>
                         )}
@@ -467,18 +443,18 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                             const showIpInTag = !globalIp && p.ip && p.showIp;
 
                             return (
-                                <div key={idx} className="px-2 py-0.5 rounded text-[10px] font-mono bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 shadow-sm flex items-center gap-1">
-                                    <a 
+                                <div key={idx} className="px-2 py-0.5 rounded text-[10px] font-mono bg-surface-2 text-text border border-border shadow-sm flex items-center gap-1">
+                                    <a
                                         href={`http://${hostname}:${p.host}`}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        className="hover:text-blue-500 hover:underline"
+                                        className="hover:text-accent hover:underline"
                                         onClick={(e) => e.stopPropagation()}
                                     >
                                         {showIpInTag ? `${p.ip}:${p.host}` : `:${p.host}`}
                                     </a>
                                     {p.container && (
-                                        <span className="text-gray-400 dark:text-gray-500">
+                                        <span className="text-muted">
                                             (to :{p.container})
                                         </span>
                                     )}
@@ -492,13 +468,13 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
      ) : (
         /* Render as "Standard Node" (Card) - used for Leaf Nodes AND Collapsed Groups */
         <div className={`w-full h-full rounded-xl border shadow-sm hover:shadow-md transition-all p-4 flex flex-col gap-3 ${nodeColor}`}>
-            <div className="flex items-center justify-between border-b border-gray-100 dark:border-gray-800/50 pb-2">
-                <div className="font-bold text-lg text-gray-900 dark:text-gray-100 truncate pr-2 flex items-center gap-2" title={data.label}>
+            <div className="flex items-center justify-between border-b border-border pb-2">
+                <div className="font-bold text-lg text-text truncate pr-2 flex items-center gap-2" title={data.label}>
                     {/* Add Expand Button if Expandable & Collapsed */}
                     {isExpandable && (
                         <button
                             onClick={(e) => { e.stopPropagation(); onToggle?.(id); }}
-                            className="hover:bg-gray-100 dark:hover:bg-gray-700 rounded p-1 text-gray-500 transition-colors"
+                            className="hover:bg-border rounded p-1 text-muted transition-colors"
                             title="Expand Group"
                         >
                             <ChevronDown size={16} className="-rotate-90" />
@@ -511,7 +487,7 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                     {behindAuth && (
                         <span
                             data-testid="badge-behind-auth"
-                            className="shrink-0 inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800"
+                            className="shrink-0 inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-surface-2 text-text border border-border"
                             title="Hinter Authelia/LLDAP (SSO)"
                         >
                             <Lock size={10} /> SSO
@@ -520,7 +496,7 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                     {usesDns && (
                         <span
                             data-testid="badge-uses-dns"
-                            className="shrink-0 inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800"
+                            className="shrink-0 inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-surface-2 text-text border border-border"
                             title="DNS über AdGuard"
                         >
                             <Globe size={10} /> DNS
@@ -529,25 +505,25 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
 
                     {/* Host IP moved to Header */}
                     {globalIp && (
-                         <div className="text-[10px] font-mono font-bold text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 px-1.5 py-0.5 rounded border border-gray-100 dark:border-gray-800 ml-1" title="Host IP">
+                         <div className="text-[10px] font-mono font-bold text-muted bg-surface-2 px-1.5 py-0.5 rounded border border-border ml-1" title="Host IP">
                             {globalIp}
                          </div>
                     )}
                 </div>
                 {data.status && (
-                    <div className={`w-3 h-3 rounded-full shrink-0 ${data.status === 'up' ? 'bg-green-500' : 'bg-red-500'}`} />
+                    <div className={`w-3 h-3 rounded-full shrink-0 ${data.status === 'up' ? 'bg-status-ok' : 'bg-status-fail'}`} />
                 )}
             </div>
             
             <div className="flex-1 flex flex-col gap-2 min-h-0">
                 <div className="flex gap-2">
                   {data.subLabel && !['router', 'service', 'pod', 'proxy', 'unmanaged-service'].includes(effectiveType) && (
-                      <div className="text-xs text-gray-500 dark:text-gray-400 font-mono bg-white/50 dark:bg-black/20 px-2 py-1 rounded break-all" title={data.subLabel}>
+                      <div className="text-xs text-muted font-mono bg-surface px-2 py-1 rounded break-all" title={data.subLabel}>
                           {data.subLabel}
                       </div>
                   )}
                   {!!data.metadata?.pod && (typeof data.metadata.pod === 'string' || typeof data.metadata.pod === 'number') && (
-                     <div className="text-xs text-pink-600 dark:text-pink-400 font-mono bg-pink-50 dark:bg-pink-900/20 border border-pink-200 dark:border-pink-800/30 px-2 py-1 rounded break-all flex items-center gap-1">
+                     <div className="text-xs text-text font-mono bg-surface-2 border border-border px-2 py-1 rounded break-all flex items-center gap-1">
                         <span className="opacity-50 text-[10px]">POD:</span> {data.metadata.pod as React.ReactNode}
                      </div>
                   )}
@@ -558,19 +534,19 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                     <div className="grid grid-cols-2 gap-x-3 gap-y-2">
                         {details.map((d, i) => d.value && (
                             <div key={i} className={`flex flex-col min-w-0 ${d.full ? 'col-span-2' : ''}`}>
-                                <span className="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wider font-semibold">{d.label}</span>
+                                <span className="text-[10px] text-muted uppercase tracking-wider font-semibold">{d.label}</span>
                                 {d.label === 'URL' ? (
-                                    <a 
-                                        href={String(d.value)} 
-                                        target="_blank" 
-                                        rel="noopener noreferrer" 
-                                        className="text-sm text-blue-600 dark:text-blue-400 font-medium break-words hover:underline" 
+                                    <a
+                                        href={String(d.value)}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-sm text-accent font-medium break-words hover:underline"
                                         onClick={(e) => e.stopPropagation()}
                                     >
                                         {d.value}
                                     </a>
                                 ) : (
-                                    <span className="text-sm text-gray-800 dark:text-gray-200 font-medium break-words" title={String(d.value)}>{d.value}</span>
+                                    <span className="text-sm text-text font-medium break-words" title={String(d.value)}>{d.value}</span>
                                 )}
                             </div>
                         ))}
@@ -579,8 +555,8 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
 
                 {/* Verified Domains List (Filtered for Proxies/Services) */}
                 {displayDomains.length > 0 && (
-                    <div className="mt-2 pt-2 border-t border-gray-100 dark:border-gray-800/50">
-                        <span className="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wider font-semibold block mb-1">
+                    <div className="mt-2 pt-2 border-t border-border">
+                        <span className="text-[10px] text-muted uppercase tracking-wider font-semibold block mb-1">
                             {effectiveType === 'proxy' && 'Routed Domains'}
                             {effectiveType !== 'proxy' && 'Verified Domains'}
                         </span>
@@ -599,11 +575,11 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         onClick={(e) => e.stopPropagation()}
-                                        className="flex items-center gap-2 text-xs font-mono text-blue-600 dark:text-blue-400 hover:underline px-1.5 py-1 bg-blue-50 dark:bg-blue-900/20 rounded border border-blue-100 dark:border-blue-800/30 transition-colors"
+                                        className="flex items-center gap-2 text-xs font-mono text-accent hover:underline px-1.5 py-1 bg-surface-2 rounded border border-border transition-colors"
                                     >
                                         {looksLikeDomain
                                             ? <DomainHealthDot domain={bareDomain} />
-                                            : <div className="w-1.5 h-1.5 rounded-full bg-gray-400 shrink-0" />}
+                                            : <div className="w-1.5 h-1.5 rounded-full bg-border shrink-0" />}
                                         <span className="truncate" title={domain}>{domain}</span>
                                     </a>
                                 );
@@ -613,39 +589,39 @@ export const CustomNode = ({ id, data }: NodeProps<CustomNodeType>) => {
                 )}
 
                 {data.hostname && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400 font-mono bg-white/50 dark:bg-black/20 px-2 py-1 rounded break-all flex items-center gap-1" title="Hostname">
+                    <div className="text-xs text-muted font-mono bg-surface px-2 py-1 rounded break-all flex items-center gap-1" title="Hostname">
                         <Globe size={10} className="opacity-50" />
                         {data.hostname}
                     </div>
                 )}
 
                 {data.metadata?.description && data.type !== 'link' && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 mt-1 italic" title={data.metadata.description}>
+                    <div className="text-xs text-muted line-clamp-2 mt-1 italic" title={data.metadata.description}>
                         {data.metadata.description}
                     </div>
                 )}
                 
-                <div className="mt-auto pt-3 flex items-center justify-between border-t border-gray-100 dark:border-gray-800/50">
+                <div className="mt-auto pt-3 flex items-center justify-between border-t border-border">
                     <PortTagsList portMap={portMap} globalIp={globalIp} nodeData={data} />
-                    
+
                     <div className="flex flex-col items-end gap-1 ml-auto">
                         {data.node && data.node !== 'local' && (!data.parentNode || data.type === 'link') && (
-                            <span className="px-1.5 py-0.5 rounded text-[10px] bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-800 uppercase tracking-wider font-bold">
+                            <span className="px-1.5 py-0.5 rounded text-[10px] bg-surface-2 text-text border border-border uppercase tracking-wider font-bold">
                                 {data.node}
                             </span>
                         )}
-                        
-                        <span className="text-[10px] font-semibold px-2 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded border border-gray-200 dark:border-gray-700 uppercase tracking-wider whitespace-nowrap">
+
+                        <span className="text-[10px] font-semibold px-2 py-0.5 bg-surface-2 text-muted rounded border border-border uppercase tracking-wider whitespace-nowrap">
                             {isMissing ? 'Missing Node' : (typeLabels[effectiveType] || effectiveType)}
                         </span>
                         
-                         {!!data.metadata?.isExternalMissing && (
-                            <button 
+                        {!!data.metadata?.isExternalMissing && (
+                            <button
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     data.onCreateExternalLink?.(data);
                                 }}
-                                className="mt-1 px-2 py-1 bg-blue-600 hover:bg-blue-700 text-white text-[10px] font-bold uppercase tracking-wider rounded transition-colors shadow-sm flex items-center gap-1"
+                                className="mt-1 px-2 py-1 bg-accent hover:bg-accent-strong text-on-accent text-[10px] font-bold uppercase tracking-wider rounded transition-colors shadow-sm flex items-center gap-1"
                             >
                                 <Plus size={10} />
                                 Add Link
@@ -679,9 +655,9 @@ const PortTagsList = ({ portMap, globalIp, nodeData }: { portMap: Array<{ host: 
                 const showIpInTag = !globalIp && p.ip && p.showIp;
                 const link = `http://${hostname}:${p.host}`;
                 const content = (
-                    <span className="text-[11px] font-medium px-2 py-0.5 bg-white dark:bg-black/20 text-blue-600 dark:text-blue-400 rounded border border-blue-100 dark:border-blue-800/30 hover:bg-blue-50 dark:hover:bg-blue-900/30 transition-colors cursor-pointer flex items-center gap-1">
+                    <span className="text-[11px] font-medium px-2 py-0.5 bg-surface-2 text-accent rounded border border-border hover:bg-surface transition-colors cursor-pointer flex items-center gap-1">
                         <span>{showIpInTag ? `${p.ip}:${p.host}` : `:${p.host}`}</span>
-                        {p.container && <span className="text-gray-400 dark:text-gray-500 opacity-75">(to :{p.container})</span>}
+                        {p.container && <span className="text-muted opacity-75">(to :{p.container})</span>}
                     </span>
                 );
 
@@ -725,12 +701,12 @@ type LinkFormState = {
 
 // Helper: get MiniMap color for node type
 function getMiniMapNodeColor(type: string): string {
-  return MINIMAP_NODE_COLORS[type] ?? '#d1d5db';
+  return MINIMAP_NODE_COLORS[type] ?? MINIMAP_NODE_COLORS.internet;
 }
 
 // Helper: get MiniMap stroke color for node type
 function getMiniMapStrokeColor(type: string): string {
-  return MINIMAP_STROKE_COLORS[type] ?? '#9ca3af';
+  return MINIMAP_STROKE_COLORS[type] ?? MINIMAP_STROKE_COLORS.internet;
 }
 
 // Legend body extracted from NetworkLegend so the panel wrapper stays under
@@ -738,26 +714,26 @@ function getMiniMapStrokeColor(type: string): string {
 function LegendBody() {
     return (
         <div className="px-3 pb-2 space-y-1.5 border-t border-border pt-2">
-            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-blue-500" /><span>Service / Pod</span></div>
-            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-purple-500" /><span>Container</span></div>
-            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-orange-500" /><span>Gateway</span></div>
-            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-cyan-500" /><span>External Link</span></div>
-            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-gray-400" /><span>Group / Node</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-status-info" /><span>Service / Pod</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-accent" /><span>Container</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-accent-secondary" /><span>Gateway</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-accent" /><span>External Link</span></div>
+            <div className="flex items-center gap-2"><div className="w-3 h-3 rounded bg-border" /><span>Group / Node</span></div>
             <div className="border-t border-border pt-1.5 mt-1.5">
-                <div className="flex items-center gap-2"><div className="w-2.5 h-2.5 rounded-full bg-green-500" /><span>Active / Running</span></div>
-                <div className="flex items-center gap-2 mt-1"><div className="w-2.5 h-2.5 rounded-full bg-red-500" /><span>Stopped / Error</span></div>
+                <div className="flex items-center gap-2"><div className="w-2.5 h-2.5 rounded-full bg-status-ok" /><span>Active / Running</span></div>
+                <div className="flex items-center gap-2 mt-1"><div className="w-2.5 h-2.5 rounded-full bg-status-fail" /><span>Stopped / Error</span></div>
             </div>
             <div className="border-t border-border pt-1.5 mt-1.5 space-y-1">
                 <div className="flex items-center gap-2">
-                    <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="#0ea5e9" strokeWidth="2" /></svg>
+                    <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="var(--status-info)" strokeWidth="2" /></svg>
                     <span>Observed TCP flow</span>
                 </div>
                 <div className="flex items-center gap-2">
-                    <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="#d97706" strokeWidth="2" strokeDasharray="4 4" /></svg>
+                    <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="var(--status-warn)" strokeWidth="2" strokeDasharray="4 4" /></svg>
                     <span>Declared dependency</span>
                 </div>
                 <div className="flex items-center gap-2">
-                    <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="#a855f7" strokeWidth="2" strokeDasharray="2 3" /></svg>
+                    <svg width="20" height="6"><line x1="0" y1="3" x2="20" y2="3" stroke="var(--accent-secondary)" strokeWidth="2" strokeDasharray="2 3" /></svg>
                     <span>Inferred (env / host)</span>
                 </div>
             </div>
@@ -766,11 +742,11 @@ function LegendBody() {
                 badges to keep the map planar. */}
             <div className="border-t border-border pt-1.5 mt-1.5 space-y-1">
                 <div className="flex items-center gap-2">
-                    <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 border border-emerald-200 dark:border-emerald-800"><Lock size={9} /> SSO</span>
+                    <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1 py-0.5 rounded bg-surface-2 text-text border border-border"><Lock size={9} /> SSO</span>
                     <span>Hinter Authelia/LLDAP</span>
                 </div>
                 <div className="flex items-center gap-2">
-                    <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1 py-0.5 rounded bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300 border border-sky-200 dark:border-sky-800"><Globe size={9} /> DNS</span>
+                    <span className="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1 py-0.5 rounded bg-surface-2 text-text border border-border"><Globe size={9} /> DNS</span>
                     <span>DNS über AdGuard</span>
                 </div>
             </div>
@@ -1286,7 +1262,7 @@ export default function NetworkDashboard() {
             },
             parentId: n.parentNode,
             extent: n.parentNode ? 'parent' : undefined,
-            className: isGroup ? 'border border-dashed border-slate-300 dark:border-white/10 bg-slate-500/[0.02] dark:bg-white/[0.01] rounded-2xl backdrop-blur-[2px]' : undefined,
+            className: isGroup ? 'border border-dashed border-border bg-surface-2/5 rounded-2xl backdrop-blur-[2px]' : undefined,
             // #2201 — React Flow v12 reads layout dims from top-level
             // width/height, not style. Set the initial group guess top-level so
             // it doesn't fight the top-level dims getLayoutedElements stamps.
@@ -1639,7 +1615,7 @@ export default function NetworkDashboard() {
                 </Panel>
             )}
             <NetworkLegend />
-            <Background color="#999" gap={16} size={1} className="opacity-10" />
+            <Background color="var(--text-muted)" gap={16} size={1} className="opacity-10" />
             <Controls
                 showInteractive={false}
                 className="!bg-surface !border-border shadow-lg [&>button]:!bg-surface [&>button]:!border-border [&>button]:!text-text [&>button:hover]:!bg-surface-2 [&>button>svg]:!fill-current"
@@ -1740,7 +1716,7 @@ export default function NetworkDashboard() {
                             <FileText size={16} />
                             Device Logs
                         </h4>
-                        <div className="bg-gray-950 text-gray-300 rounded-card border border-gray-800 p-4 font-mono text-xs overflow-auto max-h-[400px] whitespace-pre-wrap">
+                        <div className="bg-surface-muted text-muted rounded-card border border-border p-4 font-mono text-xs overflow-auto max-h-[400px] whitespace-pre-wrap">
                             {healthData.deviceLog || 'No logs available.'}
                         </div>
                     </div>
@@ -1847,7 +1823,7 @@ export default function NetworkDashboard() {
 
       {/* Context Menu / Details Panel */}
       {selectedNodeData && (
-          <div className="fixed inset-0 z-50 flex justify-end bg-gray-950/60 backdrop-blur-sm">
+          <div className="fixed inset-0 z-50 flex justify-end bg-black/60 backdrop-blur-sm">
               <div className="w-full sm:max-w-md h-full bg-surface border-l border-border shadow-2xl flex flex-col animate-in slide-in-from-right-10">
                   <div className="flex items-start justify-between px-5 py-4 border-b border-border gap-3">
                       <div className="min-w-0 flex-1">
@@ -2070,7 +2046,7 @@ export default function NetworkDashboard() {
       )}
 
       {selectedEdge && (
-          <div className="fixed inset-0 z-40 flex justify-end bg-gray-950/60 backdrop-blur-sm">
+          <div className="fixed inset-0 z-40 flex justify-end bg-black/60 backdrop-blur-sm">
               <div className="w-full sm:max-w-sm h-full bg-surface border-l border-border shadow-2xl flex flex-col animate-in slide-in-from-right-10">
                   <div className="flex items-center justify-between px-5 py-4 border-b border-border">
                       <div>

--- a/packages/frontend/src/dashboards/RegistryDashboard.test.tsx
+++ b/packages/frontend/src/dashboards/RegistryDashboard.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * RegistryDashboard — load/sync failures must be visible (#2462).
+ *
+ * `loadData`/`handleSync` used to be try/finally with no catch: a rejected
+ * fetchTemplates()/syncAllRegistries() reset the loading flag and left the
+ * operator staring at an empty registry with no clue anything failed, unlike
+ * every sibling dashboard which reports fetch errors via `addToast`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const { fetchTemplates, syncAllRegistries, addToast } = vi.hoisted(() => ({
+  fetchTemplates: vi.fn(),
+  syncAllRegistries: vi.fn(),
+  addToast: vi.fn<(type: string, title: string, message?: string, duration?: number) => string>(
+    () => 'toast-id',
+  ),
+}));
+
+vi.mock('@/app/actions', () => ({ fetchTemplates, syncAllRegistries }));
+vi.mock('@/providers/ToastProvider', () => ({
+  useToast: () => ({ addToast, updateToast: vi.fn(), removeToast: vi.fn() }),
+}));
+// RegistryBrowser drags in the installer modals + react-markdown; the registry
+// chrome is what's under test here.
+vi.mock('@/components/RegistryBrowser', () => ({ __esModule: true, default: () => <div>browser</div> }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), back: vi.fn() }) }));
+
+import RegistryDashboard from './RegistryDashboard';
+
+describe('RegistryDashboard error reporting (#2462)', () => {
+  beforeEach(() => {
+    addToast.mockClear();
+    fetchTemplates.mockReset().mockResolvedValue([]);
+    syncAllRegistries.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('reports a failed template load with an error toast', async () => {
+    fetchTemplates.mockRejectedValue(new Error('registry unreachable'));
+    render(<RegistryDashboard />);
+
+    await waitFor(() => expect(addToast).toHaveBeenCalled());
+    const [type, title, message] = addToast.mock.calls[0];
+    expect(type).toBe('error');
+    expect(title).toMatch(/Failed to load registry/i);
+    expect(message).toMatch(/registry unreachable/);
+    // The spinner still clears — the point is that it doesn't clear silently.
+    await waitFor(() => expect(screen.getByText('browser')).toBeTruthy());
+  });
+
+  it('reports a failed sync with an error toast', async () => {
+    syncAllRegistries.mockRejectedValue(new Error('git fetch denied'));
+    render(<RegistryDashboard />);
+    await waitFor(() => expect(screen.getByText('browser')).toBeTruthy());
+    addToast.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: /Sync Registries/i }));
+
+    await waitFor(() => expect(addToast).toHaveBeenCalled());
+    const [type, title, message] = addToast.mock.calls[0];
+    expect(type).toBe('error');
+    expect(title).toMatch(/Registry sync failed/i);
+    expect(message).toMatch(/git fetch denied/);
+    // Button re-enabled for a retry, not stuck on "Syncing...".
+    await waitFor(() =>
+      expect((screen.getByRole('button', { name: /Sync Registries/i }) as HTMLButtonElement).disabled).toBe(false),
+    );
+  });
+
+  it('stays quiet when load and sync both succeed', async () => {
+    render(<RegistryDashboard />);
+    await waitFor(() => expect(screen.getByText('browser')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: /Sync Registries/i }));
+    await waitFor(() => expect(syncAllRegistries).toHaveBeenCalled());
+    await waitFor(() => expect(fetchTemplates).toHaveBeenCalledTimes(2));
+    expect(addToast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/dashboards/RegistryDashboard.tsx
+++ b/packages/frontend/src/dashboards/RegistryDashboard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { fetchTemplates, syncAllRegistries } from '@/app/actions';
 import { Template } from '@servicebay/api-client';
 import RegistryBrowser from '@/components/RegistryBrowser';
 import { Loader2, RefreshCw, DownloadCloud } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
+import { useToast } from '@/providers/ToastProvider';
 
 interface RegistryDashboardProps {
     variant?: 'page' | 'embedded';
@@ -16,6 +17,7 @@ export default function RegistryDashboard({ variant = 'page' }: RegistryDashboar
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
   const isFetchingRef = useRef(false);
+  const { addToast } = useToast();
 
   const loadData = async () => {
     if (isFetchingRef.current) return;
@@ -30,19 +32,32 @@ export default function RegistryDashboard({ variant = 'page' }: RegistryDashboar
     }
   };
 
+  // A rejected load used to be swallowed by try/finally: the spinner cleared
+  // and the operator was left staring at an empty registry with no clue
+  // anything failed. Report it like every sibling dashboard does (#2462). The
+  // handler sits here rather than inside `loadData` so the mount effect doesn't
+  // reach a synchronous setState-in-catch (react-hooks/set-state-in-effect).
+  const refresh = useCallback(() => {
+    void loadData().catch(e =>
+      addToast('error', 'Failed to load registry', e instanceof Error ? e.message : String(e)),
+    );
+  }, [addToast]);
+
   const handleSync = async () => {
       setSyncing(true);
       try {
           await syncAllRegistries();
           await loadData();
+      } catch (e) {
+          addToast('error', 'Registry sync failed', e instanceof Error ? e.message : String(e));
       } finally {
           setSyncing(false);
       }
   };
 
   useEffect(() => {
-    loadData();
-  }, []);
+    refresh();
+  }, [refresh]);
 
   const actionButtons = (
     <div className="flex items-center gap-2">
@@ -55,7 +70,7 @@ export default function RegistryDashboard({ variant = 'page' }: RegistryDashboar
             {syncing ? 'Syncing...' : 'Sync Registries'}
         </button>
         <button 
-            onClick={loadData}
+            onClick={refresh}
             className="p-2 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded hover:bg-gray-50 dark:hover:bg-gray-700 shadow-sm transition-colors"
             title="Refresh"
         >

--- a/packages/frontend/src/dashboards/_lib/networkDashboard.ts
+++ b/packages/frontend/src/dashboards/_lib/networkDashboard.ts
@@ -401,17 +401,17 @@ export function mergeGraphPreservingPositions<TNode extends Node, TEdge extends 
 // operator never confuses the two. Down-target dashes still win —
 // service-down is a stronger signal than provenance.
 // ────────────────────────────────────────────────────────────────────
-export const DEFAULT_EDGE_COLOR = 'rgba(148, 163, 184, 0.2)';
-export const DOWN_EDGE_COLOR = '#ef4444';
+export const DEFAULT_EDGE_COLOR = 'var(--edge-default)';
+export const DOWN_EDGE_COLOR = 'var(--edge-down)';
 export const DOWN_EDGE_DASHES = '6 3';
 
-export const DECLARED_EDGE_COLOR = '#64748b'; // Slate
+export const DECLARED_EDGE_COLOR = 'var(--edge-declared)';
 export const DECLARED_EDGE_DASHES = '4 4';
-export const OBSERVED_EDGE_COLOR = '#3b82f6'; // Clean blue
+export const OBSERVED_EDGE_COLOR = 'var(--edge-observed)';
 // #2175 — inferred edges (env-target inference + fallback anchor). Violet
 // with a dotted stroke so they read as "derived, not declared/observed":
 // distinct from declared's slate dash and observed's solid blue.
-export const INFERRED_EDGE_COLOR = '#a855f7'; // Violet
+export const INFERRED_EDGE_COLOR = 'var(--edge-inferred)';
 export const INFERRED_EDGE_DASHES = '2 3';
 
 // ────────────────────────────────────────────────────────────────────
@@ -420,31 +420,31 @@ export const INFERRED_EDGE_DASHES = '2 3';
 // visualization colors. Each type has a fill color and a darker stroke.
 // ────────────────────────────────────────────────────────────────────
 export const MINIMAP_NODE_COLORS: Record<string, string> = {
-  container: '#60a5fa',           // blue-400
-  service: '#c084fc',            // purple-400
-  'unmanaged-service': '#fbbf24', // amber-400
-  pod: '#f472b6',                // pink-400
-  proxy: '#34d399',              // emerald-400
-  router: '#fb923c',             // orange-400
-  gateway: '#fb923c',            // orange-400
-  internet: '#9ca3af',           // gray-400
-  link: '#22d3ee',               // cyan-400
-  device: '#818cf8',             // indigo-400
-  group: 'transparent',
+  container: 'var(--minimap-container)',
+  service: 'var(--minimap-service)',
+  'unmanaged-service': 'var(--minimap-unmanaged-service)',
+  pod: 'var(--minimap-pod)',
+  proxy: 'var(--minimap-proxy)',
+  router: 'var(--minimap-router)',
+  gateway: 'var(--minimap-gateway)',
+  internet: 'var(--minimap-internet)',
+  link: 'var(--minimap-link)',
+  device: 'var(--minimap-device)',
+  group: 'var(--minimap-group)',
 };
 
 export const MINIMAP_STROKE_COLORS: Record<string, string> = {
-  container: '#2563eb',           // blue-600
-  service: '#9333ea',            // purple-600
-  'unmanaged-service': '#d97706', // amber-600
-  pod: '#db2777',                // pink-600
-  router: '#ea580c',             // orange-600
-  gateway: '#ea580c',            // orange-600
-  internet: '#4b5563',           // slate-700
-  proxy: '#059669',              // emerald-600
-  link: '#0891b2',               // cyan-600
-  device: '#4f46e5',             // indigo-600
-  group: '#d1d5db',              // gray-300
+  container: 'var(--minimap-container-stroke)',
+  service: 'var(--minimap-service-stroke)',
+  'unmanaged-service': 'var(--minimap-unmanaged-service-stroke)',
+  pod: 'var(--minimap-pod-stroke)',
+  router: 'var(--minimap-router-stroke)',
+  gateway: 'var(--minimap-gateway-stroke)',
+  internet: 'var(--minimap-internet-stroke)',
+  proxy: 'var(--minimap-proxy-stroke)',
+  link: 'var(--minimap-link-stroke)',
+  device: 'var(--minimap-device-stroke)',
+  group: 'var(--minimap-group-stroke)',
 };
 
 export function styleForEdgeKind(

--- a/scripts/check-backup-coverage.ts
+++ b/scripts/check-backup-coverage.ts
@@ -39,12 +39,37 @@ interface TemplateVolume {
 }
 
 /**
+ * Bare `{{VAR}}` hostPaths that are NOT persistent household state, each with
+ * the reason it is exempt. This is the ONLY way a bare-variable hostPath leaves
+ * the coverage check — everything else is a candidate.
+ *
+ * #2465: the previous rule failed *open*. A bare `{{VAR}}` counted as a
+ * persistent volume only when its name ended in `_PATH`/`_DIR`; every other
+ * name returned `null` and was dropped before the coverage check saw it — not
+ * reported as uncovered, invisible. A template naming its data variable
+ * slightly off-pattern (`{{MEDIA_ROOT}}`, `{{PHOTOS}}`) got a green
+ * `check:backup-coverage` with a silently un-backed-up volume, which is the one
+ * outcome this gate exists to prevent. Now the gate fails *closed*: an
+ * off-pattern name is flagged until it is covered, excluded, or (if it really
+ * isn't household state) matched by an entry below.
+ */
+const NON_VOLUME_HOSTPATH_VARS: readonly { pattern: RegExp; reason: string }[] = [
+  { pattern: /_DEVICES?$/, reason: 'device passthrough (e.g. /dev/serial/…), not stored state' },
+  { pattern: /_(SOCKET|SOCK)$/, reason: 'host socket mount, not stored state' },
+  { pattern: /_PORT$/, reason: 'not a filesystem path' },
+];
+
+/** The exemption an off-pattern bare `{{VAR}}` matched, if any. */
+function hostPathVarExemption(name: string): string | null {
+  return NON_VOLUME_HOSTPATH_VARS.find(e => e.pattern.test(name))?.reason ?? null;
+}
+
+/**
  * A hostPath volume is a candidate for the backup contract when it points at
- * the box's persistent data root (`{{DATA_DIR}}/…`) or a whole-volume variable
- * (`{{SOME_MEDIA_PATH}}`). Device passthroughs (`{{ZWAVE_DEVICE}}`) and in-pod /
- * ephemeral mounts are NOT persistent household state — a volume rooted at a
- * bare device/`/dev`/`/run` path is skipped. We include `{{DATA_DIR}}/…` and any
- * single `{{VAR}}` whose name reads like a data path (ends in `_PATH`/`_DIR`).
+ * the box's persistent data root (`{{DATA_DIR}}/…`) or at a whole-volume
+ * variable (`{{JELLYFIN_MEDIA_PATH}}`, `{{MEDIA_ROOT}}`, …). Absolute host
+ * paths (`/dev/…`, `/run/…`, in-pod mounts) are outside the contract, and a
+ * bare variable is only skipped when it matches `NON_VOLUME_HOSTPATH_VARS`.
  */
 function toCoverageKey(raw: string): string | null {
   const dataDir = raw.match(/^\{\{DATA_DIR\}\}\/(.+)$/);
@@ -53,8 +78,8 @@ function toCoverageKey(raw: string): string | null {
   if (bareVar) {
     const name = bareVar[1];
     if (name === 'DATA_DIR') return null; // the root itself, not a leaf volume
-    if (/_(PATH|DIR)$/.test(name)) return raw.slice(2, -2); // e.g. JELLYFIN_MEDIA_PATH
-    return null; // device/port/other vars — not a persistent data volume
+    if (hostPathVarExemption(name)) return null; // explicitly not stored state
+    return name; // fail closed: every other variable volume must be accounted for
   }
   return null; // absolute host paths (devices, /run, in-pod) — not our contract
 }
@@ -90,27 +115,31 @@ function isUnder(key: string, roots: string[]): boolean {
   return roots.some(root => key === root || key.startsWith(root + '/'));
 }
 
-function main(): void {
+/**
+ * The volumes that satisfy neither a manifest nor an explicit bulk-exclude.
+ * Exported so the gate's own coverage decision is testable without the
+ * filesystem (tests/scripts/gate-config-truth.test.ts).
+ */
+function uncoveredVolumes(vols: readonly TemplateVolume[]): TemplateVolume[] {
   const manifestRoots = manifestDataDirs();
   const excludedRoots = Object.keys(EXCLUDED_BULK_VOLUMES).map(k => k.replace(/\/+$/, ''));
+  return vols.filter(v => !isUnder(v.key, manifestRoots) && !isUnder(v.key, excludedRoots));
+}
 
+function main(): void {
   const templates = readdirSync(TEMPLATES_DIR, { withFileTypes: true })
     .filter(e => e.isDirectory())
     .map(e => e.name);
 
-  const uncovered: TemplateVolume[] = [];
-  let checked = 0;
-
+  const all: TemplateVolume[] = [];
   for (const template of templates) {
     const tmplPath = path.join(TEMPLATES_DIR, template, 'template.yml');
     if (!existsSync(tmplPath)) continue;
-    const vols = extractHostPathVolumes(template, readFileSync(tmplPath, 'utf8'));
-    for (const vol of vols) {
-      checked++;
-      const covered = isUnder(vol.key, manifestRoots) || isUnder(vol.key, excludedRoots);
-      if (!covered) uncovered.push(vol);
-    }
+    all.push(...extractHostPathVolumes(template, readFileSync(tmplPath, 'utf8')));
   }
+
+  const checked = all.length;
+  const uncovered = uncoveredVolumes(all);
 
   if (uncovered.length > 0) {
     console.error('✗ backup-coverage contract (#2153): persistent volume(s) with no manifest entry and no EXCLUDED_BULK_VOLUMES marker:\n');
@@ -119,10 +148,20 @@ function main(): void {
     }
     console.error('\nAdd a SERVICE_BACKUP_MANIFESTS entry for it, or list it in EXCLUDED_BULK_VOLUMES with a reason.');
     console.error('Both live in packages/backend/src/lib/externalBackup/serviceManifest.ts (mirror the worker copy).');
+    console.error('If a bare `{{VAR}}` hostPath is genuinely not stored state (a device, a socket), add a');
+    console.error('pattern + reason to NON_VOLUME_HOSTPATH_VARS in scripts/check-backup-coverage.ts (#2465).');
     process.exit(1);
   }
 
   console.log(`✓ backup-coverage: ${checked} persistent template volume(s) all covered (manifest or explicit bulk-exclude).`);
 }
 
-main();
+// Run only when invoked as the CLI — `toCoverageKey` / `extractHostPathVolumes`
+// / `uncoveredVolumes` are imported by tests/scripts/gate-config-truth.test.ts,
+// which must not trigger a full run (and a `process.exit`) just by importing.
+if (/check-backup-coverage\.ts$/.test(process.argv[1] ?? '')) {
+  main();
+}
+
+export { toCoverageKey, extractHostPathVolumes, uncoveredVolumes };
+export type { TemplateVolume };

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -622,6 +622,51 @@ async function checkGatePathsResolve() {
 // ---------------------------------------------------------------------------
 const WORKFLOW_DIR = path.join(REPO_ROOT, '.github', 'workflows');
 
+/**
+ * The subset of a workflow file GitHub Actions actually EXECUTES: the shell text
+ * of every `run:` step (inline scalar or `|`/`>` block), with comment-only lines
+ * dropped.
+ *
+ * #2466: this check used to match `npm run <name>` against the raw joined text
+ * of every workflow file, so a `#` comment satisfied it just as well as a step.
+ * ci.yml already carries prose comments naming script names next to (not inside)
+ * their run steps — so deleting a real `- run: npm run check:foo` while leaving
+ * its neighbouring comment kept the meta-gate green. That is the same "a gate
+ * that runs nowhere reports green" failure (#2429) this check exists to catch,
+ * one level up. Matching only executed text closes it.
+ */
+export function extractCiRunText(yamlText: string): string {
+    const lines = yamlText.split('\n');
+    const steps: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        const m = /^(\s*)(?:(-\s+))?run:(.*)$/.exec(lines[i]);
+        if (!m) continue;
+        const keyIndent = m[1].length + (m[2]?.length ?? 0);
+        const inline = m[3].trim();
+        // `run: |`, `run: >-`, `run: |2` … — the command is the indented block
+        // below. Anything else on the line IS the command (`run: npm ci`); an
+        // empty value is a mapping (`defaults:` → `run:` → `shell:`), not a step.
+        if (!/^[|>][+-]?\d*$/.test(inline)) {
+            if (inline) steps.push(inline.replace(/^(['"])(.*)\1$/, '$2'));
+            continue;
+        }
+        const body: string[] = [];
+        let j = i + 1;
+        for (; j < lines.length; j++) {
+            if (lines[j].trim() === '') continue; // blank lines belong to the block
+            if (lines[j].length - lines[j].trimStart().length <= keyIndent) break;
+            body.push(lines[j].trimStart());
+        }
+        i = j - 1;
+        steps.push(body.join('\n'));
+    }
+    // A `#` line inside a run block is a shell comment — also not executed.
+    return steps
+        .flatMap(s => s.split('\n'))
+        .filter(l => !/^\s*#/.test(l))
+        .join('\n');
+}
+
 async function checkCiRunsEveryCheckScript() {
     const pkg = JSON.parse(await readFile(path.join(REPO_ROOT, 'package.json'), 'utf-8')) as {
         scripts: Record<string, string>;
@@ -631,7 +676,19 @@ async function checkCiRunsEveryCheckScript() {
     const workflowFiles = (await readdir(WORKFLOW_DIR)).filter(f => /\.ya?ml$/.test(f));
     const workflowText = (
         await Promise.all(workflowFiles.map(f => readFile(path.join(WORKFLOW_DIR, f), 'utf-8')))
-    ).join('\n');
+    )
+        .map(extractCiRunText)
+        .join('\n');
+
+    // Fail closed if the extractor itself goes blind (a workflow-syntax change
+    // it can't parse). Without this, "no executed text" would silently turn the
+    // reverse-drift scan below into a vacuous pass.
+    if (!/\bnpm (run|ci)\b/.test(workflowText)) {
+        violations.push({
+            check: 'ci-runs-every-check-script',
+            detail: `no executable \`run:\` step in .github/workflows/ mentions npm — the run-step extractor (extractCiRunText) parsed nothing, so this gate would pass vacuously (#2466). Fix the extractor for the workflow syntax in use.`,
+        });
+    }
 
     const runsInCi = (name: string) => new RegExp(`npm run ${name.replace(/[:]/g, '[:]')}(?![\\w:-])`).test(workflowText);
 

--- a/tests/scripts/gate-config-truth.test.ts
+++ b/tests/scripts/gate-config-truth.test.ts
@@ -7,7 +7,13 @@ import {
   gateGlobToRegExp,
   extractSemgrepPathGlobs,
   extractDepcruiseRoots,
+  extractCiRunText,
 } from '../../scripts/check-invariants';
+import {
+  toCoverageKey,
+  extractHostPathVolumes,
+  uncoveredVolumes,
+} from '../../scripts/check-backup-coverage';
 
 /**
  * #2428 / #2429 / #2427 — the two ways a quality gate lies, and the doc that
@@ -41,6 +47,26 @@ const trackedFiles: string[] = execFileSync('git', ['ls-files'], {
 const matchCount = (glob: string) => {
   const re = gateGlobToRegExp(glob);
   return trackedFiles.filter(f => re.test(f)).length;
+};
+
+/** The gate's own "is this script invoked here" test, over an arbitrary text. */
+const runsInText = (text: string, name: string) =>
+  new RegExp(`npm run ${name.replace(/:/g, '[:]')}(?![\\w:-])`).test(text);
+
+/**
+ * The gate's aggregator rule: a script is covered when it is invoked directly,
+ * or when every `npm run` it chains is itself covered.
+ */
+const isSatisfied = (
+  text: string,
+  scripts: Record<string, string>,
+  name: string,
+  depth = 0,
+): boolean => {
+  if (runsInText(text, name)) return true;
+  if (depth > 2) return false;
+  const members = [...(scripts[name] ?? '').matchAll(/npm run ([\w:-]+)/g)].map(m => m[1]);
+  return members.length > 0 && members.every(m => isSatisfied(text, scripts, m, depth + 1));
 };
 
 describe('gateGlobToRegExp — gitignore / Semgrepignore v2 semantics', () => {
@@ -115,20 +141,17 @@ describe('#2429 — every local check:* gate runs in CI', () => {
     scripts: Record<string, string>;
   };
   const workflowDir = path.join(REPO_ROOT, '.github', 'workflows');
+  // Only what Actions executes — #2466. The gate itself uses the same
+  // extractor, so this spec can't drift from the script it pins.
   const workflowText = readdirSync(workflowDir)
     .filter(f => /\.ya?ml$/.test(f))
-    .map(f => readFileSync(path.join(workflowDir, f), 'utf-8'))
+    .map(f => extractCiRunText(readFileSync(path.join(workflowDir, f), 'utf-8')))
     .join('\n');
 
-  const runsInCi = (name: string) =>
-    new RegExp(`npm run ${name.replace(/:/g, '[:]')}(?![\\w:-])`).test(workflowText);
+  const runsInCi = (name: string) => runsInText(workflowText, name);
 
-  const satisfied = (name: string, depth = 0): boolean => {
-    if (runsInCi(name)) return true;
-    if (depth > 2) return false;
-    const members = [...(pkg.scripts[name] ?? '').matchAll(/npm run ([\w:-]+)/g)].map(m => m[1]);
-    return members.length > 0 && members.every(m => satisfied(m, depth + 1));
-  };
+  const satisfied = (name: string, depth = 0): boolean =>
+    isSatisfied(workflowText, pkg.scripts, name, depth);
 
   const checkScripts = Object.keys(pkg.scripts).filter(n => n.startsWith('check:'));
 
@@ -152,6 +175,135 @@ describe('#2429 — every local check:* gate runs in CI', () => {
       .map(m => m[1])
       .filter(name => !pkg.scripts[name]);
     expect(missing).toEqual([]);
+  });
+});
+
+describe('#2466 — the ci-runs-every-check-script gate sees only text Actions executes', () => {
+  const WITH_STEP = [
+    'jobs:',
+    '  arch:',
+    '    steps:',
+    '      # #2429: this is the only gate between a new volume and data loss.',
+    '      - run: npm run check:foo',
+  ].join('\n');
+
+  // The exact regression shape: the real step deleted in a refactor, its
+  // descriptive comment left behind next to where it used to be.
+  const COMMENT_ONLY = [
+    'jobs:',
+    '  arch:',
+    '    steps:',
+    '      # dropped in a refactor, but still described here: npm run check:foo',
+    '      - run: npm run typecheck',
+  ].join('\n');
+
+  const scripts = { 'check:foo': 'tsx scripts/foo.ts', typecheck: 'tsc --noEmit' };
+
+  it('a comment mentioning the script does NOT satisfy the gate', () => {
+    // Pre-fix, the gate matched the raw file text and this passed.
+    expect(COMMENT_ONLY).toContain('npm run check:foo');
+    expect(runsInText(extractCiRunText(COMMENT_ONLY), 'check:foo')).toBe(false);
+    expect(isSatisfied(extractCiRunText(COMMENT_ONLY), scripts, 'check:foo')).toBe(false);
+  });
+
+  it('a real run step DOES satisfy it (no false positive)', () => {
+    expect(runsInText(extractCiRunText(WITH_STEP), 'check:foo')).toBe(true);
+    expect(isSatisfied(extractCiRunText(WITH_STEP), scripts, 'check:foo')).toBe(true);
+  });
+
+  it('reads a `run: |` block, and drops shell comments inside it', () => {
+    const yaml = [
+      '      - name: gates',
+      '        run: |',
+      '          npm run check:one',
+      '',
+      '          # npm run check:two   <- commented out, not executed',
+      '          npm run check:three',
+      '      - run: npm run check:four',
+    ].join('\n');
+    const text = extractCiRunText(yaml);
+    expect(runsInText(text, 'check:one')).toBe(true);
+    expect(runsInText(text, 'check:three')).toBe(true);
+    expect(runsInText(text, 'check:four')).toBe(true);
+    expect(runsInText(text, 'check:two')).toBe(false);
+  });
+
+  it('does not treat a `defaults:` → `run:` mapping as a command', () => {
+    const yaml = ['defaults:', '  run:', '    shell: bash', '    working-directory: ./x'].join('\n');
+    expect(extractCiRunText(yaml).trim()).toBe('');
+  });
+
+  it('unquotes an inline scalar and stops a block at the next key', () => {
+    expect(extractCiRunText('        run: "npm run check:q"')).toBe('npm run check:q');
+    const yaml = ['      - run: |', '          npm run check:a', '        env:', '          X: 1'].join('\n');
+    expect(extractCiRunText(yaml)).toBe('npm run check:a');
+  });
+
+  it('the real workflows still expose npm commands to the gate (extractor not blind)', () => {
+    // The fail-closed guard in checkCiRunsEveryCheckScript pins this too; if the
+    // extractor ever parses nothing, every check:* would report uncovered.
+    const workflowDir = path.join(REPO_ROOT, '.github', 'workflows');
+    const executed = readdirSync(workflowDir)
+      .filter(f => /\.ya?ml$/.test(f))
+      .map(f => extractCiRunText(readFileSync(path.join(workflowDir, f), 'utf-8')))
+      .join('\n');
+    expect([...executed.matchAll(/npm run ([\w:-]+)/g)].length).toBeGreaterThan(5);
+    // …and the prose that names a script without running it is gone from view.
+    expect(executed).not.toContain('chained from');
+  });
+});
+
+describe('#2465 — backup-coverage fails closed on volume variables of any name', () => {
+  it('flags a bare {{VAR}} hostPath whose name is off the _PATH/_DIR pattern', () => {
+    // Pre-fix these returned null and were dropped before the coverage check —
+    // not reported as uncovered, invisible.
+    expect(toCoverageKey('{{MEDIA_ROOT}}')).toBe('MEDIA_ROOT');
+    expect(toCoverageKey('{{PHOTOS}}')).toBe('PHOTOS');
+    expect(toCoverageKey('{{JELLYFIN_MEDIA_PATH}}')).toBe('JELLYFIN_MEDIA_PATH');
+  });
+
+  it('exempts only the explicit non-volume patterns', () => {
+    expect(toCoverageKey('{{ZWAVE_DEVICE}}')).toBeNull();
+    expect(toCoverageKey('{{USB_DEVICES}}')).toBeNull();
+    expect(toCoverageKey('{{DOCKER_SOCKET}}')).toBeNull();
+    expect(toCoverageKey('{{HTTP_PORT}}')).toBeNull();
+    expect(toCoverageKey('{{DATA_DIR}}')).toBeNull(); // the root, not a leaf volume
+    expect(toCoverageKey('/run/dbus')).toBeNull(); // absolute host path, not our contract
+    expect(toCoverageKey('{{DATA_DIR}}/adguard/work/')).toBe('adguard/work');
+  });
+
+  it('an off-pattern uncovered volume reaches the uncovered list end to end', () => {
+    const yaml = [
+      'spec:',
+      '  volumes:',
+      '    - name: media',
+      '      hostPath:',
+      '        path: {{MEDIA_ROOT}}',
+      '        type: DirectoryOrCreate',
+      '    - name: zwave',
+      '      hostPath:',
+      '        path: {{ZWAVE_DEVICE}}',
+      '    - name: conf',
+      '      hostPath:',
+      '        path: {{DATA_DIR}}/adguard/conf',
+    ].join('\n');
+    const vols = extractHostPathVolumes('probe', yaml);
+    // The device is not a volume at all; the other two are candidates.
+    expect(vols.map(v => v.raw)).toEqual(['{{MEDIA_ROOT}}', '{{DATA_DIR}}/adguard/conf']);
+    // `adguard/conf` is manifest-covered; the off-pattern variable is not.
+    expect(uncoveredVolumes(vols).map(v => v.raw)).toEqual(['{{MEDIA_ROOT}}']);
+  });
+
+  it('leaves the volumes the real templates ship covered (no false positives)', () => {
+    const templatesDir = path.join(REPO_ROOT, 'templates');
+    const vols = readdirSync(templatesDir, { withFileTypes: true })
+      .filter(e => e.isDirectory())
+      .flatMap(e => {
+        const f = path.join(templatesDir, e.name, 'template.yml');
+        return existsSync(f) ? extractHostPathVolumes(e.name, readFileSync(f, 'utf-8')) : [];
+      });
+    expect(vols.length).toBeGreaterThan(10);
+    expect(uncoveredVolumes(vols)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Batch of 8: last 5 findings from the 2026-07-29 codebase eval, plus a lint-ratchet burn-down continuation.

- **silent-failure-toasts** (#2460, #2461, #2462) — setup wizard's Finish step, the API-token revoke modal, and the registry dashboard now surface real errors (visible message, modal stays open on failure) instead of silently succeeding-looking.
- **gate-meta-check-blindspots** (#2465, #2466) — two of ServiceBay's own quality gates had fail-open holes: `check-backup-coverage` now fails closed on any un-recognized `{{VAR}}` hostPath instead of silently allowing it through, and `ci-runs-every-check-script` now only matches executed CI `run:` steps (was previously fooled by dead/commented text).
- **dep-update-sweep** — no safe merges; #2291 (TypeScript 7) still genuinely CI-red, held again.
- **Lint ratchet continuation** — remaining `sb/no-raw-color-literal` violations in NetworkDashboard.tsx and its `_lib` helper. Baseline down from 670 to 566 this batch (1270 → 566 overall this session).

This closes out the entire 15-finding codebase eval from earlier in this session (3 severe security fixes, 3 misc script bugs, 6 frontend race/silent-failure bugs, 2 quality-gate blind spots — all now shipped).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
