### PR TITLE
fix(ServiceMonitor): stop Button defaults from clobbering the tab strip

### DIFF
--- a/packages/frontend/src/components/ServiceMonitor.tsx
+++ b/packages/frontend/src/components/ServiceMonitor.tsx
@@ -235,30 +235,35 @@ export default function ServiceMonitor({ serviceName, initialNode, onBack, varia
             <div className={`flex-1 flex flex-col min-h-0 ${variant === 'embedded' ? 'p-0' : 'p-6'}`}>
       <div className="bg-surface dark:bg-surface rounded-lg border border-border dark:border-border shadow-sm overflow-hidden flex flex-col flex-1 min-h-0">
         <div className="flex border-b border-border dark:border-border bg-surface dark:bg-surface/50 shrink-0">
+            {/* `!h-auto !px-6` forces out Button's default size="md" (h-10/px-space-4) so it
+                can't win the cascade against this tab strip's own px-6/py-3 geometry — cn()
+                has no Tailwind-merge dedup, same escape hatch as the EmailNotificationsSection
+                fix (box-verify dbf73003 regression: tabs silently rendered 24px→16px padding
+                and a clipped fixed height because no `size` override was passed here). */}
             <Button
             variant="ghost"
-            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'status' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
+            className={`!h-auto !px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'status' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('status')}
             >
             <Activity size={16} /> Status
             </Button>
             <Button
             variant="ghost"
-            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'service' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
+            className={`!h-auto !px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'service' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('service')}
             >
             <Terminal size={16} /> Service Logs
             </Button>
             <Button
             variant="ghost"
-            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'container-logs' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
+            className={`!h-auto !px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'container-logs' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('container-logs')}
             >
             <Box size={16} /> Container Logs & Info
             </Button>
             <Button
             variant="ghost"
-            className={`px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'network' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
+            className={`!h-auto !px-6 py-3 font-medium text-sm flex items-center gap-2 transition-colors ${activeTab === 'network' ? 'bg-surface dark:bg-surface text-accent dark:text-accent border-t-2 border-t-accent dark:border-t-accent' : 'text-subtle dark:text-subtle hover:text-muted dark:hover:text-muted'}`}
             onClick={() => setActiveTab('network')}
             >
             <FileJson size={16} /> Raw Data / Config


### PR DESCRIPTION
## Summary
Box-verify on `dbf73003` (PR #2480, the ui-primitive/color-literal lint sweep batch) found that `ServiceMonitor`'s four tab buttons (Status / Service Logs / Container Logs & Info / Raw Data & Config) were migrated from raw `<button>`s to `<Button variant="ghost">` without a `size` override. `cn()` is a plain string joiner (no Tailwind-merge dedup), so Button's default `size="md"` utilities (`h-10`, `px-space-4`) land in the compiled stylesheet after the tab's own `px-6`/`py-3` and win the cascade.

Verified against an actual `@tailwindcss/postcss` build of the compiled stylesheet: `.px-space-4` (1rem) sits after `.px-6` (1.5rem) and wins — silently shrinking the tabs' horizontal padding from 24px to 16px — and `.h-10` imposes a fixed 40px height the original never had.

This is the same regression class just fixed in #2479 (EmailNotificationsSection).

## Fix
Same `!`-important escape hatch already used there and in `ContainerLogsPanel.tsx`/`Sidebar.tsx`: `!h-auto !px-6` forces the tab's own geometry to win regardless of stylesheet order. Re-verified against the compiled CSS: both now carry `!important` and beat `h-10`/`px-space-4` unconditionally.

## Test plan
- [x] `npm run lint` — 0 errors, lint-ratchet held at baseline
- [x] `npm run typecheck` — clean
- [x] `npm run check:arch` — all checks passed
- [x] `npx vitest run --changed=main~1` — 21 files / 176 tests passed
- [x] Compiled-CSS cascade re-verified: `!px-6`/`!h-auto` carry `!important`, win unconditionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._