### PR TITLE
fix(StackInstallFlow): stop Button defaults from clobbering the per-service row

### DIFF
--- a/packages/frontend/src/components/StackInstallFlow.tsx
+++ b/packages/frontend/src/components/StackInstallFlow.tsx
@@ -560,11 +560,17 @@ function InstallServiceRows({ items, installingNow, deployedNames, perService }:
         const statusText = isDone ? 'Deployed' : isInstalling ? 'Installing…' : 'Pending';
         return (
           <div key={item.name} className="border-b border-border last:border-b-0">
+            {/* `!h-auto !px-3` forces out Button's default size="md" (h-10/px-space-4) so it
+                can't win the cascade against this row's own px-3/py-2 geometry — cn() has no
+                Tailwind-merge dedup, same escape hatch as ServiceMonitor.tsx's tab strip
+                (box-verify 2a9decfa follow-up: this row shipped in the same #2480 batch with
+                the identical unguarded Button migration, just never caught until the sibling
+                fix's re-verify swept the rest of the PR). */}
             <Button
               type="button"
               onClick={() => toggle(item.name)}
               variant="ghost"
-              className="w-full justify-start px-3 py-2 flex items-center gap-2 text-left hover:bg-surface-2 transition-colors"
+              className="!h-auto !px-3 w-full justify-start py-2 flex items-center gap-2 text-left hover:bg-surface-2 transition-colors"
             >
               {isOpen ? <ChevronDown size={14} className="text-text-subtle shrink-0" /> : <ChevronRight size={14} className="text-text-subtle shrink-0" />}
               {statusIcon}


### PR DESCRIPTION
## Summary
- Box-verify re-verifying #2482 (the ServiceMonitor tab-strip Button-size-collision fix) swept the rest of PR #2480's batch and found the identical, unfixed regression in `StackInstallFlow.tsx`'s `InstallServiceRows`: the per-service log-toggle row was migrated from a raw `<button>` to `<Button variant="ghost">` with no `size` override, in the same PR that introduced the ServiceMonitor bug.
- `cn()` has no Tailwind-merge dedup, so Button's default `size="md"` (`h-10`, `px-space-4`) compiles after the row's own `px-3`/`py-2` and silently wins: confirmed via an actual `@tailwindcss/postcss` build that `.px-space-4` sits after `.px-3` and wins, and `.h-10` imposes a fixed 40px height the row never had.
- Same fix pattern as #2479/#2482: `!h-auto !px-3` forces the row's own geometry to win regardless of stylesheet order.

## Test plan
- [x] Compiled the real `@tailwindcss/postcss` pipeline against the changed file; confirmed `.\!h-auto` and `.\!px-3` both carry `!important` and unconditionally beat `.h-10`/`.px-space-4`.
- [x] `npx eslint packages/frontend/src/components/StackInstallFlow.tsx` — 0 errors (pre-existing max-lines-per-function warnings only).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKhpc56PoUiCARWhaq7M6j