### PR TITLE
fix(docker): tolerate npm hoisting workspace deps to the root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,30 @@ RUN npm ci
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-# Copy workspace-scoped node_modules that npm did not hoist to root.
-# npm may deoptimize hoisting for some packages (e.g. nodemailer, semver),
-# leaving them under packages/*/node_modules instead of the root.
-# Without this copy the Turbopack build fails with "Module not found" when a
-# frontend API route imports a backend module that depends on those packages
+# Carry over any workspace-scoped node_modules that npm did NOT hoist to root.
+# Without them the Turbopack build fails with "Module not found" when a frontend
+# API route imports a backend module that depends on such a package
 # (email.ts → nodemailer, approve/route.ts → email.ts, #2148 regression).
-COPY --from=deps /app/packages/backend/node_modules ./packages/backend/node_modules
+#
+# npm's hoisting decision is a MOVING TARGET, so this must not name a concrete
+# workspace path. It deoptimized nodemailer into packages/backend/node_modules
+# when #2148 landed, then re-hoisted it to the root when the ^9.0.3 → ^9.0.5
+# bump in 547090c3 re-resolved the tree — leaving the deps stage with no
+# packages/backend/node_modules at all, and the hard
+# `COPY --from=deps /app/packages/backend/node_modules` failing the whole build
+# with "not found" (#2528).
+#
+# Instead copy the deps stage's packages/ tree wholesale — that directory always
+# exists, the manifest COPYs above create it — and merge back whatever
+# node_modules it happens to contain (no-clobber, so the source tree wins).
+COPY --from=deps /app/packages ./packages-deps
 COPY . .
+RUN set -e; for d in packages-deps/*/node_modules; do \
+      [ -d "$d" ] || continue; \
+      w="$(basename "$(dirname "$d")")"; \
+      mkdir -p "packages/$w/node_modules"; \
+      cp -rn "$d/." "packages/$w/node_modules/"; \
+    done; rm -rf packages-deps
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry

--- a/tests/backend/dockerfile_workspace_deps.test.ts
+++ b/tests/backend/dockerfile_workspace_deps.test.ts
@@ -77,6 +77,32 @@ describe('Dockerfile workspace dependency install (#2422)', () => {
     ).toEqual([]);
   });
 
+  it('never hard-COPYs a concrete packages/<member>/node_modules across stages (#2528)', () => {
+    // npm's hoisting decision is not stable across lockfile changes. When the
+    // nodemailer ^9.0.3 → ^9.0.5 bump (547090c3) re-hoisted it to the root, the
+    // deps stage stopped producing packages/backend/node_modules entirely and
+    // `COPY --from=deps /app/packages/backend/node_modules ...` failed the whole
+    // build with "not found" — three consecutive red release.yml runs, :dev
+    // stale for 13 days. A stage that needs those modules must copy the whole
+    // packages/ tree (which always exists) and merge what it finds.
+    const problems: string[] = [];
+    for (const file of DOCKERFILES) {
+      const text = fs.readFileSync(path.join(REPO_ROOT, file), 'utf-8');
+      for (const line of text.split('\n')) {
+        if (/^\s*COPY\s.*\bpackages\/[A-Za-z0-9._-]+\/node_modules\b/.test(line)) {
+          problems.push(`${file}: ${line.trim()}`);
+        }
+      }
+    }
+
+    expect(
+      problems,
+      `Dockerfile COPY of a concrete workspace node_modules path:\n  ${problems.join('\n  ')}\n\n` +
+        'That directory only exists when npm happens to deoptimize hoisting for that ' +
+        'workspace. Copy `/app/packages` and merge the node_modules you find instead.',
+    ).toEqual([]);
+  });
+
   it('Dockerfile.dev merges workspace-scoped node_modules into the root', () => {
     // npm deoptimizes hoisting for some packages (nodemailer today) and leaves
     // them in packages/backend/node_modules. dist-server/server.cjs require()s


### PR DESCRIPTION
Batch `2026-08-12c` — 1 unit, build layer only.

## Closes #2528 — release Docker build broken since 2026-08-12, `:dev` stale, `:latest` unbuildable

`release.yml`'s Docker build failed on the last **three consecutive** `main` runs (`9c5c41d2`, `3526c82c`, `3fa112d1`); last green was `c9415e85` on 2026-07-30. Consequence: `ghcr.io/mdopp/servicebay:dev` is ~13 days stale, `:latest` cannot be rebuilt, PR #2524 is deployed nowhere and cannot be box-verified, and release PR #2525 cannot ship.

### Root cause — cause, not coincidence

The first red is `9c5c41d2`, the merge of dependabot #2516. Within it, commit `547090c3` bumped **nodemailer** `^9.0.3` → `^9.0.5`, which made npm **re-hoist** it to the root `node_modules`. Reproduced with real `npm ci`: at last-green `c9415e85` the lockfile had exactly one workspace-scoped entry (`packages/backend/node_modules/nodemailer`); at HEAD it has zero. So the `deps` stage no longer creates `packages/backend/node_modules` at all, and the hard `COPY --from=deps /app/packages/backend/node_modules` at `Dockerfile:33` fails "not found".

The two later reds are the same lockfile state — a docs-only and a frontend-only commit could not break a container build on their own.

### Fix — build layer, nothing disabled

The builder stage now copies `/app/packages` wholesale into `packages-deps` and merges back whatever `node_modules` it finds (`cp -rn`) — the tolerant pattern the runner stage and `Dockerfile.dev` already use. It works in **both** hoisting states, so #2148 is preserved.

Deliberately **not** pinning or reverting nodemailer: hoisting is a moving target, and the next transitive bump would reintroduce the same break. A guard case in `tests/backend/dockerfile_workspace_deps.test.ts` now forbids any concrete `packages/<member>/node_modules` COPY so this cannot regress.

### Verification limit — stated plainly

A local container build was **not** possible in this sandbox (rootless podman fails with `exec: "newuidmap": executable file not found`; no docker, no root). Instead the deps-stage precondition was reproduced and the exact merge `RUN` executed against **both** hoisting states (exit 0 both; restores `nodemailer` in the deoptimized case). `ci.yml` is green on `3fa112d1`, including its `npm run build` and `Dockerfile.dev` image jobs on the current lockfile.

**The authoritative proof is `release.yml` going green on `main` after this merges.** If it does not, this PR did not fix it.

## Gates

`npm run lint` 0 errors (460 warnings, unchanged) · `typecheck` clean · `check:arch` ratchet held at baseline · `npm test` 5007 passed / 1 skipped.

`box_verify` stays `owed` @ `3fa112d1` — this unit does not verify #2524.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
