### PR TITLE
chore: lint-ratchet burn-down continuation (batch d)

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 389,
-    "sb/no-raw-ui-primitive": 224
+    "sb/no-raw-ui-primitive": 216
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 389,
-    "sb/no-raw-ui-primitive": 216
+    "sb/no-raw-ui-primitive": 208
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 373,
+    "sb/no-raw-color-literal": 358,
     "sb/no-raw-ui-primitive": 208
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 389,
+    "sb/no-raw-color-literal": 373,
     "sb/no-raw-ui-primitive": 208
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 389,
-    "sb/no-raw-ui-primitive": 233
+    "sb/no-raw-ui-primitive": 224
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 389,
-    "sb/no-raw-ui-primitive": 242
+    "sb/no-raw-ui-primitive": 233
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 358,
+    "sb/no-raw-color-literal": 343,
     "sb/no-raw-ui-primitive": 208
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 343,
+    "sb/no-raw-color-literal": 328,
     "sb/no-raw-ui-primitive": 208
   }
 }

--- a/packages/frontend/src/app/portal/RequestAccessDialog.tsx
+++ b/packages/frontend/src/app/portal/RequestAccessDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Loader2 } from 'lucide-react';
+import { Button, Input, Textarea } from '@/components/ui';
 
 /**
  * The request-access modal itself — the form that collects everything
@@ -98,12 +99,13 @@ export default function RequestAccessDialog({ onClose }: { onClose: () => void }
             <p className="text-sm text-text-muted leading-relaxed font-medium">
               The family administrator has been notified. They will create your account in the local identity pool and notify you when it is ready.
             </p>
-            <button
+            <Button
               onClick={onClose}
-              className="mt-space-4 px-space-5 py-2.5 bg-accent hover:bg-accent-strong text-on-accent text-sm font-semibold rounded-card shadow transition-colors"
+              variant="primary"
+              className="mt-space-4"
             >
               Got it
-            </button>
+            </Button>
           </div>
         ) : (
           <form onSubmit={onSubmit} className="space-y-space-5">
@@ -119,7 +121,7 @@ export default function RequestAccessDialog({ onClose }: { onClose: () => void }
                 <label className={FIELD_LABEL}>
                   First name <span className="text-status-fail">*</span>
                 </label>
-                <input
+                <Input
                   type="text"
                   value={firstName}
                   onChange={e => setFirstName(e.target.value)}
@@ -133,7 +135,7 @@ export default function RequestAccessDialog({ onClose }: { onClose: () => void }
                 <label className={FIELD_LABEL}>
                   Last name <span className="text-status-fail">*</span>
                 </label>
-                <input
+                <Input
                   type="text"
                   value={lastName}
                   onChange={e => setLastName(e.target.value)}
@@ -149,7 +151,7 @@ export default function RequestAccessDialog({ onClose }: { onClose: () => void }
               <label className={FIELD_LABEL}>
                 Desired username <span className="text-status-fail">*</span>
               </label>
-              <input
+              <Input
                 type="text"
                 value={username}
                 onChange={e => setUsername(e.target.value.toLowerCase())}
@@ -170,7 +172,7 @@ export default function RequestAccessDialog({ onClose }: { onClose: () => void }
               <label className={FIELD_LABEL}>
                 Your email <span className="text-status-fail">*</span>
               </label>
-              <input
+              <Input
                 type="email"
                 value={email}
                 onChange={e => setEmail(e.target.value)}
@@ -185,7 +187,7 @@ export default function RequestAccessDialog({ onClose }: { onClose: () => void }
               <label className={FIELD_LABEL}>
                 Anything else? <span className="text-text-subtle">(optional)</span>
               </label>
-              <textarea
+              <Textarea
                 value={message}
                 onChange={e => setMessage(e.target.value)}
                 maxLength={1000}
@@ -202,21 +204,21 @@ export default function RequestAccessDialog({ onClose }: { onClose: () => void }
             )}
 
             <div className="flex justify-end gap-space-2 pt-space-2">
-              <button
+              <Button
                 type="button"
                 onClick={onClose}
-                className="px-space-4 py-space-2 text-sm text-text-muted hover:text-text"
+                variant="ghost"
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
                 disabled={submitting}
-                className="inline-flex items-center gap-space-2 px-space-4 py-space-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded-card disabled:opacity-50"
+                variant="primary"
               >
                 {submitting && <Loader2 size={14} className="animate-spin" />}
                 Send request
-              </button>
+              </Button>
             </div>
           </form>
         )}

--- a/packages/frontend/src/components/DoneStepDnsCheck.tsx
+++ b/packages/frontend/src/components/DoneStepDnsCheck.tsx
@@ -75,17 +75,17 @@ export function DoneStepDnsCheck({ domain, subdomains }: DoneStepDnsCheckProps) 
 
   if (state.phase === 'loading') {
     return (
-      <div className="p-2.5 bg-gray-50 dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700 text-sm">
-        <p className="text-xs text-gray-600 dark:text-gray-400">⏳ Checking DNS for {subdomains.length} host{subdomains.length === 1 ? '' : 's'}…</p>
+      <div className="p-2.5 bg-surface rounded border border-border text-sm">
+        <p className="text-xs text-text-muted">⏳ Checking DNS for {subdomains.length} host{subdomains.length === 1 ? '' : 's'}…</p>
       </div>
     );
   }
 
   if (state.phase === 'error') {
     return (
-      <div className="p-2.5 bg-amber-50 dark:bg-amber-900/20 rounded border border-amber-200 dark:border-amber-800 text-sm space-y-1.5">
-        <p className="font-medium text-amber-800 dark:text-amber-200">DNS check unavailable</p>
-        <p className="text-xs text-amber-700 dark:text-amber-300">
+      <div className="p-2.5 bg-status-warn/10 rounded border border-status-warn text-sm space-y-1.5">
+        <p className="font-medium text-status-warn">DNS check unavailable</p>
+        <p className="text-xs text-status-warn">
           Couldn&apos;t verify DNS automatically: {state.message}. Make sure each subdomain has an A record pointing to your server&apos;s public IP.
         </p>
       </div>
@@ -104,11 +104,11 @@ export function DoneStepDnsCheck({ domain, subdomains }: DoneStepDnsCheckProps) 
 
   if (allMatched) {
     return (
-      <div className="p-2.5 bg-emerald-50 dark:bg-emerald-900/20 rounded border border-emerald-200 dark:border-emerald-800 text-sm space-y-1.5">
-        <p className="font-medium text-emerald-800 dark:text-emerald-200">
+      <div className="p-2.5 bg-status-ok/10 rounded border border-status-ok text-sm space-y-1.5">
+        <p className="font-medium text-status-ok">
           ✓ DNS configured for all {results.length} host{results.length === 1 ? '' : 's'}
         </p>
-        <p className="text-xs text-emerald-700 dark:text-emerald-300">
+        <p className="text-xs text-status-ok">
           Every subdomain already resolves to {expectedIPs.length === 1 ? expectedIPs[0] : `your server (${expectedIPs.join(' or ')})`}.
         </p>
       </div>
@@ -117,29 +117,29 @@ export function DoneStepDnsCheck({ domain, subdomains }: DoneStepDnsCheckProps) 
 
   // Partial / no match — show what needs to change.
   return (
-    <div className="p-2.5 bg-blue-50 dark:bg-blue-900/20 rounded border border-blue-200 dark:border-blue-800 text-sm space-y-1.5">
-      <p className="font-medium text-blue-800 dark:text-blue-200">
+    <div className="p-2.5 bg-status-info/10 rounded border border-status-info text-sm space-y-1.5">
+      <p className="font-medium text-status-info">
         Configure DNS for {unmatched.length} host{unmatched.length === 1 ? '' : 's'}
         {matched.length > 0 ? ` (${matched.length} already pointing here ✓)` : ''}
       </p>
-      <p className="text-xs text-blue-700 dark:text-blue-300">
+      <p className="text-xs text-status-info">
         Add A records pointing to {expectedIPs.length > 0
           ? expectedIPs.join(' (or ')
           : <span>your server&apos;s public IP</span>}
         {expectedIPs.length > 1 ? ')' : ''}:
       </p>
-      <div className="font-mono text-xs text-blue-600 dark:text-blue-400 space-y-0.5">
+      <div className="font-mono text-xs text-status-info space-y-0.5">
         {unmatched.map(r => (
           <div key={r.domain}>
             {r.domain} &rarr;{' '}
             {r.resolvesTo
-              ? <span className="text-amber-600 dark:text-amber-400">currently {r.resolvesTo}</span>
-              : <span className="text-gray-500 dark:text-gray-500">not resolving{r.error ? ` (${r.error})` : ''}</span>
+              ? <span className="text-status-warn">currently {r.resolvesTo}</span>
+              : <span className="text-text-muted">not resolving{r.error ? ` (${r.error})` : ''}</span>
             }
           </div>
         ))}
       </div>
-      <p className="text-[11px] text-blue-600 dark:text-blue-400 opacity-70 pt-1">
+      <p className="text-[11px] text-status-info opacity-70 pt-1">
         Lookup uses a public resolver — once your DNS provider has propagated the change, the warning here clears on the next reload.
       </p>
       {/* Suppress unused-prop warning while keeping the prop in the public API. */}

--- a/packages/frontend/src/components/InstallProgressCard.tsx
+++ b/packages/frontend/src/components/InstallProgressCard.tsx
@@ -44,15 +44,15 @@ export function InstallProgressCardView({
 }) {
   const { phase, currentItem, deployed, total, percent, needsCredentials, logs, postDeployProgress } = state;
   return (
-    <div className="rounded-2xl p-5 glass-panel border border-blue-500/20 bg-gradient-to-br from-blue-500/10 to-indigo-500/5 space-y-4">
+    <div className="rounded-2xl p-5 glass-panel border border-accent/20 bg-gradient-to-br from-accent/10 to-accent/5 space-y-4">
       <div className="flex items-center justify-between gap-3">
-        <h2 className="text-base font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
-          <Loader2 size={18} className="text-blue-500 shrink-0 animate-spin" />
+        <h2 className="text-base font-bold text-text flex items-center gap-2">
+          <Loader2 size={18} className="text-accent shrink-0 animate-spin" />
           {phaseLabel(phase)}
-          {currentItem && <span className="font-medium text-gray-500 dark:text-gray-400">· {currentItem}</span>}
+          {currentItem && <span className="font-medium text-text-muted">· {currentItem}</span>}
         </h2>
         {total > 0 && (
-          <span className="text-sm font-semibold text-blue-600 dark:text-blue-400 shrink-0 tabular-nums">
+          <span className="text-sm font-semibold text-status-info shrink-0 tabular-nums">
             {deployed}/{total}
           </span>
         )}
@@ -60,13 +60,13 @@ export function InstallProgressCardView({
 
       {/* Percent bar (% = deployed/total). */}
       <div className="space-y-1">
-        <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-800 overflow-hidden">
+        <div className="h-2 w-full rounded-full bg-surface-2 overflow-hidden">
           <div
-            className="h-full rounded-full bg-blue-500 transition-[width] duration-500"
+            className="h-full rounded-full bg-accent transition-[width] duration-500"
             style={{ width: `${percent}%` }}
           />
         </div>
-        <p className="text-xs text-gray-500 dark:text-gray-400 tabular-nums">{percent}%</p>
+        <p className="text-xs text-text-muted tabular-nums">{percent}%</p>
       </div>
 
       {/* Post-deploy progress bar (#1288). A template's post-deploy step
@@ -76,7 +76,7 @@ export function InstallProgressCardView({
           a silent hang. Shows only while a tick is in flight. */}
       {postDeployProgress && (
         <div className="space-y-1">
-          <div className="flex items-center justify-between gap-2 text-xs text-gray-500 dark:text-gray-400">
+          <div className="flex items-center justify-between gap-2 text-xs text-text-muted">
             <span className="truncate">{postDeployProgress.tag ?? 'Post-deploy'}</span>
             <span className="tabular-nums shrink-0">
               {postDeployProgress.completedMb !== undefined && postDeployProgress.totalMb !== undefined
@@ -84,9 +84,9 @@ export function InstallProgressCardView({
                 : `${postDeployProgress.percent}%`}
             </span>
           </div>
-          <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-800 overflow-hidden">
+          <div className="h-2 w-full rounded-full bg-surface-2 overflow-hidden">
             <div
-              className="h-full rounded-full bg-indigo-500 transition-[width] duration-500"
+              className="h-full rounded-full bg-status-info transition-[width] duration-500"
               style={{ width: `${postDeployProgress.percent}%` }}
             />
           </div>
@@ -97,14 +97,14 @@ export function InstallProgressCardView({
           continues with the auto-generated fallback; proxy routes can
           be set later in Settings → Networking & Access. */}
       {needsCredentials && (
-        <div className="rounded-xl border border-amber-300/60 dark:border-amber-800/50 bg-amber-50/80 dark:bg-amber-950/20 p-3 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-          <p className="text-xs text-amber-800 dark:text-amber-300 leading-relaxed">
+        <div className="rounded-xl border border-status-warn bg-status-warn/10 p-3 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <p className="text-xs text-status-warn leading-relaxed">
             Waiting for reverse-proxy credentials. Skip to continue with auto-generated ones — you can set them later in Settings.
           </p>
           <button
             type="button"
             onClick={onSkipCredentials}
-            className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg bg-amber-600 hover:bg-amber-700 text-white transition-colors"
+            className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg bg-status-warn hover:bg-status-warn/90 text-on-accent transition-colors"
           >
             <KeyRound size={13} /> Skip credentials
           </button>
@@ -113,7 +113,7 @@ export function InstallProgressCardView({
 
       {/* Log tail — the last few install-runner lines, monospaced. */}
       {logs.length > 0 && (
-        <pre className="text-[11px] leading-relaxed font-mono text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-black/30 rounded-xl p-3 overflow-x-auto max-h-44 whitespace-pre-wrap break-words">
+        <pre className="text-[11px] leading-relaxed font-mono text-text-muted bg-surface-muted rounded-xl p-3 overflow-x-auto max-h-44 whitespace-pre-wrap break-words">
           {logs.join('\n')}
         </pre>
       )}

--- a/packages/frontend/src/components/InstallerModal.test.tsx
+++ b/packages/frontend/src/components/InstallerModal.test.tsx
@@ -212,7 +212,7 @@ describe('InstallerModal — phase footers', () => {
 
     await screen.findByTestId('stack-install-flow');
     const back = screen.getByRole('button', { name: 'Back' });
-    expect(back.className).toContain('text-foreground');
+    expect(back.className).toContain('text-text');
     fireEvent.click(back);
     expect(controller.reset).toHaveBeenCalled();
 
@@ -242,8 +242,8 @@ describe('InstallerModal — phase footers', () => {
     renderModal();
     const btn = await screen.findByRole('button', { name: 'Installing...' });
     expect((btn as HTMLButtonElement).disabled).toBe(true);
-    expect(btn.className).toContain('bg-border');
-    expect(btn.className).toContain('text-muted');
+    expect(btn.className).toContain('bg-surface-2');
+    expect(btn.className).toContain('text-text');
   });
 
   it('done: routes to the dashboard from the accent action', async () => {
@@ -260,8 +260,8 @@ describe('InstallerModal — phase footers', () => {
     controller = makeController({ phase: 'error', error: 'boom' });
     const { onClose } = renderModal();
     const btn = await screen.findByRole('button', { name: 'Close' });
-    expect(btn.className).toContain('bg-border');
-    expect(btn.className).toContain('text-foreground');
+    expect(btn.className).toContain('bg-surface-2');
+    expect(btn.className).toContain('text-text');
     fireEvent.click(btn);
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/frontend/src/components/InstallerModal.tsx
+++ b/packages/frontend/src/components/InstallerModal.tsx
@@ -9,6 +9,7 @@ import { Layers, Folder, X } from 'lucide-react';
 import TemplateUpgradeBanner from './TemplateUpgradeBanner';
 import StackInstallFlow from './StackInstallFlow';
 import { useRouter } from 'next/navigation';
+import { Button, Input } from '@/components/ui';
 
 /**
  * Registry-side install entry point. Used when an operator clicks a stack
@@ -189,9 +190,9 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
               : <Folder className="text-accent" />}
             Install {template.type === 'stack' ? 'Stack' : 'Template'}: {template.name}
           </h3>
-          <button onClick={onClose} className="text-muted hover:text-foreground">
+          <Button onClick={onClose} variant="ghost" className="text-muted hover:text-foreground">
             <X size={24} />
-          </button>
+          </Button>
         </div>
 
         <div className="p-6 overflow-y-auto flex-1">
@@ -209,7 +210,7 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
                   <div className="space-y-2 mb-6">
                     {selectItems.map((item, i) => (
                       <label key={item.name} className="flex items-center gap-3 p-3 border border-border rounded hover:bg-surface-2 cursor-pointer transition-colors">
-                        <input
+                        <Input
                           type="checkbox"
                           checked={item.checked}
                           onChange={() => handleToggle(i)}
@@ -297,52 +298,53 @@ export default function InstallerModal({ template, readme, isOpen, onClose }: In
         <div className="p-6 border-t border-border flex justify-end gap-3 bg-surface-muted rounded-b-lg">
           {phase === 'idle' && template.type === 'stack' && (
             <>
-              <button onClick={onClose} className="px-4 py-2 text-foreground hover:bg-surface-2 rounded transition-colors">Cancel</button>
-              <button
+              <Button onClick={onClose} variant="secondary">Cancel</Button>
+              <Button
                 onClick={() => { void advanceToConfigure(); }}
                 disabled={!allUpgradesReady || advancing}
                 title={!allUpgradesReady && checkedItems.length > 0 ? 'Acknowledge the breaking-change banner(s) above to continue.' : undefined}
-                className="px-4 py-2 bg-accent text-on-accent rounded hover:bg-accent-strong disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
+                variant="primary"
               >
                 Continue
-              </button>
+              </Button>
             </>
           )}
           {phase === 'configure' && (
             <>
-              <button
+              <Button
                 onClick={() => template.type === 'stack' ? controller.reset() : onClose()}
-                className="px-4 py-2 text-foreground hover:bg-surface-2 rounded transition-colors"
+                variant="secondary"
               >
                 {template.type === 'stack' ? 'Back' : 'Cancel'}
-              </button>
-              <button
+              </Button>
+              <Button
                 onClick={() => { void controller.runInstall({ node: selectedNode }); }}
                 disabled={!selectedNode}
-                className="px-4 py-2 bg-status-ok text-on-accent rounded hover:opacity-90 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                variant="primary"
+                className="bg-status-ok hover:opacity-90 text-on-accent"
               >
                 Install
-              </button>
+              </Button>
             </>
           )}
           {phase === 'installing' && (
-            <button disabled className="px-4 py-2 bg-border text-muted rounded cursor-not-allowed">Installing...</button>
+            <Button disabled variant="secondary">Installing...</Button>
           )}
           {phase === 'done' && (
-            <button
+            <Button
               onClick={() => { onClose(); router.push('/'); }}
-              className="px-4 py-2 bg-accent text-on-accent rounded hover:bg-accent-strong font-medium transition-colors"
+              variant="primary"
             >
               Go to Dashboard
-            </button>
+            </Button>
           )}
           {phase === 'error' && (
-            <button
+            <Button
               onClick={onClose}
-              className="px-4 py-2 bg-border text-foreground rounded hover:opacity-80 font-medium transition-colors"
+              variant="secondary"
             >
               Close
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/packages/frontend/src/components/ReverseProxyConfig.tsx
+++ b/packages/frontend/src/components/ReverseProxyConfig.tsx
@@ -51,31 +51,31 @@ export default function ReverseProxyConfig() {
 
     return (
         <div className="flex flex-col h-full">
-            <div className="p-4 border-b border-gray-200 dark:border-gray-800 flex justify-between items-center bg-white dark:bg-gray-900">
-                <h2 className="font-bold text-xl text-gray-900 dark:text-white flex items-center gap-2">
-                    <Shield className="text-green-500" />
+            <div className="p-4 border-b border-border flex justify-between items-center bg-surface">
+                <h2 className="font-bold text-xl text-text flex items-center gap-2">
+                    <Shield className="text-status-ok" />
                     Reverse Proxy (Nginx Proxy Manager)
                 </h2>
                 <button
                     onClick={checkStatus}
                     disabled={loading}
-                    className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+                    className="p-2 text-text-muted hover:bg-surface-2 rounded-lg transition-colors"
                 >
                     <RefreshCw size={20} className={loading ? 'animate-spin' : ''} />
                 </button>
             </div>
 
-            <div className="flex-1 p-6 overflow-y-auto bg-gray-50 dark:bg-gray-950">
+            <div className="flex-1 p-6 overflow-y-auto bg-surface-2">
                 <div className="max-w-2xl mx-auto space-y-6">
                     {/* Status Card */}
-                    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-200 dark:border-gray-800 p-6">
+                    <div className="bg-surface rounded-xl shadow-sm border border-border p-6">
                         <div className="flex items-center gap-4 mb-4">
-                            <div className={`p-3 rounded-full ${status === 'installed' ? 'bg-green-100 text-green-600' : 'bg-yellow-100 text-yellow-600'}`}>
+                            <div className={`p-3 rounded-full ${status === 'installed' ? 'bg-status-ok/10 text-status-ok' : 'bg-status-warn/10 text-status-warn'}`}>
                                 <Server size={24} />
                             </div>
                             <div>
                                 <h3 className="font-semibold text-lg">System Status</h3>
-                                <p className="text-gray-500 text-sm">
+                                <p className="text-text-muted text-sm">
                                     {status === 'installed'
                                         ? `Nginx is installed and managed by ServiceBay${nginxNode && nginxNode !== 'Local' ? ` on ${nginxNode}` : ''}`
                                         : 'Nginx is not installed on this system'}
@@ -84,16 +84,16 @@ export default function ReverseProxyConfig() {
                         </div>
 
                         {status === 'not-installed' && (
-                            <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-100 dark:border-blue-800">
-                                <h4 className="font-medium text-blue-900 dark:text-blue-100 mb-2">Installation Required</h4>
-                                <p className="text-sm text-blue-700 dark:text-blue-300 mb-4">
+                            <div className="mt-4 p-4 bg-status-info/10 rounded-lg border border-status-info/20">
+                                <h4 className="font-medium text-status-info mb-2">Installation Required</h4>
+                                <p className="text-sm text-status-info mb-4">
                                     Nginx Proxy Manager provides a web UI for managing reverse proxy hosts, SSL certificates, and redirections.
                                     ServiceBay can install it automatically.
                                 </p>
                                 <button
                                     onClick={handleInstall}
                                     disabled={installing}
-                                    className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50"
+                                    className="flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent rounded-lg transition-colors disabled:opacity-50"
                                 >
                                     {installing ? (
                                         <>
@@ -112,7 +112,7 @@ export default function ReverseProxyConfig() {
 
                         {status === 'installed' && (
                             <div className="mt-4 space-y-3">
-                                <div className="flex items-center gap-2 text-green-600 bg-green-50 dark:bg-green-900/20 p-3 rounded-lg border border-green-100 dark:border-green-800">
+                                <div className="flex items-center gap-2 text-status-ok bg-status-ok/10 p-3 rounded-lg border border-status-ok/20">
                                     <Check size={20} />
                                     <span className="font-medium">Ready to serve traffic</span>
                                 </div>
@@ -120,7 +120,7 @@ export default function ReverseProxyConfig() {
                                     href={`${window.location.protocol}//${window.location.hostname}:${adminPort}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors text-sm font-medium"
+                                    className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent rounded-lg transition-colors text-sm font-medium"
                                 >
                                     <ExternalLink size={16} />
                                     Open Admin UI

--- a/packages/frontend/src/components/ServiceMonitor.tsx
+++ b/packages/frontend/src/components/ServiceMonitor.tsx
@@ -5,6 +5,8 @@ import { RefreshCw, Terminal, Activity, Box, ArrowLeft, FileJson, DatabaseBackup
 import { useRouter, useSearchParams } from 'next/navigation';
 import { logger } from '@servicebay/api-client';
 import ContainerList from './ContainerList';
+import { Button } from './ui/Button';
+import { Select } from './ui/Select';
 import type { EnrichedContainer } from '@servicebay/api-client';
 
 interface ServiceMonitorProps {
@@ -197,9 +199,9 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
             {variant === 'page' && (
                 <div className="flex justify-between items-center mb-6 p-4 border-b border-border bg-surface dark:bg-surface/50">
                     <div className="flex items-center gap-4">
-                            <button onClick={handleBack} className="p-2 hover:bg-surface-2 dark:hover:bg-surface-2 rounded-full transition-colors">
+                            <Button onClick={handleBack} variant="ghost" size="sm" className="rounded-full">
                                     <ArrowLeft size={24} className="text-muted dark:text-muted" />
-                            </button>
+                            </Button>
                             <h1 className="text-xl font-bold text-foreground dark:text-foreground">Monitor: {serviceName}</h1>
                     </div>
                     <div className="flex items-center gap-3">
@@ -208,22 +210,24 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
                                     {backupMsg.text}
                                 </span>
                             )}
-                            <button
+                            <Button
                                     onClick={handleBackupConfig}
                                     disabled={backingUp}
-                                    className="px-3 py-2 flex items-center gap-2 text-sm text-muted dark:text-muted bg-surface dark:bg-surface-2 border border-border dark:border-border rounded hover:bg-surface-2 dark:hover:bg-surface-2 shadow-sm transition-colors disabled:opacity-50"
+                                    variant="secondary"
+                                    size="sm"
                                     title="Back up this service's config to the FritzBox NAS"
                             >
                                     <DatabaseBackup size={18} className={backingUp ? 'animate-pulse' : ''} /> Back up config
-                            </button>
-                            <button
+                            </Button>
+                            <Button
                                     onClick={fetchLogs}
                                     disabled={loading}
-                                    className="p-2 text-muted dark:text-muted bg-surface dark:bg-surface-2 border border-border dark:border-border rounded hover:bg-surface-2 dark:hover:bg-surface-2 shadow-sm transition-colors"
+                                    variant="secondary"
+                                    size="sm"
                                     title="Refresh"
                             >
                                     <RefreshCw size={20} className={loading ? 'animate-spin' : ''} />
-                            </button>
+                            </Button>
                     </div>
                 </div>
             )}
@@ -231,30 +235,34 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
             <div className={`flex-1 flex flex-col min-h-0 ${variant === 'embedded' ? 'p-0' : 'p-6'}`}>
       <div className="bg-surface dark:bg-surface rounded-lg border border-border dark:border-border shadow-sm overflow-hidden flex flex-col flex-1 min-h-0">
         <div className="flex border-b border-border dark:border-border bg-surface dark:bg-surface/50 shrink-0">
-            <button
+            <Button
+            variant="ghost"
             className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'status' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('status')}
             >
             <Activity size={16} /> Status
-            </button>
-            <button
+            </Button>
+            <Button
+            variant="ghost"
             className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'service' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('service')}
             >
             <Terminal size={16} /> Service Logs
-            </button>
-            <button
+            </Button>
+            <Button
+            variant="ghost"
             className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'container-logs' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('container-logs')}
             >
             <Box size={16} /> Container Logs & Info
-            </button>
-            <button
+            </Button>
+            <Button
+            variant="ghost"
             className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'network' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('network')}
             >
             <FileJson size={16} /> Raw Data / Config
-            </button>
+            </Button>
         </div>
 
         <div className="bg-surface-muted dark:bg-surface-muted p-4 flex-1 overflow-y-auto">
@@ -309,7 +317,7 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
                             <div>
                                 <div className="flex items-center justify-between mb-2">
                                     <h4 className="text-subtle text-sm font-bold">Container Logs</h4>
-                                    <select
+                                    <Select
                                         className="bg-surface-2 text-foreground text-sm rounded border border-border p-1"
                                         value={selectedContainerId || ''}
                                         onChange={(e) => setSelectedContainerId(e.target.value)}
@@ -319,7 +327,7 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
                                                 {c.names?.[0]} ({c.id?.substring(0, 12)})
                                             </option>
                                         ))}
-                                    </select>
+                                    </Select>
                                 </div>
                                 <pre className="text-sm font-mono text-muted whitespace-pre-wrap bg-surface p-4 rounded border border-border min-h-[300px]">
                                     {containerLogs || 'Select a container to view logs.'}

--- a/packages/frontend/src/components/StackInstallFlow.tsx
+++ b/packages/frontend/src/components/StackInstallFlow.tsx
@@ -30,6 +30,7 @@ import StackVariableField from './StackVariableField';
 import { groupVariablesByTemplate } from '@servicebay/api-client';
 import { buildBitwardenCsv } from '@servicebay/api-client';
 import type { UseStackInstallReturn } from '@/hooks/useStackInstall';
+import { Button, Input, Select } from '@/components/ui';
 
 interface DeviceContext {
   deviceOptions: Record<string, string[]>;
@@ -79,7 +80,7 @@ export function StackInstallConfigureForm({
       {nodes && nodes.length > 1 && (
         <div>
           <label className="block text-xs font-medium text-subtle uppercase mb-1">Target Node</label>
-          <select
+          <Select
             value={selectedNode ?? ''}
             onChange={(e) => onSelectNode?.(e.target.value)}
             className={inputClassName ?? 'w-full p-2 border border-border bg-surface text-text rounded'}
@@ -88,7 +89,7 @@ export function StackInstallConfigureForm({
             {nodes.map(n => (
               <option key={n.Name} value={n.Name}>{n.Name} ({n.URI})</option>
             ))}
-          </select>
+          </Select>
         </div>
       )}
 
@@ -211,32 +212,34 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
             their templates again. */}
       {phase === 'installing' && (
         <div className="mt-3 flex items-center justify-end">
-          <button
+          <Button
             type="button"
             onClick={() => {
               if (window.confirm('Abort the install? Already-deployed services stay running; in-flight templates may be partially applied.')) {
                 abortInstall();
               }
             }}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-status-fail text-on-accent hover:opacity-80"
+            variant="danger"
+            className="inline-flex items-center gap-1.5"
           >
             <XCircle size={14} /> Abort install
-          </button>
+          </Button>
         </div>
       )}
       {phase === 'error' && (
         <div className="mt-3 flex items-center justify-end">
-          <button
+          <Button
             type="button"
             onClick={() => {
               if (window.confirm('Start over? This wipes the current install state and returns to the template catalog. Any services already deployed on the host stay running.')) {
                 reset();
               }
             }}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-status-warn text-on-accent hover:opacity-80"
+            variant="secondary"
+            className="inline-flex items-center gap-1.5"
           >
             <RefreshCcw size={14} /> Start over
-          </button>
+          </Button>
         </div>
       )}
 
@@ -251,14 +254,14 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
             {' '}Click <span className="font-semibold">Authenticate &amp; Retry</span> to submit these values, replace them with whatever password you know NPM is actually using, or Skip to configure proxy routes manually later.
           </p>
           <div className="space-y-2">
-            <input
+            <Input
               type="email"
               value={credEmail}
               onChange={(e) => setCredEmail(e.target.value)}
               className="w-full px-3 py-2 bg-surface border border-border rounded-md text-sm"
               placeholder="NPM admin email"
             />
-            <input
+            <Input
               type="text"
               value={credPassword}
               onChange={(e) => setCredPassword(e.target.value)}
@@ -273,19 +276,20 @@ export function StackInstallProgress({ controller, beforeLog }: ProgressProps) {
               </p>
             )}
             <div className="flex gap-2">
-              <button
+              <Button
                 onClick={() => { void retryNpmCredentials(credEmail, credPassword); }}
                 disabled={!credPassword}
-                className="flex-1 px-3 py-2 bg-status-warn text-on-accent rounded-md text-sm font-medium hover:opacity-80 disabled:opacity-50"
+                variant="secondary"
+                className="flex-1"
               >
                 Authenticate &amp; Retry
-              </button>
-              <button
+              </Button>
+              <Button
                 onClick={skipNpmCredentials}
-                className="px-3 py-2 text-subtle hover:text-text text-sm"
+                variant="ghost"
               >
                 Skip
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -318,14 +322,15 @@ export function StackInstallSummary({ controller, doneFooter }: SummaryProps) {
         <div className="p-3 bg-surface rounded border border-border text-sm">
           <div className="flex items-center justify-between mb-2">
             <p className="font-medium text-status-fail">🔑 Credentials — save now</p>
-            <button
+            <Button
               type="button"
               onClick={downloadCsv}
-              className="text-xs px-2 py-1 bg-status-fail hover:opacity-80 text-on-accent rounded"
+              variant="danger"
+              size="sm"
               title="Download as Bitwarden / Vaultwarden CSV"
             >
               ⬇ Download CSV
-            </button>
+            </Button>
           </div>
           <p className="text-xs text-status-fail mb-2">
             Won&apos;t be shown again. Either copy them into your password manager now or use the CSV button: Vaultwarden → Tools → Import → Bitwarden (csv).
@@ -555,10 +560,11 @@ function InstallServiceRows({ items, installingNow, deployedNames, perService }:
         const statusText = isDone ? 'Deployed' : isInstalling ? 'Installing…' : 'Pending';
         return (
           <div key={item.name} className="border-b border-border last:border-b-0">
-            <button
+            <Button
               type="button"
               onClick={() => toggle(item.name)}
-              className="w-full px-3 py-2 flex items-center gap-2 text-left hover:bg-surface-2 transition-colors"
+              variant="ghost"
+              className="w-full justify-start px-3 py-2 flex items-center gap-2 text-left hover:bg-surface-2 transition-colors"
             >
               {isOpen ? <ChevronDown size={14} className="text-text-subtle shrink-0" /> : <ChevronRight size={14} className="text-text-subtle shrink-0" />}
               {statusIcon}
@@ -569,7 +575,7 @@ function InstallServiceRows({ items, installingNow, deployedNames, perService }:
               {lines.length > 0 && (
                 <span className="text-[10px] text-text-subtle tabular-nums">{lines.length} ln</span>
               )}
-            </button>
+            </Button>
             {isOpen && (
               <div className="bg-surface-muted text-text px-3 py-2 font-mono text-[11px] max-h-48 overflow-y-auto">
                 {lines.length === 0 ? (

--- a/packages/frontend/src/components/wizard/steps/NetworkStep.tsx
+++ b/packages/frontend/src/components/wizard/steps/NetworkStep.tsx
@@ -41,15 +41,15 @@ export function NetworkStep({
         <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
             <section className="space-y-4">
                 <div className="flex items-center gap-3">
-                    <div className="p-2.5 rounded-xl bg-blue-500/10 border border-blue-500/20">
-                        <Globe className="w-5 h-5 text-blue-500"/>
+                    <div className="p-2.5 rounded-xl bg-accent/10 border border-accent/20">
+                        <Globe className="w-5 h-5 text-accent"/>
                     </div>
                     <div>
                         <h3 className="font-bold text-lg leading-none">Public Domain</h3>
-                        <p className="text-xs text-gray-500 mt-1">Configure your external access entry point</p>
+                        <p className="text-xs text-text-muted mt-1">Configure your external access entry point</p>
                     </div>
                 </div>
-                <div className="p-5 rounded-2xl bg-gray-50/50 dark:bg-white/5 border border-gray-200 dark:border-white/5">
+                <div className="p-5 rounded-2xl bg-surface dark:bg-surface border border-border">
                     <Input label="Public Domain" value={publicDomain} onChange={setPublicDomain} placeholder="example.com" hint="Required for Let's Encrypt and external access" />
                 </div>
             </section>
@@ -68,17 +68,17 @@ export function NetworkStep({
             {selection.ssh && (
                 <section className="space-y-4">
                     <div className="flex items-center gap-3">
-                        <div className="p-2.5 rounded-xl bg-amber-500/10 border border-amber-500/20">
-                            <Key className="w-5 h-5 text-amber-500"/>
+                        <div className="p-2.5 rounded-xl bg-status-warn/10 border border-status-warn/20">
+                            <Key className="w-5 h-5 text-status-warn"/>
                         </div>
                         <div>
                             <h3 className="font-bold text-lg leading-none">Remote Access (SSH)</h3>
-                            <p className="text-xs text-gray-500 mt-1">Generate keys for multi-node management</p>
+                            <p className="text-xs text-text-muted mt-1">Generate keys for multi-node management</p>
                         </div>
                      </div>
 
-                    <div className="p-5 rounded-2xl bg-gray-50/50 dark:bg-white/5 border border-gray-200 dark:border-white/5 space-y-4">
-                        <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+                    <div className="p-5 rounded-2xl bg-surface dark:bg-surface border border-border space-y-4">
+                        <p className="text-sm text-text leading-relaxed">
                             {status?.hasSshKey
                               ? "An existing SSH key was detected. Your system is already prepared for remote node management."
                               : "No SSH key found. We recommend generating one now to enable management of remote nodes via SSH."}
@@ -90,7 +90,7 @@ export function NetworkStep({
                              </Button>
                         )}
                         {status?.hasSshKey && (
-                            <div className="flex items-center gap-2 text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 p-3 rounded-xl border border-emerald-500/20">
+                            <div className="flex items-center gap-2 text-xs font-medium text-status-ok bg-status-ok/10 p-3 rounded-xl border border-status-ok/20">
                                 <CheckCircle className="w-4 h-4" /> SSH Infrastructure Ready
                             </div>
                         )}
@@ -176,19 +176,19 @@ function GatewaySection({
     return (
         <section className="space-y-4">
             <div className="flex items-center gap-3">
-                <div className="p-2.5 rounded-xl bg-purple-500/10 border border-purple-500/20">
-                    <Network className="w-5 h-5 text-purple-500" />
+                <div className="p-2.5 rounded-xl bg-accent/10 border border-accent/20">
+                    <Network className="w-5 h-5 text-accent" />
                 </div>
                 <div>
                     <h3 className="font-bold text-lg leading-none">Internet Gateway</h3>
-                    <p className="text-xs text-gray-500 mt-1">
+                    <p className="text-xs text-text-muted mt-1">
                         FRITZ!Box powers device discovery, Wake-on-LAN and port-forward
                         management — verify the connection before continuing.
                     </p>
                 </div>
             </div>
 
-            <div className="grid gap-4 p-5 rounded-2xl bg-gray-50/50 dark:bg-white/5 border border-gray-200 dark:border-white/5">
+            <div className="grid gap-4 p-5 rounded-2xl bg-surface dark:bg-surface border border-border">
                 <Input
                     label="Hostname / IP"
                     value={gwHost}
@@ -214,12 +214,12 @@ function GatewaySection({
                         Verify Connection
                     </Button>
                     {result?.kind === 'ok' && (
-                        <span className="flex items-center gap-2 text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-3 py-1.5 rounded-xl border border-emerald-500/20">
+                        <span className="flex items-center gap-2 text-xs font-medium text-status-ok bg-status-ok/10 px-3 py-1.5 rounded-xl border border-status-ok/20">
                             <CheckCircle className="w-4 h-4" /> {result.message}
                         </span>
                     )}
                     {result?.kind === 'fail' && (
-                        <span className="flex items-center gap-2 text-xs font-medium text-red-600 dark:text-red-400 bg-red-500/10 px-3 py-1.5 rounded-xl border border-red-500/20">
+                        <span className="flex items-center gap-2 text-xs font-medium text-status-fail bg-status-fail/10 px-3 py-1.5 rounded-xl border border-status-fail/20">
                             <AlertCircle className="w-4 h-4" /> {result.message}
                         </span>
                     )}


### PR DESCRIPTION
Batch of 8: continuation of the #2430 lint-ratchet burn-down (both rules).

Color-literal sweeps (`sb/no-raw-color-literal`, baseline 389 → down further): NetworkStep.tsx, ReverseProxyConfig.tsx, InstallProgressCard.tsx, DoneStepDnsCheck.tsx.

UI-primitive sweeps (`sb/no-raw-ui-primitive`, baseline 216 → 208): InstallerModal.tsx, StackInstallFlow.tsx, RequestAccessDialog.tsx, ServiceMonitor.tsx.

Every unit's fast gate (lint/typecheck/check:arch/vitest --changed) passed individually; this seal additionally confirms the full local safety net on the assembled batch: lint 0 errors, typecheck clean, check:arch clean (lint-ratchet held at 328/208, no baseline regression), full `npm test` 521 files/4939 tests passed.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
