### PR TITLE
fix(frontend): close out lint-ratchet color-literal burn-down (batch n)

### DIFF
--- a/.eslint-ratchet-baseline.json
+++ b/.eslint-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "$comment": "Monotonic lint ratchet (#2430) — highest violation count each staged rule is allowed to have. Maintained by scripts/check-lint-ratchet.ts: a local `npm run check:lint-ratchet` rewrites these DOWNWARDS when a sweep lands; CI (`--check`) fails any commit that raises one. Never raise a number by hand — that is the one thing this file exists to prevent. When a count reaches 0, flip that rule to \"error\" in eslint.config.mjs and drop it from RATCHETED_RULES (docs/ARCHITECTURE_INVARIANTS.md § UI-primitive and design-token reuse).",
   "updated": "2026-07-30",
   "rules": {
-    "sb/no-raw-color-literal": 2,
+    "sb/no-raw-color-literal": 1,
     "sb/no-raw-ui-primitive": 92
   }
 }

--- a/packages/frontend/src/components/MaintenanceChatEmbed.tsx
+++ b/packages/frontend/src/components/MaintenanceChatEmbed.tsx
@@ -37,7 +37,7 @@ const CHAT_SUBDOMAIN = 'chat';
 
 function Notice({ children }: { children: ReactNode }) {
   return (
-    <div className="flex-1 flex items-center justify-center p-6 text-center text-gray-500 dark:text-gray-400">
+    <div className="flex-1 flex items-center justify-center p-6 text-center text-text-muted">
       <p className="max-w-sm">{children}</p>
     </div>
   );


### PR DESCRIPTION
Batch of 1: closes out the #2430 lint-ratchet burn-down for `sb/no-raw-color-literal` — this was the last planned unit in the queue.

- MaintenanceChatEmbed.tsx: replaced `text-gray-500 dark:text-gray-400` with `text-text-muted` in the Notice() helper.

Baseline down from 2 to 1. Repo-wide count is now **1**, one unit away from the exact-0 threshold that flips `sb/no-raw-color-literal` from warn to error tier per `docs/ARCHITECTURE_INVARIANTS.md § ui-primitive-and-design-token-reuse` — the next planner pass should locate and close the remaining violation.

Fast gates green (lint, typecheck, arch, vitest — full suite 522 files/4984 tests).

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
