### PR TITLE
docs: consuming a loopback-bound sibling is not an ADR 0007 carve-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,12 @@ real secrets**: no private keys, API tokens, passwords, or `sb_` box tokens.
 
 
 ## Solaris System Architecture & Naming Directives
-- See  for binding guidelines.
-- Stack identity is **Solaris** (). Legacy hermes path references are deprecated.
-- All container-to-container connections must use container DNS service names (e.g. , ).
+- See `docs/SOLARIS_SYSTEM_DIRECTIVES.md` for binding guidelines.
+- Stack identity is **Solaris** (`mdopp/solaris`: `solaris-chat`,
+  `solaris-gatekeeper`, `solaris-whisper`, `solaris-tts`). Legacy `hermes` path
+  references are deprecated.
+- **No hard-coded IPs in cross-service references** — so a reinstall or a new
+  LAN address doesn't break the wiring. The *name* to use is set by ADR 0007,
+  not by this section: containers inside one pod share a netns and use
+  `127.0.0.1:<port>`; anything crossing a service boundary uses
+  `host.containers.internal:<port>`. Never `{{LAN_IP}}`.

--- a/assists/new-service-architecture.md
+++ b/assists/new-service-architecture.md
@@ -120,9 +120,15 @@ The app should be: **stateless-restartable** (all state on a mounted volume),
   "Secret hygiene" (a build-time scan enforces this).
 
 ## Networking & SSO
-- Default to an **isolated netns** with explicit `hostPort`s; use
-  `hostNetwork: true` only when the app must reach another on-box service on
-  loopback (ADR 0007). A pod with neither is silently unreachable.
+- **Isolated netns + explicit `hostPort`s — always, for a new service.** A pod
+  with neither is silently unreachable. `hostNetwork: true` is reserved for the
+  **closed, named** carve-out list in ADR 0007; a new service does not join it.
+- **Needing a loopback-bound sibling is not a reason to take host networking**
+  (ADR 0007 Decision 3). Reach the sibling at
+  `http://host.containers.internal:<port>` — never `127.0.0.1`, never
+  `{{LAN_IP}}` — and have the *sibling's* port variable carry
+  `blockLanAccess: true` so the wider bind stays off the LAN
+  (`docs/TEMPLATE_AUTHORING.md`). Siblings first, consumer second.
 - User-facing? Put it on a subdomain with Authelia forward-auth (ADR 0001/0006).
   Reference `{{PUBLIC_DOMAIN}}` in the template or the proxy host is skipped —
   see `footgun-subdomain-needs-public-domain`.

--- a/docs/SOLARIS_SYSTEM_DIRECTIVES.md
+++ b/docs/SOLARIS_SYSTEM_DIRECTIVES.md
@@ -17,14 +17,23 @@
 
 To guarantee that after a **full system reinstallation** or **IP address change**, all connections between Home Assistant, Jellyfin, Solaris, and Voice Speakers automatically work without manual intervention:
 
-### A. Container-to-Container Internal DNS (Zero Hardcoded IPs)
-All inter-container communication in ServiceBay templates **must** use container DNS hostnames instead of hardcoded `127.0.0.1` or static IP addresses:
+### A. Zero Hardcoded IPs in cross-service references
 
-| Integration / Link | Correct Service Name URL | Legacy Incorrect Hardcoded URL |
+The rule is **no hardcoded LAN or static IP in a cross-service reference** — that
+is what breaks after a reinstall or a DHCP change. **Which name to use instead is
+set by [ADR 0007](adr/0007-container-network-isolation-and-carveouts.md), not by
+this document**; there is no shared podman DNS network, so a bare service name
+(`http://media-jellyfin:8096`) does **not** resolve between services:
+
+| Reference | Use | Not |
 |---|---|---|
-| **Home Assistant ➔ Jellyfin** | `http://media-jellyfin:8096` (or `http://media:8096`) | `http://127.0.0.1:8096` ❌ |
-| **Home Assistant ➔ Solaris Chat** | `http://solaris-chat:8787/ollama` | `http://127.0.0.1:8787` ❌ |
-| **Solaris Gatekeeper ➔ Wyoming** | `http://solaris-whisper:10300` | `http://127.0.0.1:10300` ❌ |
+| **Between containers of the same service** (one kube pod → one netns) | `http://127.0.0.1:<containerPort>` | a service name ❌ |
+| **Across services** (e.g. Home Assistant ➔ Jellyfin, Solaris Gatekeeper ➔ Wyoming) | `http://host.containers.internal:<hostPort>` | `{{LAN_IP}}` / a static IP ❌ |
+
+A sibling that must stay off the LAN binds wider and carries `blockLanAccess:
+true` on its port variable (ADR 0007 Decision 3; contract in
+`TEMPLATE_AUTHORING.md`) — it does **not** get `hostNetwork: true` on the
+consumer's behalf.
 
 ### B. Host / Network Device Connections (Speakers, Voice PE, Cast)
 For external network devices (ESPHome Voice PE speakers, Google Cast, mobile apps):

--- a/docs/adr/0007-container-network-isolation-and-carveouts.md
+++ b/docs/adr/0007-container-network-isolation-and-carveouts.md
@@ -1,6 +1,7 @@
 # ADR 0007 — App containers move off `hostNetwork` into isolated netns; named carve-outs stay on host networking
 
-- **Status:** Accepted (incremental; epic #817)
+- **Status:** Accepted (incremental; epic #817) — amended 2026-08-12 (see
+  [Amendment 2026-08-12](#amendment-2026-08-12--consuming-a-loopback-bound-sibling-is-not-a-carve-out))
 - **Date:** 2026-06-05
 - **Deciders:** operator (mdopp)
 - **Related:** [ADR 0001](0001-authentication-via-authelia-sso-or-lldap.md)
@@ -25,16 +26,60 @@ radicale's LDAP bind.
    Server-side OIDC discovery keeps a `hostAliases` entry mapping
    `auth.{{PUBLIC_DOMAIN}}` → `{{HOST_GATEWAY_IP}}` (default `169.254.1.2`) so
    the issuer name stays canonical.
-2. **These stay on `hostNetwork` deliberately — do not re-litigate per #817:**
+2. **These stay on `hostNetwork` deliberately — do not re-litigate per #817.**
+   The list is **closed**: it is enumerated here by name, and a new service does
+   **not** join it by arguing its case. Adding a name is an amendment to this
+   ADR, not a template decision.
    - **nginx, adguard, home-assistant** — genuinely need host networking
      (ingress :80/:443, DNS :53, mDNS/SSDP).
    - **ollama + hermes** — ollama ships no auth and is loopback-bound by design;
      a plain `hostPort` would newly LAN-expose it, and isolated hermes can only
      reach ollama via the host. Revisit only once a host-firewall / private-
-     network story exists.
+     network story exists. **That precondition was met by #2388** — see the
+     amendment below; this entry is grandfathered, not a precedent.
    - **file-share** — Samba needs privileged ports 139/445 (hard under rootless)
      and the Syncthing GUI is loopback-bound. Needs design work first.
    - **auth** — migrated last, on its own (LLDAP holds all identity data).
+3. **Consuming a loopback-bound sibling on the box is NOT a carve-out.** Needing
+   to reach another on-box service that binds `127.0.0.1` does not qualify a
+   service for `hostNetwork: true` and does not add it to the list in Decision 2.
+   The intended pattern is Decision 1 plus a host-firewall rule on the *sibling*:
+   - the **consumer** runs isolated (no `hostNetwork`), publishes its own ports
+     as `hostPort`, and addresses the sibling as
+     `http://host.containers.internal:<port>` — never `127.0.0.1`, never
+     `{{LAN_IP}}`;
+   - the **sibling** binds wider than loopback so that path resolves (pasta maps
+     `host.containers.internal` to the host's LAN address, not to loopback), and
+     its port variable carries **`blockLanAccess: true`**, which installs an
+     nftables rule refusing that port on physical interfaces while still
+     accepting loopback and the pasta-proxied path (#2388, mechanics in
+     `packages/backend/src/lib/hostFirewall.ts`, contract in
+     `docs/TEMPLATE_AUTHORING.md`).
+
+   The order matters: **siblings first, consumer second.** Until the sibling
+   binds wider and carries `blockLanAccess`, an isolated consumer cannot reach
+   it, and the honest state of such a service is a *documented deviation* — not
+   a carve-out. When the sibling is owned by another repo, that deviation is
+   recorded in the consuming template, and this ADR's list stays unchanged.
+
+## Amendment 2026-08-12 — consuming a loopback-bound sibling is not a carve-out
+
+Decision 3 was added after #2518 asked whether a service that talks to two
+loopback-bound siblings counts as a named carve-out. It does not.
+
+The trigger: Decision 2's `ollama + hermes` entry made its own revisit
+conditional on *"a host-firewall / private-network story"*. That story shipped in
+**#2388** — the `blockLanAccess` port flag and its nftables capability handler —
+and this ADR was never updated, which left three documents stating three
+different rules (this ADR, `assists/new-service-architecture.md`, and the
+Solaris directives' container-DNS table). With the firewall story in place, the
+motivating reason for a loopback-consumer carve-out is gone, so the list stays
+closed and Decision 3 states the pattern instead.
+
+Consequences of the amendment tracked separately, **not** in this ADR: the
+grandfathered entries whose stated precondition is now met should be re-examined
+against Decision 3, and `templates/claude-dev` runs `hostNetwork: true` without
+appearing on the list at all — see #2522.
 
 ## Consequences
 


### PR DESCRIPTION
Batch `2026-08-12a` — 1 unit, docs/standards only. No template, backend, frontend or Quadlet changes.

## Closes #2518 — is a loopback-consuming service an ADR 0007 carve-out?

A sibling repo asked whether a service that reaches other on-box services over `127.0.0.1` counts as a named carve-out. It was unanswerable from the repo, because three documents stated three different rules:

- `docs/adr/0007-…` — carve-outs are a **closed named list**; siblings via `host.containers.internal`.
- `assists/new-service-architecture.md` — stated a **criterion** ("`hostNetwork: true` only when the app must reach another on-box service on loopback") and attributed it to ADR 0007, which never said that.
- `CLAUDE.md` / `docs/SOLARIS_SYSTEM_DIRECTIVES.md` — a **third** mechanism (container DNS service names), with literally empty examples and a table of bare names that do not resolve here.

The decisive detail: ADR 0007's `ollama + hermes` carve-out is the identical shape and conditioned its own revisit on *"Revisit only once a host-firewall / private-network story exists."* That story shipped in #2388 (`blockLanAccess` + nftables, `packages/backend/src/lib/hostFirewall.ts`) and the ADR was never revisited.

**Owner decision (option B, 2026-08-12):** the list stays closed.

## What changed

- **ADR 0007** — Decision 2's list explicitly marked **closed** (adding a name is an ADR amendment, not a template decision); `ollama + hermes` marked **grandfathered, not a precedent**. New **Decision 3**: consuming a loopback-bound sibling is not a carve-out; the pattern is isolated netns + `host.containers.internal` on the consumer, plus `blockLanAccess: true` on the *sibling's* port. Order is stated explicitly — **siblings first, consumer second** — and a service whose sibling isn't ready yet is a *documented deviation*, not a carve-out. An "Amendment 2026-08-12" section records the #2388 precondition.
- **`assists/new-service-architecture.md`** — the false ADR-attributed criterion removed, replaced by the actual rule.
- **`CLAUDE.md`** — empty parentheticals filled; the container-DNS rule rescoped to "no hardcoded IPs", deferring the name to ADR 0007.
- **`docs/SOLARIS_SYSTEM_DIRECTIVES.md` §2A** — the table that actually held the contradiction (bare service names that don't resolve; no shared podman DNS network exists here).

## Follow-up filed, not built

#2522 — `templates/claude-dev` runs `hostNetwork: true` without appearing on the carve-out list at all, and the "revisit"-worded entries need re-reading against Decision 3. Referenced from the ADR.

## Gates

`npm run lint` 0 errors · `typecheck` clean · `check:arch` lint-ratchet held at baseline (`no-raw-color-literal: 1`, `no-raw-ui-primitive: 92`) · `npm test` 522/522 files, 4983 passed / 1 skipped.

No `box_verify` owed: docs-only, nothing on the path-mandated list.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
