### PR TITLE
chore: lint-ratchet burn-down continuation (batch h)

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 116,
+    "sb/no-raw-color-literal": 108,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 169,
+    "sb/no-raw-color-literal": 160,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 108,
-    "sb/no-raw-ui-primitive": 139
+    "sb/no-raw-ui-primitive": 133
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 142,
+    "sb/no-raw-color-literal": 133,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 124,
+    "sb/no-raw-color-literal": 116,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 160,
+    "sb/no-raw-color-literal": 151,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 151,
+    "sb/no-raw-color-literal": 142,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 133,
+    "sb/no-raw-color-literal": 124,
     "sb/no-raw-ui-primitive": 139
   }
 }

--- a/packages/frontend/src/app/(dashboard)/backup/_lib/ExternalBackupDestinationSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/backup/_lib/ExternalBackupDestinationSection.tsx
@@ -21,8 +21,8 @@ interface TargetView {
 }
 
 const INPUT_CLASS =
-  'w-full px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white';
-const LABEL_CLASS = 'block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1';
+  'w-full px-3 py-2 text-sm rounded-lg border border-border bg-surface-2 text-text';
+const LABEL_CLASS = 'block text-xs font-medium text-text-muted mb-1';
 
 function Field({
   label,
@@ -38,7 +38,7 @@ function Field({
   return (
     <div className={full ? 'sm:col-span-2' : undefined}>
       <label className={LABEL_CLASS}>
-        {label} {optional && <span className="text-gray-400">{optional}</span>}
+        {label} {optional && <span className="text-text-muted">{optional}</span>}
       </label>
       {children}
     </div>
@@ -202,13 +202,13 @@ function DestinationFields({ form, view, set }: FieldsProps) {
     <>
       <TypePicker type={form.type} onChange={t => set({ type: t })} />
       {isFritz && (
-        <p className="text-[11px] text-gray-500 dark:text-gray-400">
+        <p className="text-[11px] text-text-subtle">
           Leave the fields blank to use the gateway FritzBox credentials. Override them for a dedicated FRITZ.NAS / file-access user.
         </p>
       )}
       <CredentialGrid form={form} view={view} set={set} />
       {(isFritz || form.type === 'ftp') && (
-        <label className="inline-flex items-center gap-2 text-xs text-gray-700 dark:text-gray-300 cursor-pointer">
+        <label className="inline-flex items-center gap-2 text-xs text-text-muted cursor-pointer">
           <Input type="checkbox" checked={form.secure} onChange={e => set({ secure: e.target.checked })} className="w-4 h-4" />
           Use FTPS (explicit AUTH TLS) — uncommon on a LAN FritzBox
         </label>
@@ -279,7 +279,7 @@ export default function ExternalBackupDestinationSection({ onSaved }: { onSaved?
 
   if (busy === 'load') {
     return (
-      <div className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2">
+      <div className="text-sm text-text-subtle flex items-center gap-2">
         <Loader2 className="animate-spin" size={16} /> Loading destination…
       </div>
     );
@@ -290,9 +290,9 @@ export default function ExternalBackupDestinationSection({ onSaved }: { onSaved?
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-2">
-        <h4 className="text-sm font-semibold text-gray-900 dark:text-white">Destination</h4>
+        <h4 className="text-sm font-semibold text-text">Destination</h4>
         {view?.inheritsGateway && isFritz ? (
-          <span className="inline-flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400">
+          <span className="inline-flex items-center gap-1 text-[11px] text-text-subtle">
             <CheckCircle2 size={12} /> Using gateway FritzBox credentials
           </span>
         ) : null}
@@ -322,7 +322,7 @@ export default function ExternalBackupDestinationSection({ onSaved }: { onSaved?
       </div>
 
       {form.type !== 'fritzbox' && !view?.hasPassword && !view?.hasPrivateKey && (
-        <p className="inline-flex items-center gap-1 text-[11px] text-amber-600 dark:text-amber-300">
+        <p className="inline-flex items-center gap-1 text-[11px] text-status-warn">
           <AlertCircle size={12} /> Secrets are stored encrypted at rest.
         </p>
       )}

--- a/packages/frontend/src/app/(dashboard)/backup/_lib/helpers.ts
+++ b/packages/frontend/src/app/(dashboard)/backup/_lib/helpers.ts
@@ -17,17 +17,17 @@ export type BackupStreamEvent =
   | { type: 'error'; message: string };
 
 export const LOG_STATUS_BADGES: Record<BackupLogStatus, string> = {
-  info: 'text-slate-600 bg-slate-100 dark:text-slate-300 dark:bg-slate-800',
-  success: 'text-emerald-700 bg-emerald-100 dark:text-emerald-300 dark:bg-emerald-900/30',
-  error: 'text-red-700 bg-red-100 dark:text-red-300 dark:bg-red-900/30',
-  skip: 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/30',
+  info: 'text-text-muted bg-status-info/10',
+  success: 'text-status-ok bg-status-ok/10',
+  error: 'text-status-fail bg-status-fail/10',
+  skip: 'text-status-warn bg-status-warn/10',
 };
 
 export const LOG_STATUS_DOTS: Record<BackupLogStatus, string> = {
-  info: 'bg-slate-400',
-  success: 'bg-emerald-500',
-  error: 'bg-red-500',
-  skip: 'bg-amber-500',
+  info: 'bg-status-info',
+  success: 'bg-status-ok',
+  error: 'bg-status-fail',
+  skip: 'bg-status-warn',
 };
 
 export const formatBytes = (size: number): string => {

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/GatewaySection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/GatewaySection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
 import { useToast } from '@/providers/ToastProvider';
+import { Button, Field, Input } from '@/components/ui';
 
 interface GatewayState {
   configured: boolean;
@@ -112,43 +113,49 @@ export default function GatewaySection() {
 
       <div className="space-y-4">
         <div className="grid sm:grid-cols-2 gap-4">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">Host</span>
-            <input
-              type="text"
-              value={host}
-              onChange={(e) => setHost(e.target.value)}
-              placeholder="fritz.box or 192.168.178.1"
-              className="p-2 border border-border bg-surface rounded text-sm font-mono"
-              autoComplete="off"
-            />
-          </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">Username</span>
-            <input
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="fritz4554"
-              className="p-2 border border-border bg-surface rounded text-sm font-mono"
-              autoComplete="off"
-            />
-          </label>
-          <label className="flex flex-col gap-1 sm:col-span-2">
-            <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">Password</span>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder={state.hasPassword ? '•••••••• (leave blank to keep current)' : '(set a password)'}
-              className="p-2 border border-border bg-surface rounded text-sm font-mono"
-              autoComplete="new-password"
-            />
-          </label>
+          <Field label="Host">
+            {(props) => (
+              <Input
+                {...props}
+                type="text"
+                value={host}
+                onChange={(e) => setHost(e.target.value)}
+                placeholder="fritz.box or 192.168.178.1"
+                className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface text-text font-mono"
+                autoComplete="off"
+              />
+            )}
+          </Field>
+          <Field label="Username">
+            {(props) => (
+              <Input
+                {...props}
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="fritz4554"
+                className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface text-text font-mono"
+                autoComplete="off"
+              />
+            )}
+          </Field>
+          <Field label="Password" className="sm:col-span-2">
+            {(props) => (
+              <Input
+                {...props}
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder={state.hasPassword ? '•••••••• (leave blank to keep current)' : '(set a password)'}
+                className="w-full px-3 py-2 text-sm rounded-card border border-border bg-surface text-text font-mono"
+                autoComplete="new-password"
+              />
+            )}
+          </Field>
         </div>
 
         <label className="inline-flex items-center gap-2 cursor-pointer text-sm text-text">
-          <input
+          <Input
             type="checkbox"
             checked={ssl}
             onChange={(e) => setSsl(e.target.checked)}
@@ -158,23 +165,25 @@ export default function GatewaySection() {
         </label>
 
         <div className="flex gap-2 pt-2">
-          <button
+          <Button
             onClick={() => submit(true)}
             disabled={busy !== null}
-            className="inline-flex items-center gap-2 px-4 py-2 bg-accent hover:bg-accent-strong text-white text-sm font-medium rounded disabled:opacity-50"
+            variant="primary"
+            size="md"
           >
             {busy === 'test' && <Loader2 size={14} className="animate-spin" />}
             Test connection &amp; save
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={() => submit(false)}
             disabled={busy !== null}
-            className="inline-flex items-center gap-2 px-4 py-2 border border-border hover:bg-surface-2 text-text text-sm font-medium rounded disabled:opacity-50"
+            variant="secondary"
+            size="md"
             title="Save without testing — useful when the FritzBox is currently unreachable"
           >
             {busy === 'save' && <Loader2 size={14} className="animate-spin" />}
             Save without test
-          </button>
+          </Button>
         </div>
 
         <p className="text-[11px] text-text-muted italic">

--- a/packages/frontend/src/components/CoreHealthBanner.tsx
+++ b/packages/frontend/src/components/CoreHealthBanner.tsx
@@ -46,26 +46,26 @@ export default function CoreHealthBanner() {
   if (visible.length === 0) return null;
 
   return (
-    <div className="fixed top-4 left-1/2 -translate-x-1/2 z-40 max-w-2xl w-[calc(100%-2rem)] bg-red-50 dark:bg-red-950/40 border border-red-300 dark:border-red-800 rounded-xl shadow-lg overflow-hidden">
+    <div className="fixed top-4 left-1/2 -translate-x-1/2 z-40 max-w-2xl w-[calc(100%-2rem)] bg-status-fail/10 border border-status-fail/40 rounded-xl shadow-lg overflow-hidden">
       <div className="p-3 flex items-start gap-3">
-        <div className="shrink-0 p-1.5 rounded-lg bg-red-100 dark:bg-red-900/40 text-red-600 dark:text-red-300">
+        <div className="shrink-0 p-1.5 rounded-lg bg-status-fail/15 text-status-fail">
           <AlertTriangle size={18} />
         </div>
         <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-semibold text-red-900 dark:text-red-100">
+          <h3 className="text-sm font-semibold text-text">
             Core {visible.length === 1 ? 'stack' : 'stacks'} unhealthy: {visible.map(d => d.label).join(', ')}
           </h3>
           <ul className="mt-1.5 space-y-1.5">
             {visible.flatMap(d => d.notReady.filter(n => n.state === 'unhealthy').map(n => (
-              <li key={`${d.stack}/${n.template}`} className="text-xs text-red-800/90 dark:text-red-200/90">
+              <li key={`${d.stack}/${n.template}`} className="text-xs text-status-fail/90">
                 <code className="font-mono">{n.template}</code>{' '}
-                <span className="text-red-700/70 dark:text-red-300/70">({n.state})</span>
+                <span className="text-status-fail/70">({n.state})</span>
                 {/* #665 — S5: render the causal-chain hint when the
                     server inferred a known config-side blocker, so
                     operators see "X unhealthy → because Y, click Z"
                     instead of a bare "(unhealthy)" red badge. */}
                 {n.cause && (
-                  <div className="mt-0.5 ml-3 text-red-800/80 dark:text-red-200/80">
+                  <div className="mt-0.5 ml-3 text-status-fail/80">
                     → {n.cause.summary}
                     {n.cause.action && (
                       <>
@@ -80,7 +80,7 @@ export default function CoreHealthBanner() {
               </li>
             )))}
           </ul>
-          <p className="text-xs text-red-800/80 dark:text-red-200/80 mt-2">
+          <p className="text-xs text-status-fail/80 mt-2">
             Feature installs are gated on core health. Open <Link href="/diagnose" className="underline font-medium">Self-diagnose</Link> for the full recovery path.
           </p>
         </div>
@@ -88,7 +88,7 @@ export default function CoreHealthBanner() {
           type="button"
           aria-label="Dismiss"
           onClick={dismiss}
-          className="shrink-0 p-1 rounded text-red-400 hover:text-red-700 dark:hover:text-red-200 hover:bg-red-100/60 dark:hover:bg-red-900/40"
+          className="shrink-0 p-1 rounded text-status-fail hover:text-status-fail/80 hover:bg-status-fail/10"
         >
           <X size={14} />
         </button>

--- a/packages/frontend/src/components/FileViewerOverlay.tsx
+++ b/packages/frontend/src/components/FileViewerOverlay.tsx
@@ -108,23 +108,23 @@ export default function FileViewerOverlay({ isOpen, path, nodeName, onClose }: F
 
   return (
     <div className="fixed inset-0 z-[120] flex items-stretch justify-center p-0 md:p-6" onMouseDown={stopEventPropagation} onClick={stopEventPropagation} role="dialog" aria-modal="true" aria-label={`File viewer: ${path}`}>
-      <div className="absolute inset-0 bg-gray-950/70 backdrop-blur-sm" onMouseDown={stopEventPropagation} onClick={handleBackdropClick} />
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onMouseDown={stopEventPropagation} onClick={handleBackdropClick} />
       <FocusTrap>
-      <div className="relative z-10 flex w-full h-full max-w-full flex-col rounded-none border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 shadow-2xl md:h-auto md:max-h-[90vh] md:max-w-5xl md:rounded-2xl">
-        <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-800 px-5 py-4">
+      <div className="relative z-10 flex w-full h-full max-w-full flex-col rounded-none border border-border bg-surface-2 shadow-2xl md:h-auto md:max-h-[90vh] md:max-w-5xl md:rounded-2xl">
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
           <div className="flex flex-col gap-1 text-sm">
-            <div className="flex items-center gap-2 text-gray-600 dark:text-gray-300">
+            <div className="flex items-center gap-2 text-text-muted">
               <FileText size={16} />
-              <span className="font-medium text-gray-900 dark:text-gray-100 text-sm md:text-base whitespace-normal break-all max-w-full" title={path}>
+              <span className="font-medium text-text text-sm md:text-base whitespace-normal break-all max-w-full" title={path}>
                 {path}
               </span>
             </div>
-            <span className="text-xs uppercase tracking-wide text-gray-400">Node: {nodeLabel}</span>
+            <span className="text-xs uppercase tracking-wide text-text-subtle">Node: {nodeLabel}</span>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-full p-2 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800"
+            className="rounded-full p-2 text-text-muted hover:text-text hover:bg-surface"
             aria-label="Close file viewer"
           >
             <X size={18} />
@@ -132,12 +132,12 @@ export default function FileViewerOverlay({ isOpen, path, nodeName, onClose }: F
         </div>
         <div className="flex-1 overflow-hidden">
           {isLoading ? (
-            <div className="flex h-full flex-col items-center justify-center gap-2 text-gray-500">
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-text-subtle">
               <RefreshCw className="animate-spin" />
               Loading file...
             </div>
           ) : activeError ? (
-            <div className="flex h-full flex-col items-center justify-center gap-2 text-red-600 dark:text-red-400 px-6 text-center">
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-status-fail px-6 text-center">
               <AlertCircle size={20} />
               <p className="text-sm">{activeError}</p>
             </div>

--- a/packages/frontend/src/components/ServiceActionBar.tsx
+++ b/packages/frontend/src/components/ServiceActionBar.tsx
@@ -22,19 +22,19 @@ export function ServiceActionBar({ service, onMonitor, onEdit, onActions, onEdit
   const isLink = service.type === 'link';
 
   return (
-    <div className={`flex items-center gap-1 shrink-0 ml-auto bg-gray-50 dark:bg-gray-800/50 p-1 rounded-lg border border-gray-100 dark:border-gray-800 ${className || ''}`}>
+    <div className={`flex items-center gap-1 shrink-0 ml-auto bg-surface-2 p-1 rounded-lg border border-border ${className || ''}`}>
       {isGateway ? (
         <>
           <Link
             href="/services/gateway"
-            className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/30 rounded transition-colors"
+            className="p-1.5 text-text-subtle hover:text-status-info hover:bg-status-info/10 rounded transition-colors"
             title="Monitor Gateway"
           >
             <Activity size={16} />
           </Link>
           <Link
             href="/settings/network-domain#gateway"
-            className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+            className="p-1.5 text-text-subtle hover:text-text hover:bg-surface-2 rounded transition-colors"
             title="Edit Gateway"
           >
             <Edit size={16} />
@@ -45,7 +45,7 @@ export function ServiceActionBar({ service, onMonitor, onEdit, onActions, onEdit
           <button
             type="button"
             onClick={() => onEditLink?.(service)}
-            className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+            className="p-1.5 text-text-subtle hover:text-text hover:bg-surface-2 rounded transition-colors"
             title="Edit Link"
           >
             <Edit size={16} />
@@ -53,7 +53,7 @@ export function ServiceActionBar({ service, onMonitor, onEdit, onActions, onEdit
           <button
             type="button"
             onClick={() => onDelete?.(service)}
-            className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/30 rounded transition-colors"
+            className="p-1.5 text-text-subtle hover:text-status-fail hover:bg-status-fail/10 rounded transition-colors"
             title="Delete"
           >
             <Trash2 size={16} />
@@ -64,7 +64,7 @@ export function ServiceActionBar({ service, onMonitor, onEdit, onActions, onEdit
           <button
             type="button"
             onClick={() => onMonitor?.(service)}
-            className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/30 rounded transition-colors"
+            className="p-1.5 text-text-subtle hover:text-status-info hover:bg-status-info/10 rounded transition-colors"
             title="Monitor"
           >
             <Activity size={16} />
@@ -73,20 +73,20 @@ export function ServiceActionBar({ service, onMonitor, onEdit, onActions, onEdit
             <button
               type="button"
               onClick={() => onEdit?.(service)}
-              className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+              className="p-1.5 text-text-subtle hover:text-text hover:bg-surface-2 rounded transition-colors"
               title="Edit Configuration"
             >
               <Edit size={16} />
             </button>
           ) : (
-            <div className="p-1.5 text-gray-300 dark:text-gray-700 cursor-not-allowed opacity-50" title="Not Managed via Quadlet Kube">
+            <div className="p-1.5 text-text-subtle cursor-not-allowed opacity-50" title="Not Managed via Quadlet Kube">
               <Edit size={16} />
             </div>
           )}
           <button
             type="button"
             onClick={() => onActions?.(service)}
-            className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-100 dark:hover:bg-purple-900/30 rounded transition-colors"
+            className="p-1.5 text-text-subtle hover:text-accent-strong hover:bg-accent/10 rounded transition-colors"
             title="Actions"
           >
             <MoreVertical size={16} />

--- a/packages/frontend/src/components/StackVariableField.tsx
+++ b/packages/frontend/src/components/StackVariableField.tsx
@@ -76,7 +76,7 @@ export default function StackVariableField({
   onExposureChange,
   inputClassName,
 }: StackVariableFieldProps) {
-  const cls = inputClassName ?? 'w-full p-2 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded focus:ring-2 focus:ring-blue-500';
+  const cls = inputClassName ?? 'w-full p-2 border border-border bg-surface-2 text-text rounded focus:ring-2 focus:ring-accent';
 
   // Select dropdown
   if (v.meta?.type === 'select' && v.meta.options) {
@@ -146,10 +146,10 @@ export default function StackVariableField({
       : v.meta.exposure === 'internal' ? 'internal'
       : 'lan';
     const badgeClass = exposure === 'public'
-      ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100'
+      ? 'bg-status-info/10 text-status-info'
       : exposure === 'internal'
-        ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-100'
-        : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300';
+        ? 'bg-status-warn/10 text-status-warn'
+        : 'bg-surface text-text-muted';
     const badgeLabel = exposure === 'public' ? 'Public' : exposure === 'internal' ? 'Internal' : 'LAN';
     return (
       <div className="flex items-center gap-2 flex-wrap">
@@ -161,12 +161,12 @@ export default function StackVariableField({
             className={`${cls} rounded-r-none border-r-0`}
             placeholder={v.meta.default || 'subdomain'}
           />
-          <span className="px-3 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-700 text-gray-500 dark:text-gray-400 rounded-r text-sm whitespace-nowrap">
+          <span className="px-3 py-2 bg-surface-2 border border-border text-text-muted rounded-r text-sm whitespace-nowrap">
             .{publicDomain || 'example.com'}
           </span>
         </div>
         {onExposureChange ? (
-          <div className="inline-flex rounded border border-gray-300 dark:border-gray-700 overflow-hidden text-xs" role="group" aria-label="Exposure profile">
+          <div className="inline-flex rounded border border-border overflow-hidden text-xs" role="group" aria-label="Exposure profile">
             <Button
               variant={exposure === 'public' ? 'primary' : 'secondary'}
               size="sm"
@@ -181,7 +181,7 @@ export default function StackVariableField({
               size="sm"
               onClick={() => onExposureChange('internal')}
               title="LAN-only access but with a real Let's Encrypt cert. Authelia forward-auth works (needs HTTPS); NPM blocks non-LAN IPs. ACME challenge bypasses the allowlist so LE can validate."
-              className="rounded-none border-l border-gray-300 dark:border-gray-700"
+              className="rounded-none border-l border-border"
             >
               Internal
             </Button>
@@ -190,7 +190,7 @@ export default function StackVariableField({
               size="sm"
               onClick={() => onExposureChange('lan')}
               title="LAN-only, plain HTTP — no cert provisioned. Authelia forward-auth does NOT work here (rejects http scheme)."
-              className="rounded-none border-l border-gray-300 dark:border-gray-700"
+              className="rounded-none border-l border-border"
             >
               LAN
             </Button>
@@ -298,7 +298,7 @@ function SecretField({
         </Button>
       </div>
       {error && (
-        <p role="alert" className="mt-1 text-xs text-red-600 dark:text-red-400">
+        <p role="alert" className="mt-1 text-xs text-status-fail">
           Couldn&apos;t generate a secret — check your connection or type one manually.
         </p>
       )}

--- a/packages/frontend/src/components/wizard/SelectedStacksPanel.tsx
+++ b/packages/frontend/src/components/wizard/SelectedStacksPanel.tsx
@@ -46,32 +46,32 @@ const ROW_STYLES: Record<Status, { icon: typeof Check; label: string; classes: s
   already: {
     icon: Check,
     label: 'Already installed',
-    classes: 'text-gray-400',
+    classes: 'text-text-muted',
   },
   done: {
     icon: Check,
     label: 'Done',
-    classes: 'text-emerald-500',
+    classes: 'text-status-ok',
   },
   installing: {
     icon: Loader2,
     label: 'Installing',
-    classes: 'text-blue-500',
+    classes: 'text-status-info',
   },
   queued: {
     icon: Clock,
     label: 'Queued',
-    classes: 'text-gray-400',
+    classes: 'text-text-muted',
   },
   failed: {
     icon: AlertCircle,
     label: 'Failed',
-    classes: 'text-red-500',
+    classes: 'text-status-fail',
   },
   skipped: {
     icon: Check,
     label: 'Skipped',
-    classes: 'text-gray-400',
+    classes: 'text-text-muted',
   },
 };
 
@@ -82,7 +82,7 @@ function StatusRow({ name, status }: StatusRowProps) {
     <li className="flex items-center justify-between gap-3 py-1.5 text-sm">
       <span className="flex items-center gap-2 min-w-0 truncate">
         <Icon className={`shrink-0 ${classes} ${animate}`} size={14} aria-hidden="true" />
-        <span className="text-gray-700 dark:text-gray-200 truncate">{name}</span>
+        <span className="text-text truncate">{name}</span>
       </span>
       <span className={`text-[10px] font-bold uppercase tracking-wider ${classes}`}>{label}</span>
     </li>
@@ -160,11 +160,11 @@ export default function SelectedStacksPanel({
       className="rounded-2xl border border-white/5 bg-white/[0.02] p-4"
     >
       <header className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest text-gray-400">
+        <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-widest text-text-muted">
           <Package size={12} />
           Selected stacks
         </div>
-        <div className="text-[11px] font-mono text-gray-400">{summary}</div>
+        <div className="text-[11px] font-mono text-text-muted">{summary}</div>
       </header>
       <ul role="list" className="divide-y divide-white/5">
         {rows.map(r => (


### PR DESCRIPTION
Batch of 8: continuation of the #2430 lint-ratchet burn-down.

Color-literal sweeps (`sb/no-raw-color-literal`, baseline 124 → 108): SelectedStacksPanel.tsx, StackVariableField.tsx, ServiceActionBar.tsx, ExternalBackupDestinationSection.tsx, FileViewerOverlay.tsx, backup/_lib/helpers.ts, CoreHealthBanner.tsx.

UI-primitive sweeps (`sb/no-raw-ui-primitive`, baseline 139 → 133): GatewaySection.tsx.

All Button/Input/Select migrations use the now-structural cn()/tailwind-merge fix from #2484 (no `!`-important workarounds needed). Semantic color tokens verified against globals.css's @theme block.

Local safety net: lint 0 errors, typecheck clean, check:arch clean (lint-ratchet held at 108/133), full `npm test` 522 files/4967 tests passed.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
