### PR TITLE
fix(frontend): align sidebar nav entries the same way in both groups

### DIFF
--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -22,7 +22,14 @@ const navItemClass = (active: boolean, collapsed: boolean) =>
     active
       ? 'bg-accent/10 border-accent/20 text-accent font-bold shadow-sm shadow-accent/5'
       : 'border-transparent hover:bg-surface-2 text-text-muted hover:text-text'
-  } ${collapsed ? 'justify-center' : 'gap-3.5'}`;
+  } ${collapsed ? 'justify-center' : 'justify-start gap-3.5'}`;
+// `justify-start` is not redundant (#2542): the internal entries render as
+// <Button>, whose base class carries `justify-center` (ui/Button.tsx), while the
+// external entries are plain <a> and fall back to the flex default. Without it
+// the two groups sit at different indents — visible only when expanded, because
+// the collapsed branch already pins both to `justify-center`. Stating it here
+// keeps this function the single source of truth it claims to be, rather than
+// leaving the alignment to whichever element a caller happens to use.
 
 export default function Sidebar() {
     const pathname = usePathname() || '';

--- a/tests/frontend/Sidebar.test.tsx
+++ b/tests/frontend/Sidebar.test.tsx
@@ -242,6 +242,30 @@ describe('Sidebar', () => {
             }
         });
 
+        it('aligns both groups identically when expanded (#2542)', async () => {
+            // The in-app entries render as <Button>, whose base class carries
+            // `justify-center`; the app-leaving entries are plain <a> and fall
+            // back to the flex default. Before #2542 that left the two groups at
+            // visibly different indents. Compare them against each other rather
+            // than asserting one literal, so a future third variant that skips
+            // navItemClass fails here instead of drifting silently.
+            lldapResponse.url = 'https://ldap.example.com';
+            const { container } = render(<Sidebar />);
+            await waitFor(() => expect(screen.getByText('Users & Groups')).toBeDefined());
+
+            const internal = container.querySelector('[data-testid="nav-services"]');
+            const external = container.querySelector('[data-testid="nav-users"]');
+            expect(internal).not.toBeNull();
+            expect(external).not.toBeNull();
+
+            const justify = (el: Element | null) =>
+                Array.from(el?.classList ?? []).filter(c => c.startsWith('justify-')).sort();
+            expect(justify(internal)).toEqual(justify(external));
+            // …and it is start, not centre — a nav row reads left-to-right.
+            expect(justify(internal)).toContain('justify-start');
+            expect(justify(internal)).not.toContain('justify-center');
+        });
+
         it('keeps both groups usable when collapsed (labels drop, divider stays)', async () => {
             lldapResponse.url = 'https://ldap.example.com';
             const { container } = render(<Sidebar />);


### PR DESCRIPTION
Batch `2026-08-13c` — 1 unit. Found by the owner while verifying PR #2524 on the live box.

## Closes #2542 — sidebar groups sat at different indents

"Home / Services / Status / Settings / …" rendered **centred**, while "Users & Groups" and "View as user" rendered **flush left** — the two groups' icons started at visibly different x positions.

`ui/Button.tsx:27` carries `justify-center` in its base class. The in-app entries render as `<Button className={navItemClass(...)}>`; the app-leaving entries are a plain `<a className={navItemClass(...)}>` and fall back to the flex default. `navItemClass` set no `justify-*` in its expanded branch, so the element type decided the alignment. The collapsed branch was never affected — it already pins both to `justify-center`, which is why this only showed up expanded.

`cn(base, variants, sizes, className)` already lets the passed class win, so this is not a specificity problem — the rule was simply never stated. It belongs in `navItemClass`, which exists to be the single source of truth for the link variants ("One source of truth so the four link variants stay in sync").

The regression test compares the two groups **against each other** rather than asserting a literal class, so a future third variant that skips `navItemClass` fails there instead of drifting silently. Verified to fail without the change.

## Context

Completes #2521 (PR #2524): that unit correctly moved the entries into `NAVIGATION_ENTRIES` and grouped them, but both groups still render through two different element types with different base classes.

Same class as #2484 — "Button-primitive migrations silently regress custom-sized elements". This is the third instance.

`MobileNav` is unaffected: it is a horizontal icon row with its own classes and does not use `navItemClass`.

## Owner verification of PR #2524, same session

Confirmed on the live box at v5.11.18: URLs render on one line, the table scrolls horizontally instead of crushing columns, the app-leaving group carries its divider and "Opens in a new tab" label, and mobile now shows the same destinations as desktop. The alignment above was the one defect found.

## Gates

`npm run lint` 0 errors (460 warnings, unchanged) · `typecheck` clean · `check:arch` ratchet held at baseline · `npm test` 5244 passed / 1 skipped.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
