### PR TITLE
chore: lint-ratchet burn-down continuation (batch j)

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 68,
+    "sb/no-raw-color-literal": 62,
     "sb/no-raw-ui-primitive": 128
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 48,
+    "sb/no-raw-color-literal": 44,
     "sb/no-raw-ui-primitive": 118
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 62,
-    "sb/no-raw-ui-primitive": 123
+    "sb/no-raw-ui-primitive": 118
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 44,
+    "sb/no-raw-color-literal": 40,
     "sb/no-raw-ui-primitive": 118
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 62,
+    "sb/no-raw-color-literal": 57,
     "sb/no-raw-ui-primitive": 118
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 52,
+    "sb/no-raw-color-literal": 48,
     "sb/no-raw-ui-primitive": 118
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 62,
-    "sb/no-raw-ui-primitive": 128
+    "sb/no-raw-ui-primitive": 123
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 57,
+    "sb/no-raw-color-literal": 52,
     "sb/no-raw-ui-primitive": 118
   }
 }

--- a/packages/frontend/src/app/(dashboard)/edit/[name]/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/edit/[name]/page.tsx
@@ -35,11 +35,11 @@ export default async function EditPage({
     const isConnectionError = err.message && (err.message.includes('Agent not connected') || err.message.includes('ECONNREFUSED') || err.message.includes('timeout'));
 
     return (
-      <div className="p-8 text-center bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 m-8">
-        <div className="text-red-600 text-xl font-bold mb-2">
+      <div className="p-8 text-center bg-surface dark:bg-surface rounded-lg border border-border dark:border-border m-8">
+        <div className="text-status-fail text-xl font-bold mb-2">
             {isConnectionError ? 'Connection Failed' : 'Service Not Found'}
         </div>
-        <div className="text-gray-600 dark:text-gray-400 mb-6 max-w-md mx-auto">
+        <div className="text-text-muted dark:text-text-muted mb-6 max-w-md mx-auto">
             {isConnectionError
                 ? `Could not communicate with the node "${nodeName}". The agent might be restarting or the node is unreachable.`
                 : (e instanceof Error ? e.message : String(e))
@@ -50,13 +50,13 @@ export default async function EditPage({
             <div className="flex gap-4 justify-center">
                  <a
                     href={`/services?node=${nodeName}`}
-                    className="px-4 py-2 bg-gray-200 hover:bg-gray-300 dark:bg-gray-800 dark:hover:bg-gray-700 rounded-lg text-sm font-medium transition-colors"
+                    className="px-4 py-2 bg-surface-2 hover:bg-border dark:bg-surface-2 dark:hover:bg-border rounded-lg text-sm font-medium transition-colors"
                 >
                     Back to Services
                 </a>
                 <a
                     href={`/edit/${encodeURIComponent(name)}?node=${nodeName}`}
-                    className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
+                    className="px-4 py-2 bg-accent hover:bg-accent-strong text-on-accent rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
                 >
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg>
                     Retry Connection
@@ -64,7 +64,7 @@ export default async function EditPage({
             </div>
         )}
 
-        <div className="mt-8 text-xs text-gray-400 font-mono">
+        <div className="mt-8 text-xs text-text-subtle font-mono">
           Target: {name} @ {nodeName}
         </div>
       </div>

--- a/packages/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -14,7 +14,7 @@ function SettingsShell({ children }: { children: React.ReactNode }) {
   const activeGroupId = pathname.split('/').filter(Boolean)[1] ?? DEFAULT_GROUP.id;
 
   if (loading) {
-    return <div className="p-8 text-center text-gray-500">Loading settings...</div>;
+    return <div className="p-8 text-center text-text-subtle">Loading settings...</div>;
   }
 
   return (
@@ -22,7 +22,7 @@ function SettingsShell({ children }: { children: React.ReactNode }) {
       <PageHeader
         title="Settings"
         actions={
-          <span className="text-sm text-gray-500 dark:text-gray-400 inline-flex items-center gap-2">
+          <span className="text-sm text-text-muted inline-flex items-center gap-2">
             {saving ? (
               <>
                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -37,7 +37,7 @@ function SettingsShell({ children }: { children: React.ReactNode }) {
         <SettingsSearch />
       </PageHeader>
 
-      <div className="flex border-b border-gray-200 dark:border-gray-700 px-6 bg-white dark:bg-gray-900 sticky top-0 z-10 overflow-x-auto">
+      <div className="flex border-b border-border px-6 bg-surface sticky top-0 z-10 overflow-x-auto">
         {SETTINGS_GROUPS.map(group => {
           const Icon = group.icon;
           const isActive = activeGroupId === group.id;
@@ -48,8 +48,8 @@ function SettingsShell({ children }: { children: React.ReactNode }) {
               title={group.intent}
               className={`flex items-center gap-1.5 px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
                 isActive
-                  ? 'border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300'
+                  ? 'border-status-info text-status-info'
+                  : 'border-transparent text-text-subtle hover:text-text dark:hover:text-text-muted hover:border-border'
               }`}
             >
               <Icon size={16} />

--- a/packages/frontend/src/components/Autocomplete.tsx
+++ b/packages/frontend/src/components/Autocomplete.tsx
@@ -57,7 +57,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
       <div className="relative">
         <input
           type="text"
-          className={`w-full p-2 border rounded bg-gray-50 dark:bg-gray-700 dark:border-gray-600 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+          className={`w-full p-2 border rounded bg-surface-2 border-border ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           placeholder={loading ? 'Loading...' : placeholder}
           value={filter}
           disabled={disabled || loading}
@@ -70,16 +70,16 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
         />
         {loading && (
           <div className="absolute right-2 top-2.5">
-            <div className="animate-spin h-5 w-5 border-2 border-blue-500 rounded-full border-t-transparent"></div>
+            <div className="animate-spin h-5 w-5 border-2 border-status-info rounded-full border-t-transparent"></div>
           </div>
         )}
       </div>
       {isOpen && !disabled && !loading && filteredOptions.length > 0 && (
-        <ul className="absolute z-10 w-full mt-1 max-h-60 overflow-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg">
+        <ul className="absolute z-10 w-full mt-1 max-h-60 overflow-auto bg-surface border-border rounded shadow-lg">
           {filteredOptions.map((option, index) => (
             <li
               key={index}
-              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+              className="p-2 hover:bg-surface-2 cursor-pointer"
               onClick={() => {
                 onChange(option);
                 setFilter(option);

--- a/packages/frontend/src/components/PageHeader.tsx
+++ b/packages/frontend/src/components/PageHeader.tsx
@@ -24,19 +24,19 @@ export default function PageHeader({ title, children, actions, showBack = false,
   };
 
   return (
-    <div className="flex items-center gap-4 p-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+    <div className="flex items-center gap-4 p-4 border-b border-border bg-surface">
       <div className="flex items-center gap-4 shrink-0">
         {showBack && (
           <button
             onClick={handleBack}
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full transition-colors"
+            className="p-2 hover:bg-surface-2 rounded-full transition-colors"
             title="Go Back"
             aria-label="Go back"
           >
-            <ArrowLeft size={24} className="text-gray-600 dark:text-gray-300" />
+            <ArrowLeft size={24} className="text-text-muted" />
           </button>
         )}
-        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{title}</h1>
+        <h1 className="text-xl font-bold text-text">{title}</h1>
         {helpId && <SectionHelp helpId={helpId} />}
       </div>
 

--- a/packages/frontend/src/components/SectionLoading.tsx
+++ b/packages/frontend/src/components/SectionLoading.tsx
@@ -7,12 +7,12 @@ interface SectionLoadingProps {
 
 export default function SectionLoading({ message = "Waiting for data...", subMessage }: SectionLoadingProps) {
     return (
-        <div className="flex-1 flex flex-col items-center justify-center text-gray-500 h-full min-h-[300px]">
+        <div className="flex-1 flex flex-col items-center justify-center text-text-subtle h-full min-h-[300px]">
             <div className="text-center">
-                <RefreshCw className="animate-spin inline-block mb-3 text-blue-500 opacity-80" size={28} />
-                <p className="font-medium text-gray-600 dark:text-gray-300">{message}</p>
+                <RefreshCw className="animate-spin inline-block mb-3 text-accent opacity-80" size={28} />
+                <p className="font-medium text-text-muted dark:text-text">{message}</p>
                 {subMessage && (
-                    <p className="text-sm text-gray-400 mt-1">{subMessage}</p>
+                    <p className="text-sm text-text-muted mt-1">{subMessage}</p>
                 )}
             </div>
         </div>

--- a/packages/frontend/src/components/ServerIdentityWatcher.tsx
+++ b/packages/frontend/src/components/ServerIdentityWatcher.tsx
@@ -107,16 +107,16 @@ export default function ServerIdentityWatcher() {
     <div
       role="status"
       aria-live="polite"
-      className="fixed top-3 left-1/2 -translate-x-1/2 z-[60] max-w-md px-3.5 py-2 rounded-full border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 shadow-lg flex items-center gap-2.5"
+      className="fixed top-3 left-1/2 -translate-x-1/2 z-[60] max-w-md px-3.5 py-2 rounded-full border border-status-warn bg-surface shadow-lg flex items-center gap-2.5"
     >
-      <RefreshCcw size={15} className="shrink-0 text-amber-700 dark:text-amber-300" />
-      <span className="text-sm text-amber-900 dark:text-amber-100">
+      <RefreshCcw size={15} className="shrink-0 text-status-warn" />
+      <span className="text-sm text-text">
         ServiceBay updated
       </span>
       <button
         type="button"
         onClick={() => window.location.reload()}
-        className="text-xs font-medium px-2.5 py-1 rounded-full bg-amber-600 hover:bg-amber-700 text-white"
+        className="text-xs font-medium px-2.5 py-1 rounded-full bg-status-warn hover:opacity-80 text-white"
       >
         Reload
       </button>
@@ -127,7 +127,7 @@ export default function ServerIdentityWatcher() {
           setDismissed(true);
           setPending(false);
         }}
-        className="text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-100"
+        className="text-status-warn hover:text-text"
       >
         <X size={14} />
       </button>

--- a/packages/frontend/src/components/ServiceActionBar.tsx
+++ b/packages/frontend/src/components/ServiceActionBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { Activity, Edit, MoreVertical, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
 import { ServiceViewModel } from '@servicebay/api-client';
 
 type ServiceActionHandlers = {
@@ -42,55 +43,60 @@ export function ServiceActionBar({ service, onMonitor, onEdit, onActions, onEdit
         </>
       ) : isLink ? (
         <>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onEditLink?.(service)}
-            className="p-1.5 text-text-subtle hover:text-text hover:bg-surface-2 rounded transition-colors"
+            className="text-text-subtle"
             title="Edit Link"
           >
             <Edit size={16} />
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onDelete?.(service)}
-            className="p-1.5 text-text-subtle hover:text-status-fail hover:bg-status-fail/10 rounded transition-colors"
+            className="text-text-subtle hover:text-status-fail hover:bg-status-fail/10"
             title="Delete"
           >
             <Trash2 size={16} />
-          </button>
+          </Button>
         </>
       ) : (
         <>
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onMonitor?.(service)}
-            className="p-1.5 text-text-subtle hover:text-status-info hover:bg-status-info/10 rounded transition-colors"
+            className="text-text-subtle hover:text-status-info hover:bg-status-info/10"
             title="Monitor"
           >
             <Activity size={16} />
-          </button>
+          </Button>
           {service.type === 'kube' ? (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => onEdit?.(service)}
-              className="p-1.5 text-text-subtle hover:text-text hover:bg-surface-2 rounded transition-colors"
+              className="text-text-subtle"
               title="Edit Configuration"
             >
               <Edit size={16} />
-            </button>
+            </Button>
           ) : (
             <div className="p-1.5 text-text-subtle cursor-not-allowed opacity-50" title="Not Managed via Quadlet Kube">
               <Edit size={16} />
             </div>
           )}
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onActions?.(service)}
-            className="p-1.5 text-text-subtle hover:text-accent-strong hover:bg-accent/10 rounded transition-colors"
+            className="text-text-subtle hover:text-accent-strong hover:bg-accent/10"
             title="Actions"
           >
             <MoreVertical size={16} />
-          </button>
+          </Button>
         </>
       )}
     </div>

--- a/packages/frontend/src/components/wizard/steps/StacksStep.tsx
+++ b/packages/frontend/src/components/wizard/steps/StacksStep.tsx
@@ -3,7 +3,9 @@
 import { useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { Layers, Package, Loader2, CheckCircle, Box, ArrowRight } from 'lucide-react';
-import { Button } from '../WizardUI';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Select } from '@/components/ui/Select';
 import type { Template } from '@servicebay/api-client';
 import type { StackItem as BaseStackItem, StackVariable, useStackInstall } from '@/hooks/useStackInstall';
 import type { TemplateTier } from '@servicebay/api-client';
@@ -149,13 +151,14 @@ export function StacksStep({
                         without installing anything. In stacks-only mode
                         this also marks setup as complete. */}
                     <div className="flex justify-start pt-2">
-                        <button
-                            type="button"
+                        <Button
+                            variant="ghost"
+                            size="sm"
                             onClick={() => void handleStackSkip()}
-                            className="px-4 py-2 text-sm text-text-muted hover:text-text underline-offset-4 hover:underline"
+                            className="underline-offset-4 hover:underline"
                         >
                             Install services later
-                        </button>
+                        </Button>
                     </div>
                 </div>
             )}
@@ -204,7 +207,7 @@ export function StacksStep({
                                                 ? 'bg-surface border-accent shadow-sm ring-1 ring-accent'
                                                 : 'border-border hover:bg-surface-2 cursor-pointer'
                                     }`}>
-                                        <input
+                                        <Input
                                             type="checkbox"
                                             checked={item.checked}
                                             disabled={item.alreadyInstalled}
@@ -281,14 +284,14 @@ export function StacksStep({
                     {stackNodes.length > 1 && (
                         <div className="p-4 rounded-2xl soft-depth">
                             <label className="block text-[10px] font-bold text-text-muted uppercase tracking-widest mb-2 ml-1">Target Node</label>
-                            <select
+                            <Select
                                 value={stackSelectedNode || ''}
                                 onChange={(e) => setStackSelectedNode(e.target.value)}
                                 className="w-full px-4 py-2.5 bg-surface border border-border rounded-xl focus:ring-2 focus:ring-accent outline-none text-sm"
                             >
                                 <option value="" disabled>Select a node</option>
                                 {stackNodes.map(n => <option key={n.Name} value={n.Name}>{n.Name}</option>)}
-                            </select>
+                            </Select>
                         </div>
                     )}
 
@@ -325,11 +328,12 @@ export function StacksStep({
                                 return (
                                     <div className="flex gap-1 border-b border-border">
                                         {tabs.map(t => (
-                                            <button
+                                            <Button
                                                 key={t.id}
-                                                type="button"
+                                                variant="ghost"
+                                                size="sm"
                                                 onClick={() => setConfigureTab(t.id)}
-                                                className={`px-4 py-2 text-sm font-bold border-b-2 transition-all ${
+                                                className={`px-4 py-2 text-sm font-bold border-b-2 transition-all rounded-none ${
                                                     activeTab === t.id
                                                         ? 'border-accent text-accent'
                                                         : 'border-transparent text-text-muted hover:text-text'
@@ -337,7 +341,7 @@ export function StacksStep({
                                             >
                                                 {t.label}
                                                 <span className="ml-2 px-1.5 py-0.5 rounded-full bg-surface-2 text-[10px] opacity-70">{t.count}</span>
-                                            </button>
+                                            </Button>
                                         ))}
                                     </div>
                                 );
@@ -548,7 +552,7 @@ function StackPickerRow({ stack, checked, installState, isUninstalling, setPicke
                     : 'bg-surface-muted border-border opacity-80 hover:opacity-100 hover:border-accent/50'
             }`}
         >
-            <input
+            <Input
                 type="checkbox"
                 checked={checked}
                 // Core/atomic-wipe stacks can't be unchecked here


### PR DESCRIPTION
Batch of 8: continuation of the #2430 lint-ratchet burn-down.

Color-literal sweeps (`sb/no-raw-color-literal`, baseline 57 → 40 across this batch): edit/[name]/page.tsx, ServerIdentityWatcher.tsx, settings/layout.tsx, Autocomplete.tsx, PageHeader.tsx, SectionLoading.tsx.

UI-primitive sweeps (`sb/no-raw-ui-primitive`, baseline 128 → 118): StacksStep.tsx, ServiceActionBar.tsx.

`sb/no-raw-color-literal` is now down to 40 violations — getting close to the 0 needed to flip that rule to "error" tier per docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse. All Button/Input/Select migrations use the structural cn()/tailwind-merge fix from #2484 (no `!`-important workarounds needed).

Local safety net: lint 0 errors, typecheck clean, check:arch clean (lint-ratchet held at 40/118), full `npm test` 522 files/4982 tests passed.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
