### PR TITLE
fix(frontend): stop DataTable crushing columns; render every nav entry from the schema

### DIFF
--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
@@ -20,20 +20,26 @@ interface Manifest {
 /** URL cell (#1626): render an admin-reachable http(s) URL as a clickable
  *  link; render non-URL hints (`env:`, `\\…`, `ssh://`, bearer tokens) as
  *  plain text. The loopback→public-subdomain rewrite happens in
- *  `resolveCredentialUrl`. */
+ *  `resolveCredentialUrl`.
+ *
+ *  No `break-all` here (#2520) — it collapsed the cell's min-content width to a
+ *  single character, so the auto table-layout crushed this column to ~8 chars
+ *  and rendered `https://nginx.dopp.cloud` as "http/s://ngi/nx.dop/p.cloud".
+ *  <DataTable>'s cells carry `break-words`, which contains a long URL without
+ *  ever breaking it mid-token. */
 function CredentialUrlCell({ cred, hosts, publicDomain }: {
   cred: Credential;
   hosts: CredentialUrlHost[];
   publicDomain: string | null;
 }) {
   const resolved = resolveCredentialUrl(cred, { hosts, publicDomain: publicDomain ?? undefined });
-  if (!isHttpUrl(resolved)) return <span className="break-all">{resolved}</span>;
+  if (!isHttpUrl(resolved)) return <span>{resolved}</span>;
   return (
     <a
       href={resolved}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-accent hover:underline break-all"
+      className="text-accent hover:underline"
     >
       {resolved}
     </a>
@@ -176,11 +182,18 @@ export default function CredentialsSection() {
             Nothing saved yet. The install wizard writes here at the end of every successful run.
           </p>
         ) : (
+          // Explicit per-column widths (#2520): without them the browser's auto
+          // table-layout hands the spare width to whichever column holds the
+          // longest prose — Notes — and starves Service/URL/Username. These are
+          // preferred widths, so a column still grows past its share rather
+          // than clipping its content; the table's min-width makes a narrow
+          // viewport scroll instead of crushing them.
           <DataTable<Credential>
             columns={[
               {
                 key: 'service',
                 header: 'Service',
+                className: 'w-[16%]',
                 cell: (c) => (
                   <div>
                     {c.service}
@@ -196,18 +209,19 @@ export default function CredentialsSection() {
                 header: 'URL',
                 cell: (c) => <CredentialUrlCell cred={c} hosts={proxyHosts} publicDomain={publicDomain} />,
                 align: 'left',
-                className: 'font-mono text-xs',
+                className: 'w-[28%] font-mono text-xs',
               },
               {
                 key: 'username',
                 header: 'Username',
                 cell: (c) => c.username,
                 align: 'left',
-                className: 'font-mono text-xs',
+                className: 'w-[16%] font-mono text-xs',
               },
               {
                 key: 'password',
                 header: 'Password',
+                className: 'w-[18%]',
                 cell: (c, i) => {
                   const isRevealed = !!revealed[i];
                   return (
@@ -245,9 +259,15 @@ export default function CredentialsSection() {
                 header: 'Notes',
                 cell: (c) => c.notes ?? '',
                 align: 'left',
-                className: 'text-xs text-text-muted',
+                className: 'w-[22%] text-xs text-text-muted',
               },
             ]}
+            // Above the primitive's 5×8rem default: these five columns are all
+            // dense (a URL, an e-mail username, a masked password + two
+            // buttons, a sentence of notes), so a 40rem floor still stacks the
+            // notes 6 lines deep on a phone. 56rem keeps every row ~2 lines and
+            // lets the wrapper scroll instead.
+            minWidthClassName="min-w-[56rem]"
             rows={manifest.credentials}
             rowKey={(c, i) => String(i)}
             rowClassName={(c) =>

--- a/packages/frontend/src/components/MobileNav.tsx
+++ b/packages/frontend/src/components/MobileNav.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { Code, Wrench } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import DomainTag from './DomainTag';
-import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
+import { isNavActive } from '@/config/navigation';
+import { useNavigationEntries } from '@/hooks/useNavigationEntries';
 import { useToast } from '@/providers/ToastProvider';
 
 const FIRST_VISIT_KEY = 'sb.mobileHintShown.v1';
@@ -13,8 +14,6 @@ const FIRST_VISIT_KEY = 'sb.mobileHintShown.v1';
 export function MobileTopBar() {
   const router = useRouter();
   const pathname = usePathname() || '';
-  const searchParams = useSearchParams();
-  const node = searchParams?.get('node');
   const { addToast } = useToast();
   const hintFired = useRef(false);
   // Mirror of the desktop Sidebar's hasActiveInstall pill — mobile
@@ -70,7 +69,12 @@ export function MobileTopBar() {
   // reachable on a phone. Surface them as icons in the top bar's right row,
   // driven by the same navigation schema (no hand-coded duplication), so a
   // future `hiddenOnMobileBottom` entry stays reachable automatically.
-  const topBarEntries = NAVIGATION_ENTRIES.filter(p => p.hiddenOnMobileBottom);
+  // #2521 — that now includes the app-leaving links (Users & Groups, View as
+  // user), which the desktop sidebar used to show and mobile did not. They
+  // render as real links after a divider, so the two groups stay readable.
+  const topBarEntries = useNavigationEntries().filter(p => p.hiddenOnMobileBottom);
+  const internalTopEntries = topBarEntries.filter(p => !p.external);
+  const externalTopEntries = topBarEntries.filter(p => p.external);
 
   return (
     <div className="h-14 bg-surface border-b border-border flex items-center justify-between px-4 shrink-0 md:hidden z-20">
@@ -89,12 +93,15 @@ export function MobileTopBar() {
        <div className="flex-1 min-w-0 flex justify-center px-2">
           <DomainTag />
        </div>
-       {/* Right: Icons */}
-       <div className="flex items-center gap-4">
+       {/* Right: Icons. The row carries two groups now (in-app destinations,
+           then the app-leaving links, #2521), so it can outgrow a 360px phone.
+           Same degradation as the bottom bar (#1992): non-shrinking items in an
+           x-scrollable row — it never clips an icon off the screen. */}
+       <div className="flex items-center gap-3 min-w-0 overflow-x-auto no-scrollbar">
           {hasActiveInstall && (
             <button
               onClick={() => router.push('/setup')}
-              className="relative transition-colors text-accent hover:text-accent-strong"
+              className="relative transition-colors text-accent hover:text-accent-strong shrink-0"
               aria-label="Resume setup"
               title="Resume setup"
             >
@@ -102,14 +109,15 @@ export function MobileTopBar() {
               <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-accent animate-pulse" />
             </button>
           )}
-          {topBarEntries.map(p => {
+          {internalTopEntries.map(p => {
             const Icon = p.icon;
-            const isActive = isNavActive(pathname, p.path);
+            const isActive = p.path ? isNavActive(pathname, p.path) : false;
             return (
               <button
                 key={p.id}
-                onClick={() => router.push(`${p.path}${node ? `?node=${node}` : ''}`)}
-                className={`transition-colors ${
+                data-testid={`nav-${p.id}`}
+                onClick={() => router.push(p.href)}
+                className={`transition-colors shrink-0 ${
                   isActive
                     ? 'text-accent'
                     : 'text-text-muted hover:text-text'
@@ -121,9 +129,42 @@ export function MobileTopBar() {
               </button>
             );
           })}
-          <a href="https://github.com/mdopp/servicebay" target="_blank" rel="noreferrer" className="text-text-muted hover:text-text transition-colors">
-             <Code size={20} />
-          </a>
+          {/* App-leaving links, fenced off by a rule so they don't read as one
+              more in-app icon (#2521). GitHub has always lived out here; it
+              joins the group it belongs to. */}
+          <div
+              data-testid="external-nav-group"
+              aria-label="Opens in a new tab"
+              className="flex items-center gap-3 shrink-0 pl-3 border-l border-border"
+            >
+              {externalTopEntries.map(p => {
+                const Icon = p.icon;
+                return (
+                  <a
+                    key={p.id}
+                    data-testid={`nav-${p.id}`}
+                    href={p.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-text-muted hover:text-text transition-colors shrink-0"
+                    aria-label={p.name}
+                    title={`${p.name} — opens in a new tab`}
+                  >
+                    <Icon size={20} />
+                  </a>
+                );
+              })}
+              <a
+                href="https://github.com/mdopp/servicebay"
+                target="_blank"
+                rel="noreferrer"
+                className="text-text-muted hover:text-text transition-colors shrink-0"
+                aria-label="ServiceBay on GitHub"
+                title="ServiceBay on GitHub — opens in a new tab"
+              >
+                <Code size={20} />
+              </a>
+          </div>
        </div>
     </div>
   );
@@ -132,13 +173,13 @@ export function MobileTopBar() {
 export function MobileBottomBar() {
    const pathname = usePathname() || '';
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const node = searchParams?.get('node');
 
   // Honor the per-entry `hiddenOnMobileBottom` flag from the navigation
   // schema — Settings & Backup opt out of the bottom bar (they live in the
   // mobile top bar's icon row instead, so the bottom bar doesn't overflow).
-  const bottomDashboards = NAVIGATION_ENTRIES.filter(p => !p.hiddenOnMobileBottom);
+  // Every external entry carries the flag too, so the bottom bar is the
+  // in-app group only; nothing here leaves ServiceBay (#2521).
+  const bottomDashboards = useNavigationEntries().filter(p => !p.hiddenOnMobileBottom);
 
   // #1992 — as top-level entries grow, a fixed `justify-around` row crowds the
   // labels and eventually overflows on narrow phones. Use an x-scrollable flex
@@ -152,11 +193,12 @@ export function MobileBottomBar() {
     >
        {bottomDashboards.map(p => {
           const Icon = p.icon;
-          const isActive = isNavActive(pathname, p.path);
+          const isActive = p.path ? isNavActive(pathname, p.path) : false;
           return (
              <button
                 key={p.id}
-                onClick={() => router.push(`${p.path}${node ? `?node=${node}` : ''}`)}
+                data-testid={`nav-${p.id}`}
+                onClick={() => router.push(p.href)}
                 title={p.name}
                 aria-label={p.name}
                 className={`p-2 rounded-xl flex flex-col items-center justify-center gap-1 shrink-0 min-w-[3.5rem] transition-all ${

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -2,18 +2,13 @@
 
 import { useState, useEffect } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { ChevronLeft, Code, Users, ExternalLink, Sparkles, Home, User as UserIcon, LogOut, MessageCircle } from 'lucide-react';
+import { ChevronLeft, Code, ExternalLink, Sparkles, User as UserIcon, LogOut } from 'lucide-react';
 import ServiceBayLogo from './ServiceBayLogo';
 import SectionHelp from './SectionHelp';
 import DomainTag from './DomainTag';
 import { Button } from '@/components/ui';
-import { NAVIGATION_ENTRIES, isNavActive } from '@/config/navigation';
-import { useDigitalTwin } from '@/hooks/useDigitalTwin';
-
-// Back-compat re-export — MobileNav imports `dashboards` from here.
-// New code should import NAVIGATION_ENTRIES directly from
-// `@/config/navigation`. (#845)
-export const dashboards = NAVIGATION_ENTRIES;
+import { isNavActive } from '@/config/navigation';
+import { useNavigationEntries } from '@/hooks/useNavigationEntries';
 
 // Renders nothing — lets SectionHelp act as a plain text link (no icon) in the
 // tidied footer's inline secondary-link row.
@@ -34,14 +29,15 @@ export default function Sidebar() {
   const searchParams = useSearchParams();
   const node = searchParams?.get('node');
   const router = useRouter();
-  const { data: twin } = useDigitalTwin();
-  // #1755 / #1781 — the maintenance chat link only appears once solilos-chat
-  // is installed (the chat surface we embed). Gated on the live digital-twin
-  // installedTemplates, like the rest of the service-aware UI.
-  const chatInstalled = Boolean(twin?.installedTemplates?.includes('solilos-chat'));
+  // Every entry — including the conditional Maintenance Chat and the two
+  // app-leaving links — comes from the navigation schema (#2521). No inline
+  // entries here; that is what keeps this in sync with MobileNav
+  // (docs/UX_DECISIONS.md → "Primary sidebar is a user-task list").
+  const navEntries = useNavigationEntries();
+  const appEntries = navEntries.filter(e => !e.external);
+  const externalEntries = navEntries.filter(e => e.external);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [showCollapsedNodeLabel, setShowCollapsedNodeLabel] = useState(false);
-  const [lldapUrl, setLldapUrl] = useState<string | null>(null);
   // The redundant /setup sidebar rider was removed (#1503): setup is now
   // integrated into the dashboard, which renders the live install
   // progress directly. The separate rider led operators to the wizard's
@@ -118,13 +114,6 @@ export default function Sidebar() {
     window.location.href = logoutHref;
   };
 
-  useEffect(() => {
-    fetch('/api/auth/lldap-url')
-      .then(r => r.ok ? r.json() : null)
-      .then(data => { if (data?.url) setLldapUrl(data.url); })
-      .catch(() => {});
-  }, []);
-
   return (
     <div className={`${isCollapsed ? 'w-16' : 'w-64'} flex flex-col sidebar-transition h-full shrink-0`}>
         <div className="h-16 flex items-center justify-between px-4">
@@ -174,66 +163,65 @@ export default function Sidebar() {
                 )}
             </Button>
         )}
-        <div className="overflow-y-auto flex-1 p-2 space-y-1">
-            {dashboards.map(p => {
-                const Icon = p.icon;
-                const isActive = isNavActive(pathname, p.path);
-                return (
-                    <Button
-                        key={p.id}
-                        onClick={() => router.push(`${p.path}${node ? `?node=${node}` : ''}`)}
-                        variant="ghost"
-                        className={`${navItemClass(isActive, isCollapsed)} !h-auto`}
-                        title={isCollapsed ? p.name : ''}
-                    >
-                        <Icon size={20} className={`shrink-0 ${isActive ? 'text-accent' : 'text-text-subtle'}`} />
-                        {!isCollapsed && <span className="font-semibold whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-300">{p.name}</span>}
-                    </Button>
-                );
-            })}
-            {chatInstalled && (
-                <Button
-                    onClick={() => router.push(`/chat${node ? `?node=${node}` : ''}`)}
-                    variant="ghost"
-                    className={`${navItemClass(isNavActive(pathname, '/chat'), isCollapsed)} !h-auto`}
-                    title={isCollapsed ? 'Maintenance Chat' : ''}
+        <div className="overflow-y-auto flex-1 p-2">
+            {/* Group 1 — destinations inside the app. */}
+            <nav aria-label="Primary" className="space-y-1">
+                {appEntries.map(p => {
+                    const Icon = p.icon;
+                    const isActive = p.path ? isNavActive(pathname, p.path) : false;
+                    return (
+                        <Button
+                            key={p.id}
+                            data-testid={`nav-${p.id}`}
+                            onClick={() => router.push(p.href)}
+                            variant="ghost"
+                            className={`${navItemClass(isActive, isCollapsed)} !h-auto`}
+                            title={isCollapsed ? p.name : ''}
+                        >
+                            <Icon size={20} className={`shrink-0 ${isActive ? 'text-accent' : 'text-text-subtle'}`} />
+                            {!isCollapsed && <span className="font-semibold whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-300">{p.name}</span>}
+                        </Button>
+                    );
+                })}
+            </nav>
+            {/* Group 2 — links that LEAVE ServiceBay (#2521). Separated by a
+                divider and, when expanded, a section label, so an app-leaving
+                link isn't just a 12px icon in an otherwise flat list. The
+                divider survives the collapsed state (the label doesn't). */}
+            {externalEntries.length > 0 && (
+                <nav
+                    aria-label="Opens in a new tab"
+                    className="space-y-1 mt-3 pt-3 border-t border-border"
                 >
-                    <MessageCircle size={20} className={`shrink-0 ${isNavActive(pathname, '/chat') ? 'text-accent' : 'text-text-subtle'}`} />
-                    {!isCollapsed && <span className="font-semibold whitespace-nowrap overflow-hidden animate-in fade-in slide-in-from-left-2 duration-300">Maintenance Chat</span>}
-                </Button>
-            )}
-            {lldapUrl && (
-                <a
-                    href={lldapUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={navItemClass(false, isCollapsed)}
-                    title={isCollapsed ? 'Users & Groups (LLDAP)' : ''}
-                >
-                    <Users size={20} className="shrink-0 text-text-subtle" />
                     {!isCollapsed && (
-                        <span className="font-semibold whitespace-nowrap overflow-hidden flex items-center gap-1.5 animate-in fade-in slide-in-from-left-2 duration-300">
-                            Users & Groups
-                            <ExternalLink size={12} className="text-text-subtle" />
-                        </span>
+                        <p className="px-3.5 pb-1 text-[9px] uppercase font-black text-text-subtle tracking-[0.15em]">
+                            Opens in a new tab
+                        </p>
                     )}
-                </a>
+                    {externalEntries.map(p => {
+                        const Icon = p.icon;
+                        return (
+                            <a
+                                key={p.id}
+                                data-testid={`nav-${p.id}`}
+                                href={p.href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={navItemClass(false, isCollapsed)}
+                                title={isCollapsed ? `${p.name} — opens in a new tab` : ''}
+                            >
+                                <Icon size={20} className="shrink-0 text-text-subtle" />
+                                {!isCollapsed && (
+                                    <span className="font-semibold whitespace-nowrap overflow-hidden flex items-center gap-1.5 animate-in fade-in slide-in-from-left-2 duration-300">
+                                        {p.name}
+                                        <ExternalLink size={12} className="text-text-subtle" />
+                                    </span>
+                                )}
+                            </a>
+                        );
+                    })}
+                </nav>
             )}
-            <a
-                href="/portal"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={navItemClass(false, isCollapsed)}
-                title={isCollapsed ? 'View as user' : ''}
-            >
-                <Home size={20} className="shrink-0 text-text-subtle" />
-                {!isCollapsed && (
-                    <span className="font-semibold whitespace-nowrap overflow-hidden flex items-center gap-1.5 animate-in fade-in slide-in-from-left-2 duration-300">
-                        View as user
-                        <ExternalLink size={12} className="text-text-subtle" />
-                    </span>
-                )}
-            </a>
         </div>
 
         <div className="p-2 space-y-1 border-t border-border pt-3 mt-auto">

--- a/packages/frontend/src/components/ui/DataTable.test.tsx
+++ b/packages/frontend/src/components/ui/DataTable.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { DataTable, type Column } from './DataTable';
+import { DataTable, defaultMinWidth, type Column } from './DataTable';
 
 interface Row {
   id: string;
@@ -45,5 +45,63 @@ describe('ui/DataTable', () => {
     render(<DataTable columns={columns} rows={[]} rowKey={(r) => r.id} empty="Nothing here" />);
     const cell = screen.getByText('Nothing here');
     expect(cell.getAttribute('colspan')).toBe('2');
+  });
+
+  // #2520 — the credentials table crushed its URL column to ~8 characters and
+  // broke `https://nginx.dopp.cloud` into "http/s://ngi/nx.dop/p.cloud", while
+  // Notes took half the table. Two root causes, both fixed in the primitive.
+  describe('column widths and wrapping (#2520)', () => {
+    it('wraps cells with break-words, never break-all', () => {
+      render(<DataTable columns={columns} rows={rows} rowKey={(r) => r.id} />);
+      const cell = screen.getByText('a1');
+      // `break-all` drops a cell's min-content width to ONE character, which is
+      // what let auto table-layout squeeze the URL column to nothing. The
+      // primitive must never ship it as a default.
+      expect(cell.className).toContain('break-words');
+      expect(cell.className).not.toContain('break-all');
+    });
+
+    it('gives the table a column-count derived min-width so overflow-x-auto can fire', () => {
+      render(<DataTable columns={columns} rows={rows} rowKey={(r) => r.id} />);
+      // Before the fix the table was pinned to w-full with no floor, so the
+      // scroll container could never overflow and columns crushed instead.
+      expect(screen.getByRole('table').style.minWidth).toBe(defaultMinWidth(2));
+    });
+
+    it('scales the default min-width with the column count and caps it', () => {
+      expect(defaultMinWidth(3)).toBe('24rem');
+      expect(defaultMinWidth(5)).toBe('40rem');
+      expect(defaultMinWidth(7)).toBe('56rem');
+      // Capped, so a very wide table scrolls rather than forcing an absurd floor.
+      expect(defaultMinWidth(20)).toBe('64rem');
+    });
+
+    it('lets a caller override the min-width without the inline default winning', () => {
+      render(
+        <DataTable
+          columns={columns}
+          rows={rows}
+          rowKey={(r) => r.id}
+          minWidthClassName="min-w-[80rem]"
+        />,
+      );
+      const table = screen.getByRole('table');
+      expect(table.className).toContain('min-w-[80rem]');
+      // An inline style beats a Tailwind utility — emitting both would silently
+      // ignore the caller's override.
+      expect(table.style.minWidth).toBe('');
+    });
+
+    it('applies a column width class to both the header and the cell', () => {
+      const sized: Column<Row>[] = [
+        { key: 'id', header: 'ID', cell: (r) => r.id, className: 'w-[28%]' },
+        { key: 'name', header: 'Name', cell: (r) => r.name, className: 'w-[22%]' },
+      ];
+      render(<DataTable columns={sized} rows={rows} rowKey={(r) => r.id} />);
+      // Width lives on <th> AND <td> so the browser can't hand the spare width
+      // to whichever column happens to hold the longest prose.
+      expect(screen.getByRole('columnheader', { name: 'ID' }).className).toContain('w-[28%]');
+      expect(screen.getByText('a1').className).toContain('w-[28%]');
+    });
   });
 });

--- a/packages/frontend/src/components/ui/DataTable.tsx
+++ b/packages/frontend/src/components/ui/DataTable.tsx
@@ -33,8 +33,37 @@ export interface DataTableProps<Row> {
   empty?: React.ReactNode;
   /** Classes on the scroll container. */
   className?: string;
-  /** Min table width to force horizontal scroll on narrow viewports. */
+  /**
+   * Min table width to force horizontal scroll on narrow viewports.
+   *
+   * Optional — when omitted the table falls back to a **column-count derived
+   * default** (see `defaultMinWidth`). Before #2520 this prop had no default
+   * and *zero* call-sites set it, which made the `overflow-x-auto` wrapper
+   * below dead code everywhere: the table was pinned to `w-full`, so it could
+   * never overflow and narrow viewports crushed columns instead of scrolling.
+   * Pass an explicit class to override, or `'min-w-0'` to opt out entirely.
+   */
   minWidthClassName?: string;
+}
+
+/**
+ * Per-column floor for the derived default min-width (#2520). Wide enough that
+ * a column keeps a readable few words rather than collapsing to one token per
+ * line, narrow enough that a small table doesn't grow a spurious scrollbar on a
+ * desktop viewport. Capped so a very wide table scrolls rather than exploding.
+ */
+const MIN_WIDTH_REM_PER_COLUMN = 8;
+const MIN_WIDTH_REM_CAP = 64;
+
+/**
+ * The table's min-width when the caller didn't specify one: `columns × 8rem`,
+ * capped at 64rem. A 3-column table gets 24rem (no scrollbar in a drawer), a
+ * 5-column table 40rem, a 7-column table 56rem — each below a typical desktop
+ * content width but above a phone's, so the scroll only kicks in where the
+ * alternative is crushed columns.
+ */
+export function defaultMinWidth(columnCount: number): string {
+  return `${Math.min(columnCount * MIN_WIDTH_REM_PER_COLUMN, MIN_WIDTH_REM_CAP)}rem`;
 }
 
 const alignClass: Record<NonNullable<Column<unknown>['align']>, string> = {
@@ -88,7 +117,18 @@ function BodyRow<Row>({
       {columns.map((col) => (
         <td
           key={col.key}
-          className={cn('px-space-3 py-space-2', col.align && alignClass[col.align], col.className)}
+          // `break-words` (overflow-wrap) — NOT `break-all` (#2520). Both stop a
+          // long token overflowing its cell, but `break-all` also drops the
+          // cell's min-content width to a single character, so the browser's
+          // auto table-layout happily squeezes that column to ~8 chars and hands
+          // the width to whichever column has the longest prose. `break-words`
+          // leaves min-content at the longest token, so a URL stays readable as
+          // a unit and only wraps when it genuinely cannot fit.
+          className={cn(
+            'px-space-3 py-space-2 break-words',
+            col.align && alignClass[col.align],
+            col.className,
+          )}
         >
           {col.cell(row, index)}
         </td>
@@ -109,7 +149,12 @@ export function DataTable<Row>({
 }: DataTableProps<Row>) {
   return (
     <div className={cn('overflow-x-auto rounded-card border border-border', className)}>
-      <table className={cn('w-full text-left text-sm', minWidthClassName)}>
+      <table
+        className={cn('w-full text-left text-sm', minWidthClassName)}
+        // Only when the caller didn't pass a class — an inline style would win
+        // over their Tailwind `min-w-*` utility and silently ignore the override.
+        style={minWidthClassName ? undefined : { minWidth: defaultMinWidth(columns.length) }}
+      >
         <thead>
           <HeaderRow columns={columns} />
         </thead>

--- a/packages/frontend/src/config/navigation.test.ts
+++ b/packages/frontend/src/config/navigation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { isNavActive, NAVIGATION_ENTRIES } from './navigation';
+import { isNavActive, NAVIGATION_ENTRIES, resolveNavigationEntries } from './navigation';
+import type { InternalNavigationEntry } from './navigation';
 
 describe('isNavActive', () => {
   it('marks the root path active ONLY on the exact root path', () => {
@@ -30,14 +31,25 @@ describe('top nav — Home + the four nouns + Network Map + Terminal (IA slice 2
   // a recovery tool and must not be buried in a Settings launch card.
   // Diagnostics stays off the top nav (it lives under Status).
   const ids = NAVIGATION_ENTRIES.map(e => e.id);
+  // The schema is a union since #2521 (external entries carry an href, not a
+  // route), so a path assertion narrows to the in-app half first.
+  const internal = (id: string) =>
+    NAVIGATION_ENTRIES.find((e): e is InternalNavigationEntry => e.id === id && !e.external);
 
   it('is exactly Home · Services · Status · Settings · Backup · Network Map · Terminal', () => {
-    expect(ids).toEqual(['home', 'services', 'status', 'settings', 'backup', 'network', 'terminal']);
+    // The unconditional in-app destinations. Maintenance Chat is in the schema
+    // too but only renders when solilos-chat is installed, and the two
+    // app-leaving links are a separate group — neither is a new top-level
+    // destination (#2521 moved them out of Sidebar.tsx, it did not add them).
+    const alwaysOn = NAVIGATION_ENTRIES
+      .filter(e => !e.external && !e.requiresTemplate)
+      .map(e => e.id);
+    expect(alwaysOn).toEqual(['home', 'services', 'status', 'settings', 'backup', 'network', 'terminal']);
   });
 
   it('Home is the first entry and renders at /', () => {
     expect(ids[0]).toBe('home');
-    const home = NAVIGATION_ENTRIES.find(e => e.id === 'home');
+    const home = internal('home');
     expect(home?.path).toBe('/');
   });
 
@@ -46,7 +58,7 @@ describe('top nav — Home + the four nouns + Network Map + Terminal (IA slice 2
   });
 
   it('keeps Terminal in the sidebar as a recovery tool (#2083) → /terminal', () => {
-    const terminal = NAVIGATION_ENTRIES.find(e => e.id === 'terminal');
+    const terminal = internal('terminal');
     expect(terminal, 'Terminal must be a top-level nav entry (recovery tool, not buried)').toBeDefined();
     expect(terminal?.path).toBe('/terminal');
     expect(terminal?.name).toBe('Terminal');
@@ -55,18 +67,18 @@ describe('top nav — Home + the four nouns + Network Map + Terminal (IA slice 2
   });
 
   it('Services links to /services (the list of every app)', () => {
-    const services = NAVIGATION_ENTRIES.find(e => e.id === 'services');
+    const services = internal('services');
     expect(services?.path).toBe('/services');
   });
 
   it('Status links to /status (the single box-wide health screen)', () => {
-    const status = NAVIGATION_ENTRIES.find(e => e.id === 'status');
+    const status = internal('status');
     expect(status?.path).toBe('/status');
     expect(status?.name).toBe('Status');
   });
 
   it('keeps Network Map top-level (operator preference)', () => {
-    const network = NAVIGATION_ENTRIES.find(e => e.id === 'network');
+    const network = internal('network');
     expect(network, 'Network Map must stay a top-level nav entry').toBeDefined();
     expect(network?.path).toBe('/network');
   });
@@ -93,5 +105,99 @@ describe('mobile reachability (#1992)', () => {
     expect(bottom.length + top.length).toBe(NAVIGATION_ENTRIES.length);
     // Bottom bar must stay small enough that a phone row doesn't overflow.
     expect(bottom.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('conditional + external schema entries (#2521)', () => {
+  // These three used to be inline JSX in Sidebar.tsx, which is exactly the
+  // drift docs/UX_DECISIONS.md forbids ("Sidebar.tsx / MobileNav.tsx map over
+  // the schema; no inline entries") and the reason mobile showed a different
+  // set of destinations than desktop.
+  const byId = (id: string) => NAVIGATION_ENTRIES.find(e => e.id === id);
+
+  it('Maintenance Chat is a schema entry gated on the solilos-chat template', () => {
+    const chat = byId('chat');
+    expect(chat, 'Maintenance Chat must live in the schema, not inline in Sidebar.tsx').toBeDefined();
+    expect(chat?.requiresTemplate).toBe('solilos-chat');
+    expect(chat?.external).toBeUndefined();
+    expect(chat && !chat.external && chat.path).toBe('/chat');
+  });
+
+  it('Users & Groups is external with a runtime href source (LLDAP)', () => {
+    const users = byId('users');
+    expect(users?.external).toBe(true);
+    expect(users && users.external && users.hrefSource).toBe('lldap');
+    // No static href — the URL only exists once LLDAP is deployed.
+    expect(users && users.external && users.href).toBeUndefined();
+  });
+
+  it('View as user is external with a static href to the family portal', () => {
+    const portal = byId('portal');
+    expect(portal?.external).toBe(true);
+    expect(portal && portal.external && portal.href).toBe('/portal');
+  });
+
+  it('every app-leaving entry stays off the phone bottom bar', () => {
+    for (const entry of NAVIGATION_ENTRIES.filter(e => e.external)) {
+      expect(entry.hiddenOnMobileBottom, `${entry.id} must not sit in the bottom bar`).toBe(true);
+    }
+  });
+
+  it('external entries are the ONLY app-leaving ones (no new destinations)', () => {
+    expect(NAVIGATION_ENTRIES.filter(e => e.external).map(e => e.id)).toEqual(['users', 'portal']);
+  });
+});
+
+describe('resolveNavigationEntries — the one list both nav components render (#2521)', () => {
+  const full = { installedTemplates: ['solilos-chat'], lldapUrl: 'https://ldap.example.com', node: null };
+
+  it('hides Maintenance Chat until solilos-chat is installed', () => {
+    const without = resolveNavigationEntries({ installedTemplates: ['media'] });
+    expect(without.map(e => e.id)).not.toContain('chat');
+    const withChat = resolveNavigationEntries({ installedTemplates: ['media', 'solilos-chat'] });
+    expect(withChat.map(e => e.id)).toContain('chat');
+  });
+
+  it('hides Users & Groups until the LLDAP url resolves, then uses it as the href', () => {
+    expect(resolveNavigationEntries({}).map(e => e.id)).not.toContain('users');
+    const users = resolveNavigationEntries({ lldapUrl: 'https://ldap.example.com' }).find(e => e.id === 'users');
+    expect(users?.href).toBe('https://ldap.example.com');
+    expect(users?.external).toBe(true);
+    // External entries have no route — they must never be matched by isNavActive.
+    expect(users?.path).toBeNull();
+  });
+
+  it('keeps View as user unconditional and pointed at /portal', () => {
+    const portal = resolveNavigationEntries({}).find(e => e.id === 'portal');
+    expect(portal?.href).toBe('/portal');
+    expect(portal?.external).toBe(true);
+  });
+
+  it('threads ?node= onto in-app routes only, never onto an external url', () => {
+    const entries = resolveNavigationEntries({ ...full, node: 'edge-1' });
+    expect(entries.find(e => e.id === 'services')?.href).toBe('/services?node=edge-1');
+    expect(entries.find(e => e.id === 'chat')?.href).toBe('/chat?node=edge-1');
+    expect(entries.find(e => e.id === 'users')?.href).toBe('https://ldap.example.com');
+    expect(entries.find(e => e.id === 'portal')?.href).toBe('/portal');
+  });
+
+  it('resolves every destination the desktop sidebar and mobile nav share', () => {
+    const resolved = resolveNavigationEntries(full);
+    // The sidebar renders the whole list; mobile splits it into the bottom bar
+    // and the top-bar icon row. That partition must cover it exactly — that IS
+    // the desktop/mobile parity guarantee.
+    const bottom = resolved.filter(e => !e.hiddenOnMobileBottom);
+    const top = resolved.filter(e => e.hiddenOnMobileBottom);
+    expect([...bottom, ...top].map(e => e.id).sort()).toEqual(resolved.map(e => e.id).sort());
+    expect(bottom.length).toBeLessThanOrEqual(5);
+    expect(resolved.map(e => e.id)).toEqual([
+      'home', 'services', 'status', 'settings', 'backup', 'network', 'terminal', 'chat', 'users', 'portal',
+    ]);
+  });
+
+  it('renders nothing conditional on a bare box (no chat, no LLDAP)', () => {
+    expect(resolveNavigationEntries({}).map(e => e.id)).toEqual([
+      'home', 'services', 'status', 'settings', 'backup', 'network', 'terminal', 'portal',
+    ]);
   });
 });

--- a/packages/frontend/src/config/navigation.ts
+++ b/packages/frontend/src/config/navigation.ts
@@ -14,11 +14,23 @@
  *      bottom bar stays uncluttered (they surface in the mobile top
  *      bar's icon row instead, so they're still reachable on a phone;
  *      see MobileNav.tsx #1992).
+ *
+ * EVERY entry both nav components render lives here — including the
+ * conditional one (Maintenance Chat) and the two that leave the app
+ * (Users & Groups → LLDAP, View as user → the family portal). Before
+ * #2521 those three were inline JSX in `Sidebar.tsx`, which bypassed the
+ * indirection the UX rule depends on (docs/UX_DECISIONS.md → "Primary
+ * sidebar is a user-task list": *"Sidebar.tsx / MobileNav.tsx map over
+ * the schema; no inline entries"*) and made the desktop sidebar show a
+ * different set of destinations than the mobile nav. The schema now
+ * carries the two concepts they needed — `external` + href, and
+ * `requiresTemplate` — so both components can render from one list.
+ * Anything runtime-dependent is resolved by `resolveNavigationEntries`.
  */
-import { Home, Box, HeartPulse, Settings, Network, DatabaseBackup, SquareTerminal } from 'lucide-react';
+import { Home, Box, HeartPulse, Settings, Network, DatabaseBackup, SquareTerminal, MessageCircle, Users } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
-export interface NavigationEntry {
+interface NavigationEntryBase {
   /** Stable identifier used in keys / `data-testid` / `dashboards.id`
    *  references throughout the codebase. Do not change once shipped. */
   id: string;
@@ -29,15 +41,40 @@ export interface NavigationEntry {
   /** Lucide icon component. Accepts the full Lucide prop surface
    *  (size, strokeWidth, className, color, …). */
   icon: LucideIcon;
-  /** Route path. The `usePathname().startsWith(path)` test marks an
-   *  entry active, so prefer "/X" over "/X/" or "/X/index". */
-  path: string;
   /** When true, the mobile bottom bar omits this entry; instead it is
    *  rendered as an icon in the mobile top bar's right-hand row, so it
    *  stays reachable on a phone (#1992). The desktop sidebar always
-   *  renders every entry. Used for Settings and Backup. */
+   *  renders every entry. Used for Settings, Backup and every external
+   *  entry (an app-leaving link never belongs in the bottom bar). */
   hiddenOnMobileBottom?: boolean;
+  /** Render this entry only when the named template is installed on the
+   *  box (`digital twin → installedTemplates`). Lets a conditional
+   *  destination live in the schema instead of as inline component JSX
+   *  (#2521). Maintenance Chat uses this. */
+  requiresTemplate?: string;
 }
+
+/** A destination inside the ServiceBay app — client-side route push. */
+export interface InternalNavigationEntry extends NavigationEntryBase {
+  external?: false;
+  /** Route path. The `usePathname().startsWith(path)` test marks an
+   *  entry active, so prefer "/X" over "/X/" or "/X/index". */
+  path: string;
+}
+
+/** A destination that LEAVES the app — rendered as an `<a target="_blank">`
+ *  in its own visual group, never as a router push (#2521). */
+export interface ExternalNavigationEntry extends NavigationEntryBase {
+  external: true;
+  /** Static URL, when it is known without asking the box (`/portal`). */
+  href?: string;
+  /** Where to read the URL at runtime when it depends on the box's
+   *  configuration. `'lldap'` → `GET /api/auth/lldap-url`. The entry is
+   *  hidden until (and unless) that URL resolves. */
+  hrefSource?: 'lldap';
+}
+
+export type NavigationEntry = InternalNavigationEntry | ExternalNavigationEntry;
 
 /**
  * Active-route test for a nav entry. The root entry (`/`) must match the
@@ -89,4 +126,79 @@ export const NAVIGATION_ENTRIES: NavigationEntry[] = [
   { id: 'backup', name: 'Backup & restore', shortLabel: 'Backup', icon: DatabaseBackup, path: '/backup', hiddenOnMobileBottom: true },
   { id: 'network', name: 'Network Map', shortLabel: 'Network', icon: Network, path: '/network' },
   { id: 'terminal', name: 'Terminal', shortLabel: 'Terminal', icon: SquareTerminal, path: '/terminal', hiddenOnMobileBottom: true },
+  // Conditional in-app destination: the chat surface only exists once
+  // solilos-chat is installed (#1755/#1781). Schema-driven since #2521 —
+  // it used to be inline JSX in Sidebar.tsx, so the mobile nav never saw it.
+  { id: 'chat', name: 'Maintenance Chat', shortLabel: 'Chat', icon: MessageCircle, path: '/chat', requiresTemplate: 'solilos-chat' },
+  // App-leaving links. Not new destinations (#2521 moved them out of
+  // Sidebar.tsx verbatim) — they render in their own group, after a
+  // divider, and stay off the phone bottom bar.
+  { id: 'users', name: 'Users & Groups', shortLabel: 'Users', icon: Users, external: true, hrefSource: 'lldap', hiddenOnMobileBottom: true },
+  { id: 'portal', name: 'View as user', shortLabel: 'Portal', icon: Home, external: true, href: '/portal', hiddenOnMobileBottom: true },
 ];
+
+/** Runtime inputs the schema's conditional / external entries need. */
+export interface NavigationContext {
+  /** `digitalTwin.installedTemplates` — gates `requiresTemplate` entries. */
+  installedTemplates?: string[] | null;
+  /** Resolved LLDAP admin URL (`GET /api/auth/lldap-url`), or null when
+   *  LLDAP is not deployed / not reachable. */
+  lldapUrl?: string | null;
+  /** Active `?node=` — threaded onto in-app routes only. */
+  node?: string | null;
+}
+
+/** A schema entry with everything runtime-dependent already resolved. */
+export interface ResolvedNavigationEntry {
+  id: string;
+  name: string;
+  shortLabel: string;
+  icon: LucideIcon;
+  /** Where the entry goes: an in-app route (with `?node=` threaded) for an
+   *  internal entry, an absolute/app-leaving URL for an external one. */
+  href: string;
+  /** The raw route, for `isNavActive`. `null` for external entries. */
+  path: string | null;
+  external: boolean;
+  hiddenOnMobileBottom: boolean;
+}
+
+/**
+ * Resolve the schema against live box state — the ONE place a nav
+ * component gets its entries from (#2521). Both `Sidebar.tsx` and
+ * `MobileNav.tsx` render whatever this returns, which is what keeps
+ * desktop and mobile showing the same set of destinations.
+ *
+ * Drops an entry when its precondition isn't met: a `requiresTemplate`
+ * entry whose template isn't installed, or an `hrefSource` entry whose
+ * URL hasn't resolved (LLDAP not deployed).
+ */
+export function resolveNavigationEntries(
+  ctx: NavigationContext,
+  entries: NavigationEntry[] = NAVIGATION_ENTRIES,
+): ResolvedNavigationEntry[] {
+  const resolved: ResolvedNavigationEntry[] = [];
+  for (const entry of entries) {
+    if (entry.requiresTemplate && !ctx.installedTemplates?.includes(entry.requiresTemplate)) continue;
+    const common = {
+      id: entry.id,
+      name: entry.name,
+      shortLabel: entry.shortLabel,
+      icon: entry.icon,
+      hiddenOnMobileBottom: Boolean(entry.hiddenOnMobileBottom),
+    };
+    if (entry.external) {
+      const href = entry.hrefSource === 'lldap' ? ctx.lldapUrl : entry.href;
+      if (!href) continue;
+      resolved.push({ ...common, href, path: null, external: true });
+      continue;
+    }
+    resolved.push({
+      ...common,
+      href: `${entry.path}${ctx.node ? `?node=${ctx.node}` : ''}`,
+      path: entry.path,
+      external: false,
+    });
+  }
+  return resolved;
+}

--- a/packages/frontend/src/hooks/useNavigationEntries.ts
+++ b/packages/frontend/src/hooks/useNavigationEntries.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useDigitalTwin } from '@/hooks/useDigitalTwin';
+import { resolveNavigationEntries, type ResolvedNavigationEntry } from '@/config/navigation';
+
+/**
+ * The primary navigation, resolved against live box state (#2521).
+ *
+ * `Sidebar.tsx` and `MobileNav.tsx` both call this, so they cannot drift
+ * apart: whatever the schema resolves to is what both render. It gathers
+ * the two runtime inputs the schema's conditional entries need —
+ * installed templates (Maintenance Chat) and the LLDAP admin URL (Users &
+ * Groups) — plus the active `?node=`, and hands them to the pure
+ * `resolveNavigationEntries`.
+ *
+ * The LLDAP URL is fetched per mounting component, matching how the nav
+ * components already fetch `/api/system/version`; the endpoint is a cheap
+ * config read and no cross-component fetch cache exists in this app.
+ */
+export function useNavigationEntries(): ResolvedNavigationEntry[] {
+  const searchParams = useSearchParams();
+  const node = searchParams?.get('node') ?? null;
+  const { data: twin } = useDigitalTwin();
+  const [lldapUrl, setLldapUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/auth/lldap-url')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (!cancelled && data?.url) setLldapUrl(data.url); })
+      .catch(() => { /* LLDAP not deployed / offline — the entry stays hidden */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  const installedTemplates = twin?.installedTemplates;
+  return useMemo(
+    () => resolveNavigationEntries({ installedTemplates, lldapUrl, node }),
+    [installedTemplates, lldapUrl, node],
+  );
+}

--- a/tests/frontend/MobileNav.test.tsx
+++ b/tests/frontend/MobileNav.test.tsx
@@ -1,6 +1,6 @@
 
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MobileTopBar, MobileBottomBar } from '@/components/MobileNav';
 import { ToastProvider } from '@/providers/ToastProvider';
 
@@ -12,14 +12,45 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => ({ get: (key: string) => (key === 'node' ? currentNode : null) }),
 }));
 
+// #2521 — the mobile nav now renders the same resolved navigation schema as
+// the desktop sidebar, so it consumes the digital twin (Maintenance Chat is
+// gated on installedTemplates). These tests render outside a
+// DigitalTwinProvider, so stub the hook with a mutable snapshot.
+const twinRef: { current: { installedTemplates?: string[] } | null } = { current: null };
+vi.mock('@/hooks/useDigitalTwin', () => ({
+  useDigitalTwin: () => ({ data: twinRef.current, isConnected: false, lastUpdate: 0, isNodeSynced: () => false }),
+}));
+
 const renderWithToast = (ui: React.ReactNode) =>
     render(<ToastProvider>{ui}</ToastProvider>);
 
 describe('MobileNav', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+    // Route-aware fetch mock — a fresh Response per URL (a Response body can
+    // only be read once, and the bars fetch in parallel).
+    const lldapResponse = { url: null as string | null };
+    function mockFetch(url: RequestInfo | URL) {
+        const u = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+        if (u.includes('/api/auth/lldap-url')) {
+            return new Response(JSON.stringify(lldapResponse), { status: 200 });
+        }
+        if (u.includes('/api/system/version')) {
+            return new Response(JSON.stringify({ version: '9.9.9' }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ jobIsActive: false, stackSetupPending: false }), { status: 200 });
+    }
+
     beforeEach(() => {
         vi.clearAllMocks();
         currentNode = null;
+        twinRef.current = null;
+        lldapResponse.url = null;
+        fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((url) => Promise.resolve(mockFetch(url)));
         if (typeof window !== 'undefined') window.localStorage.clear();
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
     });
 
     it('MobileTopBar renders logo and routes Settings click', () => {
@@ -71,5 +102,77 @@ describe('MobileNav', () => {
         renderWithToast(<MobileBottomBar />);
         fireEvent.click(screen.getByTitle('Services'));
         expect(mockPush).toHaveBeenCalledWith('/services?node=edge-1');
+    });
+
+    // #2521 — before this, Sidebar.tsx rendered Maintenance Chat, Users &
+    // Groups and View as user as inline JSX, so the mobile nav (which maps the
+    // schema) simply did not have them. Desktop and mobile must offer the same
+    // destinations.
+    describe('desktop/mobile destination parity (#2521)', () => {
+        it('surfaces the app-leaving links in the top bar, after a divider', async () => {
+            lldapResponse.url = 'https://ldap.example.com';
+            const { container } = renderWithToast(<MobileTopBar />);
+
+            await waitFor(() => {
+                expect(container.querySelector('[data-testid="nav-users"]')).not.toBeNull();
+            });
+            const users = container.querySelector('[data-testid="nav-users"]');
+            expect(users?.tagName).toBe('A');
+            expect(users?.getAttribute('href')).toBe('https://ldap.example.com');
+            expect(users?.getAttribute('target')).toBe('_blank');
+
+            const portal = container.querySelector('[data-testid="nav-portal"]');
+            expect(portal?.getAttribute('href')).toBe('/portal');
+            expect(portal?.getAttribute('target')).toBe('_blank');
+
+            // In-app icons come first, then a ruled-off group with the links.
+            const group = container.querySelector('[data-testid="external-nav-group"]');
+            expect(group?.className).toContain('border-l');
+            expect(group?.className).toContain('border-border');
+            expect(group?.contains(users!)).toBe(true);
+            expect(group?.contains(portal!)).toBe(true);
+            expect(group?.querySelector('[data-testid="nav-settings"]')).toBeNull();
+            const order = Array.from(container.querySelectorAll('[data-testid^="nav-"]'))
+                .map(el => el.getAttribute('data-testid'));
+            expect(order.indexOf('nav-settings')).toBeLessThan(order.indexOf('nav-users'));
+        });
+
+        it('shows Maintenance Chat on the bottom bar once solilos-chat is installed', () => {
+            twinRef.current = { installedTemplates: ['solilos-chat'] };
+            const { container } = renderWithToast(<MobileBottomBar />);
+            expect(container.querySelector('[data-testid="nav-chat"]')).not.toBeNull();
+            expect(screen.getByTitle('Maintenance Chat')).toBeDefined();
+        });
+
+        it('hides Maintenance Chat when solilos-chat is not installed', () => {
+            twinRef.current = { installedTemplates: ['media'] };
+            const { container } = renderWithToast(<MobileBottomBar />);
+            expect(container.querySelector('[data-testid="nav-chat"]')).toBeNull();
+        });
+
+        it('top bar + bottom bar together cover the whole resolved schema', async () => {
+            const { resolveNavigationEntries } = await import('@/config/navigation');
+            twinRef.current = { installedTemplates: ['solilos-chat'] };
+            lldapResponse.url = 'https://ldap.example.com';
+
+            const top = renderWithToast(<MobileTopBar />);
+            const bottom = renderWithToast(<MobileBottomBar />);
+
+            const expected = resolveNavigationEntries({
+                installedTemplates: ['solilos-chat'],
+                lldapUrl: 'https://ldap.example.com',
+                node: null,
+            }).map(e => `nav-${e.id}`).sort();
+
+            await waitFor(() => {
+                const rendered = [...top.container.querySelectorAll('[data-testid^="nav-"]'),
+                                  ...bottom.container.querySelectorAll('[data-testid^="nav-"]')]
+                    .map(el => el.getAttribute('data-testid'))
+                    .sort();
+                // Same destinations the desktop Sidebar renders (Sidebar.test.tsx
+                // asserts the sidebar equals this same resolved list).
+                expect(rendered).toEqual(expected);
+            });
+        });
     });
 });

--- a/tests/frontend/Sidebar.test.tsx
+++ b/tests/frontend/Sidebar.test.tsx
@@ -95,10 +95,13 @@ describe('Sidebar', () => {
         expect(idle?.className).not.toMatch(/gray-\d|dark:hover:bg-white/);
     });
 
-    it('preserves EVERY navigation entry incl. the restored Terminal (#2083)', async () => {
+    it('preserves EVERY unconditional navigation entry incl. the restored Terminal (#2083)', async () => {
         const { NAVIGATION_ENTRIES } = await import('@/config/navigation');
         render(<Sidebar />);
-        for (const entry of NAVIGATION_ENTRIES) {
+        // The conditional (Maintenance Chat) and external (LLDAP) entries are
+        // covered by the schema-parity test below; on a bare box they are
+        // correctly absent.
+        for (const entry of NAVIGATION_ENTRIES.filter(e => !e.requiresTemplate && !(e.external && e.hrefSource))) {
             expect(screen.getByText(entry.name)).toBeDefined();
         }
         // Terminal must not be buried (memory: don't drop recovery tools).
@@ -187,5 +190,76 @@ describe('Sidebar', () => {
         twinRef.current = { installedTemplates: ['auth', 'hermes', 'solilos-chat'] };
         render(<Sidebar />);
         expect(screen.getByText('Maintenance Chat')).toBeDefined();
+    });
+
+    // #2521 — the sidebar renders the navigation SCHEMA and nothing else. The
+    // three entries that used to be inline JSX here (Maintenance Chat, Users &
+    // Groups, View as user) are the reason the mobile nav showed a different
+    // set of destinations; these lock the drift out.
+    describe('schema-driven rendering (#2521)', () => {
+        it('renders exactly the resolved schema — no inline entries', async () => {
+            const { resolveNavigationEntries } = await import('@/config/navigation');
+            twinRef.current = { installedTemplates: ['solilos-chat'] };
+            lldapResponse.url = 'https://ldap.example.com';
+            const { container } = render(<Sidebar />);
+
+            const expected = resolveNavigationEntries({
+                installedTemplates: ['solilos-chat'],
+                lldapUrl: 'https://ldap.example.com',
+                node: null,
+            }).map(e => `nav-${e.id}`);
+
+            await waitFor(() => {
+                const rendered = Array.from(container.querySelectorAll('[data-testid^="nav-"]'))
+                    .map(el => el.getAttribute('data-testid'));
+                expect(rendered).toEqual(expected);
+            });
+        });
+
+        it('splits in-app destinations from app-leaving links into two groups', async () => {
+            lldapResponse.url = 'https://ldap.example.com';
+            const { container } = render(<Sidebar />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Users & Groups')).toBeDefined();
+            });
+
+            const appGroup = container.querySelector('nav[aria-label="Primary"]');
+            const externalGroup = container.querySelector('nav[aria-label="Opens in a new tab"]');
+            expect(appGroup).not.toBeNull();
+            expect(externalGroup).not.toBeNull();
+            // A visible separator, not just a 12px icon after the label.
+            expect(externalGroup?.className).toContain('border-t');
+            expect(externalGroup?.className).toContain('border-border');
+            // Every app-leaving link lives in the external group, and no
+            // in-app destination leaked into it.
+            expect(externalGroup?.querySelector('[data-testid="nav-users"]')).not.toBeNull();
+            expect(externalGroup?.querySelector('[data-testid="nav-portal"]')).not.toBeNull();
+            expect(appGroup?.querySelector('[data-testid="nav-services"]')).not.toBeNull();
+            expect(appGroup?.querySelector('[data-testid="nav-portal"]')).toBeNull();
+            for (const link of Array.from(externalGroup?.querySelectorAll('a') ?? [])) {
+                expect(link.getAttribute('target')).toBe('_blank');
+            }
+        });
+
+        it('keeps both groups usable when collapsed (labels drop, divider stays)', async () => {
+            lldapResponse.url = 'https://ldap.example.com';
+            const { container } = render(<Sidebar />);
+            await waitFor(() => expect(screen.getByText('Users & Groups')).toBeDefined());
+
+            fireEvent.click(screen.getByTitle('Collapse Sidebar'));
+
+            await waitFor(() => {
+                expect(screen.getByTitle('Expand Sidebar')).toBeDefined();
+                // Section label is gone; the group divider and every entry stay.
+                expect(screen.queryByText('Opens in a new tab')).toBeNull();
+                expect(screen.queryByText('Users & Groups')).toBeNull();
+            });
+            expect(container.querySelector('nav[aria-label="Opens in a new tab"]')?.className).toContain('border-t');
+            expect(container.querySelector('[data-testid="nav-users"]')?.getAttribute('title'))
+                .toBe('Users & Groups — opens in a new tab');
+            expect(container.querySelector('[data-testid="nav-services"]')).not.toBeNull();
+            expect(container.querySelector('[data-testid="nav-portal"]')).not.toBeNull();
+        });
     });
 });


### PR DESCRIPTION
Batch `2026-08-12b` — 2 units, frontend. Both `gate: verify`.

## Closes #2520 — DataTable crushed columns and broke URLs mid-token

In Settings → Access & People the URL column collapsed to ~8 characters and broke mid-token (`http` / `s://ngi` / `nx.dop` / `p.cloud`) while Notes took half the table.

The two symptoms were one mechanism: `break-all` drops a cell's *min-content width to a single character*, so auto table-layout was free to squeeze that column to nothing and hand the width to the longest prose column. Separately, `DataTable`'s `overflow-x-auto` was dead code repo-wide — `minWidthClassName` was declared and documented but set by **zero** of the three real callers, so the table stayed pinned to `w-full` and could never overflow.

Both gaps are shared by every caller, so the fix is in the primitive, not five call-sites: cells use `break-words`; `minWidthClassName` falls back to an exported, testable `defaultMinWidth(n) = min(n × 8rem, 64rem)`, emitted as an inline style **only** when the caller passed no class, so an explicit override still wins. The call-site keeps only what is genuinely credentials-specific (16/28/16/18/22% column widths, a raised 56rem floor).

Measured in headless Chromium, before/after: the reported URL went from 7 visual lines at a 480px viewport (52px cell) to 1 line at every viewport; Notes from 51% of table width to 22%; 480px now scrolls (`table=896` vs `client=430`). The other two callers were regression-measured — neither gains a spurious scrollbar, and the disk-import rollup keeps its numbers on one line where it previously wrapped.

**Blast radius:** the new default min-width applies to every `DataTable` in the app, not just this one.

## Closes #2521 — sidebar entries bypassed the schema; desktop ≠ mobile

`Sidebar.tsx` rendered three entries as inline JSX instead of from `NAVIGATION_ENTRIES`: Maintenance Chat (conditional on `solilos-chat`), Users & Groups (→ LLDAP), View as user (→ `/portal`). `docs/UX_DECISIONS.md` requires the opposite ("map over the schema; no inline entries"), and the drift had a visible consequence: `MobileNav` maps over the schema, so mobile showed a different set of destinations than desktop.

The schema gained the concepts it was missing — a union with `external` + `href`/`hrefSource`, and `requiresTemplate` — plus a pure `resolveNavigationEntries` and one shared `useNavigationEntries` hook that both nav components render from. App-leaving links are now a distinct group: divider + "Opens in a new tab" label in the sidebar, a `border-l` rule in the mobile top bar. No destinations added or removed; the UX rule is enforced, not re-litigated.

Also fixed: the mobile top bar clipped at 360px once the two extra icons were present — the row now x-scrolls, matching the bottom bar (#1992 pattern).

Verified in headless Chromium at 1440 / 480 / 360 / 320 px, expanded and collapsed; desktop and mobile render the identical 10-destination resolved set.

## Gates

`npm run lint` 0 errors (460 warnings, unchanged) · `typecheck` clean · `check:arch` lint-ratchet held at baseline (`no-raw-color-literal: 1`, `no-raw-ui-primitive: 92`) · `npm test` 522/522 files, 5006 passed / 1 skipped (+23 new tests).

Both units are `gate: verify` → box-verify owed before release.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
