### PR TITLE
chore: lint-ratchet burn-down continuation (batch k)

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 32,
-    "sb/no-raw-ui-primitive": 108
+    "sb/no-raw-ui-primitive": 104
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 32,
-    "sb/no-raw-ui-primitive": 104
+    "sb/no-raw-ui-primitive": 100
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 32,
-    "sb/no-raw-ui-primitive": 113
+    "sb/no-raw-ui-primitive": 108
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 32,
-    "sb/no-raw-ui-primitive": 96
+    "sb/no-raw-ui-primitive": 92
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 32,
-    "sb/no-raw-ui-primitive": 100
+    "sb/no-raw-ui-primitive": 96
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -3,6 +3,6 @@
   "updated": "2026-07-30",
   "rules": {
     "sb/no-raw-color-literal": 32,
-    "sb/no-raw-ui-primitive": 118
+    "sb/no-raw-ui-primitive": 113
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 40,
+    "sb/no-raw-color-literal": 36,
     "sb/no-raw-ui-primitive": 118
   }
 }

--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 36,
+    "sb/no-raw-color-literal": 32,
     "sb/no-raw-ui-primitive": 118
   }
 }

--- a/packages/frontend/src/app/(dashboard)/backup/_lib/LocalTargetPicker.tsx
+++ b/packages/frontend/src/app/(dashboard)/backup/_lib/LocalTargetPicker.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Loader2, RefreshCw, HardDrive, Usb, CheckCircle2 } from 'lucide-react';
+import { Button, Input } from '@/components/ui';
 import type { MountCandidate } from '@/lib/backup/mounts';
 
 const REMOVABLE_FSTYPES = new Set(['vfat', 'exfat', 'ntfs']);
@@ -44,7 +45,7 @@ function MountRow({
   const selectable = mount.mounted && !!mount.mountpoint;
   const Icon = REMOVABLE_FSTYPES.has(mount.fstype ?? '') ? Usb : HardDrive;
   return (
-    <button type="button" disabled={!selectable} onClick={onSelect} aria-pressed={active} className={rowClass(active, selectable)}>
+    <Button type="button" disabled={!selectable} onClick={onSelect} aria-pressed={active} variant="ghost" size="sm" className={rowClass(active, selectable)}>
       <Icon size={16} className={`mt-0.5 flex-shrink-0 ${active ? 'text-accent' : 'text-text-muted'}`} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5 flex-wrap">
@@ -57,7 +58,7 @@ function MountRow({
         </div>
         <MountDetail mount={mount} />
       </div>
-    </button>
+    </Button>
   );
 }
 
@@ -100,7 +101,7 @@ function MountList({
 function AdvancedPath({ value, onChange }: { value: string; onChange: (path: string) => void }) {
   return (
     <div>
-      <input
+      <Input
         type="text"
         className="w-full px-3 py-2 text-sm rounded-lg border border-border bg-surface-2 text-text"
         value={value}
@@ -177,14 +178,16 @@ export default function LocalTargetPicker({
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <label className="block text-xs font-medium text-text">Target disk</label>
-        <button
+        <Button
           type="button"
           onClick={() => void load()}
           disabled={loading}
+          variant="ghost"
+          size="sm"
           className="flex items-center gap-1 text-[11px] text-text-muted hover:text-text disabled:opacity-50"
         >
           {loading ? <Loader2 size={11} className="animate-spin" /> : <RefreshCw size={11} />} Rescan
-        </button>
+        </Button>
       </div>
 
       {loading && mounts === null ? (
@@ -195,13 +198,15 @@ export default function LocalTargetPicker({
         <>
           <MountList mounts={mounts ?? []} value={value} error={error} onChange={onChange} />
 
-          <button
+          <Button
             type="button"
             onClick={() => setShowAdvanced(v => !v)}
+            variant="ghost"
+            size="sm"
             className="text-[11px] text-accent hover:underline"
           >
             {advancedOpen ? 'Hide advanced path' : 'Advanced: enter a path manually'}
-          </button>
+          </Button>
 
           {advancedOpen && <AdvancedPath value={value} onChange={onChange} />}
         </>

--- a/packages/frontend/src/app/(dashboard)/disk-import/_lib/RoutingTree.tsx
+++ b/packages/frontend/src/app/(dashboard)/disk-import/_lib/RoutingTree.tsx
@@ -13,6 +13,7 @@
 
 import { useMemo, useState } from 'react';
 import { ChevronRight, ChevronDown, Folder, FileText } from 'lucide-react';
+import { Button, Field, Select } from '@/components/ui';
 import {
   DISPOSITION_LABELS,
   type Disposition,
@@ -142,13 +143,15 @@ function Row({
         className="flex items-center gap-2 py-1.5 pr-3 text-xs hover:bg-surface-2"
         style={{ paddingLeft: `${indent}px` }}
       >
-        <button
+        <Button
           onClick={() => hasChildren && toggle(node.dir)}
-          className={`shrink-0 ${hasChildren ? 'text-text-muted' : 'invisible'}`}
+          variant="ghost"
+          size="sm"
+          className={`shrink-0 ${hasChildren ? 'text-text-muted' : 'invisible'} p-0`}
           aria-label={isOpen ? 'Collapse' : 'Expand'}
         >
           {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-        </button>
+        </Button>
         <Folder size={14} className="shrink-0 text-accent" />
         <span className="font-medium text-text truncate" title={node.dir || '/'}>
           {dirLabel(node.dir)}
@@ -210,21 +213,19 @@ function Row({
  */
 function BaseToggle({ active, onToggle }: { active: boolean; onToggle: () => void }) {
   return (
-    <button
+    <Button
       onClick={onToggle}
+      variant={active ? 'primary' : 'secondary'}
+      size="sm"
       title={
         active
           ? "Base root — this folder's name is dropped; the structure below it is kept"
           : "Mark as a base/backup root — drop this folder's name, keep what's inside"
       }
-      className={`rounded border px-1.5 py-0.5 text-[11px] ${
-        active
-          ? 'bg-accent text-on-accent border-accent font-medium'
-          : 'bg-surface text-text-muted border-border hover:text-text-muted'
-      }`}
+      className="text-[11px]"
     >
       strip
-    </button>
+    </Button>
   );
 }
 
@@ -242,20 +243,25 @@ function OwnerPicker({
 }) {
   const inherited = explicit === undefined;
   return (
-    <select
-      value={value}
-      onChange={e => onChange(e.target.value)}
-      title={inherited ? 'Inherited — pick to set explicitly' : 'Set on this folder'}
-      className={`rounded border px-1.5 py-0.5 text-[11px] bg-surface border-border ${
-        inherited ? 'text-text-muted italic' : 'text-text font-medium'
-      }`}
-    >
-      {owners.map(o => (
-        <option key={o.id} value={o.id}>
-          {o.label}
-        </option>
-      ))}
-    </select>
+    <Field label="">
+      {(props) => (
+        <Select
+          {...props}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          title={inherited ? 'Inherited — pick to set explicitly' : 'Set on this folder'}
+          className={`rounded border px-1.5 py-0.5 text-[11px] bg-surface border-border ${
+            inherited ? 'text-text-muted italic' : 'text-text font-medium'
+          }`}
+        >
+          {owners.map(o => (
+            <option key={o.id} value={o.id}>
+              {o.label}
+            </option>
+          ))}
+        </Select>
+      )}
+    </Field>
   );
 }
 
@@ -273,19 +279,24 @@ function TargetPicker({
 }) {
   const inherited = explicit === undefined;
   return (
-    <select
-      value={value}
-      onChange={e => onChange(e.target.value as Disposition)}
-      title={inherited ? 'Inherited — pick to set explicitly' : 'Set on this folder'}
-      className={`rounded border px-1.5 py-0.5 text-[11px] bg-surface border-border ${
-        inherited ? 'text-text-muted italic' : 'text-text font-medium'
-      }`}
-    >
-      {dispositions.map(d => (
-        <option key={d} value={d}>
-          {DISPOSITION_LABELS[d]}
-        </option>
-      ))}
-    </select>
+    <Field label="">
+      {(props) => (
+        <Select
+          {...props}
+          value={value}
+          onChange={e => onChange(e.target.value as Disposition)}
+          title={inherited ? 'Inherited — pick to set explicitly' : 'Set on this folder'}
+          className={`rounded border px-1.5 py-0.5 text-[11px] bg-surface border-border ${
+            inherited ? 'text-text-muted italic' : 'text-text font-medium'
+          }`}
+        >
+          {dispositions.map(d => (
+            <option key={d} value={d}>
+              {DISPOSITION_LABELS[d]}
+            </option>
+          ))}
+        </Select>
+      )}
+    </Field>
   );
 }

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/KnowledgeSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/KnowledgeSection.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { BookOpen, Loader2, Search } from 'lucide-react';
-import { Badge, Card } from '@/components/ui';
+import { Badge, Card, Button, Input, Select } from '@/components/ui';
 import { ASSIST_KINDS, type AssistKind } from '../knowledge/validation';
 import { useKnowledge } from '../knowledge/useKnowledge';
 import AssistDetail from '../knowledge/AssistDetail';
@@ -98,13 +98,12 @@ function Filters({
   onKind: (v: KindFilter) => void;
   onSource: (v: SourceFilter) => void;
 }) {
-  const selectClass =
-    'p-2 rounded-card border border-border bg-surface-2 text-text text-sm focus:ring-2 focus:ring-accent outline-none';
+  const selectClass = 'flex-1 p-2 rounded-card border border-border bg-surface-2 text-text text-sm focus:ring-2 focus:ring-accent outline-none';
   return (
     <div className="space-y-2">
       <div className="relative">
         <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-subtle" />
-        <input
+        <Input
           type="search"
           value={query}
           onChange={e => onQuery(e.target.value)}
@@ -114,27 +113,27 @@ function Filters({
         />
       </div>
       <div className="flex gap-2">
-        <select
+        <Select
           value={kind}
           onChange={e => onKind(e.target.value as KindFilter)}
           aria-label="Filter by kind"
-          className={`${selectClass} flex-1`}
+          className={selectClass}
         >
           <option value="all">All kinds</option>
           {ASSIST_KINDS.map(k => (
             <option key={k} value={k}>{k}</option>
           ))}
-        </select>
-        <select
+        </Select>
+        <Select
           value={source}
           onChange={e => onSource(e.target.value as SourceFilter)}
           aria-label="Filter by source"
-          className={`${selectClass} flex-1`}
+          className={selectClass}
         >
           <option value="all">All sources</option>
           <option value="Built-in">Built-in</option>
           <option value="Local">Local</option>
-        </select>
+        </Select>
       </div>
     </div>
   );
@@ -161,23 +160,24 @@ function CatalogList({
         const active = a.id === selectedId;
         return (
           <li key={a.id}>
-            <button
+            <Button
               type="button"
+              variant="ghost"
               onClick={() => onSelect(a.id)}
               aria-current={active}
-              className={`w-full text-left p-2 rounded-card border transition-colors ${
+              className={`w-full h-auto justify-start text-left p-2 rounded-card border transition-colors ${
                 active ? 'border-accent bg-accent/10' : 'border-transparent hover:bg-surface-2'
               }`}
             >
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 w-full">
                 <span className="text-sm font-medium text-text truncate flex-1">{a.title}</span>
                 {pending > 0 && <Badge variant="warn">{pending}</Badge>}
                 <Badge variant={a.source === 'Local' ? 'accent' : 'neutral'} className="font-mono text-[10px]">
                   {a.kind}
                 </Badge>
               </div>
-              <p className="text-[11px] text-text-subtle truncate mt-0.5">{a.whenToUse}</p>
-            </button>
+              <p className="text-[11px] text-text-subtle truncate mt-0.5 w-full text-left">{a.whenToUse}</p>
+            </Button>
           </li>
         );
       })}

--- a/packages/frontend/src/components/ActionProgressModal.tsx
+++ b/packages/frontend/src/components/ActionProgressModal.tsx
@@ -5,6 +5,7 @@ import type { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
 import { useToast } from '@/providers/ToastProvider';
 import { humanizeError } from '@servicebay/api-client';
+import { Button } from '@/components/ui';
 
 // xterm terminal theme colors — dark background with light foreground for
 // contrast and readability. Not mapped to semantic tokens as these define
@@ -207,16 +208,19 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
           </h3>
           <div className="flex items-center gap-1">
             {status === 'running' && (
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={() => setMinimized(true)}
-                className="text-text-muted hover:text-text p-1 rounded transition-colors"
                 title="Run in background"
                 aria-label="Run in background"
               >
                 <Minimize2 size={18} />
-              </button>
+              </Button>
             )}
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => {
                 // While the action is still running, treat the X like
                 // "Run in background" — closing this modal aborts the
@@ -229,12 +233,11 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
                   onClose();
                 }
               }}
-              className="text-text-muted hover:text-text p-1 rounded transition-colors"
               aria-label={status === 'running' ? 'Run in background' : 'Close'}
               title={status === 'running' ? 'Run in background' : 'Close'}
             >
               <X size={20} />
-            </button>
+            </Button>
           </div>
         </div>
         
@@ -254,17 +257,19 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
             <div className="p-4 border-t border-border flex flex-col sm:flex-row justify-between items-center gap-3 bg-surface">
                 {status === 'error' ? (
                     <div className="flex flex-wrap gap-2 w-full sm:w-auto">
-                        <button
+                        <Button
+                            size="sm"
+                            variant="secondary"
                             onClick={() => {
                                 setElapsed(0);
                                 setRetryCount(prev => prev + 1);
                                 setStatus('running');
                             }}
-                            className="flex items-center gap-1.5 px-3 py-1.5 bg-status-warn hover:bg-status-warn/90 text-on-accent text-xs font-semibold rounded-md transition-colors shadow-sm"
+                            className="bg-status-warn hover:bg-status-warn/90 text-on-accent font-semibold shadow-sm"
                         >
                             <RotateCw size={14} className="animate-spin" style={{ animationDuration: '3s' }} />
                             Retry Action
-                        </button>
+                        </Button>
                         
                         <a
                             href={`/api/services/${serviceName}/logs`}
@@ -284,25 +289,29 @@ export default function ActionProgressModal({ isOpen, onClose, serviceName, node
                             Self-Diagnose
                         </a>
 
-                        <button
+                        <Button
+                            size="sm"
+                            variant="primary"
                             onClick={() => addToast('info', 'AI Assistant Triggered', `Claude is reviewing the logs for ${serviceName}...`)}
-                            className="flex items-center gap-1.5 px-3 py-1.5 bg-status-info hover:bg-status-info/90 text-on-accent text-xs font-semibold rounded-md transition-colors shadow-sm"
+                            className="bg-status-info hover:bg-status-info/90 font-semibold shadow-sm"
                         >
                             <Bot size={14} />
                             Ask AI to Fix
-                        </button>
+                        </Button>
                     </div>
                 ) : (
                     <div className="text-xs text-status-ok font-medium">
                         ✓ Operation completed successfully.
                     </div>
                 )}
-                <button
+                <Button
+                    size="md"
+                    variant="primary"
                     onClick={onClose}
-                    className="w-full sm:w-auto px-5 py-2 bg-status-info hover:bg-status-info/90 text-on-accent rounded-md font-semibold text-sm transition-colors shadow-sm"
+                    className="w-full sm:w-auto bg-status-info hover:bg-status-info/90 font-semibold shadow-sm"
                 >
                     Close
-                </button>
+                </Button>
             </div>
         )}
       </div>

--- a/packages/frontend/src/components/DiagnoseProbeList.tsx
+++ b/packages/frontend/src/components/DiagnoseProbeList.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { AlertCircle, AlertTriangle, CheckCircle2, History, Info, Loader2, Wrench, X } from 'lucide-react';
-import { Button } from '@/components/ui';
+import { Button, DataTable, Field, Input } from '@/components/ui';
 
 /**
  * Shared probe-list renderer used by Settings → Self-Diagnose and by the
@@ -347,15 +347,16 @@ export default function DiagnoseProbeList({
                 <div className="flex items-start justify-between gap-2">
                   <ProbeHistoryBadge history={probe.history} compact={compact} />
                   {probe.history && probe.history.trend.length > 0 && (
-                    <button
-                      type="button"
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={() => void handleViewHistory(probe)}
                       title="View history"
                       aria-label={`View history for ${probe.label}`}
-                      className="shrink-0 mt-1.5 p-1 rounded-card hover:bg-surface-2 text-text-muted transition-colors"
+                      className="shrink-0 mt-1.5 p-1"
                     >
                       <History size={14} />
-                    </button>
+                    </Button>
                   )}
                 </div>
                 {(probe.actions ?? []).length > 0 && (
@@ -428,28 +429,30 @@ export default function DiagnoseProbeList({
                         >
                           <p className="text-xs text-text-muted">{action.description}</p>
                           {inputs.map(input => (
-                            <div key={input.name} className="space-y-1">
-                              <label className="block text-xs font-medium text-text-muted">
-                                {input.label}{input.required !== false && <span className="text-status-fail"> *</span>}
-                              </label>
-                              <input
-                                type={input.type}
-                                value={values[input.name] ?? ''}
-                                placeholder={input.placeholder}
-                                required={input.required !== false}
-                                onChange={e =>
-                                  setFormValues(s => ({
-                                    ...s,
-                                    [key]: { ...(s[key] ?? {}), [input.name]: e.target.value },
-                                  }))
-                                }
-                                className="w-full px-space-2 py-1.5 text-sm rounded-card border border-border bg-surface-2 text-text focus:outline-none focus:ring-1 focus:ring-accent"
-                                autoComplete="off"
-                              />
-                              {input.hint && (
-                                <p className="text-xs text-text-muted">{input.hint}</p>
+                            <Field
+                              key={input.name}
+                              label={input.label}
+                              required={input.required !== false}
+                              help={input.hint}
+                            >
+                              {(fieldProps) => (
+                                <Input
+                                  {...fieldProps}
+                                  type={input.type}
+                                  value={values[input.name] ?? ''}
+                                  placeholder={input.placeholder}
+                                  required={input.required !== false}
+                                  onChange={e =>
+                                    setFormValues(s => ({
+                                      ...s,
+                                      [key]: { ...(s[key] ?? {}), [input.name]: e.target.value },
+                                    }))
+                                  }
+                                  className="w-full px-space-2 py-1.5 text-sm rounded-card border border-border bg-surface-2 text-text focus:outline-none focus:ring-1 focus:ring-accent"
+                                  autoComplete="off"
+                                />
                               )}
-                            </div>
+                            </Field>
                           ))}
                           <div className="flex items-center gap-2 pt-1">
                             <Button
@@ -602,14 +605,15 @@ export default function DiagnoseProbeList({
                 <h3 className="text-lg font-bold text-text truncate">{historyProbe.label}</h3>
                 <p className="text-xs text-text-muted font-mono truncate">diagnose:{historyProbe.id}</p>
               </div>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={closeHistory}
                 aria-label="Close history"
-                className="shrink-0 p-2 rounded-card hover:bg-surface-2 text-text-muted"
+                className="shrink-0"
               >
                 <X size={18} />
-              </button>
+              </Button>
             </div>
             <div className="flex-1 overflow-y-auto p-space-5">
               {historyLoading && historyData.length === 0 ? (
@@ -622,36 +626,37 @@ export default function DiagnoseProbeList({
                   No history recorded yet for this probe.
                 </div>
               ) : (
-                <table className="w-full text-left text-sm border border-border rounded-card overflow-hidden">
-                  <thead className="bg-surface-2 text-text-muted">
-                    <tr>
-                      <th className="p-3 font-semibold">Time</th>
-                      <th className="p-3 font-semibold">Status</th>
-                      <th className="p-3 font-semibold">Message</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border">
-                    {historyData.map((h, i) => (
-                      <tr key={i} className="hover:bg-surface-2 align-top">
-                        <td className="p-3 text-text whitespace-nowrap">
-                          {new Date(h.timestamp).toLocaleString()}
-                        </td>
-                        <td className="p-3">
-                          <span className={`inline-flex items-center px-space-2 py-0.5 rounded-chip text-xs font-medium ${
-                            h.status === 'ok'
-                              ? 'bg-status-ok/10 text-status-ok'
-                              : 'bg-status-fail/10 text-status-fail'
-                          }`}>
-                            {h.status.toUpperCase()}
-                          </span>
-                        </td>
-                        <td className="p-3 text-text-muted whitespace-pre-wrap break-words font-mono text-xs">
-                          {h.message ?? ''}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <DataTable
+                  columns={[
+                    {
+                      key: 'time',
+                      header: 'Time',
+                      cell: (h) => new Date(h.timestamp).toLocaleString(),
+                      className: 'whitespace-nowrap',
+                    },
+                    {
+                      key: 'status',
+                      header: 'Status',
+                      cell: (h) => (
+                        <span className={`inline-flex items-center px-space-2 py-0.5 rounded-chip text-xs font-medium ${
+                          h.status === 'ok'
+                            ? 'bg-status-ok/10 text-status-ok'
+                            : 'bg-status-fail/10 text-status-fail'
+                        }`}>
+                          {h.status.toUpperCase()}
+                        </span>
+                      ),
+                    },
+                    {
+                      key: 'message',
+                      header: 'Message',
+                      cell: (h) => <div className="whitespace-pre-wrap break-words font-mono text-xs">{h.message ?? ''}</div>,
+                    },
+                  ]}
+                  rows={historyData}
+                  rowKey={(h, i) => String(i)}
+                  rowClassName={() => 'align-top'}
+                />
               )}
             </div>
           </div>

--- a/packages/frontend/src/components/ExternalLinkModal.tsx
+++ b/packages/frontend/src/components/ExternalLinkModal.tsx
@@ -1,5 +1,5 @@
 import { X, AlertCircle } from 'lucide-react';
-import { Card, Button } from '@/components/ui';
+import { Card, Button, Input } from '@/components/ui';
 
 interface LinkForm {
     name: string;
@@ -51,7 +51,7 @@ export default function ExternalLinkModal({ isOpen, onClose, onSave, isEditing, 
                 <div className="p-space-4 space-y-4">
                     <div>
                         <label className={labelCls}>Name</label>
-                        <input
+                        <Input
                             type="text"
                             value={form.name}
                             onChange={e => setForm({ ...form, name: e.target.value })}
@@ -61,7 +61,7 @@ export default function ExternalLinkModal({ isOpen, onClose, onSave, isEditing, 
                     </div>
                     <div>
                         <label className={labelCls}>URL</label>
-                        <input
+                        <Input
                             type="url"
                             value={form.url}
                             onChange={e => setForm({ ...form, url: e.target.value })}
@@ -81,7 +81,7 @@ export default function ExternalLinkModal({ isOpen, onClose, onSave, isEditing, 
                     </div>
                     <div>
                         <label className={labelCls}>Description (Optional)</label>
-                        <input
+                        <Input
                             type="text"
                             value={form.description}
                             onChange={e => setForm({ ...form, description: e.target.value })}
@@ -90,7 +90,7 @@ export default function ExternalLinkModal({ isOpen, onClose, onSave, isEditing, 
                         />
                     </div>
                     <label className="flex items-center gap-space-2 text-sm text-text-muted">
-                        <input
+                        <Input
                             type="checkbox"
                             checked={form.monitor}
                             onChange={e => setForm({ ...form, monitor: e.target.checked })}
@@ -100,7 +100,7 @@ export default function ExternalLinkModal({ isOpen, onClose, onSave, isEditing, 
                     </label>
                     <div>
                         <label className={labelCls}>Target IPs/Ports (Optional)</label>
-                        <input
+                        <Input
                             type="text"
                             value={form.ipTargetsText || ''}
                             onChange={e => setForm({ ...form, ipTargetsText: e.target.value })}

--- a/packages/frontend/src/components/WorkspaceDrawer.tsx
+++ b/packages/frontend/src/components/WorkspaceDrawer.tsx
@@ -78,21 +78,21 @@ export default function WorkspaceDrawer({
   // through to the page behind; the panel itself re-enables pointer
   // events so it stays interactive.
   const wrapperClass = hasBackdrop
-    ? 'fixed inset-0 z-[70] flex justify-end bg-gray-950/70 backdrop-blur-sm'
+    ? 'fixed inset-0 z-[70] flex justify-end bg-black/50 backdrop-blur-sm'
     : 'fixed inset-0 z-[70] flex justify-end pointer-events-none';
   const panelExtraClass = hasBackdrop ? '' : 'pointer-events-auto';
 
   return (
     <div className={wrapperClass}>
       <div
-        className={`w-full ${widthClass[width]} h-full bg-white dark:bg-gray-950 border-l border-gray-200 dark:border-gray-800 shadow-2xl flex flex-col transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] ${panelExtraClass}`}
+        className={`w-full ${widthClass[width]} h-full bg-surface border-l border-border shadow-2xl flex flex-col transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] ${panelExtraClass}`}
       >
-        <div className="flex items-start justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+        <div className="flex items-start justify-between px-6 py-4 border-b border-border bg-surface-2">
           <div className="min-w-0">{header}</div>
           <button
             type="button"
             onClick={onClose}
-            className="p-2 rounded-full text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-800 shrink-0"
+            className="p-2 rounded-full text-text-muted hover:text-text hover:bg-surface-2 shrink-0"
             aria-label={closeAriaLabel}
           >
             <X size={20} />

--- a/packages/frontend/src/dashboards/TerminalDashboard.tsx
+++ b/packages/frontend/src/dashboards/TerminalDashboard.tsx
@@ -105,14 +105,14 @@ export default function TerminalDashboard() {
                 label: node.Name,
                 value: node.Name,
                 description: node.URI,
-                icon: <Server size={16} className="text-blue-600 dark:text-blue-300" />
+                icon: <Server size={16} className="text-status-info" />
             }));
         return [
             {
                 label: 'Local',
                 value: 'Local',
                 description: 'This ServiceBay host',
-                icon: <Monitor size={16} className="text-indigo-600 dark:text-indigo-300" />
+                icon: <Monitor size={16} className="text-accent" />
             },
             ...remote
         ];
@@ -147,16 +147,16 @@ export default function TerminalDashboard() {
                             placeholder="Select node"
                             compact
                         />
-                        <button 
+                        <button
                             onClick={() => terminalRef.current?.clear()}
-                            className="p-2 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded hover:bg-gray-50 dark:hover:bg-gray-700 shadow-sm transition-colors" 
+                            className="p-2 text-text bg-surface-2 border border-border rounded hover:bg-surface shadow-sm transition-colors"
                             title="Clear Terminal"
                         >
                             <Eraser size={18} />
                         </button>
-                        <button 
+                        <button
                             onClick={() => terminalRef.current?.reconnect()}
-                            className="p-2 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded hover:bg-gray-50 dark:hover:bg-gray-700 shadow-sm transition-colors" 
+                            className="p-2 text-text bg-surface-2 border border-border rounded hover:bg-surface shadow-sm transition-colors"
                             title="Reconnect"
                         >
                             <RefreshCw size={18} />


### PR DESCRIPTION
Batch of 8: continuation of the #2430 lint-ratchet burn-down.

Color-literal sweeps (`sb/no-raw-color-literal`, baseline 40 → 32): WorkspaceDrawer.tsx, TerminalDashboard.tsx.

UI-primitive sweeps (`sb/no-raw-ui-primitive`, baseline 118 → 92): ActionProgressModal.tsx, ExternalLinkModal.tsx, LocalTargetPicker.tsx, RoutingTree.tsx, KnowledgeSection.tsx, DiagnoseProbeList.tsx.

`sb/no-raw-ui-primitive` dropped substantially this batch (-26). All Button/Input/Select migrations use the structural cn()/tailwind-merge fix from #2484 (no `!`-important workarounds needed).

Local safety net: lint 0 errors, typecheck clean, check:arch clean (lint-ratchet held at 32/92), full `npm test` 522 files/4982 tests passed.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
