### PR TITLE
fix(frontend): restore intended styling on 4 Button/ghost migrations lost to cascade collision

### DIFF
--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/ApiTokensSection.tsx
@@ -40,7 +40,11 @@ function BootstrapBanner({ status, revoking, reactivating, onRevoke, onReactivat
   // Show whenever the bootstrap entry still exists — including after its
   // window lapsed — so an expired token can be re-activated (#1419).
   if (!status.active && !status.present) return null;
-  const btnClass = 'text-xs font-medium px-3 py-1.5 rounded-card border border-status-warn/40 text-status-warn bg-status-warn/10 hover:bg-status-warn/20 disabled:opacity-50';
+  // `!`-prefixed: Button's default ghost/md classes (bg-transparent, text-text-muted,
+  // hover:bg-surface-2, h-10, px-space-4) sort after these in the compiled stylesheet
+  // and would otherwise silently win, dropping the warning tint and enlarging the
+  // button (confirmed via the compiled CSS rule order — #2484).
+  const btnClass = '!h-auto !text-xs font-medium !px-3 !py-1.5 rounded-card border border-status-warn/40 !text-status-warn !bg-status-warn/10 hover:!bg-status-warn/20 disabled:opacity-50';
   return (
     <div className="mt-4 rounded-card border border-status-warn/30 bg-status-warn/10 px-4 py-3 flex items-start justify-between gap-4">
       <div className="flex-1 min-w-0">

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FileShareSection.tsx
@@ -167,7 +167,7 @@ export default function FileShareSection() {
                 <button
                   onClick={() => setPassword(u.id)}
                   disabled={busyUser === u.id}
-                  className="inline-flex items-center gap-1 px-3 py-1.5 text-xs bg-status-ok hover:bg-accent-strong text-on-accent rounded disabled:opacity-50"
+                  className="inline-flex items-center gap-1 px-3 py-1.5 text-xs bg-status-ok hover:bg-status-ok/80 text-on-accent rounded disabled:opacity-50"
                   type="button"
                 >
                   {busyUser === u.id ? <Loader2 size={12} className="animate-spin" /> : <KeyRound size={12} />}

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/NodesSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/NodesSection.tsx
@@ -137,7 +137,14 @@ export default function NodesSection() {
             <p className="text-text-muted text-xs">
               ServiceBay requires password-less SSH access to remote nodes.
               If you haven&apos;t set this up, use the
-              <Button variant="ghost" onClick={() => openSSHModal()} className="!h-auto mx-1 underline font-medium text-accent hover:text-accent-strong">
+              {/* `!`-prefixed: ghost's default text-text-muted / hover:bg-surface-2 / md
+                  padding sort after these in the compiled stylesheet and would otherwise
+                  silently win, turning this inline text link gray and boxy (#2484). */}
+              <Button
+                variant="ghost"
+                onClick={() => openSSHModal()}
+                className="!h-auto !px-0 !py-0 hover:!bg-transparent mx-1 underline font-medium !text-accent hover:!text-accent-strong"
+              >
                 Setup SSH Keys
               </Button>
               tool to copy your public key to the server.

--- a/packages/frontend/src/app/portal/PortalGrid.tsx
+++ b/packages/frontend/src/app/portal/PortalGrid.tsx
@@ -354,10 +354,13 @@ function CardDisclosure({
  *  markdown help modal. */
 function HowToButton({ onClick }: { onClick: () => void }) {
   return (
+    // `!`-prefixed: ghost's default text-text-muted / md h-10+px-space-4 sort after
+    // these in the compiled stylesheet and would otherwise silently win, turning this
+    // inline text link gray and boxy instead of a plain accent-colored line (#2484).
     <Button
       onClick={onClick}
       variant="ghost"
-      className="text-accent hover:underline"
+      className="!h-auto !p-0 hover:!bg-transparent !text-accent hover:underline"
       aria-haspopup="dialog"
     >
       How do I use this?


### PR DESCRIPTION
## Summary

Box-verify of `47d2af20` (batch/2026-07-30f, #2488 — the color-literal +
ui-primitive sweep across ApiTokensSection/FileShareSection/NodesSection/
PortalGrid + HistoryViewer/MobileNav/ConfirmModal/ContainerList) found a
live instance of the #2484 regression pattern in 3 of the 4 gate=`verify`
files: a raw-button→`Button` migration passes `variant="ghost"` (or the
default variant/size) alongside a custom `className` meant to override the
primitive's own colors/sizing. `@/components/ui/cn()` is a plain
string-join (no tailwind-merge), so which class wins is decided by
whichever utility sorts later in the *compiled* stylesheet — not by
source/JSX order. I checked this against this repo's actual compiled
Tailwind output (not just theory):

- `.text-text-muted` sorts after `.text-accent`, `.bg-transparent` sorts
  after `.bg-status-warn/10`, `.hover\:bg-surface-2:hover` sorts after
  `.hover\:bg-status-warn/20:hover`, and `.px-space-4` sorts after `.px-3`.

Concretely, this silently broke:
- **`ApiTokensSection.tsx`** (`BootstrapBanner` "Re-activate (30 min)" /
  "Revoke now"): lost the warning-tinted background and text color, and
  grew a taller/wider box than intended.
- **`NodesSection.tsx`** (inline "Setup SSH Keys" link inside the SSH-access
  paragraph): lost its accent-blue link color entirely (at rest *and* on
  hover), and gained unwanted padding + a hover background pill it never
  had as a raw `<button>`.
- **`PortalGrid.tsx`** (`HowToButton`, "How do I use this?"): same
  accent-color loss, plus unwanted `h-10`/`px-space-4` padding on what
  should read as a plain inline text link.

Fix: `!`-prefix the custom classes that need to win — the same pattern
already used elsewhere in this exact batch (`ContainerList.tsx`, other
`PortalGrid` buttons) for sizing overrides, just extended here to also
cover color/background, which those other conversions didn't need.

Also fixed an adjacent, unrelated color-token bug caught in the same
pass: `FileShareSection.tsx`'s "Set password" button mapped
`bg-emerald-600 hover:bg-emerald-700` (same-hue hover) to `bg-status-ok
hover:bg-accent-strong` — the hover state jumps to a completely different
hue (green → blue) instead of darkening. Changed to
`hover:bg-status-ok/80`, matching the same-hue opacity-hover pattern used
everywhere else in this batch (e.g. `ConfirmModal`'s `bg-status-fail
hover:bg-status-fail/80`).

No logic changes — className-only.

## Test plan
- [x] `eslint` on the 4 touched files: 0 errors (only pre-existing
      ratcheted `max-lines-per-function` warnings + FileShareSection's
      pre-existing raw-`<button>` warnings, unrelated to this change)
- [x] `tsc --noEmit` on `packages/frontend`: clean
- [x] Verified the fix empirically against the compiled Tailwind CSS rule
      order (the same mechanism that caused the bug) rather than just
      visual inspection — `!important` unconditionally wins regardless of
      stylesheet order, so this is not another instance of the same class
      of bug
- [ ] Operator visual confirm recommended for the 3 affected buttons/links
      (pixel-level look is not something this check can assert)

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
