### PR TITLE
chore: lint-ratchet burn-down continuation (batch f)

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 272,
+    "sb/no-raw-color-literal": 259,
     "sb/no-raw-ui-primitive": 163
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 272,
-    "sb/no-raw-ui-primitive": 170
+    "sb/no-raw-ui-primitive": 163
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 234,
+    "sb/no-raw-color-literal": 222,
     "sb/no-raw-ui-primitive": 163
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 222,
-    "sb/no-raw-ui-primitive": 156
+    "sb/no-raw-ui-primitive": 150
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 272,
-    "sb/no-raw-ui-primitive": 177
+    "sb/no-raw-ui-primitive": 170
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 222,
-    "sb/no-raw-ui-primitive": 163
+    "sb/no-raw-ui-primitive": 156
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 259,
+    "sb/no-raw-color-literal": 234,
     "sb/no-raw-ui-primitive": 163
   }
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Check, Copy, Plus, Trash2 } from 'lucide-react';
-import { Button } from '@/components/ui';
+import { Button, Input } from '@/components/ui';
 import ConfirmModal from '@/components/ConfirmModal';
 import { copyToClipboard } from '../clipboard';
 
@@ -55,18 +55,19 @@ function BootstrapBanner({ status, revoking, reactivating, onRevoke, onReactivat
         </p>
       </div>
       <div className="shrink-0 flex items-center gap-2">
-        <button
+        <Button
           type="button"
           disabled={reactivating}
           onClick={onReactivate}
+          variant="ghost"
           className={btnClass}
           title="Re-issue the existing LAN-only bootstrap token for another ~30 minutes so an MCP client can reconnect — same token value."
         >
           {reactivating ? 'Re-activating…' : 'Re-activate (30 min)'}
-        </button>
-        <button type="button" disabled={revoking} onClick={onRevoke} className={btnClass}>
+        </Button>
+        <Button type="button" disabled={revoking} onClick={onRevoke} variant="ghost" className={btnClass}>
           {revoking ? 'Revoking…' : 'Revoke now'}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -77,7 +78,7 @@ function RevealedSecretBox({ secret, copied, onCopy, onDismiss }: { secret: stri
     <div className="p-3 bg-status-warn/10 rounded-card border border-status-warn/30 space-y-2">
       <p className="text-xs font-semibold text-status-warn">⚠️ Save this token now — it will not be shown again.</p>
       <div className="flex items-stretch gap-2">
-        <input
+        <Input
           type="text"
           readOnly
           value={secret}
@@ -163,7 +164,7 @@ function NeverExpiresField({ readOnly, checked, onToggle }: { readOnly: boolean;
         className={`flex items-center gap-1.5 text-xs ${readOnly ? 'cursor-pointer text-text-muted' : 'cursor-not-allowed text-text-subtle opacity-60'}`}
         title={readOnly ? 'Mint a non-expiring token — safe only for a read-only, unattended consumer.' : 'Never-expiring tokens are limited to the read scope. Select only "read" to enable this.'}
       >
-        <input
+        <Input
           type="checkbox"
           checked={readOnly && checked}
           disabled={!readOnly}
@@ -184,7 +185,7 @@ function CreateTokenForm(props: CreateTokenFormProps) {
     <div className="space-y-2 p-3 rounded-card border border-border bg-surface-2">
       <div>
         <label className="block text-[11px] font-semibold uppercase tracking-wider text-text-subtle mb-1">Name</label>
-        <input
+        <Input
           type="text"
           value={props.name}
           onChange={e => props.onName(e.target.value)}
@@ -197,7 +198,7 @@ function CreateTokenForm(props: CreateTokenFormProps) {
         <div className="flex flex-wrap gap-2">
           {ALL_SCOPES.map(scope => (
             <label key={scope} className="flex items-center gap-1.5 text-xs cursor-pointer text-text-muted">
-              <input type="checkbox" checked={props.scopes.includes(scope)} onChange={() => props.onToggleScope(scope)} className="rounded accent-accent" />
+              <Input type="checkbox" checked={props.scopes.includes(scope)} onChange={() => props.onToggleScope(scope)} className="rounded accent-accent" />
               <span className="font-mono">{scope}</span>
             </label>
           ))}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
@@ -106,7 +106,7 @@ export default function FileShareSection() {
           <button
             onClick={loadUsers}
             disabled={loading}
-            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:bg-surface-2 rounded disabled:opacity-50"
             type="button"
             title="Re-run LLDAP → Samba sync"
           >
@@ -117,48 +117,48 @@ export default function FileShareSection() {
 
       <div className="space-y-3">
         {error && (
-          <div className="p-3 rounded-lg text-sm bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-800">
+          <div className="p-3 rounded-lg text-sm bg-surface text-status-fail border border-status-fail">
             {error}
           </div>
         )}
 
         {loading && !users && (
-          <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+          <div className="flex items-center gap-2 text-sm text-text-subtle">
             <Loader2 className="w-4 h-4 animate-spin" /> Loading LLDAP users…
           </div>
         )}
 
         {users && users.length === 0 && (
-          <p className="text-sm text-gray-500 dark:text-gray-400">No LLDAP users yet — create one in LLDAP first.</p>
+          <p className="text-sm text-text-subtle">No LLDAP users yet — create one in LLDAP first.</p>
         )}
 
         {users && users.length > 0 && (
-          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+          <ul className="divide-y divide-border">
             {users.map(u => (
               <li key={u.id} className="py-2 flex items-center gap-3">
                 <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
+                  <div className="text-sm font-medium text-text truncate">
                     {u.displayName || u.id}
-                    <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
+                    <span className="ml-2 text-xs font-normal text-text-subtle">
                       ({u.id})
                     </span>
                   </div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                  <div className="text-xs text-text-subtle">
                     {u.presentInSamba ? 'Samba account ready' : 'Samba account missing — click Set password to provision'}
                   </div>
                   {flashed?.id === u.id && (
-                    <div className="mt-2 p-2 rounded bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-xs">
+                    <div className="mt-2 p-2 rounded bg-surface border border-status-warn text-xs">
                       <div className="flex items-center gap-2">
                         <span className="font-mono break-all">{flashed.password}</span>
                         <button
                           onClick={() => copyPassword(flashed.password)}
-                          className="inline-flex items-center gap-1 px-2 py-1 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/40 rounded"
+                          className="inline-flex items-center gap-1 px-2 py-1 text-status-warn hover:bg-surface-2 rounded"
                           type="button"
                         >
                           <Copy size={12} /> Copy
                         </button>
                       </div>
-                      <div className="mt-1 text-amber-700 dark:text-amber-300">
+                      <div className="mt-1 text-status-warn">
                         This is the only time the password is shown — copy it now.
                       </div>
                     </div>
@@ -167,7 +167,7 @@ export default function FileShareSection() {
                 <button
                   onClick={() => setPassword(u.id)}
                   disabled={busyUser === u.id}
-                  className="inline-flex items-center gap-1 px-3 py-1.5 text-xs bg-emerald-600 hover:bg-emerald-700 text-white rounded disabled:opacity-50"
+                  className="inline-flex items-center gap-1 px-3 py-1.5 text-xs bg-status-ok hover:bg-accent-strong text-on-accent rounded disabled:opacity-50"
                   type="button"
                 >
                   {busyUser === u.id ? <Loader2 size={12} className="animate-spin" /> : <KeyRound size={12} />}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/NodesSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/NodesSection.tsx
@@ -15,7 +15,7 @@ import {
   ShieldAlert,
   WifiOff,
 } from 'lucide-react';
-import { Badge, Button } from '@/components/ui';
+import { Badge, Button, Input } from '@/components/ui';
 import ConfirmModal from '@/components/ConfirmModal';
 import { useSettings } from '../SettingsContext';
 import { PodmanConnection } from '@/lib/nodes';
@@ -137,9 +137,9 @@ export default function NodesSection() {
             <p className="text-text-muted text-xs">
               ServiceBay requires password-less SSH access to remote nodes.
               If you haven&apos;t set this up, use the
-              <button onClick={() => openSSHModal()} className="mx-1 underline font-medium text-accent hover:text-accent-strong">
+              <Button variant="ghost" onClick={() => openSSHModal()} className="!h-auto mx-1 underline font-medium text-accent hover:text-accent-strong">
                 Setup SSH Keys
-              </button>
+              </Button>
               tool to copy your public key to the server.
             </p>
           </div>
@@ -148,7 +148,7 @@ export default function NodesSection() {
         <div className="grid grid-cols-1 md:grid-cols-12 gap-4 items-end mb-6" id="node-form">
           <div className="md:col-span-3">
             <label className="block text-sm font-medium text-text-muted mb-1">Name</label>
-            <input
+            <Input
               type="text"
               value={newNodeName}
               onChange={e => setNewNodeName(e.target.value)}
@@ -159,7 +159,7 @@ export default function NodesSection() {
           </div>
           <div className="md:col-span-5">
             <label className="block text-sm font-medium text-text-muted mb-1">Destination (SSH)</label>
-            <input
+            <Input
               type="text"
               value={newNodeDest}
               onChange={e => setNewNodeDest(e.target.value)}
@@ -172,7 +172,7 @@ export default function NodesSection() {
             <label className="block text-sm font-medium text-text-muted mb-1">Identity File</label>
             <div className="relative">
               <Key className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-subtle" />
-              <input
+              <Input
                 type="text"
                 value={newNodeIdentity}
                 onChange={e => setNewNodeIdentity(e.target.value)}
@@ -253,7 +253,7 @@ export default function NodesSection() {
                     <div className="grid grid-cols-1 md:grid-cols-12 gap-3">
                       <div className="md:col-span-3">
                         <label className="block text-xs font-medium text-text-muted mb-1">Name</label>
-                        <input
+                        <Input
                           type="text"
                           value={nodeDraft.name}
                           onChange={e => setNodeDraft(prev => ({ ...prev, name: e.target.value }))}
@@ -264,7 +264,7 @@ export default function NodesSection() {
                       </div>
                       <div className="md:col-span-5">
                         <label className="block text-xs font-medium text-text-muted mb-1">Destination (SSH)</label>
-                        <input
+                        <Input
                           type="text"
                           value={nodeDraft.destination}
                           onChange={e => setNodeDraft(prev => ({ ...prev, destination: e.target.value }))}
@@ -275,7 +275,7 @@ export default function NodesSection() {
                       </div>
                       <div className="md:col-span-4">
                         <label className="block text-xs font-medium text-text-muted mb-1">Identity File</label>
-                        <input
+                        <Input
                           type="text"
                           value={nodeDraft.identity}
                           onChange={e => setNodeDraft(prev => ({ ...prev, identity: e.target.value }))}

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { ChevronRight } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
-import { Card } from '@/components/ui';
+import { Card, Button } from '@/components/ui';
 import type { PortalCard } from '@/lib/portal/services';
 import type { AppPlatform, PortalAction, PortalIconName, SetupAssetKind } from '@/lib/portal/userGuide';
 import { ACCENT_CHIP_CLASS, serviceAccent, groupCardsBySection } from './portalAccent';
@@ -354,13 +354,14 @@ function CardDisclosure({
  *  markdown help modal. */
 function HowToButton({ onClick }: { onClick: () => void }) {
   return (
-    <button
+    <Button
       onClick={onClick}
-      className="flex items-center gap-1 text-sm text-accent hover:underline mt-space-2"
+      variant="ghost"
+      className="text-accent hover:underline"
       aria-haspopup="dialog"
     >
       How do I use this?
-    </button>
+    </Button>
   );
 }
 
@@ -630,14 +631,15 @@ function CardHelpModal({ card, onClose }: { card: PortalCard; onClose: () => voi
               )}
             </div>
           </div>
-          <button
+          <Button
             type="button"
             aria-label="Close"
             onClick={onClose}
-            className="shrink-0 p-1 rounded-card text-text-subtle hover:text-text hover:bg-surface-2"
+            variant="ghost"
+            className="shrink-0 !p-1 !h-auto !w-auto"
           >
             <X size={20} />
-          </button>
+          </Button>
         </div>
         <div className="overflow-y-auto px-space-5 py-space-4">
           <div className="prose prose-sm dark:prose-invert max-w-none text-text-muted">
@@ -701,14 +703,16 @@ function CommandBlock({ command }: { command: string }) {
       <code className="flex-1 min-w-0 overflow-x-auto rounded-chip bg-surface-muted px-2 py-1.5 text-[11px] font-mono text-text whitespace-pre">
         {command}
       </code>
-      <button
+      <Button
         type="button"
         onClick={onCopy}
         aria-label={copied ? 'Copied' : 'Copy command'}
-        className="shrink-0 inline-flex items-center justify-center w-8 rounded-chip bg-surface-2 text-text-muted hover:bg-surface-muted hover:text-text transition-colors"
+        variant="secondary"
+        size="sm"
+        className="!w-8 !h-8"
       >
         {copied ? <Check size={14} /> : <Copy size={14} />}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -769,12 +773,13 @@ function DeepLinkButton({
   };
   return (
     <div>
-      <button
+      <Button
         onClick={onClick}
-        className={PORTAL_LINK_BUTTON}
+        variant="primary"
+        className="w-full !py-2"
       >
         <Icon size={14} /> {label}
-      </button>
+      </Button>
       {description && !error && (
         <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{description}</p>
       )}
@@ -816,12 +821,13 @@ function BasicSyncInstallQrButton({
   return (
     <>
       <div>
-        <button
+        <Button
           onClick={() => setOpen(true)}
-          className={PORTAL_LINK_BUTTON}
+          variant="primary"
+          className="w-full !py-2"
         >
           <Icon size={14} /> {label}
-        </button>
+        </Button>
         {description && (
           <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{description}</p>
         )}
@@ -917,12 +923,13 @@ function SyncthingQrButton({
   return (
     <>
       <div>
-        <button
+        <Button
           onClick={onOpen}
-          className={PORTAL_LINK_BUTTON}
+          variant="primary"
+          className="w-full !py-2"
         >
           <Icon size={14} /> {label}
-        </button>
+        </Button>
         {description && (
           <p className="text-[11px] text-text-subtle mt-space-1 leading-snug text-center">{description}</p>
         )}
@@ -955,12 +962,13 @@ function SyncthingQrButton({
               </p>
             )}
 
-            <button
+            <Button
               onClick={() => setOpen(false)}
-              className="mt-space-4 px-space-4 py-space-2 text-sm text-text-muted hover:text-text"
+              variant="ghost"
+              className="mt-space-4 px-space-4 !py-space-2"
             >
               Close
-            </button>
+            </Button>
           </Card>
         </div>
       )}

--- a/packages/frontend/src/components/ConfirmModal.tsx
+++ b/packages/frontend/src/components/ConfirmModal.tsx
@@ -81,25 +81,25 @@ export default function ConfirmModal({
       aria-labelledby="confirm-modal-title"
       onKeyDown={handleKeyDown}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl max-w-md w-full border border-gray-200 dark:border-gray-800 overflow-hidden animate-in zoom-in-95 duration-200">
+      <div className="bg-surface rounded-lg shadow-xl max-w-md w-full border border-border overflow-hidden animate-in zoom-in-95 duration-200">
         <div className="p-6">
           <div className="flex items-start gap-4">
-            <div className={`p-3 rounded-full shrink-0 ${isDestructive ? 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400' : 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400'}`}>
+            <div className={`p-3 rounded-full shrink-0 ${isDestructive ? 'bg-surface-2 text-status-fail' : 'bg-surface-2 text-accent'}`}>
               <AlertTriangle size={24} />
             </div>
             <div className="flex-1 min-w-0">
-              <h3 id="confirm-modal-title" className="text-lg font-bold text-gray-900 dark:text-white mb-2">{title}</h3>
-              <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
+              <h3 id="confirm-modal-title" className="text-lg font-bold text-text mb-2">{title}</h3>
+              <p className="text-text-muted text-sm leading-relaxed">
                 {message}
               </p>
               {resourceName && (
-                <p className="mt-2 font-mono text-sm text-gray-900 dark:text-gray-100 break-all bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">
+                <p className="mt-2 font-mono text-sm text-text break-all bg-surface-2 px-2 py-1 rounded">
                   {resourceName}
                 </p>
               )}
               {requireTypedConfirm && resourceName && (
                 <div className="mt-3">
-                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  <label className="block text-xs text-text-subtle mb-1">
                     Type <span className="font-mono">{resourceName}</span> to confirm
                   </label>
                   <input
@@ -108,7 +108,7 @@ export default function ConfirmModal({
                     onChange={(e) => setTyped(e.target.value)}
                     autoComplete="off"
                     autoFocus
-                    className="w-full px-3 py-2 text-sm font-mono rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-red-500 focus:border-transparent outline-none"
+                    className="w-full px-3 py-2 text-sm font-mono rounded-md border border-border bg-surface-2 text-text focus:ring-2 focus:ring-status-fail focus:border-transparent outline-none"
                   />
                 </div>
               )}
@@ -116,12 +116,12 @@ export default function ConfirmModal({
           </div>
         </div>
 
-        <div className="bg-gray-50 dark:bg-gray-900/50 px-6 py-4 flex justify-end gap-3 border-t border-gray-200 dark:border-gray-800">
+        <div className="bg-surface-muted px-6 py-4 flex justify-end gap-3 border-t border-border">
           <button
             ref={cancelButtonRef}
             onClick={handleCancel}
             disabled={isLoading}
-            className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-800 rounded-md transition-colors font-medium text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+            className="px-4 py-2 text-text-muted hover:bg-surface-2 rounded-md transition-colors font-medium text-sm focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
           >
             {cancelText}
           </button>
@@ -130,10 +130,10 @@ export default function ConfirmModal({
             onClick={handleConfirm}
             disabled={!canConfirm}
             aria-label={confirmText}
-            className={`px-4 py-2 text-white rounded-md transition-colors font-medium text-sm shadow-sm flex items-center gap-2 focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+            className={`px-4 py-2 text-on-accent rounded-md transition-colors font-medium text-sm shadow-sm flex items-center gap-2 focus:outline-none focus:ring-2 focus:ring-offset-1 ${
               isDestructive
-                ? 'bg-red-600 hover:bg-red-700 focus:ring-red-500'
-                : 'bg-blue-600 hover:bg-blue-700 focus:ring-blue-500'
+                ? 'bg-status-fail hover:bg-status-fail/80 focus:ring-status-fail'
+                : 'bg-accent-strong hover:bg-accent-strong/80 focus:ring-accent'
             } disabled:opacity-50 disabled:cursor-not-allowed`}
           >
             {isLoading && <Loader2 size={14} className="animate-spin" />}

--- a/packages/frontend/src/components/ContainerList.tsx
+++ b/packages/frontend/src/components/ContainerList.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { Activity, Eraser, MoreVertical, RefreshCw, Terminal as TerminalIcon, X } from 'lucide-react';
 import type { EnrichedContainer } from '@servicebay/api-client';
-import { Card, SectionHeading, StatusDot } from '@/components/ui';
+import { Button, Card, SectionHeading, StatusDot } from '@/components/ui';
 import { useContainerActions } from '@/hooks/useContainerActions';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import ContainerLogsPanel, { type ContainerLogsPanelData } from '@/components/ContainerLogsPanel';
@@ -159,13 +159,14 @@ export default function ContainerList({ containers, groups, showParentBadge, ini
           {isLoading && slowConnect && 'Still connecting to Digital Twin… check Settings → Nodes if this persists.'}
         </span>
         {isLoading && slowConnect && (
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => { if (typeof window !== 'undefined') window.location.reload(); }}
-            className="flex items-center gap-1 px-3 py-1.5 text-xs bg-surface-2 hover:bg-surface-muted text-text rounded transition-colors not-italic"
+            className="not-italic"
           >
             <RefreshCw size={12} /> Refresh
-          </button>
+          </Button>
         )}
       </Card>
     );
@@ -209,27 +210,33 @@ export default function ContainerList({ containers, groups, showParentBadge, ini
             </div>
           </div>
           <div className="flex items-center gap-1.5">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => openLogs(c)}
-              className="p-1.5 text-text-muted hover:text-accent hover:bg-surface-2 rounded"
+              className="!p-1.5"
               title="Logs & Info"
             >
               <Activity size={18} />
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => openTerminal(c)}
-              className="p-1.5 text-text-muted hover:text-accent hover:bg-surface-2 rounded"
+              className="!p-1.5"
               title="Terminal"
             >
               <TerminalIcon size={18} />
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => openActions(c)}
-              className="p-1.5 text-text-muted hover:text-accent hover:bg-surface-2 rounded"
+              className="!p-1.5"
               title="Actions"
             >
               <MoreVertical size={18} />
-            </button>
+            </Button>
           </div>
         </div>
         <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3 text-xs sm:text-sm text-text-muted">
@@ -367,27 +374,33 @@ export default function ContainerList({ containers, groups, showParentBadge, ini
                     )}
                   </div>
                   <div className="flex items-center gap-2">
-                    <button
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={() => terminalRef.current?.clear()}
-                      className="p-2 rounded-full text-text-muted hover:text-text hover:bg-surface-2"
+                      className="!p-2 !rounded-full"
                       title="Clear terminal"
                     >
                       <Eraser size={18} />
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={() => terminalRef.current?.reconnect()}
-                      className="p-2 rounded-full text-text-muted hover:text-text hover:bg-surface-2"
+                      className="!p-2 !rounded-full"
                       title="Reconnect"
                     >
                       <RefreshCw size={18} />
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={closeDrawer}
-                      className="p-2 rounded-full text-text-muted hover:text-text hover:bg-surface-2"
+                      className="!p-2 !rounded-full"
                       title="Close"
                     >
                       <X size={18} />
-                    </button>
+                    </Button>
                   </div>
                 </div>
                 <div className="flex-1 overflow-hidden">

--- a/packages/frontend/src/components/HistoryViewer.tsx
+++ b/packages/frontend/src/components/HistoryViewer.tsx
@@ -61,9 +61,9 @@ export default function HistoryViewer({ filename, currentContent, onRestore }: H
         {diff.map((part, index) => {
           // Added means present in current but not in old
           // Removed means present in old but not in current
-          const color = part.added ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200' :
-                        part.removed ? 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200' :
-                        'text-gray-600 dark:text-gray-400';
+          const color = part.added ? 'bg-surface-2 text-status-ok' :
+                        part.removed ? 'bg-surface-2 text-status-fail' :
+                        'text-text-muted';
           const prefix = part.added ? '+ ' : part.removed ? '- ' : '  ';
           
           // Don't render empty parts
@@ -87,10 +87,10 @@ export default function HistoryViewer({ filename, currentContent, onRestore }: H
 
   return (
     <div className="flex h-full gap-4">
-      <div className="w-64 border-r border-gray-200 dark:border-gray-800 overflow-y-auto shrink-0">
-        <h3 className="font-bold mb-2 flex items-center gap-2 text-gray-700 dark:text-gray-300"><Clock size={16}/> History</h3>
+      <div className="w-64 border-r border-border overflow-y-auto shrink-0">
+        <h3 className="font-bold mb-2 flex items-center gap-2 text-text"><Clock size={16}/> History</h3>
         {history.length === 0 ? (
-            <div className="text-gray-500 text-sm italic">No history available.</div>
+            <div className="text-text-muted text-sm italic">No history available.</div>
         ) : (
             <div className="space-y-1 pr-2">
                 {history.map(entry => (
@@ -99,9 +99,9 @@ export default function HistoryViewer({ filename, currentContent, onRestore }: H
                         key={entry.timestamp}
                         onClick={() => handleSelectVersion(entry.timestamp)}
                         className={`w-full text-left px-3 py-2 rounded text-sm transition-colors ${
-                            selectedVersion === entry.timestamp 
-                            ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium' 
-                            : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400'
+                            selectedVersion === entry.timestamp
+                            ? 'bg-surface-2 text-accent font-medium'
+                            : 'hover:bg-surface-2 text-text-muted'
                         }`}
                     >
                         {entry.displayDate}
@@ -114,23 +114,23 @@ export default function HistoryViewer({ filename, currentContent, onRestore }: H
         {selectedVersion && versionContent ? (
             <>
                 <div className="flex justify-between items-center mb-4 shrink-0">
-                    <h3 className="font-bold text-gray-700 dark:text-gray-300">
-                        Comparing: <span className="text-blue-600 dark:text-blue-400">{selectedVersion}</span> vs Current
+                    <h3 className="font-bold text-text">
+                        Comparing: <span className="text-accent">{selectedVersion}</span> vs Current
                     </h3>
-                    <button 
+                    <button
                         type="button"
                         onClick={() => onRestore(versionContent)}
-                        className="flex items-center gap-2 bg-yellow-500 hover:bg-yellow-600 text-white px-3 py-1.5 rounded text-sm font-medium shadow-sm transition-colors"
+                        className="flex items-center gap-2 bg-status-warn hover:brightness-75 text-foreground px-3 py-1.5 rounded text-sm font-medium shadow-sm transition-colors"
                     >
                         <RotateCcw size={16} /> Restore this version
                     </button>
                 </div>
-                <div className="flex-1 overflow-y-auto border border-gray-200 dark:border-gray-800 rounded-lg bg-white dark:bg-gray-950 p-4 shadow-inner">
+                <div className="flex-1 overflow-y-auto border border-border rounded-lg bg-surface p-4 shadow-inner">
                     {loadingVersion ? <Loader2 className="animate-spin mx-auto" /> : renderDiff()}
                 </div>
             </>
         ) : (
-            <div className="flex flex-col items-center justify-center h-full text-gray-400 dark:text-gray-600">
+            <div className="flex flex-col items-center justify-center h-full text-text-subtle">
                 <Clock size={48} className="mb-4 opacity-20" />
                 <p>Select a version from the left to compare</p>
             </div>

--- a/packages/frontend/src/components/MobileNav.tsx
+++ b/packages/frontend/src/components/MobileNav.tsx
@@ -66,8 +66,6 @@ export function MobileTopBar() {
     return () => { cancelled = true; clearInterval(handle); };
   }, []);
 
-  const setupActive = pathname.startsWith('/setup');
-
   // #1992 — entries the bottom bar omits (Backup, Settings) must still be
   // reachable on a phone. Surface them as icons in the top bar's right row,
   // driven by the same navigation schema (no hand-coded duplication), so a
@@ -75,15 +73,15 @@ export function MobileTopBar() {
   const topBarEntries = NAVIGATION_ENTRIES.filter(p => p.hiddenOnMobileBottom);
 
   return (
-    <div className="h-14 bg-gray-100 dark:bg-black border-b border-gray-200 dark:border-gray-800 flex items-center justify-between px-4 shrink-0 md:hidden z-20">
+    <div className="h-14 bg-surface border-b border-border flex items-center justify-between px-4 shrink-0 md:hidden z-20">
        {/* Left: Logo + Text */}
        <div className="flex items-center gap-2">
-          <ServiceBayLogo size={24} className="text-blue-600 dark:text-blue-400" />
+          <ServiceBayLogo size={24} className="text-accent" />
           <div className="flex flex-col">
-             <span className="font-bold text-gray-900 dark:text-white text-sm leading-none">
+             <span className="font-bold text-text text-sm leading-none">
                 ServiceBay
              </span>
-             <span className="text-[10px] text-gray-500 dark:text-gray-400">by Korgraph.io{appVersion ? ` - v${appVersion}` : ''}</span>
+             <span className="text-[10px] text-text-muted">by Korgraph.io{appVersion ? ` - v${appVersion}` : ''}</span>
           </div>
        </div>
        {/* Center: where this ServiceBay lives — the desktop Sidebar is
@@ -96,16 +94,12 @@ export function MobileTopBar() {
           {hasActiveInstall && (
             <button
               onClick={() => router.push('/setup')}
-              className={`relative transition-colors ${
-                setupActive
-                  ? 'text-blue-600 dark:text-blue-400'
-                  : 'text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300'
-              }`}
+              className="relative transition-colors text-accent hover:text-accent-strong"
               aria-label="Resume setup"
               title="Resume setup"
             >
               <Wrench size={20} />
-              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-accent animate-pulse" />
             </button>
           )}
           {topBarEntries.map(p => {
@@ -117,8 +111,8 @@ export function MobileTopBar() {
                 onClick={() => router.push(`${p.path}${node ? `?node=${node}` : ''}`)}
                 className={`transition-colors ${
                   isActive
-                    ? 'text-blue-600 dark:text-blue-400'
-                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+                    ? 'text-accent'
+                    : 'text-text-muted hover:text-text'
                 }`}
                 aria-label={p.name}
                 title={p.name}
@@ -127,7 +121,7 @@ export function MobileTopBar() {
               </button>
             );
           })}
-          <a href="https://github.com/mdopp/servicebay" target="_blank" rel="noreferrer" className="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
+          <a href="https://github.com/mdopp/servicebay" target="_blank" rel="noreferrer" className="text-text-muted hover:text-text transition-colors">
              <Code size={20} />
           </a>
        </div>
@@ -154,7 +148,7 @@ export function MobileBottomBar() {
   return (
     <nav
       aria-label="Primary"
-      className="h-[72px] bg-gray-100 dark:bg-black border-t border-gray-200 dark:border-gray-800 flex items-center justify-around gap-1 px-2 shrink-0 md:hidden z-20 pb-2 overflow-x-auto no-scrollbar"
+      className="h-[72px] bg-surface border-t border-border flex items-center justify-around gap-1 px-2 shrink-0 md:hidden z-20 pb-2 overflow-x-auto no-scrollbar"
     >
        {bottomDashboards.map(p => {
           const Icon = p.icon;
@@ -167,8 +161,8 @@ export function MobileBottomBar() {
                 aria-label={p.name}
                 className={`p-2 rounded-xl flex flex-col items-center justify-center gap-1 shrink-0 min-w-[3.5rem] transition-all ${
                     isActive
-                    ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20'
-                    : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
+                    ? 'text-accent bg-surface-2'
+                    : 'text-text-muted hover:bg-surface-2'
                 }`}
              >
                 <Icon size={20} strokeWidth={isActive ? 2.5 : 2} />

--- a/tests/frontend/MobileNav.test.tsx
+++ b/tests/frontend/MobileNav.test.tsx
@@ -61,9 +61,9 @@ describe('MobileNav', () => {
     it('MobileBottomBar highlights active route', () => {
         renderWithToast(<MobileBottomBar />);
         const networkBtn = screen.getByTitle('Network Map');
-        expect(networkBtn.className).toContain('text-blue-600');
+        expect(networkBtn.className).toContain('text-accent');
         const servicesBtn = screen.getByTitle('Services');
-        expect(servicesBtn.className).not.toContain('text-blue-600');
+        expect(servicesBtn.className).not.toContain('text-accent');
     });
 
     it('MobileBottomBar threads ?node= into navigation', () => {


### PR DESCRIPTION
Batch of 8: continuation of the #2430 lint-ratchet burn-down (both rules).

Color-literal sweeps (`sb/no-raw-color-literal`, baseline 259 → 222): HistoryViewer.tsx, MobileNav.tsx, FileShareSection.tsx, ConfirmModal.tsx.

UI-primitive sweeps (`sb/no-raw-ui-primitive`, baseline 170 → 150): ContainerList.tsx, PortalGrid.tsx, NodesSection.tsx, ApiTokensSection.tsx.

Every Button/Input/Select migration checked against the tracked #2484 regression pattern (unguarded size/variant losing the Tailwind cascade); no new instance found. All semantic color tokens verified against globals.css's @theme block.

Local safety net: lint 0 errors, typecheck clean, check:arch clean (lint-ratchet held at 222/150), full `npm test` 521 files/4939 tests passed.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
