### PR TITLE
fix(settings): stop Button defaults from clobbering the email-toggle pill

### DIFF
--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/EmailNotificationsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/EmailNotificationsSection.tsx
@@ -88,8 +88,14 @@ export default function EmailNotificationsSection() {
           aria-label="Enable email notifications"
           onClick={() => handleEnabledToggle(!emailEnabled)}
           disabled={saving}
-          className={`relative h-6 w-11 shrink-0 items-center rounded-chip transition-colors ${emailEnabled ? 'bg-accent' : 'bg-surface-muted border border-border'}`}
           type="button"
+          variant="ghost"
+          // The track is a fixed-size pill, not a padded/filled action button — force the
+          // primitive's size/variant defaults out with `!` (same escape hatch used for
+          // Button overrides elsewhere, e.g. ContainerLogsPanel.tsx, Sidebar.tsx) so
+          // `size="md"`'s h-10/px-space-4 and the ghost hover fill can't silently win the
+          // cascade against this element's own geometry/colour (#box-verify bde0d914 regression).
+          className={`relative !h-6 !w-11 !px-0 shrink-0 items-center !rounded-chip transition-colors ${emailEnabled ? '!bg-accent hover:!bg-accent' : '!bg-surface-muted hover:!bg-surface-muted border border-border'}`}
         >
           <span className={`inline-block h-4 w-4 transform rounded-chip bg-white transition-transform ${emailEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
         </Button>


### PR DESCRIPTION
## Summary

Box-verify on merge SHA `bde0d914` (PR #2477, the color-literal/ui-primitive
lint sweep) found a real render regression in
`EmailNotificationsSection.tsx`'s "Enable email notifications" toggle switch,
introduced when it was migrated from a raw `<button>` to the `<Button>`
primitive without an explicit `variant`/`size` override.

`cn()` (`packages/frontend/src/components/ui/cn.ts`) is a plain string
joiner — it does not dedupe conflicting Tailwind utilities. So `Button`'s
default `size="md"` (`h-10 px-space-4`) and `variant="primary"`
(`bg-accent`, `hover:bg-accent-strong`) utilities land in the class list
alongside the switch's own pill classes (`h-6 w-11`, conditional
`bg-accent`/`bg-surface-muted`), with nothing resolving the conflict.

Verified against an actual `@tailwindcss/postcss` build of the compiled
stylesheet: `h-10` is emitted after `h-6` and wins the cascade, so the
switch was rendering at button height with unwanted horizontal padding, and
hover always flashed `accent-strong` regardless of on/off state.

## Fix

Keep `<Button>` (reverting to a raw `<button>` would regress the monotonic
`sb/no-raw-ui-primitive` lint ratchet in `.eslint-ratchet-baseline.json`),
but force the track's own geometry/colour with `!`-important overrides — the
same escape hatch already used elsewhere for `Button` overrides
(`ContainerLogsPanel.tsx`, `Sidebar.tsx`, wizard steps). Re-verified the fix
against the compiled CSS: `!h-6`/`!w-11`/`!px-0`/`!rounded-chip`/`!bg-accent`/
`!bg-surface-muted`/`hover:!bg-*` all carry `!important` and win regardless
of stylesheet order.

## Test plan
- [x] `npm run check:lint-ratchet` — holds at baseline (no new raw-primitive violation)
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run check:arch` — all checks pass
- [x] `EmailNotificationsSection.test.tsx` — 3/3 pass
- [x] Compiled-CSS check confirms the `!important` overrides win the cascade for both on/off states and hover

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
