### PR TITLE
chore: adopt tailwind-merge in cn() (#2484) + lint-ratchet burn-down (batch g)

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 199,
-    "sb/no-raw-ui-primitive": 150
+    "sb/no-raw-color-literal": 178,
+    "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 222,
-    "sb/no-raw-ui-primitive": 144
+    "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 222,
-    "sb/no-raw-ui-primitive": 150
+    "sb/no-raw-ui-primitive": 144
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 222,
+    "sb/no-raw-color-literal": 210,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 178,
+    "sb/no-raw-color-literal": 169,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 210,
-    "sb/no-raw-ui-primitive": 139
+    "sb/no-raw-color-literal": 199,
+    "sb/no-raw-ui-primitive": 150
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7575,6 +7575,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12595,6 +12596,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
@@ -14002,7 +14013,8 @@
         "react-dom": "19.2.8",
         "react-markdown": "^10.1.0",
         "react-simple-code-editor": "^0.14.1",
-        "socket.io-client": "^4.8.3"
+        "socket.io-client": "^4.8.3",
+        "tailwind-merge": "^3.6.0"
       }
     }
   }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -16,6 +16,7 @@
     "react-dom": "19.2.8",
     "react-markdown": "^10.1.0",
     "react-simple-code-editor": "^0.14.1",
-    "socket.io-client": "^4.8.3"
+    "socket.io-client": "^4.8.3",
+    "tailwind-merge": "^3.6.0"
   }
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/AccessRequestsSection.test.tsx
@@ -43,7 +43,9 @@ describe('AccessRequestsSection (#2086 user-page migration)', () => {
     await waitFor(() => expect(screen.getByText('Alice Resident')).toBeDefined());
 
     // Card surface (design-system token), not the old rounded-xl/gray-800 chrome.
-    expect(container.querySelector('.bg-surface')).not.toBeNull();
+    // The row passes `bg-surface-2`, which since #2484 merges out Card's default
+    // `bg-surface` instead of racing it in the stylesheet.
+    expect(container.querySelector('.bg-surface-2')).not.toBeNull();
     // A StatusDot announces the request state.
     expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
     // Actions are Button primitives: Approve (primary) + Delete (danger).

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
@@ -10,6 +10,7 @@ import {
   type CredentialUrlHost,
 } from '@servicebay/api-client';
 import { useToast } from '@/providers/ToastProvider';
+import { Button, DataTable } from '@/components/ui';
 
 interface Manifest {
   savedAt: string;
@@ -135,35 +136,37 @@ export default function CredentialsSection() {
         )}
         {manifest && manifest.credentials.length > 0 && (
           <div className="flex items-center gap-2 flex-wrap">
-            <button
+            <Button
               onClick={downloadCsv}
-              className="inline-flex items-center gap-2 px-3 py-2 bg-accent hover:bg-accent-strong text-on-accent text-sm font-medium rounded-lg"
+              variant="primary"
+              size="md"
               title="Download the saved credentials as a Bitwarden/Vaultwarden-importable CSV."
             >
               <Download size={14} />
               Download CSV
-            </button>
+            </Button>
             {vaultwardenImportUrl && (
               <a
                 href={vaultwardenImportUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-3 py-2 bg-surface-2 hover:bg-surface text-text text-sm font-medium rounded-lg border border-border"
+                className="inline-flex items-center gap-2 px-4 py-2.5 bg-surface-2 hover:bg-surface-muted text-text text-sm font-medium rounded-card border border-border transition-colors"
                 title="Opens the Vaultwarden web-vault import page in a new tab. Download the CSV first, then pick it there. Choose an Organization collection to share entries with other admins (folders are personal)."
               >
                 <ExternalLink size={14} />
                 Open Vaultwarden import
               </a>
             )}
-            <button
+            <Button
               onClick={onWipe}
               disabled={busy === 'wipe'}
-              className="inline-flex items-center gap-2 px-3 py-2 bg-status-fail hover:bg-status-fail/90 text-on-accent text-sm font-medium rounded-lg disabled:opacity-50"
+              variant="danger"
+              size="md"
               title="Remove the saved credentials from the server. Useful once you've stored them safely in your password manager."
             >
               {busy === 'wipe' ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
               Wipe from server
-            </button>
+            </Button>
           </div>
         )}
 
@@ -173,67 +176,85 @@ export default function CredentialsSection() {
             Nothing saved yet. The install wizard writes here at the end of every successful run.
           </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="text-xs uppercase text-text-muted border-b border-border">
-                <tr>
-                  <th className="text-left py-2 pr-3">Service</th>
-                  <th className="text-left py-2 pr-3">URL</th>
-                  <th className="text-left py-2 pr-3">Username</th>
-                  <th className="text-left py-2 pr-3">Password</th>
-                  <th className="text-left py-2">Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {manifest.credentials.map((c, i) => {
+          <DataTable<Credential>
+            columns={[
+              {
+                key: 'service',
+                header: 'Service',
+                cell: (c) => (
+                  <div>
+                    {c.service}
+                    {c.importance === 'system' && (
+                      <span className="ml-2 text-[10px] uppercase tracking-wide text-text-muted">system</span>
+                    )}
+                  </div>
+                ),
+                align: 'left',
+              },
+              {
+                key: 'url',
+                header: 'URL',
+                cell: (c) => <CredentialUrlCell cred={c} hosts={proxyHosts} publicDomain={publicDomain} />,
+                align: 'left',
+                className: 'font-mono text-xs',
+              },
+              {
+                key: 'username',
+                header: 'Username',
+                cell: (c) => c.username,
+                align: 'left',
+                className: 'font-mono text-xs',
+              },
+              {
+                key: 'password',
+                header: 'Password',
+                cell: (c, i) => {
                   const isRevealed = !!revealed[i];
-                  const rowClass = c.importance === 'critical'
-                    ? 'border-b border-border'
-                    : 'border-b border-border opacity-80';
                   return (
-                    <tr key={i} className={rowClass}>
-                      <td className="py-2 pr-3 font-medium text-text">
-                        {c.service}
-                        {c.importance === 'system' && (
-                          <span className="ml-2 text-[10px] uppercase tracking-wide text-text-muted">system</span>
-                        )}
-                      </td>
-                      <td className="py-2 pr-3 text-text font-mono text-xs">
-                        <CredentialUrlCell cred={c} hosts={proxyHosts} publicDomain={publicDomain} />
-                      </td>
-                      <td className="py-2 pr-3 text-text font-mono text-xs">{c.username}</td>
-                      <td className="py-2 pr-3">
-                        <div className="flex items-center gap-2">
-                          <code className="font-mono text-xs">{isRevealed ? c.password : '••••••••••'}</code>
-                          <button
-                            onClick={() => setRevealed(s => ({ ...s, [i]: !s[i] }))}
-                            className="p-1 text-text-muted hover:text-text"
-                            title={isRevealed ? 'Hide password' : 'Reveal password'}
-                          >
-                            {isRevealed ? <EyeOff size={12} /> : <Eye size={12} />}
-                          </button>
-                          {isRevealed && (
-                            <button
-                              onClick={() => {
-                                navigator.clipboard.writeText(c.password).then(
-                                  () => addToast('success', 'Copied to clipboard', `${c.service} password`),
-                                  () => addToast('error', 'Copy failed', 'Browser refused clipboard access.'),
-                                );
-                              }}
-                              className="p-1 text-text-muted hover:text-text text-[10px] uppercase tracking-wide"
-                            >
-                              copy
-                            </button>
-                          )}
-                        </div>
-                      </td>
-                      <td className="py-2 text-xs text-text-muted">{c.notes ?? ''}</td>
-                    </tr>
+                    <div className="flex items-center gap-2">
+                      <code className="font-mono text-xs">{isRevealed ? c.password : '••••••••••'}</code>
+                      <Button
+                        onClick={() => setRevealed(s => ({ ...s, [i]: !s[i] }))}
+                        variant="ghost"
+                        className="!h-auto !p-1"
+                        title={isRevealed ? 'Hide password' : 'Reveal password'}
+                      >
+                        {isRevealed ? <EyeOff size={12} /> : <Eye size={12} />}
+                      </Button>
+                      {isRevealed && (
+                        <Button
+                          onClick={() => {
+                            navigator.clipboard.writeText(c.password).then(
+                              () => addToast('success', 'Copied to clipboard', `${c.service} password`),
+                              () => addToast('error', 'Copy failed', 'Browser refused clipboard access.'),
+                            );
+                          }}
+                          variant="ghost"
+                          className="!h-auto !p-1 text-[10px] uppercase tracking-wide"
+                        >
+                          copy
+                        </Button>
+                      )}
+                    </div>
                   );
-                })}
-              </tbody>
-            </table>
-          </div>
+                },
+                align: 'left',
+              },
+              {
+                key: 'notes',
+                header: 'Notes',
+                cell: (c) => c.notes ?? '',
+                align: 'left',
+                className: 'text-xs text-text-muted',
+              },
+            ]}
+            rows={manifest.credentials}
+            rowKey={(c, i) => String(i)}
+            rowClassName={(c) =>
+              c.importance === 'critical' ? '' : 'opacity-80'
+            }
+            empty="No credentials saved"
+          />
         )}
       </div>
     </>

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/FactoryResetSection.tsx
@@ -61,22 +61,22 @@ export default function FactoryResetSection() {
 
   return (
     <div className="space-y-4">
-        <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
+        <div className="text-sm text-text space-y-2">
           <p>This deletes every installed service (photos, vault, identity, proxy, all of it) and clears the saved credentials in ServiceBay&apos;s config. The next wizard run goes through the full first-install flow with no pre-filled values.</p>
-          <p className="font-medium text-red-700 dark:text-red-400">
+          <p className="font-medium text-status-fail">
             Not what you want for a normal re-install. To rebuild from a USB stick, pick a Factory-fresh option in the build form instead — &quot;wipe-configs&quot; keeps your app data on disk; this button does not.
           </p>
-          <p className="text-xs text-gray-700 dark:text-gray-300">
+          <p className="text-xs text-text">
             Each service&apos;s config (Home Assistant&apos;s automations + <span className="font-mono">.storage</span>, the Z-Wave network keys, AdGuard / Authelia / nginx settings) is <span className="font-semibold">not</span> pulled back automatically — restore it from a System Snapshot afterwards, or services come up with default settings. Bulk data (the Immich photo library, recorder history, the Z-Wave mesh DB) is not in the snapshot; it is wiped by a Factory Reset (restore it from Backup Sync).
           </p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-xs text-subtle">
             Family members will need to re-create their LLDAP accounts. NPM&apos;s Let&apos;s Encrypt certs are wiped (LE has a rate limit on re-issuance, so don&apos;t do this repeatedly).
           </p>
         </div>
 
         <div className="space-y-2">
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-            Type <span className="font-mono font-bold text-red-600 dark:text-red-400">{REQUIRED_CONFIRM}</span> to confirm:
+          <label className="block text-sm font-medium text-text">
+            Type <span className="font-mono font-bold text-status-fail">{REQUIRED_CONFIRM}</span> to confirm:
           </label>
           <input
             type="text"
@@ -86,27 +86,27 @@ export default function FactoryResetSection() {
             placeholder={REQUIRED_CONFIRM}
             autoComplete="off"
             spellCheck={false}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white font-mono text-sm focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50"
+            className="w-full px-3 py-2 border border-border rounded-lg bg-surface text-text font-mono text-sm focus:outline-none focus:ring-2 focus:ring-status-fail disabled:opacity-50"
           />
         </div>
 
         <button
           onClick={handleFactoryReset}
           disabled={!matches || running}
-          className="w-full sm:w-auto px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors shadow-sm flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+          className="w-full sm:w-auto px-4 py-2 bg-status-fail text-on-accent rounded-lg hover:bg-status-fail/90 transition-colors shadow-sm flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
         >
           {running ? <Loader2 size={18} className="animate-spin" /> : <Trash2 size={18} />}
           {running ? 'Resetting…' : 'Factory reset this server'}
         </button>
 
         {result && (
-          <div className="mt-4 p-4 bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-900/50 rounded-lg text-sm text-gray-700 dark:text-gray-300 space-y-1">
-            <p className="font-medium text-green-700 dark:text-green-400">Reset complete.</p>
+          <div className="mt-4 p-4 bg-status-ok/10 border border-status-ok rounded-lg text-sm text-text space-y-1">
+            <p className="font-medium text-status-ok">Reset complete.</p>
             <p>Removed {result.deleted} service{result.deleted === 1 ? '' : 's'}; wiped {result.wipeSteps.length} data group{result.wipeSteps.length === 1 ? '' : 's'}.</p>
             {result.cleared.length > 0 && (
               <p>Config fields cleared: <span className="font-mono text-xs">{result.cleared.join(', ')}</span>.</p>
             )}
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">Open the install wizard to set up the server from scratch.</p>
+            <p className="text-xs text-subtle mt-2">Open the install wizard to set up the server from scratch.</p>
           </div>
         )}
     </div>

--- a/packages/frontend/src/components/HealthChecks.tsx
+++ b/packages/frontend/src/components/HealthChecks.tsx
@@ -118,14 +118,18 @@ export default function HealthChecks({
     <>
       {/* Stats Overview & Filters — clickable counters that filter the
           list. Diagnose rows surface their own warn/fail (warn is no
-          longer folded into fail). */}
+          longer folded into fail).
+          The active tiles carry no `ring-opacity-50`: Tailwind v4 dropped that
+          utility (it emitted nothing here), and cn()'s tailwind-merge pass
+          (#2484) read it as a ring *colour*, merging the real `ring-status-*`
+          away. Use a `/50` alpha on the colour itself if the ring should fade. */}
       <div className="grid grid-cols-4 gap-2 px-2">
         <Button
             onClick={() => setStatusFilter(statusFilter === 'ok' ? 'all' : 'ok')}
             variant="ghost"
             className={`h-auto p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
                 statusFilter === 'ok'
-                ? 'bg-status-ok/5 border-status-ok/20 ring-2 ring-status-ok ring-opacity-50'
+                ? 'bg-status-ok/5 border-status-ok/20 ring-2 ring-status-ok'
                 : 'bg-surface border-border hover:bg-surface-2'
             }`}
         >
@@ -142,7 +146,7 @@ export default function HealthChecks({
             variant="ghost"
             className={`h-auto p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
                 statusFilter === 'warn'
-                ? 'bg-status-warn/5 border-status-warn/20 ring-2 ring-status-warn ring-opacity-50'
+                ? 'bg-status-warn/5 border-status-warn/20 ring-2 ring-status-warn'
                 : 'bg-surface border-border hover:bg-surface-2'
             }`}
         >
@@ -159,7 +163,7 @@ export default function HealthChecks({
             variant="ghost"
             className={`h-auto p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
                 statusFilter === 'fail'
-                ? 'bg-status-fail/5 border-status-fail/20 ring-2 ring-status-fail ring-opacity-50'
+                ? 'bg-status-fail/5 border-status-fail/20 ring-2 ring-status-fail'
                 : 'bg-surface border-border hover:bg-surface-2'
             }`}
         >
@@ -176,7 +180,7 @@ export default function HealthChecks({
             variant="ghost"
             className={`h-auto p-3 rounded-xl border shadow-sm flex flex-col items-center text-center transition-all ${
                 statusFilter === 'unknown'
-                ? 'bg-surface-2 border-border ring-2 ring-text-subtle ring-opacity-50'
+                ? 'bg-surface-2 border-border ring-2 ring-text-subtle'
                 : 'bg-surface border-border hover:bg-surface-2'
             }`}
         >

--- a/packages/frontend/src/components/MultiSelect.tsx
+++ b/packages/frontend/src/components/MultiSelect.tsx
@@ -58,8 +58,8 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
 
   return (
     <div ref={wrapperRef} className={`relative ${className}`}>
-      <div 
-        className={`flex flex-wrap items-center gap-1 p-1.5 border rounded bg-white dark:bg-slate-800 border-slate-300 dark:border-slate-600 min-h-[38px] cursor-text ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+      <div
+        className={`flex flex-wrap items-center gap-1 p-1.5 border rounded bg-surface-2 border-border min-h-[38px] cursor-text ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
         onClick={() => {
             if (!disabled) {
                 setIsOpen(true);
@@ -68,9 +68,9 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         }}
       >
         {value.map(v => (
-          <span key={v} className="flex items-center gap-1 px-1.5 py-0.5 text-xs bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200 rounded">
+          <span key={v} className="flex items-center gap-1 px-1.5 py-0.5 text-xs bg-accent/10 text-accent rounded">
             {v}
-            <button onMouseDown={(e) => removeValue(v, e)} className="hover:text-blue-600 dark:hover:text-blue-100">
+            <button onMouseDown={(e) => removeValue(v, e)} className="hover:text-accent-strong">
                 <X size={12} />
             </button>
           </span>
@@ -79,7 +79,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         <input
           ref={inputRef}
           type="text"
-          className="flex-1 min-w-[60px] bg-transparent outline-none text-sm dark:text-gray-100"
+          className="flex-1 min-w-[60px] bg-transparent outline-none text-sm text-text"
           placeholder={value.length === 0 ? placeholder : ''}
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
@@ -88,30 +88,30 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         />
         
         {loading ? (
-             <div className="animate-spin h-4 w-4 border-2 border-slate-500 rounded-full border-t-transparent mr-1"></div>
+             <div className="animate-spin h-4 w-4 border-2 border-text-muted rounded-full border-t-transparent mr-1"></div>
         ) : (
-            <ChevronDown size={16} className="text-slate-400 mr-1" />
+            <ChevronDown size={16} className="text-muted mr-1" />
         )}
       </div>
 
       {isOpen && !disabled && (
-        <ul className="absolute z-50 w-full mt-1 max-h-60 overflow-auto bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded shadow-lg">
+        <ul className="absolute z-50 w-full mt-1 max-h-60 overflow-auto bg-surface-2 border border-border rounded shadow-lg">
           {filteredOptions.length === 0 && (
-             <li className="p-2 text-sm text-slate-500 dark:text-slate-400">No options found</li>
+             <li className="p-2 text-sm text-muted">No options found</li>
           )}
           {filteredOptions.map((option) => {
             const isSelected = value.includes(option);
             return (
                 <li
                 key={option}
-                className={`flex items-center justify-between p-2 text-sm cursor-pointer hover:bg-slate-100 dark:hover:bg-slate-700 ${isSelected ? 'bg-slate-50 dark:bg-slate-700/50' : ''}`}
+                className={`flex items-center justify-between p-2 text-sm cursor-pointer hover:bg-surface ${isSelected ? 'bg-surface' : ''}`}
                 onMouseDown={(e) => {
                     e.preventDefault(); // Prevent blur/click-outside
                     toggleOption(option);
                 }}
                 >
-                <span className="dark:text-gray-200">{option}</span>
-                {isSelected && <Check size={14} className="text-blue-600 dark:text-blue-400" />}
+                <span className="text-text">{option}</span>
+                {isSelected && <Check size={14} className="text-accent" />}
                 </li>
             );
           })}

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft, Code, Users, ExternalLink, Sparkles, Home, User as UserIco
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
 import DomainTag from './DomainTag';
+import { Button } from '@/components/ui';
 import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
 import { useDigitalTwin } from '@/hooks/useDigitalTwin';
 
@@ -142,13 +143,14 @@ export default function Sidebar() {
                     </div>
                 </div>
             )}
-            <button
+            <Button
                 onClick={() => setIsCollapsed(!isCollapsed)}
-                className={`p-1.5 rounded-card border border-transparent hover:bg-surface-2 text-text-muted ${isCollapsed ? 'mx-auto' : ''}`}
+                variant="ghost"
+                className={`!h-auto !p-1.5 border border-transparent ${isCollapsed ? 'mx-auto' : ''}`}
                 title={isCollapsed ? "Expand Sidebar" : "Collapse Sidebar"}
             >
                 {isCollapsed ? <ServiceBayLogo size={20} /> : <ChevronLeft size={18} />}
-            </button>
+            </Button>
         </div>
         {node && !isCollapsed && (
             <div className="mx-2 mb-1 px-3 py-1.5 bg-status-warn/10 border border-status-warn/30 rounded-card flex items-center gap-2">
@@ -157,44 +159,48 @@ export default function Sidebar() {
             </div>
         )}
         {node && isCollapsed && (
-            <button
+            <Button
                 type="button"
                 onClick={() => setShowCollapsedNodeLabel(v => !v)}
                 title={`Node: ${node}`}
                 aria-label={`Active node: ${node}. Tap for details.`}
-                className="mx-auto mb-1 flex flex-col items-center gap-0.5 focus:outline-none"
+                variant="ghost"
+                size="sm"
+                className="mx-auto mb-1 flex flex-col items-center gap-0.5 !h-auto !p-0"
             >
                 <span className="w-3 h-3 rounded-full bg-status-warn animate-pulse" />
                 {showCollapsedNodeLabel && (
                     <span className="text-[9px] font-mono text-status-warn max-w-[3.5rem] truncate">{node}</span>
                 )}
-            </button>
+            </Button>
         )}
         <div className="overflow-y-auto flex-1 p-2 space-y-1">
             {dashboards.map(p => {
                 const Icon = p.icon;
                 const isActive = isNavActive(pathname, p.path);
                 return (
-                    <button
+                    <Button
                         key={p.id}
                         onClick={() => router.push(`${p.path}${node ? `?node=${node}` : ''}`)}
-                        className={navItemClass(isActive, isCollapsed)}
+                        variant="ghost"
+                        className={`${navItemClass(isActive, isCollapsed)} !h-auto`}
                         title={isCollapsed ? p.name : ''}
                     >
                         <Icon size={20} className={`shrink-0 ${isActive ? 'text-accent' : 'text-text-subtle'}`} />
                         {!isCollapsed && <span className="font-semibold whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-300">{p.name}</span>}
-                    </button>
+                    </Button>
                 );
             })}
             {chatInstalled && (
-                <button
+                <Button
                     onClick={() => router.push(`/chat${node ? `?node=${node}` : ''}`)}
-                    className={navItemClass(isNavActive(pathname, '/chat'), isCollapsed)}
+                    variant="ghost"
+                    className={`${navItemClass(isNavActive(pathname, '/chat'), isCollapsed)} !h-auto`}
                     title={isCollapsed ? 'Maintenance Chat' : ''}
                 >
                     <MessageCircle size={20} className={`shrink-0 ${isNavActive(pathname, '/chat') ? 'text-accent' : 'text-text-subtle'}`} />
                     {!isCollapsed && <span className="font-semibold whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-300">Maintenance Chat</span>}
-                </button>
+                </Button>
             )}
             {lldapUrl && (
                 <a
@@ -282,28 +288,30 @@ export default function Sidebar() {
                     {currentUser && (
                         <>
                             <span className="text-text-subtle select-none" aria-hidden>·</span>
-                            <button
+                            <Button
                                 type="button"
                                 onClick={handleLogout}
-                                className="hover:text-text transition-colors"
+                                variant="ghost"
+                                className="!h-auto !p-0 hover:text-text transition-colors"
                                 title={currentUser.source === 'session' ? 'Log out of ServiceBay' : 'Log out — drops the Authelia session'}
                             >
                                 Log out
-                            </button>
+                            </Button>
                         </>
                     )}
                 </div>
             ) : (
                 <>
                     {currentUser && (
-                        <button
+                        <Button
                             type="button"
                             onClick={handleLogout}
-                            className="w-full flex items-center justify-center px-3.5 py-2.5 rounded-card text-text-muted hover:text-text hover:bg-surface-2 transition-all border border-transparent"
+                            variant="ghost"
+                            className="w-full flex items-center justify-center !px-3.5 !py-2.5 border border-transparent"
                             title={currentUser.source === 'session' ? 'Log out of ServiceBay' : 'Log out — drops the Authelia session'}
                         >
                             <LogOut size={18} className="shrink-0" />
-                        </button>
+                        </Button>
                     )}
                     <div className="flex justify-center">
                         <SectionHelp

--- a/packages/frontend/src/components/TemplateUpgradesPendingBanner.tsx
+++ b/packages/frontend/src/components/TemplateUpgradesPendingBanner.tsx
@@ -120,49 +120,49 @@ export default function TemplateUpgradesPendingBanner() {
         <div
           className={`mb-4 rounded-lg border ${
             breaking
-              ? 'border-amber-300 dark:border-amber-700 bg-amber-50/70 dark:bg-amber-900/20'
-              : 'border-blue-200 dark:border-blue-800 bg-blue-50/70 dark:bg-blue-900/20'
+              ? 'border-status-warn bg-status-warn/10'
+              : 'border-status-info bg-status-info/10'
           }`}
         >
           <div className="p-4 flex items-start gap-3">
             <div
               className={`shrink-0 p-1.5 rounded ${
                 breaking
-                  ? 'bg-amber-100 dark:bg-amber-800/30 text-amber-700 dark:text-amber-300'
-                  : 'bg-blue-100 dark:bg-blue-800/30 text-blue-700 dark:text-blue-300'
+                  ? 'bg-status-warn/20 text-status-warn'
+                  : 'bg-status-info/20 text-status-info'
               }`}
             >
               <Icon size={16} />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="font-semibold text-sm text-gray-900 dark:text-white">
+              <div className="font-semibold text-sm text-text">
                 {visible.length} template upgrade{visible.length === 1 ? '' : 's'} available
                 {breaking ? ' — includes breaking changes' : ''}
               </div>
-              <ul className="mt-2 space-y-1.5 text-xs text-gray-700 dark:text-gray-300">
+              <ul className="mt-2 space-y-1.5 text-xs text-text-muted">
                 {visible.map(p => (
                   <li key={p.name} className="flex items-center gap-2 flex-wrap">
                     <span className="font-mono font-medium">{p.name}</span>
-                    <span className="text-gray-500 dark:text-gray-400">
+                    <span className="text-text-subtle">
                       v{p.installedVersion} → v{p.currentVersion}
                     </span>
                     {p.sectionHeaders.length > 0 && (
-                      <span className="text-gray-500 dark:text-gray-400">
+                      <span className="text-text-subtle">
                         ({p.sectionHeaders.join(', ')})
                       </span>
                     )}
                     {p.hasBreakingChange && (
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-amber-200 dark:bg-amber-700/50 text-amber-900 dark:text-amber-100">
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-status-warn/20 text-status-warn">
                         breaking
                       </span>
                     )}
                     <button
                       onClick={() => openInstaller(p.name)}
                       disabled={loadingName === p.name}
-                      className={`ml-auto inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded text-white disabled:opacity-50 ${
+                      className={`ml-auto inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded text-on-accent disabled:opacity-50 ${
                         p.hasBreakingChange
-                          ? 'bg-amber-600 hover:bg-amber-700'
-                          : 'bg-blue-600 hover:bg-blue-700'
+                          ? 'bg-status-warn hover:bg-status-warn/80'
+                          : 'bg-status-info hover:bg-status-info/80'
                       }`}
                       type="button"
                       title={p.hasBreakingChange ? 'Review changelog + acknowledge breaking changes, then re-deploy' : 'Re-deploy this service'}
@@ -176,7 +176,7 @@ export default function TemplateUpgradesPendingBanner() {
             </div>
             <button
               onClick={dismissAll}
-              className="shrink-0 p-1 rounded hover:bg-gray-200/50 dark:hover:bg-gray-700/50 text-gray-500 dark:text-gray-400"
+              className="shrink-0 p-1 rounded hover:bg-surface-2 text-text-subtle hover:text-text-muted"
               title="Dismiss until the next version bump"
               type="button"
             >

--- a/packages/frontend/src/components/ui/DataTable.tsx
+++ b/packages/frontend/src/components/ui/DataTable.tsx
@@ -27,6 +27,8 @@ export interface DataTableProps<Row> {
   rowKey: (row: Row, index: number) => string;
   /** Optional per-row click — makes the row a button-like target. */
   onRowClick?: (row: Row, index: number) => void;
+  /** Optional per-row className — called with (row, index) to compute the row's className. */
+  rowClassName?: (row: Row, index: number) => string;
   /** Shown (spanning all columns) when `rows` is empty. */
   empty?: React.ReactNode;
   /** Classes on the scroll container. */
@@ -66,11 +68,13 @@ function BodyRow<Row>({
   row,
   index,
   onRowClick,
+  rowClassName,
 }: {
   columns: Column<Row>[];
   row: Row;
   index: number;
   onRowClick?: (row: Row, index: number) => void;
+  rowClassName?: (row: Row, index: number) => string;
 }) {
   return (
     <tr
@@ -78,6 +82,7 @@ function BodyRow<Row>({
       className={cn(
         'border-b border-border last:border-0 text-text',
         onRowClick && 'cursor-pointer hover:bg-surface-2',
+        rowClassName && rowClassName(row, index),
       )}
     >
       {columns.map((col) => (
@@ -97,6 +102,7 @@ export function DataTable<Row>({
   rows,
   rowKey,
   onRowClick,
+  rowClassName,
   empty = 'No data',
   className,
   minWidthClassName,
@@ -125,6 +131,7 @@ export function DataTable<Row>({
                 row={row}
                 index={i}
                 onRowClick={onRowClick}
+                rowClassName={rowClassName}
               />
             ))
           )}

--- a/packages/frontend/src/components/ui/cn.test.ts
+++ b/packages/frontend/src/components/ui/cn.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { cn } from './cn';
+
+/** Button's own defaults, verbatim from Button.tsx (the #2484 collision source). */
+const BUTTON_MD = 'h-10 px-space-4 text-sm';
+const BUTTON_SM = 'h-8 px-space-3 text-xs';
+const BUTTON_GHOST = 'bg-transparent text-text-muted hover:bg-surface-2 hover:text-text';
+
+const classes = (value: string) => value.split(' ').filter(Boolean);
+
+describe('ui/cn', () => {
+  it('joins parts and drops falsy values', () => {
+    expect(cn('a', false, null, undefined, 'b')).toBe('a b');
+    expect(cn()).toBe('');
+    expect(cn('', false)).toBe('');
+  });
+
+  describe('conflict resolution — the caller className beats the primitive default (#2484)', () => {
+    it('drops the primitive geometry the caller overrides', () => {
+      const result = classes(cn(BUTTON_MD, 'h-auto px-6 py-3'));
+      expect(result).toContain('h-auto');
+      expect(result).toContain('px-6');
+      expect(result).not.toContain('h-10');
+      expect(result).not.toContain('px-space-4');
+    });
+
+    it('resolves the custom `--spacing-space-*` scale against the numeric scale', () => {
+      // The original bug: without teaching tailwind-merge the repo's `space-*`
+      // spacing namespace, `px-space-4` and `px-6` both survive and the winner
+      // is decided by stylesheet emission order.
+      expect(cn('px-space-4', 'px-6')).toBe('px-6');
+      expect(cn('px-6', 'px-space-4')).toBe('px-space-4');
+      expect(cn('gap-space-2', 'gap-0')).toBe('gap-0');
+      expect(cn('mt-space-1', 'mt-4')).toBe('mt-4');
+      // A later shorthand still clears the earlier axis utility.
+      expect(cn('px-space-4', 'p-1')).toBe('p-1');
+    });
+
+    it('resolves the custom `--radius-*` scale', () => {
+      expect(cn('rounded-card', 'rounded-chip')).toBe('rounded-chip');
+      expect(cn('rounded-card', 'rounded-none')).toBe('rounded-none');
+    });
+
+    it('resolves semantic colour tokens', () => {
+      expect(classes(cn(BUTTON_GHOST, 'text-accent'))).not.toContain('text-text-muted');
+      expect(cn('bg-accent', 'bg-status-warn/10')).toBe('bg-status-warn/10');
+      expect(cn('hover:bg-surface-2', 'hover:bg-transparent')).toBe('hover:bg-transparent');
+    });
+
+    it('keeps font-size and text-colour in separate groups', () => {
+      // `text-sm` (size) must survive a `text-accent` (colour) override.
+      expect(classes(cn('text-sm text-text-muted', 'text-accent'))).toEqual(
+        expect.arrayContaining(['text-sm', 'text-accent']),
+      );
+      expect(cn('text-sm', 'text-xs')).toBe('text-xs');
+    });
+
+    it('keeps non-conflicting utilities from every part', () => {
+      const result = classes(cn('inline-flex items-center', BUTTON_GHOST, BUTTON_SM, 'w-full'));
+      for (const kept of ['inline-flex', 'items-center', 'bg-transparent', 'h-8', 'w-full']) {
+        expect(result).toContain(kept);
+      }
+    });
+  });
+
+  describe('the `!`-important escape hatch of the pre-#2484 fixes still applies', () => {
+    // #2479/#2482/#2483/#2487/#2490 forced their geometry with `!`-important.
+    // tailwind-merge treats an important utility as its own conflict group, so
+    // it must never merge one away against a non-important default — the
+    // `!important` declaration then wins in CSS as those fixes intend.
+    it.each([
+      ['ServiceMonitor tab strip', BUTTON_MD, '!h-auto !px-6 py-3'],
+      ['StackInstallFlow row', BUTTON_MD, '!h-auto !px-3 w-full justify-start py-2'],
+      ['EmailNotificationsSection pill', BUTTON_MD, 'relative !h-6 !w-11 !px-0 !rounded-chip'],
+      ['ApiTokensSection banner button', BUTTON_MD, '!h-auto !text-xs !px-3 !py-1.5'],
+      ['PortalGrid how-to link', BUTTON_MD, '!h-auto !p-0 hover:!bg-transparent !text-accent'],
+      ['NodesSection ssh link', BUTTON_MD, '!h-auto !px-0 !py-0 hover:!bg-transparent !text-accent'],
+      ['Sidebar nav item', BUTTON_SM, '!h-auto !p-1.5'],
+      ['CredentialsSection icon button', BUTTON_SM, '!h-auto !p-1'],
+    ])('preserves every important override in %s', (_name, defaults, override) => {
+      const result = classes(cn(defaults, override));
+      for (const important of classes(override).filter((c) => c.includes('!'))) {
+        expect(result).toContain(important);
+      }
+    });
+
+    it('still merges two important utilities of the same group', () => {
+      expect(cn('!px-6', '!px-3')).toBe('!px-3');
+    });
+  });
+
+  describe('drift guard — every custom @theme token in globals.css is resolvable', () => {
+    const css = readFileSync(path.resolve(__dirname, '../../app/globals.css'), 'utf8');
+    const tokens = (namespace: string) => [
+      ...new Set(
+        [...css.matchAll(new RegExp(`--${namespace}-([a-z0-9-]+):`, 'g'))].map((m) => m[1]),
+      ),
+    ];
+
+    const spacingTokens = tokens('spacing');
+    const radiusTokens = tokens('radius');
+
+    it('found the token declarations to check', () => {
+      expect(spacingTokens.length).toBeGreaterThan(0);
+      expect(radiusTokens.length).toBeGreaterThan(0);
+    });
+
+    it.each(spacingTokens)('spacing token `%s` participates in padding conflicts', (token) => {
+      expect(cn(`p-${token}`, 'p-0')).toBe('p-0');
+      expect(cn('p-0', `p-${token}`)).toBe(`p-${token}`);
+    });
+
+    it.each(radiusTokens)('radius token `%s` participates in radius conflicts', (token) => {
+      expect(cn(`rounded-${token}`, 'rounded-none')).toBe('rounded-none');
+      expect(cn('rounded-none', `rounded-${token}`)).toBe(`rounded-${token}`);
+    });
+  });
+});

--- a/packages/frontend/src/components/ui/cn.ts
+++ b/packages/frontend/src/components/ui/cn.ts
@@ -1,12 +1,49 @@
+import { extendTailwindMerge } from 'tailwind-merge';
+
 /**
- * Tiny class-name joiner for the design-system primitives (#2071).
+ * Class-name joiner for the design-system primitives (#2071), with Tailwind
+ * conflict resolution (#2484).
  *
- * The repo has no clsx/tailwind-merge dependency, and the primitives only need
- * to drop falsy values and join with spaces (variant maps are authored to not
- * collide, so we don't need conflict-resolution merging). Keep it dependency-free.
+ * WHY tailwind-merge and not a plain string join: every primitive composes its
+ * own defaults with the caller's `className`
+ * (`cn(base, variants[v], sizes[s], className)`). A plain join emits BOTH the
+ * default and the override — e.g. Button's `h-10 px-space-4` next to a caller's
+ * `h-auto px-6` — and which one paints is then decided by the order Tailwind
+ * happens to emit those rules into the stylesheet, not by the caller's intent.
+ * That silently regressed five migrations in one session (#2479, #2482, #2483,
+ * #2487, #2490): a raw `<button>` with its own geometry became a `<Button>` and
+ * quietly rendered at the primitive's default size. tailwind-merge drops the
+ * earlier class of a conflicting pair, so the LAST one wins deterministically —
+ * which is exactly "the caller's `className` overrides the primitive's default".
+ *
+ * The `extend` below teaches it this repo's custom `@theme` namespaces from
+ * `app/globals.css`; without them `px-space-4` and `px-6` are not recognized as
+ * the same utility group and both survive the merge (the original bug):
+ *  - `--spacing-space-<n>` → `p-space-4`, `gap-space-2`, `mt-space-1`, …
+ *  - `--radius-{chip,card,panel}` → `rounded-card`, `rounded-chip`, …
+ * Semantic colours (`bg-surface-2`, `text-status-ok`, …) need no extension —
+ * tailwind-merge's colour groups already accept any token name.
+ *
+ * The `!`-important escape hatch used by the pre-#2484 fixes
+ * (`!h-auto`, `hover:!bg-transparent`) keeps working: tailwind-merge treats an
+ * important utility as its own conflict group, so it never merges an important
+ * class away against a non-important one, and `!important` still wins in CSS.
  */
+
+/** `space-1`…`space-8` (and fractional steps) from the `--spacing-space-*` tokens. */
+const isSpaceToken = (value: string) => /^space-\d+(?:\.\d+)?$/.test(value);
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      spacing: [isSpaceToken],
+      radius: ['chip', 'card', 'panel'],
+    },
+  },
+});
+
 export type ClassValue = string | false | null | undefined;
 
 export function cn(...parts: ClassValue[]): string {
-  return parts.filter(Boolean).join(' ');
+  return twMerge(parts.filter(Boolean).join(' '));
 }

--- a/packages/frontend/src/components/wizard/steps/FinishStep.tsx
+++ b/packages/frontend/src/components/wizard/steps/FinishStep.tsx
@@ -30,20 +30,20 @@ function OrphanBackupsHint() {
     if (orphans.length === 0) return null;
 
     return (
-        <div className="mx-auto max-w-md text-left rounded-2xl border border-blue-500/20 bg-blue-500/5 p-5">
-            <div className="flex items-center gap-2 text-blue-600 dark:text-blue-400">
+        <div className="mx-auto max-w-md text-left rounded-2xl border border-status-info/20 bg-status-info/5 p-5">
+            <div className="flex items-center gap-2 text-status-info">
                 <DatabaseBackup className="w-5 h-5 shrink-0" />
                 <span className="font-semibold">
                     {orphans.length} service backup{orphans.length === 1 ? '' : 's'} on your FritzBox NAS
                 </span>
             </div>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            <p className="mt-1 text-sm text-text-muted">
                 Config for {orphans.map(o => o.service).join(', ')} is on the NAS but not installed here.
                 Install {orphans.length === 1 ? 'it' : 'them'} and the saved config is restored automatically.
             </p>
             <a
                 href="/services"
-                className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+                className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-status-info hover:underline"
             >
                 Set them up <ArrowRight className="w-4 h-4" />
             </a>
@@ -55,9 +55,9 @@ export function FinishStep({ handleFinish }: FinishStepProps) {
     return (
         <div className="space-y-8 py-8 text-center animate-in fade-in zoom-in-95 duration-500">
             <div className="relative inline-block">
-                <div className="absolute inset-0 bg-emerald-500/20 blur-3xl rounded-full"></div>
-                <div className="relative p-6 rounded-3xl bg-emerald-500/10 border border-emerald-500/20">
-                    <CheckCircle className="w-16 h-16 text-emerald-500" />
+                <div className="absolute inset-0 bg-status-ok/20 blur-3xl rounded-full"></div>
+                <div className="relative p-6 rounded-3xl bg-status-ok/10 border border-status-ok/20">
+                    <CheckCircle className="w-16 h-16 text-status-ok" />
                 </div>
             </div>
 
@@ -65,7 +65,7 @@ export function FinishStep({ handleFinish }: FinishStepProps) {
                 <h3 className="text-3xl font-extrabold tracking-tight bg-clip-text text-transparent premium-gradient">
                     You&apos;re All Set!
                 </h3>
-                <p className="text-gray-600 dark:text-gray-400 max-w-md mx-auto leading-relaxed">
+                <p className="text-text-muted max-w-md mx-auto leading-relaxed">
                     Your ServiceBay environment has been successfully configured. You can now access your dashboard and start managing your services.
                 </p>
             </div>
@@ -78,7 +78,7 @@ export function FinishStep({ handleFinish }: FinishStepProps) {
                 </Button>
             </div>
 
-            <p className="text-[10px] text-gray-400 uppercase tracking-widest font-bold">
+            <p className="text-[10px] text-text-subtle uppercase tracking-widest font-bold">
                 Setup Complete · Welcome Home
             </p>
         </div>

--- a/packages/frontend/src/components/wizard/steps/WelcomeStep.tsx
+++ b/packages/frontend/src/components/wizard/steps/WelcomeStep.tsx
@@ -30,7 +30,7 @@ export function WelcomeStep({ selection, setSelection }: WelcomeStepProps) {
                 <h3 className="text-2xl font-extrabold tracking-tight bg-clip-text text-transparent premium-gradient">
                     Welcome to ServiceBay
                 </h3>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 leading-relaxed">
+                <p className="text-sm text-text-muted mt-1 leading-relaxed">
                     Let&apos;s get your environment ready. You can skip any step and configure it later in Settings.
                 </p>
             </div>
@@ -46,42 +46,42 @@ export function WelcomeStep({ selection, setSelection }: WelcomeStepProps) {
                   "Prerequisites" framing makes the impact explicit
                   rather than hiding it among optional toggles.
                 */}
-                <p className="text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-widest ml-1">
+                <p className="text-[10px] font-bold text-text-subtle uppercase tracking-widest ml-1">
                     Prerequisites
                 </p>
                 <Toggle
                     checked={selection.gateway}
                     onChange={(v: boolean) => setSelection(s => ({...s, gateway: v}))}
                     icon={Network}
-                    color="text-purple-500"
+                    color="text-accent-strong"
                     title="FRITZ!Box gateway"
                     desc="Required for device discovery, Wake-on-LAN and port-forward management — you'll verify the connection on the next step."
                 />
 
-                <p className="pt-3 text-[10px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-widest ml-1">
+                <p className="pt-3 text-[10px] font-bold text-text-subtle uppercase tracking-widest ml-1">
                     Recommended Setup
                 </p>
-                <Toggle 
-                    checked={selection.ssh} 
+                <Toggle
+                    checked={selection.ssh}
                     onChange={(v: boolean) => setSelection(s => ({...s, ssh: v}))}
-                    icon={Key} 
-                    color="text-amber-500"
-                    title="Remote Access" 
+                    icon={Key}
+                    color="text-status-warn"
+                    title="Remote Access"
                     desc="SSH keys for node management"
                 />
-                <Toggle 
-                    checked={selection.updates} 
+                <Toggle
+                    checked={selection.updates}
                     onChange={(v: boolean) => setSelection(s => ({...s, updates: v}))}
-                    icon={RefreshCw} 
-                    color="text-green-500"
-                    title="Auto Updates" 
+                    icon={RefreshCw}
+                    color="text-status-ok"
+                    title="Auto Updates"
                     desc="Keep ServiceBay and containers updated"
                 />
                  <Toggle
                     checked={selection.registries}
                     onChange={(v: boolean) => setSelection(s => ({...s, registries: v}))}
                     icon={Box}
-                    color="text-blue-500"
+                    color="text-accent"
                     title="Templates"
                     desc="Enable GitHub template registries"
                 />
@@ -89,7 +89,7 @@ export function WelcomeStep({ selection, setSelection }: WelcomeStepProps) {
                     checked={selection.stacks}
                     onChange={(v: boolean) => setSelection(s => ({...s, stacks: v}))}
                     icon={Layers}
-                    color="text-indigo-500"
+                    color="text-accent-strong"
                     title="Install Stack"
                     desc="Deploy a pre-configured service bundle"
                 />
@@ -97,7 +97,7 @@ export function WelcomeStep({ selection, setSelection }: WelcomeStepProps) {
                     checked={selection.email}
                     onChange={(v: boolean) => setSelection(s => ({...s, email: v}))}
                     icon={Mail}
-                    color="text-red-500"
+                    color="text-status-fail"
                     title="Notifications"
                     desc="Email alerts for service health"
                 />

--- a/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
+++ b/packages/frontend/src/dashboards/OverviewDashboard.smoke.test.tsx
@@ -228,11 +228,15 @@ describe('OverviewDashboard render', () => {
       </ToastProvider>,
     );
 
-    // The migrated banner sits on a <Card> (bg-surface) with a token accent —
-    // no raw blue literals (border-blue-200 / bg-blue-50 / bg-blue-600) anymore.
+    // The migrated banner sits on a <Card> (rounded-card surface) with a token
+    // accent — no raw blue literals (border-blue-200 / bg-blue-50 / bg-blue-600).
+    // Match on the Card's radius token, not `bg-surface`: since #2484 cn() merges
+    // Card's default `bg-surface` away in favour of the banner's own intended
+    // `bg-accent/5` tint, which is the whole point of that className.
     const bannerText = await screen.findByText(/1 service image update available/i);
-    const card = bannerText.closest('.bg-surface');
+    const card = bannerText.closest('.rounded-card');
     expect(card).not.toBeNull();
+    expect(card!.className).toContain('bg-accent/5');
     const html = (card as HTMLElement).outerHTML;
     expect(html).not.toMatch(/(border|bg|text)-blue-\d/);
     // Token accent present for the "update available" state.


### PR DESCRIPTION
Batch of 8: continuation of the #2430 lint-ratchet burn-down, plus the structural fix for issue #2484.

**Structural fix (#2484)**: `cn()` (`packages/frontend/src/components/ui/cn.ts`) now uses `tailwind-merge` instead of a naive string-joiner. This was a recurring bug class this session — raw-primitive→Button/Input/Select migrations losing their intended styling to the primitive's default classes via Tailwind cascade-emission-order (hit 5x: #2479, #2482, #2483, #2487, #2490). The fix is structural, not reactive: a caller's className now deterministically wins by Tailwind conflict-group semantics. Verified via the full test suite (twice, to catch and fix fallout) plus a real headless-Chromium computed-style check confirming all 5 previously-shipped `!`-important fixes still hold and the underlying collision is now prevented for new code. Fallout fixed in-unit: a dead `ring-opacity-50` utility in HealthChecks.tsx that Tailwind v4 no longer emits (tailwind-merge was reading it as a ring-color and evicting the real token), and 2 tests asserting a primitive default the caller always meant to override. Also added `cn.test.ts` (28 cases) including a drift-guard that fails if a new `--spacing-*`/`--radius-*` design token isn't taught to the merge config.

Color-literal sweeps (`sb/no-raw-color-literal`, baseline 259 → 169 across the last several batches): TemplateUpgradesPendingBanner.tsx, MultiSelect.tsx, FactoryResetSection.tsx, WelcomeStep.tsx, FinishStep.tsx.

UI-primitive sweeps (`sb/no-raw-ui-primitive`, baseline 150 → 139): Sidebar.tsx, CredentialsSection.tsx.

Note for box-verify: the cn() fix causes a handful of previously-invisible styling bugs to now render "as originally intended" (a Card accent tint, a warn tint, a selected-row highlight, some icon-button padding/geometry) — these are correct fixes, not regressions, but worth a quick visual glance since they change on-screen appearance.

Local safety net: lint 0 errors, typecheck clean, check:arch clean (lint-ratchet held at 169/139), full `npm test` 522 files/4967 tests passed.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
