### PR TITLE
fix: stop silent config loss, surface degraded RAID and a filling /boot, gate GPU limits

### DIFF
--- a/assists/create-service.md
+++ b/assists/create-service.md
@@ -60,18 +60,63 @@ proxy host at `<sub>.<PUBLIC_DOMAIN>`:
   `footgun-forward-auth-acme-collision`.
 
 ## Ordered actions
-1. **Image** — build + push it; confirm the box can `podman pull` it.
-2. **Place the template** — push to a template registry, OR drop it under
+1. **Bootstrap the repo against the standards catalog** — *before* the stack, the
+   CI, the storage engine or the auth design. Call `get_service_standards`
+   (flavor `servicebay`), read every id in its `assistsToRead` via
+   `get_assist(id)`, and write the pointer block below into the new repo's
+   `CLAUDE.md` so the next agent in that repo finds the catalog too:
+   `npm run standards:bootstrap -- --write <repo>` (verify with `-- --check <repo>`).
+   **If the ServiceBay MCP is not connected in this session, stop and say so** —
+   an unconnected session cannot see the ADRs, so its stack/CI/auth choices are
+   guesses (#2513: exactly how a sibling repo shipped without SSO awareness,
+   without a health endpoint, and with a CI that didn't gate on tests).
+2. **Image** — build + push it; confirm the box can `podman pull` it.
+3. **Place the template** — push to a template registry, OR drop it under
    `/mnt/data/servicebay/local-templates/templates/<name>/` (survives reinstall,
    no git needed).
-3. **Install** — `POST /api/install/assemble` `{items:[{name,checked:true}],
+4. **Install** — `POST /api/install/assemble` `{items:[{name,checked:true}],
    prefilled:{...}, templateSource:"Local"}` → returns `{items, variables}` →
    `POST /api/install/start` `{source, input:{items, variables, wipeMode:"install",
    templateSource:"Local", host}}` → poll `/api/install/progress?jobId=…` until
    `phase:"done"`. (All accept a `lifecycle`-scoped `sb_` token.)
-4. **Verify** — healthcheck 200; `https://<sub>.<PUBLIC_DOMAIN>/` unauthenticated
+5. **Verify** — healthcheck 200; `https://<sub>.<PUBLIC_DOMAIN>/` unauthenticated
    returns **302 → auth.<domain>** (Authelia); the app's function works; and a
    request missing `Remote-User` is rejected (no SSO bypass).
+
+## The `CLAUDE.md` standards pointer (step 1, verbatim)
+
+Paste this into the new repo's `CLAUDE.md` — or let the script write it. It is
+generated from `packages/backend/src/lib/mcp/serviceRepoBootstrap.ts` and served
+by `get_service_standards` as its `repoBootstrap.claudeMdBlock`; the copy below
+is kept byte-identical by `npm run check:arch`, so all three can't drift.
+
+```markdown
+<!-- BEGIN SERVICEBAY STANDARDS POINTER (generated — do not edit by hand) -->
+
+## Standards: fetch them, never re-derive them
+
+This repo is built for a ServiceBay box, so **ServiceBay's standards catalog is
+the binding source of its architecture decisions** — this file only points at it.
+
+1. **Before the first stack, CI, storage, or auth decision**, call the ServiceBay
+   MCP tool `get_service_standards` (flavor `servicebay`) and fetch every id it
+   lists under `assistsToRead` via `get_assist(id)`. Read first, design second —
+   a stack chosen before reading is a stack chosen against the ADRs by accident.
+2. **If the ServiceBay MCP is not connected in this session, stop and say so.**
+   An unconnected session cannot see the ADRs, so anything it decides about auth,
+   health, storage, or CI is a guess. Connecting it is the first task, not an
+   optional extra.
+3. **The catalog wins.** Where this file and the catalog disagree, this file is
+   the stale one — fix it here, not in your head.
+4. **Report gaps back.** A missing, ambiguous, or wrong standard is itself a
+   finding: file a `standards-gap` issue on `mdopp/servicebay` and propose the
+   assist/docs fix. See `get_assist("report-standards-gaps")`.
+
+This block is generated. Regenerate or verify it from a `mdopp/servicebay`
+checkout: `npm run standards:bootstrap -- --write <repo>` / `-- --check <repo>`.
+
+<!-- END SERVICEBAY STANDARDS POINTER -->
+```
 
 ## Verify the proxy actually loaded
 The install log can say "proxy hosts ensured" while nginx reverted the conf.
@@ -87,6 +132,8 @@ with an SSL connect error (000).
 - Assist `service-ui-design-standard` — if the service has a frontend, adopt
   ServiceBay's design tokens (palette/accent, radii, typography, spacing) + the
   UX baseline (styled large file picker, streaming progress, responsive/mobile,
-  focus states) so it looks and behaves like ServiceBay.
+  focus states) so it looks and behaves like ServiceBay. Its companion
+  `service-ui-user-language` covers what the UI *says* — state texts in the
+  user's language, no CLI/env/header names in rendered HTML.
 - `docs/TEMPLATE_AUTHORING.md`, `templates/CLAUDE.md` — the full template contract.
 - Worked examples in-repo: `templates/file-share/` (forward-auth), `templates/vaultwarden/` (OIDC).

--- a/assists/footgun-vaultwarden-personal-vault-write.md
+++ b/assists/footgun-vaultwarden-personal-vault-write.md
@@ -1,0 +1,75 @@
+---
+title: You cannot write into a personal Vaultwarden/Bitwarden vault with an API key
+whenToUse: You are about to build automation that pushes credentials into Vaultwarden (or Bitwarden) — a sync job, an install hook, a "store this password for the user" feature.
+kind: footgun
+tags: [vaultwarden, bitwarden, credentials, secrets, api, sync, password-manager]
+---
+
+# Writing into a Vaultwarden vault is not an API-key problem
+
+The obvious plan — "issue an API key, POST the login item, done" — does not work
+for a **personal** vault, and the failure is at the protocol level, not a config
+you can flip. Establish this *before* designing the feature; it changes the shape
+of the whole thing.
+
+## What an API key actually gets you
+
+A personal API key (`client_id` / `client_secret`) exchanges for an access token
+via `grant_type=client_credentials` on `/identity/connect/token`. That token
+**authenticates** you. It does **not** unlock the vault.
+
+Vault items are encrypted client-side with a symmetric user key. The user key is
+itself wrapped by a key derived from the **master password** (PBKDF2/Argon2 over
+password + email). The server never sees either. So to create an item that the
+web vault can later read, the writer must possess the master password (or a
+session key derived from it in a prior unlock).
+
+The Bitwarden CLI states the same thing operationally: `bw login --apikey`
+succeeds and leaves the vault **locked**; you still need `bw unlock` with the
+master password before `bw create item` works. Vaultwarden reimplements this
+protocol, so it behaves identically.
+
+Two dead ends worth naming so nobody re-explores them:
+
+- **The admin API is not a way in.** `/admin` (behind `ADMIN_TOKEN`) manages
+  users, orgs, collections and policies. It cannot create cipher items — there is
+  no server-side path to a decryptable item, by design.
+- **Posting plaintext "works" and is worse.** Vaultwarden stores cipher fields as
+  opaque strings and will accept an unencrypted `name`/`password`. The web vault
+  then fails to decrypt them — you get garbage rows in the user's real vault
+  rather than an error you can catch.
+- **SSO does not help.** Vaultwarden's OIDC login still requires the master
+  password to decrypt the vault; there is no Key Connector equivalent.
+
+## The consequence for design
+
+There are exactly two shapes, and the choice is the operator's, not yours:
+
+1. **A dedicated service account.** Generate a master password for an account
+   your system owns, hold it as a `type: "secret"` variable, unlock per sync, and
+   write into an **organization collection** shared with the humans. Blast radius
+   is bounded: that vault holds only what the automation put there. This is the
+   only shape with real automated writes.
+2. **No server-side write.** Export (Bitwarden CSV) + the vault's import
+   deep-link, but make it **tracked**: persist a per-entry `securedAt` marker, and
+   have the hand-off confirmation drop your local copy of the secret in the *same
+   write* so "secured" and "we still hold it" are never both true. Repeat
+   installs/rotations replace the entries and therefore clear the marker, which is
+   the honest state: the fresh secret is not in the vault yet.
+
+**Never take the third option** — prompting for, storing, caching or deriving the
+*operator's own* master password. It replaces one credential-hoarding problem
+with a strictly worse one: that secret unlocks everything else in their vault too,
+not just what you put there.
+
+Shape 2 is a real deliverable on its own: dropping the password column and
+tracking hand-off state is most of the security win, and its state model is the
+same one shape 1 would write into later.
+
+## Reference in this repo
+
+- `packages/backend/src/lib/stackInstall/credentialsManifest.ts` — `Credential.securedAt`,
+  `markCredentialsSecured`, `summarizeCredentialSecurity`.
+- `packages/frontend/src/app/api/system/credentials/secured/route.ts` — the
+  hand-off confirmation that drops the local secrets.
+- `templates/vaultwarden/` — the deployed instance. Note it sets no `ADMIN_TOKEN`.

--- a/assists/new-service-architecture.md
+++ b/assists/new-service-architecture.md
@@ -10,6 +10,17 @@ tags: [architecture, adr, new-service, language, libraries, tests, storage, secr
 Recommended defaults, not mandates — deviate when you have a reason, and say why.
 These sit on top of the platform ADRs in `docs/adr/` (respect those; see bottom).
 
+## Step 0 — fetch the standards before you decide anything (#2513)
+
+Every recommendation below assumes you have read the catalog. Call
+`get_service_standards` (flavor `servicebay`) first, follow its `repoBootstrap`
+block, and write the generated pointer into the new repo's `CLAUDE.md`
+(`npm run standards:bootstrap -- --write <repo>` in a `mdopp/servicebay`
+checkout). A repo that starts without that pointer has no link back to the ADRs,
+and the next agent working in it re-derives — wrongly — decisions that were
+already made. **If the ServiceBay MCP is not connected in this session, stop and
+say so** rather than guessing at auth, health, storage, or CI.
+
 An architecture recommendation must say **how** a need is solved — and the first
 decision is **where it lives**. Only then do language/structure/etc. follow.
 
@@ -67,6 +78,12 @@ The app should be: **stateless-restartable** (all state on a mounted volume),
   **real streaming progress** for long ops (not a bare spinner; reconnect by
   server job id, not localStorage), responsive/mobile layout, and visible focus
   states. See `service-ui-design-standard`.
+- **Speak the user's language, and test it.** Looking native isn't enough: every
+  rendered state text answers *what can the user do next*, and CLI commands,
+  env-var names and HTTP header names never reach rendered HTML — enforce that
+  with a test in your own suite, not a review habit. This applies
+  `docs/UX_PHILOSOPHY.md` §5 to a service frontend; see
+  `service-ui-user-language`.
 
 ## Recommended libraries
 - Lean over heavy: a minimal web framework + a good HTTP client, not a kitchen

--- a/assists/new-service-standards.md
+++ b/assists/new-service-standards.md
@@ -14,6 +14,24 @@ referenced `docs/` files directly. The `get_service_standards` MCP tool
 one-liners are scanned from `docs/adr/*.md` titles at runtime so they never
 drift from the source.
 
+## repoBootstrap — step 1, before any stack/CI/storage/auth choice
+
+A standard nobody consults is not a standard. So the first step of building a
+service repo is consulting this catalog, and the new repo carries the pointer
+back to it **from its first commit** (#2513):
+
+- Call `get_service_standards` (flavor `servicebay`) and read every id it lists
+  under `assistsToRead` via `get_assist(id)` **before** picking a stack, a CI
+  shape, a storage engine, or an auth design.
+- Write the generated pointer block into the new repo's `CLAUDE.md`:
+  `npm run standards:bootstrap -- --write <repo>`; verify with `-- --check <repo>`
+  (exit 1 when the pointer is missing or has drifted). The block itself is the
+  `repoBootstrap.claudeMdBlock` field of the tool's output and is reproduced
+  verbatim in the `create-service` recipe.
+- **If the ServiceBay MCP is not connected, stop and say so.** A session that
+  cannot reach the catalog cannot make these decisions; connecting it is the
+  first task, not an optional extra.
+
 ## mustRespectAdrs — the platform decisions a new service is bound by
 
 A new service does not get to re-litigate these. Read the one-liner, then the
@@ -50,6 +68,9 @@ opening a PR:
 - `create-service` — the concrete recipe to build and deploy a service repo
   behind SSO.
 - `servicebay-overview` — what the platform is and how the pieces fit together.
+- If the service has a UI: `service-ui-design-standard` (how it looks) **and**
+  `service-ui-user-language` (what it says — state texts in the user's language,
+  no CLI/env/header names in rendered HTML).
 - Footguns to skim: `footgun-forward-auth-acme-collision`,
   `footgun-subdomain-needs-public-domain`.
 

--- a/assists/service-ui-design-standard.md
+++ b/assists/service-ui-design-standard.md
@@ -7,6 +7,12 @@ tags: [ui, design, frontend, tokens, palette, typography, accessibility, ux, res
 
 # ServiceBay UI / design standard
 
+> **Scope:** this assist is *how it looks and behaves*. What the UI **says** —
+> state texts, empty states, onboarding conditions, settings grouping, and the
+> ban on CLI/env/header names in rendered HTML — is the companion standard
+> `service-ui-user-language`. A frontend that passes every rule here and fails
+> that one still gets rejected by the operator (#2514).
+
 A user-facing service should feel like it belongs to ServiceBay even though it
 lives on its own subdomain. This is the **descriptive** design language: copy the
 tokens below into your own stylesheet (CSS custom properties, a Tailwind theme, or

--- a/assists/service-ui-user-language.md
+++ b/assists/service-ui-user-language.md
@@ -1,0 +1,108 @@
+---
+title: Service UI language & state design — speak the user's language
+whenToUse: You're writing any text a service UI renders — status lines, empty states, error messages, onboarding, settings labels — and need the rule for who the reader is, what a state must offer, and what must never leak into rendered HTML.
+kind: guide
+tags: [ui, ux, language, copy, states, empty-state, onboarding, settings, frontend, standard]
+---
+
+# Service UI language & state design
+
+The companion to `service-ui-design-standard`. That one is about **how it
+looks** (tokens, palette, focus states, mobile); this one is about **what it
+says**. A service can pass every token rule and still be rejected by the
+operator because its status texts quote a CLI command, name an env variable, or
+describe a state the user cannot act on.
+
+## The principle already exists — this is how it applies to a service UI
+
+ServiceBay's own rule is **`docs/UX_PHILOSOPHY.md` §5 "User-facing language, not
+infra language"**, plus the locked decision *"Progress and capacity displays
+answer the household question"* in `docs/UX_DECISIONS.md`. Read those first —
+they carry the bad/good pairs and the reasoning, and they are the source this
+assist points at, not a parallel version of it. (Both ship inside the ServiceBay
+image under `/app/docs/`.)
+
+The short form: **the reader is a family-homelab operator, not the person who
+wrote the service.** They are deciding something household-shaped ("is this
+hung or normal?", "do I need a bigger disk?", "can I upload more photos?").
+Every rendered string exists to answer that.
+
+## What "honest status" means — and what it does not
+
+"Honest" is not "technically transparent". A builder who reads *be honest about
+state* as *print the state the code is in* ships exactly the UI this standard
+exists to prevent. Honest means: **do not claim success you don't have, and do
+not hide a stuck state** — it does not license leaking implementation nouns into
+the page.
+
+## The rules
+
+### 1. Every state text says what the user can do and what happens next
+
+A state that only reports the machine's condition is unfinished. Name the thing
+in the user's world, then the next step.
+
+- Bad: *"No batch entries found — run `python -m chronicle.compose`."*
+- Good: *"Nothing has been composed yet. New entries appear here within a few
+  minutes of the first import."* (…or a button that starts it.)
+
+### 2. Implementation nouns never reach rendered HTML — and that is test-enforced
+
+Banned in any string the browser renders: **CLI commands** (`python -m …`,
+`podman …`, `systemctl …`), **env-var names** (`SCREAMING_SNAKE_CASE`), **HTTP
+header names** (`Remote-User`, `X-Forwarded-*`), container/unit/table names, and
+file paths inside the container. They belong in logs and in a diagnostics panel,
+never in a user-facing state.
+
+Make it a test, not a review habit — the same way ServiceBay machine-enforces
+its token rule with `sb/no-raw-color-literal` (see
+`docs/ARCHITECTURE_INVARIANTS.md` § *UI-primitive and design-token reuse*). The
+cheap version, in the service's own suite:
+
+```
+render every page/state that has user-visible copy → assert the rendered text
+matches none of: /\b(python|podman|systemctl|docker|npm) /, /\b[A-Z][A-Z0-9]+_[A-Z0-9_]+\b/,
+/\b(Remote-User|X-Forwarded-[A-Za-z-]+)\b/
+```
+
+Keep the allow-list explicit and small (a product name like `PostgreSQL` is
+fine); a new leak then fails the suite instead of the operator's second review.
+
+### 3. A named action the user cannot trigger is a product gap, not a text problem
+
+If the empty state says "run the composer" and there is no button that runs the
+composer, the fix is the button, not a reword. Rewording it to "the composer has
+not run" ships the same dead end with better grammar. Either give the user the
+control, or state the automatic condition that will resolve it ("this runs every
+night; nothing to do").
+
+### 4. Onboarding shows while its condition holds, not only on virgin state
+
+Gating a wizard on "no data at all" means a real instance — one with a half-done
+setup, or one that got data before it got configured — never sees it. Gate on
+**the condition the wizard resolves** (no source configured, no destination
+picked) and hide it when that condition clears. Same rule ServiceBay applies to
+its own setup entry: visible while something is pending, hidden once acknowledged
+(`docs/UX_DECISIONS.md` § *Primary sidebar is a user-task list*).
+
+### 5. Settings group by user questions, not by config structure
+
+Group by *"what do I want to do?"* — not by which file or object the value lives
+in. A settings page that mirrors the config schema forces the user to learn the
+implementation to change one thing. (ServiceBay's own settings IA decision:
+goal-based groups with tiered disclosure, `docs/UX_DECISIONS.md`.)
+
+### 6. Progress and capacity answer the household question
+
+Raw counters (`7/12 images pulled`, `42.7 GB / 256 GB · 16.7%`) are the
+*details* view, not the headline. Lead with the decision the user is making
+("about 2 minutes to go", "~3 years of photos left at your current rate") and
+keep the raw numbers one expand away for whoever wants them.
+
+## Before you ship a frontend
+
+Read your own rendered strings as the operator: for each one, name the question
+it answers and the action it enables. Anything that fails that pass is either
+copy to rewrite, a control to add, or a line that belongs in the log. If a rule
+here was missing, ambiguous, or wrong when you needed it, report it back —
+`get_assist("report-standards-gaps")`.

--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -70,6 +70,25 @@ example.
 
 #### GPU passthrough (CDI)
 
+**Single-container pods only.** `podman kube play` silently ignores
+every `resources.limits` key outside cpu/memory, so a GPU limit in a
+multi-container Pod deploys perfectly — healthy unit, green
+`/healthz`, nothing in the logs — and runs on CPU (#1026, #2517).
+ServiceBay's only escape hatch is swapping the service to a
+`.container` Quadlet with `AddDevice=nvidia.com/gpu=all`, and a
+`.container` unit is one container per unit, so there is no equivalent
+for a Pod with two containers. **This is enforced, not advisory:**
+`validatePodManifest` rejects the manifest at install time (POST/PUT
+`/api/services` — so every wizard install, MCP `deploy_service`,
+`update_service_yaml`, and bundle import, whichever registry the
+template came from), and the consistency suite rejects it at PR time
+for templates shipped here.
+
+If your service needs a GPU *and* sidecars: give the GPU workload its
+own single-container service and share state with the others through a
+hostPath volume both mount. Do not add a second container to the pod
+that holds the GPU limit.
+
 Templates that benefit from a GPU (Ollama, Immich's ML, media
 transcoding) opt in via a Mustache-section-gated `resources` block:
 
@@ -94,9 +113,14 @@ transcoding) opt in via a Mustache-section-gated `resources` block:
 
 The Quadlet generator passes `resources.limits.nvidia.com/gpu` through
 to podman, which matches it against the host's CDI device registry.
-Hosts without a registered NVIDIA GPU fail-fast at unit start time
-with a clear error — there is no silent fallback to CPU once the
-operator opts in.
+On a single-container service the template's `post-deploy.py` then
+swaps the unit to a `.container` Quadlet carrying
+`AddDevice=nvidia.com/gpu=all`, which is what actually attaches the
+card; `ServiceManager.reconcileContainerQuadletShadow` retires the
+shadowing `.kube`/`.yml` on every redeploy so the swap survives
+(#2174). Without that swap the limit is dropped and the container runs
+on CPU with no error — which is why the multi-container shape above is
+refused outright rather than deployed.
 
 Worked reference: `templates/ollama/`.
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:e2e": "playwright test --config tests/e2e/playwright.config.ts",
     "browser:sandbox": "tsx scripts/provision-browser-sandbox.ts",
     "gen-template-docs": "tsx scripts/gen-template-docs.ts",
+    "standards:bootstrap": "tsx scripts/bootstrap-service-repo.ts",
     "sb-config-upload": "tsx scripts/sb-config-upload.ts",
     "disk-import": "tsx scripts/disk-import.ts",
     "check:invariants": "tsx scripts/check-invariants.ts",

--- a/packages/api-client/src/lib-types.ts
+++ b/packages/api-client/src/lib-types.ts
@@ -19,6 +19,7 @@ export type {
   Credential,
   CredentialUrlHost,
   CredentialUrlContext,
+  CredentialSecuritySummary,
 } from '@/lib/stackInstall/credentialsManifest';
 export type {
   ServiceBundle,

--- a/packages/api-client/src/lib-utils.ts
+++ b/packages/api-client/src/lib-utils.ts
@@ -20,6 +20,8 @@ export {
   buildBitwardenCsv,
   resolveCredentialUrl,
   isHttpUrl,
+  isCredentialSecured,
+  summarizeCredentialSecurity,
 } from '@/lib/stackInstall/credentialsManifest';
 export {
   generateBundleStackArtifacts,

--- a/packages/backend/src/lib/capabilities/credentials.test.ts
+++ b/packages/backend/src/lib/capabilities/credentials.test.ts
@@ -120,6 +120,40 @@ describe('credentials.handleInstalled', () => {
     expect(creds.find(c => (c as { template?: string }).template === 'immich')).toBeTruthy();
   });
 
+  it('resets a previously-secured entry to not-yet-secured on re-install (#2519)', async () => {
+    // The operator handed this off to Vaultwarden, so ServiceBay dropped
+    // the secret. A re-install brings a fresh one — ServiceBay cannot know
+    // whether it changed, so the entry must go back to "not yet secured"
+    // rather than claiming the vault already has this value.
+    mockConfig = {
+      installManifest: {
+        savedAt: '2026-08-01T00:00:00.000Z',
+        credentials: [
+          { service: 'immich OIDC client_secret', url: 'https://auth.dopp.cloud', username: 'immich', password: '', importance: 'system', template: 'immich', securedAt: '2026-08-01T00:00:00.000Z' } as never,
+          { service: 'vaultwarden OIDC client_secret', url: 'https://auth.dopp.cloud', username: 'vaultwarden', password: '', importance: 'system', template: 'vaultwarden', securedAt: '2026-08-01T00:00:00.000Z' } as never,
+        ],
+      },
+    };
+    const r = await handleInstalled({
+      kind: 'feature.installed', template: 'immich', manifest: MANIFEST,
+      variables: [
+        { name: 'PUBLIC_DOMAIN', value: 'dopp.cloud' },
+        oidcSubdomainVar('immich', 'IMMICH_SUBDOMAIN', 'immich', 'IMMICH_SSO_SECRET'),
+        { name: 'IMMICH_SSO_SECRET', value: 'rotated' },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    const creds = mockConfig.installManifest!.credentials;
+    const immich = creds.find(c => (c as { template?: string }).template === 'immich');
+    const vault = creds.find(c => (c as { template?: string }).template === 'vaultwarden');
+    expect(immich?.password).toBe('rotated');
+    expect((immich as { securedAt?: string }).securedAt).toBeUndefined();
+    // An untouched template keeps its hand-off state.
+    expect((vault as { securedAt?: string }).securedAt).toBe('2026-08-01T00:00:00.000Z');
+    // Still one entry per template — an update, not a duplicate.
+    expect(creds.filter(c => (c as { template?: string }).template === 'immich')).toHaveLength(1);
+  });
+
   it('no-ops when builder produces no entries', async () => {
     const r = await handleInstalled({
       kind: 'feature.installed', template: 'noop', manifest: MANIFEST,

--- a/packages/backend/src/lib/config.ts
+++ b/packages/backend/src/lib/config.ts
@@ -611,6 +611,13 @@ export interface InstalledCredential {
   password: string;
   importance: 'critical' | 'system';
   notes?: string;
+  /**
+   * #2519 — ISO timestamp of the Vaultwarden hand-off. Set ⇒ the secret
+   * lives in the operator's vault and `password` here is empty. Absent ⇒
+   * ServiceBay is still the only copy, and Settings marks it "not yet
+   * secured". See `stackInstall/credentialsManifest.ts`.
+   */
+  securedAt?: string;
 }
 
 export interface InstallManifest {

--- a/packages/backend/src/lib/diagnose/groupForProbe.test.ts
+++ b/packages/backend/src/lib/diagnose/groupForProbe.test.ts
@@ -25,6 +25,10 @@ describe('groupForProbe (#1534 problem-domain grouping)', () => {
       cert_expiry: 'tls',
       sso_verify: 'sso',
       disk: 'storage-backups',
+      // #2526 — a degraded array is a storage problem, so it rides the
+      // prominent "Storage & backups" card, NOT the collapsed system-info
+      // panel where an operator would never trip over it.
+      raid: 'storage-backups',
       nas_backup_reachable: 'storage-backups',
     };
     for (const [id, group] of Object.entries(cases)) {

--- a/packages/backend/src/lib/diagnose/probes/disk.ts
+++ b/packages/backend/src/lib/diagnose/probes/disk.ts
@@ -1,8 +1,10 @@
 /**
  * `disk` probe action — registers the `show_largest_dirs` handler so
  * the operator can find what's eating /mnt/data when the probe says
- * "above 90%". The detection lives inline in the diagnose route
- * (parses `df -h /mnt/data`); this file only contributes the action.
+ * "above 90%". The detection lives in `diskFill.ts` (which watches
+ * /mnt/data, /boot and / — see #2527); this file only contributes the
+ * action, and only /mnt/data offers it: the other two are reclaimed by
+ * deleting kernels and images, which ServiceBay deliberately won't do.
  *
  * Returns the top 10 directories under /mnt/data sorted by size as
  * multi-line `details`, which the UI renders as a code block under

--- a/packages/backend/src/lib/diagnose/probes/diskFill.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/diskFill.test.ts
@@ -1,0 +1,276 @@
+/**
+ * `disk` probe (#2527).
+ *
+ * Every fixture is real `df -P -B1` output shape, and the byte counts in the
+ * NEAR_FULL one are the numbers measured on the box that filed the issue:
+ * a 350 MiB usable /boot at 91% with ~56 MiB free, a 2 TB data array at 64%,
+ * and a 238 GiB root at 14%. That combination is the whole point of the
+ * change — the only filesystem that was watched before is the only one that
+ * is fine.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseDiskFill,
+  evaluateDiskFill,
+  formatBytes,
+  MONITORED_FILESYSTEMS,
+  DISK_FILL_COMMAND,
+} from './diskFill';
+
+/** The reference box: /boot critically low, everything else healthy. */
+const NEAR_FULL_BOOT = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 308402176 58467328 91% /boot
+/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+`;
+
+/** The same box after `rpm-ostree cleanup -bm` reclaimed one deployment. */
+const HEALTHY = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
+/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+`;
+
+/** /boot in the early-warning band: one kernel image no longer fits. */
+const BOOT_TIGHT = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 261000000 105869504 71% /boot
+/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+`;
+
+/** No /boot partition at all — a container/dev target. `df` prints nothing
+ *  for it, so the line comes back with an empty right-hand side. */
+const NO_BOOT_PARTITION = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/boot|
+/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+`;
+
+/** /boot exists as a plain directory on the root filesystem — `df` answers
+ *  with the root row, same device. */
+const BOOT_ON_ROOT = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/boot|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+`;
+
+/** The array never assembled — the pre-existing "not mounted yet" case. */
+const NO_DATA_MOUNT = `/mnt/data|
+/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
+/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+`;
+
+/** Root nearly gone: image pulls and journald are about to fail. */
+const ROOT_CRITICAL = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
+/|/dev/nvme1n1p4 255455465472 254800000000 655465472 99% /
+`;
+
+/** Data array full, boot and root fine — the pre-#2527 behaviour, unchanged. */
+const DATA_FULL = `/mnt/data|/dev/md127 1999285899264 1899321604300 99964294964 95% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
+/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+`;
+
+describe('DISK_FILL_COMMAND', () => {
+  it('asks about all three filesystems, in exact bytes', () => {
+    expect(DISK_FILL_COMMAND).toContain('/mnt/data');
+    expect(DISK_FILL_COMMAND).toContain('/boot');
+    // -B1 not -h: on /boot the whole signal is an absolute byte count that
+    // -h would have rounded away.
+    expect(DISK_FILL_COMMAND).toContain('-B1');
+    expect(DISK_FILL_COMMAND).toContain('-P');
+  });
+});
+
+describe('parseDiskFill', () => {
+  it('parses a df row into exact byte counts', () => {
+    const rows = parseDiskFill(NEAR_FULL_BOOT);
+    expect(rows).toHaveLength(3);
+    const boot = rows.find(r => r.path === '/boot')!;
+    expect(boot.present).toBe(true);
+    expect(boot.device).toBe('/dev/nvme1n1p3');
+    expect(boot.totalBytes).toBe(366869504);
+    expect(boot.usedBytes).toBe(308402176);
+    expect(boot.freeBytes).toBe(58467328);
+    expect(boot.usedPct).toBe(91);
+    expect(boot.mountpoint).toBe('/boot');
+  });
+
+  it('keeps the requested path distinct from the mountpoint (CoreOS symlinks /mnt to /var/mnt)', () => {
+    const data = parseDiskFill(NEAR_FULL_BOOT).find(r => r.path === '/mnt/data')!;
+    expect(data.mountpoint).toBe('/var/mnt/data');
+    expect(data.present).toBe(true);
+  });
+
+  it('marks a path df returned nothing for as absent instead of dropping it', () => {
+    const rows = parseDiskFill(NO_BOOT_PARTITION);
+    expect(rows.map(r => r.path)).toEqual(['/mnt/data', '/boot', '/']);
+    expect(rows.find(r => r.path === '/boot')!.present).toBe(false);
+  });
+
+  it('survives garbage without throwing', () => {
+    expect(() => parseDiskFill('nonsense\n|\n/boot|not a df row')).not.toThrow();
+    expect(parseDiskFill('/boot|not a df row')[0].present).toBe(false);
+  });
+});
+
+describe('formatBytes', () => {
+  it('renders the sizes an operator has to compare', () => {
+    expect(formatBytes(58467328)).toBe('55.8 MiB');
+    expect(formatBytes(128 * 1024 * 1024)).toBe('128 MiB');
+    expect(formatBytes(221072547840)).toBe('206 GiB');
+    expect(formatBytes(1999285899264)).toBe('1.8 TiB');
+  });
+});
+
+describe('evaluateDiskFill — thresholds match what each filesystem is for', () => {
+  it('the numbers are per-filesystem, not one global percentage', () => {
+    const boot = MONITORED_FILESYSTEMS.find(f => f.path === '/boot')!;
+    const data = MONITORED_FILESYSTEMS.find(f => f.path === '/mnt/data')!;
+    // /boot is judged on absolute headroom only — a percentage on a 350 MiB
+    // partition is meaningless.
+    expect(boot.warnUsedPct).toBeNull();
+    expect(boot.warnFreeBytes).toBe(128 * 1024 * 1024);
+    expect(boot.failFreeBytes).toBe(64 * 1024 * 1024);
+    // /mnt/data is judged on percentage only — a byte floor on a 2 TB array
+    // would either never fire or fire constantly.
+    expect(data.warnFreeBytes).toBeNull();
+    expect(data.warnUsedPct).toBe(90);
+  });
+
+  it('offers a fix button only where ServiceBay may safely act', () => {
+    const byPath = Object.fromEntries(MONITORED_FILESYSTEMS.map(f => [f.path, f.actionIds]));
+    expect(byPath['/mnt/data']).toEqual(['show_largest_dirs']);
+    // Reclaiming these means deleting kernels / images — operator decisions.
+    expect(byPath['/boot']).toEqual([]);
+    expect(byPath['/']).toEqual([]);
+  });
+});
+
+describe('evaluateDiskFill — near-full /boot', () => {
+  const result = evaluateDiskFill(NEAR_FULL_BOOT, 0);
+
+  it('fails rather than staying silent on the box that filed the issue', () => {
+    // 55.8 MiB free is under half a kernel image: the next rpm-ostree
+    // upgrade cannot stage a boot entry from here.
+    expect(result.status).toBe('fail');
+  });
+
+  it('names the consequence, not just the number', () => {
+    expect(result.detail).toContain('/boot');
+    expect(result.detail).toContain('91% used');
+    expect(result.detail).toContain('55.8 MiB free');
+    expect(result.detail).toMatch(/next OS update will fail/);
+    expect(result.detail).toMatch(/unable to boot/);
+  });
+
+  it('tells the operator what to do, and that ServiceBay will not do it', () => {
+    expect(result.hint).toContain('rpm-ostree cleanup -bm');
+    expect(result.hint).toMatch(/ServiceBay will not delete kernels/);
+  });
+
+  it('surfaces /boot as its own row with no one-click fix', () => {
+    expect(result.items).toHaveLength(1);
+    const [item] = result.items!;
+    expect(item.id).toBe('/boot');
+    expect(item.status).toBe('fail');
+    expect(item.actionIds).toEqual([]);
+  });
+
+  it('leads with the unhealthy filesystem so it is not below the fold', () => {
+    expect(result.detail.split('\n')[0]).toContain('/boot');
+  });
+
+  it('does not drag the healthy filesystems into the warning', () => {
+    expect(result.items!.map(i => i.id)).not.toContain('/mnt/data');
+    expect(result.detail).toContain('/mnt/data — 64% used');
+    expect(result.detail).toContain('/ — 14% used');
+  });
+});
+
+describe('evaluateDiskFill — the early-warning band', () => {
+  it('warns while the operator can still act, before the failing band', () => {
+    // ~101 MiB free: under one kernel image (warn) but above the 64 MiB
+    // floor (fail). This is the window the issue says has to exist.
+    const result = evaluateDiskFill(BOOT_TIGHT, 0);
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('/boot');
+    expect(result.hint).toContain('rpm-ostree cleanup -bm');
+    expect(result.items!.map(i => i.status)).toEqual(['warn']);
+  });
+});
+
+describe('evaluateDiskFill — healthy partitions produce no noise', () => {
+  const result = evaluateDiskFill(HEALTHY, 0);
+
+  it('is ok with no hint and no items', () => {
+    expect(result.status).toBe('ok');
+    expect(result.hint).toBeUndefined();
+    expect(result.items).toBeUndefined();
+  });
+
+  it('still reports every filesystem it looked at', () => {
+    expect(result.detail).toContain('/mnt/data — 64% used');
+    expect(result.detail).toContain('/boot — 42% used');
+    expect(result.detail).toContain('/ — 14% used');
+  });
+
+  it('does not warn about a 91%-shaped /mnt/data threshold applied to /boot', () => {
+    // 42% on /boot is 204 MiB free — above the headroom floor. A naive
+    // percentage rule would agree here; the point is that it also has to
+    // agree at 71% (BOOT_TIGHT), where it does not.
+    expect(evaluateDiskFill(BOOT_TIGHT, 0).status).not.toBe('ok');
+  });
+});
+
+describe('evaluateDiskFill — missing partitions', () => {
+  it('treats an absent /boot as information, not a problem', () => {
+    const result = evaluateDiskFill(NO_BOOT_PARTITION, 0);
+    // `info`, not `warn`/`fail` — diagnoseStatusToCheckStatus collapses it to
+    // a passing check, so a box with no /boot never nags. Same call the raid
+    // probe makes for a box with no md array.
+    expect(result.status).toBe('info');
+    expect(['warn', 'fail']).not.toContain(result.status);
+    expect(result.detail).toContain('/boot is not a separate partition');
+    expect(result.items).toBeUndefined();
+    expect(result.hint).toBeUndefined();
+  });
+
+  it('counts a /boot that shares the root filesystem under / instead of judging it by kernel-sized rules', () => {
+    const result = evaluateDiskFill(BOOT_ON_ROOT, 0);
+    expect(['warn', 'fail']).not.toContain(result.status);
+    expect(result.detail).toContain('/boot is not a separate partition');
+    expect(result.detail).toContain('counted under / below');
+    // The root's own 14%/206 GiB row is what gets judged, and it is healthy.
+    expect(result.items).toBeUndefined();
+  });
+
+  it('keeps the pre-existing "data array not mounted" warning', () => {
+    const result = evaluateDiskFill(NO_DATA_MOUNT, 0);
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('/mnt/data is not mounted');
+    expect(result.detail).toContain('first-boot RAID setup');
+  });
+
+  it('reports an unreadable df honestly rather than as empty filesystems', () => {
+    const result = evaluateDiskFill('', 1);
+    expect(result.status).toBe('info');
+    expect(result.detail).toContain('unknown');
+    expect(evaluateDiskFill('', 0).status).toBe('info');
+  });
+});
+
+describe('evaluateDiskFill — the other two filesystems', () => {
+  it('fails a root filesystem with under a GiB left', () => {
+    const result = evaluateDiskFill(ROOT_CRITICAL, 0);
+    expect(result.status).toBe('fail');
+    expect(result.items!.map(i => i.id)).toEqual(['/']);
+    expect(result.detail).toMatch(/Container image pulls, system logs and OS updates all fail/);
+    expect(result.hint).toContain('podman image prune');
+  });
+
+  it('keeps the /mnt/data 90% behaviour it had before, with its fix button', () => {
+    const result = evaluateDiskFill(DATA_FULL, 0);
+    expect(result.status).toBe('warn');
+    expect(result.items).toHaveLength(1);
+    expect(result.items![0].id).toBe('/mnt/data');
+    expect(result.items![0].actionIds).toEqual(['show_largest_dirs']);
+    expect(result.hint).toContain('Show largest directories');
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/diskFill.ts
+++ b/packages/backend/src/lib/diagnose/probes/diskFill.ts
@@ -1,0 +1,360 @@
+/**
+ * `disk` probe (#2527) — how full is every filesystem the box actually
+ * depends on, not just the data array.
+ *
+ * Until now this probe read `df -h /mnt/data` and nothing else, so the two
+ * filesystems whose exhaustion is *unrecoverable* were unwatched. `/boot`
+ * filled to 91% (~33 MB free) on a live CoreOS box and nothing said a word:
+ * a `/boot` too full to stage the next kernel leaves `rpm-ostree upgrade`
+ * failing, and a failure partway through leaves the box without a bootable
+ * entry. `/mnt/data` running out costs you writes; `/boot` running out can
+ * cost you the box.
+ *
+ * ## Why the thresholds are not one number
+ *
+ * A percentage tuned for a multi-terabyte array is meaningless on a
+ * fingernail-sized partition. On the reference box `/boot` is a **350 MiB**
+ * usable ext4 partition (Fedora CoreOS lays down 384 MiB), so 91% there is
+ * ~33-56 MiB — **less than a single kernel image**. "Warn at 90%" would have
+ * fired only once the box was already past saving, while "warn at 80%" on a
+ * 2 TB `/mnt/data` would page someone about 400 GB of free space.
+ *
+ * So each filesystem is measured against what it is *for*:
+ *
+ *   * `/boot` — **absolute headroom only.** What matters is whether one more
+ *     kernel + initramfs pair fits, and that cost is a fixed ~100-150 MiB
+ *     regardless of how big the partition is.
+ *   * `/` — **absolute headroom, with a percentage backstop.** It carries the
+ *     ostree repo, container images and journals; the things that fail are
+ *     GB-scale, but the root partition size varies enough between installs
+ *     that a percentage is still worth keeping as a slow-growth signal.
+ *   * `/mnt/data` — **percentage.** It is a bulk store whose whole job is to
+ *     be mostly full; the operator cares about the trend, not a byte count,
+ *     and nothing is bricked by it filling.
+ *
+ * Detection is a plain `df` read (see `DISK_FILL_COMMAND`). The parse and the
+ * verdict are pure functions so every shape — near-full, healthy, and a
+ * partition that isn't there — is unit-testable without a host. **This probe
+ * only reports; it never frees space.** Reclaiming `/boot` means deleting
+ * kernels (`rpm-ostree cleanup -bm`), which is an operator decision, so the
+ * rows here carry no one-click fix — the same call the `raid` probe makes.
+ */
+
+import type { ProbeItem } from '../actions';
+
+export const PROBE_ID = 'disk';
+export const PROBE_LABEL = 'Storage (/mnt/data, /boot, /)';
+
+const MiB = 1024 * 1024;
+const GiB = 1024 * MiB;
+
+export type DiskProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
+
+/**
+ * One `df` invocation per watched path, each line prefixed with the path we
+ * asked about. The prefix is what makes a *missing* partition legible: `df`
+ * writes its complaint to stderr and prints no row, so the line comes back
+ * as a bare `"/boot|"` rather than silently vanishing into a shorter list.
+ * `-P` pins the POSIX one-line-per-filesystem layout and `-B1` gives exact
+ * bytes, because the whole point on `/boot` is an absolute number that `-h`
+ * would have already rounded away.
+ */
+export const DISK_FILL_COMMAND =
+  'for p in /mnt/data /boot /; do echo "$p|$(df -P -B1 "$p" 2>/dev/null | tail -1)"; done';
+
+/** What we watch, why, and the numbers — with the reasoning attached. */
+export interface MonitoredFilesystem {
+  /** Path handed to `df`. */
+  path: string;
+  /** One line: what lives here, for the operator who has never seen it. */
+  purpose: string;
+  /** Warn below this many free bytes; null = free space is not the signal. */
+  warnFreeBytes: number | null;
+  /** Fail below this many free bytes; null = no failing band. */
+  failFreeBytes: number | null;
+  /** Warn at or above this fill percentage; null = percentage is not the signal. */
+  warnUsedPct: number | null;
+  /** What actually breaks — stated as a consequence, not a metric. */
+  consequence: string;
+  /** What the operator does about it. */
+  remedy: string;
+  /** Probe actions offered on the row. Empty = deliberately read-only. */
+  actionIds: string[];
+  /** Status when the path is not a filesystem on this box at all. */
+  absentStatus: DiskProbeStatus;
+  /** Detail for that case. */
+  absentDetail: string;
+}
+
+export const MONITORED_FILESYSTEMS: MonitoredFilesystem[] = [
+  {
+    path: '/mnt/data',
+    purpose: 'the data array — every service\'s persistent data and the local backups',
+    // Percentage, not bytes: this array is terabytes and is *meant* to run
+    // mostly full, so an absolute floor would either never fire or fire
+    // constantly depending on the box. 90% is the long-standing threshold
+    // and is left untouched — the point of this change is to add coverage,
+    // not to make the one filesystem that was already watched noisier.
+    warnFreeBytes: null,
+    failFreeBytes: null,
+    warnUsedPct: 90,
+    consequence: 'Services will start failing writes, and backups will stop completing, once it fills.',
+    remedy:
+      'Click "Show largest directories" below to find what to clean, or add a disk and extend the array.',
+    // The only row with a fix button: `du` is read-only and the cleanup that
+    // follows is ordinary file deletion the operator already does here.
+    actionIds: ['show_largest_dirs'],
+    absentStatus: 'warn',
+    absentDetail:
+      '/mnt/data is not mounted — first-boot RAID setup may still be running, or the array failed to assemble.',
+  },
+  {
+    path: '/boot',
+    purpose: 'the kernels and initramfs images the box boots from',
+    // ABSOLUTE ONLY, and small. Fedora CoreOS gives /boot a 384 MiB partition
+    // (~350 MiB usable) and keeps two deployments on it, so the numbers here
+    // are in the tens of megabytes and a percentage says nothing useful:
+    // the reference box sat at 91% with 56 MiB free, which is not "a bit
+    // tight", it is less than one kernel image.
+    //
+    // The unit that matters is a single deployment's boot payload — a vmlinuz
+    // (~15 MiB) plus its initramfs (~100-140 MiB), so call it ~150 MiB. That
+    // is the amount `rpm-ostree` must be able to write before it can stage
+    // the next update.
+    //
+    //   warn  < 128 MiB free — under roughly one kernel image. The next
+    //     update has no room to stage, but the box is still running fine and
+    //     the operator has time to reclaim space. This is deliberately the
+    //     *early* warning: it has to arrive while acting is still possible,
+    //     because by the time an update fails it is too late to have been
+    //     warned about it.
+    //   fail  < 64 MiB free — under half a kernel image. `rpm-ostree upgrade`
+    //     cannot write a new boot entry from here, and an update that dies
+    //     partway through is how a box ends up unbootable.
+    warnFreeBytes: 128 * MiB,
+    failFreeBytes: 64 * MiB,
+    warnUsedPct: null,
+    consequence:
+      'There is not enough room to stage the next kernel, so the next OS update will fail — and an update that fails partway through can leave the box unable to boot.',
+    remedy:
+      'Reclaim /boot from a shell on the box: `rpm-ostree status` shows the retained deployments, `sudo rpm-ostree cleanup -bm` drops the pending and rollback ones, and any kernel left behind by a past failed update has to go too. ServiceBay will not delete kernels for you — getting that wrong is what makes a box unbootable.',
+    // Read-only on purpose: the fix deletes boot entries.
+    actionIds: [],
+    absentStatus: 'info',
+    absentDetail: '/boot is not a separate partition on this box, so there is nothing to run out.',
+  },
+  {
+    path: '/',
+    purpose: 'the OS root — the ostree repo, container images, and system logs',
+    // Absolute floor first, percentage as a backstop. What fills / is
+    // GB-scale (a container image pull, a staged ostree deployment, journald),
+    // so the floor is expressed in GiB:
+    //   warn  < 5 GiB free — an ostree deployment plus an image pull no longer
+    //     comfortably fit; still plenty of time to act.
+    //   fail  < 1 GiB free — podman pulls, journald writes and OS updates all
+    //     start failing at around this point.
+    // The 90% backstop catches slow growth on a small root, where 5 GiB free
+    // would still be a large share of the disk.
+    warnFreeBytes: 5 * GiB,
+    failFreeBytes: 1 * GiB,
+    warnUsedPct: 90,
+    consequence:
+      'Container image pulls, system logs and OS updates all fail once the root filesystem fills.',
+    remedy:
+      'Reclaim it from a shell on the box: `podman image prune -a` drops unused images, `journalctl --vacuum-size=200M` trims logs, and `sudo rpm-ostree cleanup -bm` drops staged deployments.',
+    actionIds: [],
+    // `/` always exists; an absent row here means the read itself failed.
+    absentStatus: 'info',
+    absentDetail: 'Could not read the root filesystem, so its fill level is unknown.',
+  },
+];
+
+/** One filesystem as `df` reported it (or the fact that it did not). */
+export interface DfRow {
+  /** The path we asked `df` about — not necessarily the mountpoint. */
+  path: string;
+  /** False when `df` returned no row for this path. */
+  present: boolean;
+  /** The `Filesystem` column, e.g. `/dev/nvme1n1p3`. */
+  device: string;
+  totalBytes: number;
+  usedBytes: number;
+  freeBytes: number;
+  usedPct: number;
+  /** The `Mounted on` column — differs from `path` when the path is a
+   *  symlink (`/mnt/data` → `/var/mnt/data` on CoreOS) or not its own
+   *  filesystem at all. */
+  mountpoint: string;
+}
+
+/** `<device> <total> <used> <avail> <pct>% <mountpoint>` — the `df -P` row. */
+const DF_ROW = /^(.+?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+(.+)$/;
+
+/**
+ * Parse the `path|<df row>` lines produced by {@link DISK_FILL_COMMAND}.
+ * Tolerant by design — an unparseable line becomes `present: false` rather
+ * than throwing, because a parse hiccup must never take down the whole
+ * diagnose run (same call as the `raid` probe).
+ */
+export function parseDiskFill(raw: string): DfRow[] {
+  const rows: DfRow[] = [];
+  for (const line of (raw ?? '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const sep = trimmed.indexOf('|');
+    if (sep === -1) continue;
+    const path = trimmed.slice(0, sep).trim();
+    if (!path) continue;
+    const absent: DfRow = {
+      path,
+      present: false,
+      device: '',
+      totalBytes: 0,
+      usedBytes: 0,
+      freeBytes: 0,
+      usedPct: 0,
+      mountpoint: '',
+    };
+    const m = DF_ROW.exec(trimmed.slice(sep + 1).trim());
+    if (!m) {
+      rows.push(absent);
+      continue;
+    }
+    rows.push({
+      path,
+      present: true,
+      device: m[1],
+      totalBytes: Number.parseInt(m[2], 10),
+      usedBytes: Number.parseInt(m[3], 10),
+      freeBytes: Number.parseInt(m[4], 10),
+      usedPct: Number.parseInt(m[5], 10),
+      mountpoint: m[6].trim(),
+    });
+  }
+  return rows;
+}
+
+/** Sizes an operator reads at a glance; binary units, matching `df -h`. */
+export function formatBytes(bytes: number): string {
+  const units: [number, string][] = [
+    [1024 * GiB, 'TiB'],
+    [GiB, 'GiB'],
+    [MiB, 'MiB'],
+    [1024, 'KiB'],
+  ];
+  for (const [size, unit] of units) {
+    if (bytes >= size) {
+      const value = bytes / size;
+      return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${unit}`;
+    }
+  }
+  return `${bytes} B`;
+}
+
+export interface DiskFilesystemVerdict {
+  spec: MonitoredFilesystem;
+  row: DfRow | null;
+  status: DiskProbeStatus;
+  detail: string;
+}
+
+const SEVERITY: Record<DiskProbeStatus, number> = { ok: 0, info: 1, warn: 2, fail: 3 };
+
+function worst(a: DiskProbeStatus, b: DiskProbeStatus): DiskProbeStatus {
+  return SEVERITY[b] > SEVERITY[a] ? b : a;
+}
+
+function verdictFor(spec: MonitoredFilesystem, row: DfRow | undefined): DiskFilesystemVerdict {
+  if (!row || !row.present) {
+    return { spec, row: null, status: spec.absentStatus, detail: spec.absentDetail };
+  }
+
+  const numbers =
+    `${spec.path} — ${row.usedPct}% used, ${formatBytes(row.freeBytes)} free of ` +
+    `${formatBytes(row.totalBytes)} (${row.device})`;
+
+  let status: DiskProbeStatus = 'ok';
+  const reasons: string[] = [];
+  if (spec.failFreeBytes !== null && row.freeBytes < spec.failFreeBytes) {
+    status = 'fail';
+    reasons.push(`below the ${formatBytes(spec.failFreeBytes)} floor`);
+  } else if (spec.warnFreeBytes !== null && row.freeBytes < spec.warnFreeBytes) {
+    status = 'warn';
+    reasons.push(`below the ${formatBytes(spec.warnFreeBytes)} headroom this filesystem needs`);
+  }
+  if (spec.warnUsedPct !== null && row.usedPct >= spec.warnUsedPct) {
+    status = worst(status, 'warn');
+    reasons.push(`at or above ${spec.warnUsedPct}% full`);
+  }
+
+  if (status === 'ok') return { spec, row, status, detail: `${numbers}.` };
+  return { spec, row, status, detail: `${numbers} — ${reasons.join(' and ')}. ${spec.consequence}` };
+}
+
+export interface DiskFillResult {
+  status: DiskProbeStatus;
+  detail: string;
+  hint?: string;
+  items?: ProbeItem[];
+}
+
+/**
+ * Pure verdict over the raw {@link DISK_FILL_COMMAND} output. `execCode` is
+ * the exit code of the read itself, so an agent that could not run `df` is
+ * reported honestly rather than read as "every filesystem is empty".
+ */
+export function evaluateDiskFill(raw: string, execCode: number | undefined): DiskFillResult {
+  if (execCode !== 0) {
+    return { status: 'info', detail: 'Could not read disk usage, so fill levels are unknown.' };
+  }
+
+  const rows = parseDiskFill(raw);
+  if (rows.length === 0) {
+    return { status: 'info', detail: 'No df output — disk fill levels are unknown.' };
+  }
+
+  const byPath = new Map(rows.map(r => [r.path, r]));
+  const rootDevice = byPath.get('/')?.device;
+
+  const verdicts = MONITORED_FILESYSTEMS.map(spec => {
+    const row = byPath.get(spec.path);
+    // A path that is not its own partition lives on the root filesystem, so
+    // the root's thresholds are the ones that apply to it — measuring a
+    // 350 MiB-sized `/boot` rule against a 250 GB root would either never
+    // fire or fire on a box that is perfectly healthy. Report it as covered
+    // and evaluate it once, under `/`.
+    if (spec.path !== '/' && row?.present && rootDevice && row.device === rootDevice) {
+      return {
+        spec,
+        row,
+        status: 'info' as DiskProbeStatus,
+        detail: `${spec.path} is not a separate partition — it lives on the root filesystem, counted under / below.`,
+      };
+    }
+    return verdictFor(spec, row);
+  });
+
+  const overall = verdicts.reduce<DiskProbeStatus>((acc, v) => worst(acc, v.status), 'ok');
+  const unhealthy = verdicts.filter(v => v.status === 'warn' || v.status === 'fail');
+
+  if (unhealthy.length === 0) {
+    return { status: overall, detail: verdicts.map(v => v.detail).join('\n') };
+  }
+
+  return {
+    status: overall,
+    // Lead with what needs attention; a healthy sibling filesystem must not
+    // push the problem below the fold.
+    detail: [...unhealthy, ...verdicts.filter(v => !unhealthy.includes(v))]
+      .map(v => v.detail)
+      .join('\n'),
+    hint: unhealthy.map(v => `${v.spec.path}: ${v.spec.remedy}`).join('\n'),
+    items: unhealthy.map(v => ({
+      id: v.spec.path,
+      label: `${v.spec.path} — ${v.spec.purpose}`,
+      detail: v.detail,
+      status: v.status === 'fail' ? ('fail' as const) : ('warn' as const),
+      actionIds: v.spec.actionIds,
+    })),
+  };
+}

--- a/packages/backend/src/lib/diagnose/probes/raidDegraded.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/raidDegraded.test.ts
@@ -1,0 +1,193 @@
+/**
+ * `raid` probe (#2526).
+ *
+ * Every fixture below is verbatim-shaped `/proc/mdstat` output, not an
+ * invented format — the DEGRADED one mirrors the owner's box (single
+ * 1.8 TiB NVMe data disk, array created with `missing` in slot 1, running
+ * `[2/1] [U_]` since install), and the healthy/failed/rebuilding ones are
+ * the same layout with the member set the kernel would actually print.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseMdstat, evaluateRaidHealth } from './raidDegraded';
+
+/** The real shape on a box whose RAID1 was created with `missing`. */
+const MDSTAT_DEGRADED = `Personalities : [raid1]
+md127 : active raid1 nvme0n1p1[0]
+      1953381440 blocks super 1.2 [2/1] [U_]
+      bitmap: 0/15 pages [0KB], 65536KB chunk
+
+unused devices: <none>
+`;
+
+/** Same array once a second disk has been added and synced. */
+const MDSTAT_HEALTHY = `Personalities : [raid1]
+md127 : active raid1 nvme1n1p1[1] nvme0n1p1[0]
+      1953381440 blocks super 1.2 [2/2] [UU]
+      bitmap: 1/15 pages [4KB], 65536KB chunk
+
+unused devices: <none>
+`;
+
+/** A member the kernel kicked out — the case that really is a dead disk. */
+const MDSTAT_FAILED_MEMBER = `Personalities : [raid1]
+md127 : active raid1 nvme1n1p1[1](F) nvme0n1p1[0]
+      1953381440 blocks super 1.2 [2/1] [U_]
+      bitmap: 3/15 pages [12KB], 65536KB chunk
+
+unused devices: <none>
+`;
+
+/** A replacement disk syncing back in. */
+const MDSTAT_REBUILDING = `Personalities : [raid1]
+md127 : active raid1 nvme1n1p1[2] nvme0n1p1[0]
+      1953381440 blocks super 1.2 [2/1] [U_]
+      [==>..................]  recovery = 12.3% (240512/1953381440) finish=88.2min speed=369088K/sec
+      bitmap: 5/15 pages [20KB], 65536KB chunk
+
+unused devices: <none>
+`;
+
+/** A box with no md arrays at all (plain disk / LVM install). */
+const MDSTAT_NO_ARRAYS = `Personalities : [raid1]
+unused devices: <none>
+`;
+
+describe('parseMdstat', () => {
+  it('parses the degraded single-member array', () => {
+    const [array] = parseMdstat(MDSTAT_DEGRADED);
+    expect(array.device).toBe('md127');
+    expect(array.state).toBe('active');
+    expect(array.level).toBe('raid1');
+    expect(array.members).toEqual([{ name: 'nvme0n1p1', slot: 0, flags: [] }]);
+    expect(array.totalSlots).toBe(2);
+    expect(array.activeSlots).toBe(1);
+    expect(array.slotMap).toBe('U_');
+    expect(array.rebuilding).toBe(false);
+  });
+
+  it('parses the healthy two-member array', () => {
+    const [array] = parseMdstat(MDSTAT_HEALTHY);
+    expect(array.members.map(m => m.name)).toEqual(['nvme1n1p1', 'nvme0n1p1']);
+    expect(array.totalSlots).toBe(2);
+    expect(array.activeSlots).toBe(2);
+    expect(array.slotMap).toBe('UU');
+  });
+
+  it('reads the (F) flag off a kicked-out member', () => {
+    const [array] = parseMdstat(MDSTAT_FAILED_MEMBER);
+    expect(array.members.find(m => m.name === 'nvme1n1p1')?.flags).toEqual(['F']);
+  });
+
+  it('detects an in-progress recovery and keeps its progress line', () => {
+    const [array] = parseMdstat(MDSTAT_REBUILDING);
+    expect(array.rebuilding).toBe(true);
+    expect(array.rebuildDetail).toContain('recovery = 12.3%');
+  });
+
+  it('returns no arrays when the box has none', () => {
+    expect(parseMdstat(MDSTAT_NO_ARRAYS)).toEqual([]);
+  });
+
+  it('parses an inactive array with no personality', () => {
+    const [array] = parseMdstat('md0 : inactive nvme0n1p1[0](S)\n      1953381440 blocks super 1.2\n');
+    expect(array.state).toBe('inactive');
+    expect(array.level).toBeNull();
+    expect(array.members[0]).toEqual({ name: 'nvme0n1p1', slot: 0, flags: ['S'] });
+  });
+});
+
+describe('evaluateRaidHealth — degraded array', () => {
+  const result = evaluateRaidHealth(MDSTAT_DEGRADED, 0);
+
+  it('warns rather than staying silent', () => {
+    expect(result.status).toBe('warn');
+  });
+
+  it('names the array, the missing slot and the loss of redundancy', () => {
+    expect(result.detail).toContain('md127');
+    expect(result.detail).toContain('1 of 2 members present');
+    expect(result.detail).toContain('[U_]');
+    expect(result.detail).toMatch(/DEGRADED/);
+    expect(result.detail).toContain('slot 1 empty');
+  });
+
+  it('explains that the empty slot may be the deliberate `missing` member, not a dead disk', () => {
+    expect(result.hint).toContain('setup-raid.sh');
+    expect(result.hint).toContain('missing');
+    expect(result.hint).toContain('mdadm --detail');
+    expect(result.hint).toContain('Failed Devices: 0');
+  });
+
+  it('emits one row for the unhealthy array so the UI can list it', () => {
+    expect(result.items).toHaveLength(1);
+    expect(result.items?.[0]).toMatchObject({ id: 'md127', status: 'warn', actionIds: [] });
+  });
+});
+
+describe('evaluateRaidHealth — healthy array makes no noise', () => {
+  const result = evaluateRaidHealth(MDSTAT_HEALTHY, 0);
+
+  it('is ok', () => {
+    expect(result.status).toBe('ok');
+  });
+
+  it('carries no hint and no findings', () => {
+    expect(result.hint).toBeUndefined();
+    expect(result.items).toBeUndefined();
+  });
+
+  it('still reports the array so the operator can see it was checked', () => {
+    expect(result.detail).toContain('md127');
+    expect(result.detail).toContain('all members present');
+  });
+});
+
+describe('evaluateRaidHealth — other shapes', () => {
+  it('escalates a kernel-marked failed member to fail', () => {
+    const result = evaluateRaidHealth(MDSTAT_FAILED_MEMBER, 0);
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('nvme1n1p1');
+    expect(result.detail).toContain('FAILED');
+  });
+
+  it('reports a rebuild as a transient warn with its progress', () => {
+    const result = evaluateRaidHealth(MDSTAT_REBUILDING, 0);
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('rebuilding');
+    expect(result.detail).toContain('12.3%');
+  });
+
+  it('stays info-only on a box with no md arrays', () => {
+    const result = evaluateRaidHealth(MDSTAT_NO_ARRAYS, 0);
+    expect(result.status).toBe('info');
+    expect(result.hint).toBeUndefined();
+  });
+
+  it('says so honestly when /proc/mdstat could not be read', () => {
+    const result = evaluateRaidHealth('', 1);
+    expect(result.status).toBe('info');
+    expect(result.detail).toContain('Could not read /proc/mdstat');
+  });
+
+  it('reports an unassembled array as a failure', () => {
+    const result = evaluateRaidHealth('md0 : inactive nvme0n1p1[0](S)\n      1953381440 blocks super 1.2\n', 0);
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('inactive');
+  });
+
+  it('leads with the unhealthy array when a healthy one is also present', () => {
+    const both = `Personalities : [raid1]
+md126 : active raid1 sdb1[1] sda1[0]
+      488254464 blocks super 1.2 [2/2] [UU]
+
+md127 : active raid1 nvme0n1p1[0]
+      1953381440 blocks super 1.2 [2/1] [U_]
+
+unused devices: <none>
+`;
+    const result = evaluateRaidHealth(both, 0);
+    expect(result.status).toBe('warn');
+    expect(result.detail.split('\n')[0]).toContain('md127');
+    expect(result.items).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/raidDegraded.ts
+++ b/packages/backend/src/lib/diagnose/probes/raidDegraded.ts
@@ -1,0 +1,279 @@
+/**
+ * `raid` probe (#2526) — is the /mnt/data software-RAID array actually
+ * running with every member it declares?
+ *
+ * Nothing on the box surfaced this before. `mdmonitor` only fires on a
+ * *failure event*, so an array that was created without its second member
+ * never triggers it; the weekly `raid-check` reports `mismatch_cnt=0` on a
+ * degraded array and reads as "all fine"; and `df` (the `disk` probe) is
+ * happy because the filesystem mounts and has space. A box can therefore
+ * run with zero redundancy for months and look healthy from every angle.
+ *
+ * The added wrinkle is that ServiceBay *deliberately* creates the array
+ * degraded on a single-data-disk box: first-boot `setup-raid.sh`
+ * (`tools/sb/internal/build/assets/fedora-coreos.bu`) passes the literal
+ * keyword `missing` as the second member so a mirror can be added later
+ * without rebuilding. From outside, day-one-never-had-a-mirror and
+ * a-disk-died-last-night both render as `[2/1] [U_]`. So the probe does
+ * two things: it says the array has no redundancy, and it tells the
+ * operator how to tell those two apart before attempting a "repair" that
+ * can't work.
+ *
+ * Detection reads `/proc/mdstat` — the kernel's own view, no mdadm
+ * invocation and no privileges needed. The parse + verdict are pure
+ * functions so both shapes are unit-testable without a host.
+ */
+
+import type { ProbeItem } from '../actions';
+
+export const PROBE_ID = 'raid';
+export const PROBE_LABEL = 'RAID array';
+
+/** One member device line-item of an md array, as `/proc/mdstat` lists it. */
+export interface MdMember {
+  /** Block device name, e.g. `nvme0n1p1`. */
+  name: string;
+  /** Slot index from the `[N]` suffix, or null when unparseable. */
+  slot: number | null;
+  /** Single-letter flags from the trailing parens: `F` failed, `S` spare,
+   *  `W` write-mostly, `R` replacement. */
+  flags: string[];
+}
+
+/** One array block of `/proc/mdstat`. */
+export interface MdArray {
+  /** Kernel device name, e.g. `md127`. */
+  device: string;
+  /** `active` / `inactive` — the word right after the colon. */
+  state: string;
+  /** RAID personality (`raid1`, `raid5`, …), or null on an inactive array
+   *  that the kernel never assembled far enough to name one. */
+  level: string | null;
+  members: MdMember[];
+  /** Declared member count, from `[total/active]`. Null when the array has
+   *  no status line (inactive arrays often don't). */
+  totalSlots: number | null;
+  /** Members currently up, from `[total/active]`. */
+  activeSlots: number | null;
+  /** The `[U_]` map: `U` = slot up, `_` = slot down. Null when absent. */
+  slotMap: string | null;
+  /** A resync/recovery/reshape is in progress on this array. */
+  rebuilding: boolean;
+  /** The raw progress line when `rebuilding`, e.g.
+   *  `recovery = 12.3% (240512/1953381440) finish=88.2min speed=369088K/sec`. */
+  rebuildDetail: string | null;
+}
+
+/** `[total/active]` + `[UU_]` on the block-count line under an array header. */
+const STATUS_LINE = /\[(\d+)\/(\d+)\]\s+\[([U_]+)\]/;
+/** `recovery = 12.3% …` / `resync = …` / `reshape = …` / `check = …`. */
+const REBUILD_LINE = /\b(recovery|resync|reshape|check|repair)\s*=/;
+/** A member token: `nvme0n1p1[0]`, `sdb1[1](F)`, `sdc1[2](S)`. */
+const MEMBER_TOKEN = /^(.+?)\[(\d+)\]((?:\([A-Z]\))*)$/;
+
+function parseMember(token: string): MdMember | null {
+  const m = MEMBER_TOKEN.exec(token);
+  if (!m) return null;
+  const flags = (m[3].match(/\(([A-Z])\)/g) ?? []).map(f => f.slice(1, -1));
+  return { name: m[1], slot: Number.parseInt(m[2], 10), flags };
+}
+
+/**
+ * Parse `/proc/mdstat` into its array blocks. Tolerant by design: an
+ * unrecognised line is skipped rather than throwing, because this file's
+ * exact layout varies with personality, bitmap presence and kernel
+ * version, and a parse hiccup must never take down the diagnose run.
+ */
+export function parseMdstat(raw: string): MdArray[] {
+  const arrays: MdArray[] = [];
+  let current: MdArray | null = null;
+
+  for (const line of (raw ?? '').split('\n')) {
+    const header = /^(md\d+)\s*:\s*(.*)$/.exec(line.trim());
+    if (header) {
+      const tokens = header[2].split(/\s+/).filter(Boolean);
+      const state = tokens.shift() ?? 'unknown';
+      // `active (auto-read-only) raid1 …` — the parenthesised qualifier
+      // sits between the state and the personality.
+      if (tokens[0]?.startsWith('(')) tokens.shift();
+      // An inactive array may list members with no personality at all, so
+      // only treat the next token as the level when it isn't a member.
+      const level = tokens[0] && !MEMBER_TOKEN.test(tokens[0]) ? tokens.shift() ?? null : null;
+      current = {
+        device: header[1],
+        state,
+        level,
+        members: tokens.map(parseMember).filter((m): m is MdMember => m !== null),
+        totalSlots: null,
+        activeSlots: null,
+        slotMap: null,
+        rebuilding: false,
+        rebuildDetail: null,
+      };
+      arrays.push(current);
+      continue;
+    }
+
+    if (!current) continue;
+    // A blank line closes the array block (`unused devices:` etc. follow).
+    if (line.trim() === '') {
+      current = null;
+      continue;
+    }
+    const status = STATUS_LINE.exec(line);
+    if (status) {
+      current.totalSlots = Number.parseInt(status[1], 10);
+      current.activeSlots = Number.parseInt(status[2], 10);
+      current.slotMap = status[3];
+      continue;
+    }
+    if (REBUILD_LINE.test(line)) {
+      current.rebuilding = true;
+      current.rebuildDetail = line.trim().replace(/^\[[=>.]+\]\s*/, '');
+    }
+  }
+
+  return arrays;
+}
+
+/** Slot indices reported down by the `[U_]` map. */
+function downSlots(array: MdArray): number[] {
+  if (!array.slotMap) return [];
+  return [...array.slotMap].flatMap((c, i) => (c === '_' ? [i] : []));
+}
+
+function describeArray(array: MdArray): string {
+  const level = array.level ? ` (${array.level})` : '';
+  const counts =
+    array.totalSlots !== null && array.activeSlots !== null
+      ? `${array.activeSlots} of ${array.totalSlots} members present`
+      : 'member count unknown';
+  const map = array.slotMap ? ` [${array.slotMap}]` : '';
+  return `${array.device}${level}: ${counts}${map}`;
+}
+
+export type RaidProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
+
+export interface RaidProbeResult {
+  status: RaidProbeStatus;
+  detail: string;
+  hint?: string;
+  items?: ProbeItem[];
+}
+
+/**
+ * How to tell "the mirror was never populated" from "a disk dropped out".
+ * This is the whole reason the probe exists — `[U_]` alone reads as a dead
+ * disk and invites an `mdadm --add` against hardware that isn't there.
+ */
+const DEGRADED_HINT =
+  'An empty slot does NOT automatically mean a disk failed. ServiceBay\'s first-boot setup-raid.sh ' +
+  'creates the data array as a RAID1 whose second member is the literal keyword `missing` ' +
+  '(tools/sb/internal/build/assets/fedora-coreos.bu), so a box built with a single data disk has read ' +
+  '[U_] since the day it was installed and mdmonitor will never fire — no failure event ever happened. ' +
+  'Tell the two apart with `mdadm --detail /dev/<md>`: "Failed Devices: 0" plus a Creation Time matching ' +
+  'your install date means the mirror was never populated; a non-zero failed count or a recent event ' +
+  'means a disk really dropped out. The fix is the same either way — add a disk at least as large as the ' +
+  'array\'s member size and run `mdadm --manage /dev/<md> --add /dev/<partition>` from a shell on the box. ' +
+  'ServiceBay never changes array membership for you: that rewrites a disk and is an operator decision.';
+
+/** Per-array verdict, worst-first: a member the kernel marked failed is a
+ *  real fault; a simply-absent member is "no redundancy" (which may be
+ *  by design), and a rebuild in progress is transient. */
+function verdictForArray(array: MdArray): { status: RaidProbeStatus; detail: string } {
+  if (array.state !== 'active') {
+    return {
+      status: 'fail',
+      detail: `${array.device} is ${array.state} — the kernel has not assembled it, so anything mounted from it is unavailable.`,
+    };
+  }
+  if (array.totalSlots === null || array.activeSlots === null) {
+    return { status: 'info', detail: `${describeArray(array)} — no member counts reported.` };
+  }
+  const failed = array.members.filter(m => m.flags.includes('F'));
+  if (failed.length > 0) {
+    return {
+      status: 'fail',
+      detail:
+        `${describeArray(array)} — the kernel marked ${failed.map(m => m.name).join(', ')} FAILED. ` +
+        'A disk really dropped out of this array.',
+    };
+  }
+  if (array.activeSlots < array.totalSlots) {
+    const down = downSlots(array);
+    const present = array.members.map(m => m.name).join(', ') || 'none';
+    const slots = down.length > 0 ? `slot${down.length === 1 ? '' : 's'} ${down.join(', ')}` : 'a slot';
+    if (array.rebuilding) {
+      return {
+        status: 'warn',
+        detail:
+          `${describeArray(array)} — rebuilding onto ${slots}: ${array.rebuildDetail ?? 'in progress'}. ` +
+          'Redundancy returns when it finishes.',
+      };
+    }
+    return {
+      status: 'warn',
+      detail:
+        `${describeArray(array)} — running DEGRADED with no redundancy. Present: ${present}; ${slots} empty, ` +
+        'with nothing marked failed. If the remaining disk dies, the data on it is gone.',
+    };
+  }
+  return { status: 'ok', detail: `${describeArray(array)} — all members present.` };
+}
+
+const SEVERITY: Record<RaidProbeStatus, number> = { ok: 0, info: 1, warn: 2, fail: 3 };
+
+/**
+ * Pure verdict over a raw `/proc/mdstat` read. `execCode` is the exit code
+ * of the read itself so an unreadable file is reported honestly instead of
+ * being mistaken for "no arrays".
+ */
+export function evaluateRaidHealth(raw: string, execCode: number | undefined): RaidProbeResult {
+  if (execCode !== 0) {
+    return {
+      status: 'info',
+      detail: 'Could not read /proc/mdstat, so array health is unknown.',
+    };
+  }
+
+  const arrays = parseMdstat(raw);
+  if (arrays.length === 0) {
+    // Not every box uses md — a single-disk install without setup-raid, or
+    // storage on LVM/ZFS. Silence, not a warning.
+    return {
+      status: 'info',
+      detail: 'No software RAID array on this box — /proc/mdstat lists none.',
+    };
+  }
+
+  const verdicts = arrays.map(array => ({ array, ...verdictForArray(array) }));
+  const worst = verdicts.reduce<RaidProbeStatus>(
+    (acc, v) => (SEVERITY[v.status] > SEVERITY[acc] ? v.status : acc),
+    'ok',
+  );
+  const unhealthy = verdicts.filter(v => v.status === 'warn' || v.status === 'fail');
+
+  if (unhealthy.length === 0) {
+    return {
+      status: worst,
+      detail: verdicts.map(v => v.detail).join('\n'),
+    };
+  }
+
+  return {
+    status: worst,
+    // Lead with the arrays that need attention; a healthy sibling array
+    // shouldn't push the problem below the fold.
+    detail: [...unhealthy, ...verdicts.filter(v => !unhealthy.includes(v))].map(v => v.detail).join('\n'),
+    hint: DEGRADED_HINT,
+    items: unhealthy.map(v => ({
+      id: v.array.device,
+      label: `${v.array.device}${v.array.level ? ` (${v.array.level})` : ''}`,
+      detail: v.detail,
+      status: v.status === 'fail' ? ('fail' as const) : ('warn' as const),
+      // Read-only row: adding a mirror rewrites a physical disk, so there
+      // is deliberately no one-click repair here (see DEGRADED_HINT).
+      actionIds: [],
+    })),
+  };
+}

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -36,6 +36,7 @@ import { checkNasBackupReachable } from '@/lib/diagnose/probes/nasBackupReachabl
 import { checkHaAutomationIntegrity } from '@/lib/diagnose/probes/haAutomationIntegrity';
 import { checkSsoVerify } from '@/lib/diagnose/probes/ssoVerify';
 import { checkHermesChat } from '@/lib/diagnose/probes/hermesChat';
+import { evaluateRaidHealth, PROBE_ID as RAID_PROBE_ID, PROBE_LABEL as RAID_PROBE_LABEL } from '@/lib/diagnose/probes/raidDegraded';
 import { wasInstallActiveWithin } from '@/lib/install/jobStore';
 import { persistDiagnoseResults, buildProbeHistory, type ProbeHistory } from '@/lib/diagnose/persistDiagnoseResults';
 import '@/lib/diagnose/probes/register';
@@ -102,6 +103,7 @@ const PROBE_GROUP: Record<string, ProbeGroup> = {
   hermes_chat: 'services',
   // Storage & backups
   disk: 'storage-backups',
+  raid: 'storage-backups',
   nas_backup_reachable: 'storage-backups',
   // System info (collapsed — not a problem)
   serial: 'system-info',
@@ -393,6 +395,7 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     listen,
     serial,
     disk,
+    mdstat,
     firstBoot,
     uptimeRes,
     psStatus,
@@ -403,6 +406,10 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     exec('ss -ltn 2>/dev/null | tail -n +2 | awk \'{print $4}\' | awk -F: \'{print $NF}\' | sort -nu', 4000),
     exec('ls -la /dev/serial/by-id/ 2>/dev/null | grep -v "^total" | awk \'{print $NF}\' | grep -v "^$"', 3000),
     exec('df -h /mnt/data 2>/dev/null | tail -1', 3000),
+    // The kernel's own view of every md array (#2526). `df` above only
+    // proves the filesystem mounts — it says nothing about whether the
+    // RAID1 underneath it still has both members.
+    exec('cat /proc/mdstat', 3000),
     exec(
       'systemctl --no-pager status setup-raid install-python install-nginx 2>&1 | grep -E "(●|Active:)" | head -20',
       5000,
@@ -582,6 +589,23 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     status: diskStatus,
     detail: diskLine || 'no df output',
     hint: diskHint,
+  });
+
+  // 7b) RAID array health (#2526). Distinct probe rather than folded into
+  //     `disk`, because the two answer different questions: `disk` is
+  //     "will writes fit?", this is "is there still a mirror?". A box whose
+  //     data array lost (or never had) its second member mounts and fills
+  //     exactly like a healthy one, so nothing else on the box notices —
+  //     mdmonitor only fires on a failure *event*, and the weekly
+  //     raid-check reports mismatch_cnt=0 on a degraded array.
+  const raid = evaluateRaidHealth(mdstat.stdout ?? '', mdstat.code);
+  probes.push({
+    id: RAID_PROBE_ID,
+    label: RAID_PROBE_LABEL,
+    status: raid.status,
+    detail: raid.detail,
+    hint: raid.hint,
+    _items: raid.items,
   });
 
   // 8) First-boot oneshot units (FCOS only)

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -37,6 +37,12 @@ import { checkHaAutomationIntegrity } from '@/lib/diagnose/probes/haAutomationIn
 import { checkSsoVerify } from '@/lib/diagnose/probes/ssoVerify';
 import { checkHermesChat } from '@/lib/diagnose/probes/hermesChat';
 import { evaluateRaidHealth, PROBE_ID as RAID_PROBE_ID, PROBE_LABEL as RAID_PROBE_LABEL } from '@/lib/diagnose/probes/raidDegraded';
+import {
+  DISK_FILL_COMMAND,
+  evaluateDiskFill,
+  PROBE_ID as DISK_PROBE_ID,
+  PROBE_LABEL as DISK_PROBE_LABEL,
+} from '@/lib/diagnose/probes/diskFill';
 import { wasInstallActiveWithin } from '@/lib/install/jobStore';
 import { persistDiagnoseResults, buildProbeHistory, type ProbeHistory } from '@/lib/diagnose/persistDiagnoseResults';
 import '@/lib/diagnose/probes/register';
@@ -405,7 +411,10 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     exec('systemctl --user --failed --no-legend --no-pager 2>&1', 5000),
     exec('ss -ltn 2>/dev/null | tail -n +2 | awk \'{print $4}\' | awk -F: \'{print $NF}\' | sort -nu', 4000),
     exec('ls -la /dev/serial/by-id/ 2>/dev/null | grep -v "^total" | awk \'{print $NF}\' | grep -v "^$"', 3000),
-    exec('df -h /mnt/data 2>/dev/null | tail -1', 3000),
+    // Fill level of every filesystem the box depends on, not just the data
+    // array (#2527). `/boot` used to be unwatched, and a `/boot` too full to
+    // stage the next kernel is how a box ends up unbootable after an update.
+    exec(DISK_FILL_COMMAND, 3000),
     // The kernel's own view of every md array (#2526). `df` above only
     // proves the filesystem mounts — it says nothing about whether the
     // RAID1 underneath it still has both members.
@@ -568,27 +577,18 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     detail: serialDevices.length === 0 ? 'No USB serial devices (no Z-Wave / Zigbee stick plugged in).' : serialDevices.join('\n'),
   });
 
-  // 7) Disk usage on /mnt/data (where ServiceBay stores everything)
-  const diskLine = trimOutput(disk.stdout, 1);
-  let diskStatus: ProbeStatus = 'ok';
-  let diskHint: string | undefined;
-  const usePctMatch = diskLine.match(/(\d+)%/);
-  if (!diskLine) {
-    diskStatus = 'warn';
-    diskHint = '/mnt/data is not mounted yet — first-boot RAID setup may still be running.';
-  } else if (usePctMatch) {
-    const used = parseInt(usePctMatch[1], 10);
-    if (used >= 90) {
-      diskStatus = 'warn';
-      diskHint = 'Storage above 90% — click "Show largest directories" below to find what to clean, or extend the array.';
-    }
-  }
+  // 7) Fill level of /mnt/data, /boot and / (#2527). Each filesystem is
+  //    judged against what it is for — see the threshold rationale in
+  //    probes/diskFill.ts. Reporting only: the probe never frees space,
+  //    because reclaiming /boot means deleting kernels.
+  const diskFill = evaluateDiskFill(disk.stdout ?? '', disk.code);
   probes.push({
-    id: 'disk',
-    label: 'Storage (/mnt/data)',
-    status: diskStatus,
-    detail: diskLine || 'no df output',
-    hint: diskHint,
+    id: DISK_PROBE_ID,
+    label: DISK_PROBE_LABEL,
+    status: diskFill.status,
+    detail: diskFill.detail,
+    hint: diskFill.hint,
+    _items: diskFill.items,
   });
 
   // 7b) RAID array health (#2526). Distinct probe rather than folded into

--- a/packages/backend/src/lib/install/manifestAssembler.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.ts
@@ -62,6 +62,23 @@ export interface AssembleManifestInput {
    *  call span multiple sources (#1177). A pinned `'Built-in'` skips the
    *  registry walk, so external-registry templates resolve to null. */
   templateSource?: string;
+  /**
+   * #2537 — resolve only; never MINT credential material and never write.
+   *
+   * A read-only caller (the editor's "Re-render from template" preview) needs
+   * the exact variable set a deploy would use, but must not have the side
+   * effects a deploy has. Under `preview` the three generation branches
+   * (random secret / RSA key / bcrypt hash) are skipped: a secret-typed
+   * variable resolves from `installedSecrets` or stays EMPTY, and the caller
+   * reports it as unresolved. That is deliberate — minting a fresh password
+   * here would both write it to `installedSecrets` (diverging the store from
+   * the running pod) and hand the operator a YAML that silently rotates a
+   * live credential, which is the same class of harm as blanking it.
+   *
+   * With nothing generated, the trailing `persistSingleSecret` loop has
+   * nothing to persist, so `preview` is write-free by construction.
+   */
+  preview?: boolean;
 }
 
 export interface AssembledManifest {
@@ -378,6 +395,8 @@ export async function assembleManifest(
 ): Promise<AssembledManifest> {
   const { templateSource } = input;
   const prefilled = input.prefilled ?? {};
+  // #2537 — read-only resolve: no new credential material, no config write.
+  const preview = input.preview === true;
 
   const items: JobInputItem[] = input.items.map(i => ({
     name: i.name,
@@ -512,7 +531,10 @@ export async function assembleManifest(
     if (!value && meta?.type === 'secret') {
       if (storedValues[name]) {
         value = storedValues[name];
-      } else if (meta.noAutoGenerate) {
+      } else if (preview || meta.noAutoGenerate) {
+        // `preview` (#2537): the store had nothing, so this value is genuinely
+        // unresolvable. Leave it empty and let the caller SAY SO rather than
+        // mint a replacement credential in a read-only path.
         // #1002 — Some `type: secret` variables are operator-supplied
         // externally (Telegram/Discord bot tokens, HA long-lived
         // token, etc.). Auto-generating them as random strings
@@ -538,6 +560,7 @@ export async function assembleManifest(
       v.value = storedValues[v.name];
       continue;
     }
+    if (preview) continue; // #2537 — never mint a key in a read-only resolve.
     v.value = generateRsaPrivateKeyPem();
     newlyGenerated.push({ name: v.name, value: v.value });
   }
@@ -551,6 +574,7 @@ export async function assembleManifest(
       v.value = storedValues[v.name];
       continue;
     }
+    if (preview) continue; // #2537 — a fresh hash is fresh credential material.
     const sourceName = meta?.bcryptSource;
     if (!sourceName) continue;
     const source = variables.find(x => x.name === sourceName);

--- a/packages/backend/src/lib/mcp/server.test.ts
+++ b/packages/backend/src/lib/mcp/server.test.ts
@@ -32,6 +32,19 @@ describe('createMcpServer self-description (#1732)', () => {
     await client.close();
   });
 
+  it('tells a new-project session to call get_service_standards first (#2513)', async () => {
+    // The standards catalog was never consulted at repo-creation time because
+    // consulting it was not a step anywhere outside the catalog. The initialize
+    // handshake reaches every client BEFORE its first tool call — the one
+    // channel a fresh agent cannot skip.
+    const { client } = await connectClient();
+    const instructions = client.getInstructions() ?? '';
+    expect(instructions).toMatch(/get_service_standards/);
+    expect(instructions).toMatch(/new service\/project/i);
+    expect(instructions).toMatch(/repoBootstrap/);
+    await client.close();
+  });
+
   it('the service/container/log tool descriptions mention the naming model', async () => {
     const { client } = await connectClient();
     const { tools } = await client.listTools();

--- a/packages/backend/src/lib/mcp/server.ts
+++ b/packages/backend/src/lib/mcp/server.ts
@@ -297,6 +297,15 @@ export function createMcpServer(opts?: { auth?: McpAuthContext }) {
         'Always resolve service/container names and ids from `list_services` / `list_containers`',
         'rather than asking the user for them. Use `diagnose`, `get_health_checks`, and',
         '`get_service_files` when you need more depth on a service.',
+        '',
+        // #2513: the standards catalog was never *consulted* at repo-creation time
+        // because consulting it was not a step anywhere outside the catalog itself.
+        // The initialize handshake reaches every client before its first tool call,
+        // so this is the one place the pointer cannot be skipped.
+        'Building or bootstrapping a new service/project for this box? Call `get_service_standards`',
+        'FIRST — before choosing a stack, a CI shape, a storage engine or an auth design — and read',
+        'every id it lists under `assistsToRead` via `get_assist(id)`. Its `repoBootstrap` block holds',
+        "the pointer text the new repo's CLAUDE.md must carry so the next session finds the catalog too.",
       ].join('\n'),
     },
   );

--- a/packages/backend/src/lib/mcp/serviceRepoBootstrap.ts
+++ b/packages/backend/src/lib/mcp/serviceRepoBootstrap.ts
@@ -1,0 +1,134 @@
+/**
+ * The repo-bootstrap step of the standards catalog (#2513).
+ *
+ * `get_service_standards` is an excellent index that nothing outside an
+ * already-connected MCP session referenced: a fresh sibling repo was
+ * bootstrapped, chose its stack, its CI and its storage, and only found the
+ * catalog at review time. The catalog was never *consulted* because consulting
+ * it was not a step anywhere.
+ *
+ * This module is that step, expressed as data instead of advice: one generated
+ * block of markdown that a new service repo's `CLAUDE.md` carries from day one,
+ * plus the two pure functions that write and verify it. Three consumers share
+ * this single source:
+ *   - `serviceStandards.ts` — returns it as the `repoBootstrap` block of
+ *     `get_service_standards`, so a connected agent gets the finished text
+ *     rather than an instruction to compose one.
+ *   - `scripts/bootstrap-service-repo.ts` — `--write` / `--check` / `--print`
+ *     for a target repo, so the mechanics are a command, not prose.
+ *   - `scripts/check-invariants.ts` + the test suite — assert the step still
+ *     exists in the `create-service` recipe and that the pasteable copy has not
+ *     drifted from this generator.
+ *
+ * No imports: consumed by `tsx scripts/*.ts` (no path aliases) as well as by the
+ * backend.
+ */
+
+export const BOOTSTRAP_MARKER_BEGIN = '<!-- BEGIN SERVICEBAY STANDARDS POINTER (generated — do not edit by hand) -->';
+export const BOOTSTRAP_MARKER_END = '<!-- END SERVICEBAY STANDARDS POINTER -->';
+
+/** Substrings the pointer block is worthless without — the check's real assertion. */
+export const BOOTSTRAP_REQUIRED_REFERENCES = [
+  'get_service_standards',
+  'get_assist',
+  'standards-gap',
+] as const;
+
+/**
+ * The `CLAUDE.md` section a new ServiceBay-targeting repo must carry from its
+ * first commit. Deliberately verbatim-pasteable: "carry the pointer" is a copy,
+ * not an authoring judgment a bootstrapping agent can quietly skip.
+ */
+export function renderStandardsPointerBlock(): string {
+  return [
+    BOOTSTRAP_MARKER_BEGIN,
+    '',
+    '## Standards: fetch them, never re-derive them',
+    '',
+    'This repo is built for a ServiceBay box, so **ServiceBay\'s standards catalog is',
+    'the binding source of its architecture decisions** — this file only points at it.',
+    '',
+    '1. **Before the first stack, CI, storage, or auth decision**, call the ServiceBay',
+    '   MCP tool `get_service_standards` (flavor `servicebay`) and fetch every id it',
+    '   lists under `assistsToRead` via `get_assist(id)`. Read first, design second —',
+    '   a stack chosen before reading is a stack chosen against the ADRs by accident.',
+    '2. **If the ServiceBay MCP is not connected in this session, stop and say so.**',
+    '   An unconnected session cannot see the ADRs, so anything it decides about auth,',
+    '   health, storage, or CI is a guess. Connecting it is the first task, not an',
+    '   optional extra.',
+    '3. **The catalog wins.** Where this file and the catalog disagree, this file is',
+    '   the stale one — fix it here, not in your head.',
+    '4. **Report gaps back.** A missing, ambiguous, or wrong standard is itself a',
+    '   finding: file a `standards-gap` issue on `mdopp/servicebay` and propose the',
+    '   assist/docs fix. See `get_assist("report-standards-gaps")`.',
+    '',
+    'This block is generated. Regenerate or verify it from a `mdopp/servicebay`',
+    'checkout: `npm run standards:bootstrap -- --write <repo>` / `-- --check <repo>`.',
+    '',
+    BOOTSTRAP_MARKER_END,
+  ].join('\n');
+}
+
+/** Why the bootstrap step exists and where it is enforced — surfaced by the tool. */
+export const BOOTSTRAP_STEP = {
+  step: 'Step 1 of the create-service recipe, before the image and before any stack/CI/storage/auth choice.',
+  rule: "A new service repo's CLAUDE.md carries the get_service_standards pointer from its FIRST commit. The loop closes at repo creation, not at first review (#2513).",
+  commands: [
+    'npm run standards:bootstrap -- --write <repo>   # write/refresh the pointer block in <repo>/CLAUDE.md',
+    'npm run standards:bootstrap -- --check <repo>   # exits 1 when the pointer is missing or has drifted',
+  ],
+  ifMcpNotConnected:
+    'A session with no ServiceBay MCP cannot read the ADRs. Say so and connect it before choosing a stack — do not proceed on guesses (this is exactly how a sibling repo shipped past ADR 0001, without /healthz and with an unsafe SQLite setup).',
+  recipe: 'create-service',
+} as const;
+
+export interface BootstrapCheckResult {
+  ok: boolean;
+  /** Human-readable reasons the file does not satisfy the bootstrap step. */
+  problems: string[];
+}
+
+/**
+ * Verify a repo's `CLAUDE.md` text carries an up-to-date pointer block.
+ * Reports drift (block present but edited) separately from absence, because the
+ * fixes differ: regenerate vs. bootstrap.
+ */
+export function checkStandardsPointer(claudeMd: string): BootstrapCheckResult {
+  const problems: string[] = [];
+  const start = claudeMd.indexOf(BOOTSTRAP_MARKER_BEGIN);
+  const end = claudeMd.indexOf(BOOTSTRAP_MARKER_END);
+
+  if (start < 0 || end < 0) {
+    problems.push(
+      'CLAUDE.md carries no ServiceBay standards pointer, so nothing in this repo tells an agent that the ADRs live behind get_service_standards (#2513). Run: npm run standards:bootstrap -- --write <repo>',
+    );
+    return { ok: false, problems };
+  }
+
+  const block = claudeMd.slice(start, end + BOOTSTRAP_MARKER_END.length);
+  if (block !== renderStandardsPointerBlock()) {
+    problems.push(
+      'The standards pointer block has drifted from the generator (packages/backend/src/lib/mcp/serviceRepoBootstrap.ts). Regenerate: npm run standards:bootstrap -- --write <repo>',
+    );
+  }
+  for (const ref of BOOTSTRAP_REQUIRED_REFERENCES) {
+    if (!block.includes(ref)) problems.push(`The standards pointer block no longer mentions \`${ref}\`.`);
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+/**
+ * Return `claudeMd` with the pointer block inserted or refreshed. Idempotent:
+ * an existing block is replaced in place; a file without one gets it appended
+ * (or becomes it, when the file is empty/absent).
+ */
+export function applyStandardsPointer(claudeMd: string): string {
+  const block = renderStandardsPointerBlock();
+  const start = claudeMd.indexOf(BOOTSTRAP_MARKER_BEGIN);
+  const end = claudeMd.indexOf(BOOTSTRAP_MARKER_END);
+  if (start >= 0 && end > start) {
+    return claudeMd.slice(0, start) + block + claudeMd.slice(end + BOOTSTRAP_MARKER_END.length);
+  }
+  const body = claudeMd.trimEnd();
+  return body ? `${body}\n\n${block}\n` : `${block}\n`;
+}

--- a/packages/backend/src/lib/mcp/serviceStandards.ts
+++ b/packages/backend/src/lib/mcp/serviceStandards.ts
@@ -20,6 +20,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { logger } from '@/lib/logger';
+import { BOOTSTRAP_STEP, renderStandardsPointerBlock } from '@/lib/mcp/serviceRepoBootstrap';
 
 export const SERVICE_STANDARDS_FLAVORS = ['servicebay', 'generic'] as const;
 export type ServiceStandardsFlavor = (typeof SERVICE_STANDARDS_FLAVORS)[number];
@@ -121,6 +122,17 @@ export async function buildServiceStandards(flavor: ServiceStandardsFlavor): Pro
       summary:
         'Platform-agnostic development standards for any new project. Fetch the full text via get_assist("generic-project-standards").',
       fullTextAssist: 'generic-project-standards',
+      // #2513: the sibling repo that shipped past the ADRs was bootstrapped with
+      // the GENERIC standards, on a machine with no ServiceBay MCP — so the
+      // target-detection step belongs on this flavor too, not only on
+      // 'servicebay'. Without it, the generic flavor is a dead end for exactly
+      // the case that failed.
+      repoBootstrap: {
+        step: 'Before the first stack/CI/storage/auth decision: decide where this project will RUN.',
+        ifServiceBayTarget:
+          'If it will be installed on a ServiceBay box, these generic standards are not enough — fetch get_service_standards(flavor="servicebay") and follow its repoBootstrap block. The platform ADRs (SSO, non-destructive installs, network isolation, service tokens) are binding and are not derivable from generic dev discipline.',
+        ifMcpNotConnected: BOOTSTRAP_STEP.ifMcpNotConnected,
+      },
       standards: {
         commitConvention:
           'Conventional Commits: `type(scope): description`. Keep subjects parser-clean — no extra parentheses beyond the conventional (scope).',
@@ -143,6 +155,14 @@ export async function buildServiceStandards(flavor: ServiceStandardsFlavor): Pro
     summary:
       'Curated pointer index for building a new ServiceBay service. Read the referenced docs/ files directly and fetch each assist in full via get_assist(id). Full checklist: get_assist("new-service-standards").',
     fullTextAssist: 'new-service-standards',
+    // #2513: step 1 of building a service repo, served as finished text rather
+    // than as an instruction to compose one. A repo created without this block
+    // has no link back into the catalog, and the next agent in it re-derives
+    // everything the ADRs already decided.
+    repoBootstrap: {
+      ...BOOTSTRAP_STEP,
+      claudeMdBlock: renderStandardsPointerBlock(),
+    },
     mustRespectAdrs,
     enforcedInvariants: {
       pointer: 'docs/ARCHITECTURE_INVARIANTS.md',
@@ -168,6 +188,7 @@ export async function buildServiceStandards(flavor: ServiceStandardsFlavor): Pro
         { id: 'testing-and-ci-gate', why: 'Required standard: a real test suite, thread-aware coverage, and CI that gates image publish on green tests (build-only CI is non-compliant).' },
         { id: 'long-running-process', why: 'Standard for any operation over ~10s: server-owned durable job, reconnect via the server (not localStorage), survive restart, observable + cancelable.' },
         { id: 'service-ui-design-standard', why: 'UI/design standard for a user-facing service: real ServiceBay design tokens (palette/accent, radii, typography, spacing) + UX baseline (styled large file picker, streaming progress, responsive/mobile, focus states) so the service looks and behaves like ServiceBay.' },
+        { id: 'service-ui-user-language', why: 'Required for any rendered UI: state texts speak the user\'s language, not the implementation\'s. CLI commands, env-var and header names never reach rendered HTML; every state says what the user can do next; a named action the user cannot trigger is a product gap. Applies docs/UX_PHILOSOPHY.md §5 to a service frontend.' },
         { id: 'data-authority', why: 'Consume the canonical index (Jellyfin/Immich/Radicale) instead of re-scanning; one writer per store or an explicit coordination model.' },
         { id: 'recipe-roll-new-image-to-running-service', why: 'How to actually run a freshly-pushed image on an installed service (pull + restart), and the pinned-tag-vs-:latest versioning expectation.' },
         { id: 'report-standards-gaps', why: 'Convention: report missing/ambiguous/wrong standards back so the catalog improves from real friction.' },

--- a/packages/backend/src/lib/services/podSchema.ts
+++ b/packages/backend/src/lib/services/podSchema.ts
@@ -175,6 +175,66 @@ function validatePortReachability(
 }
 
 /**
+ * GPU passthrough is single-container-only (#2517, root cause #1026).
+ *
+ * `podman kube play` silently ignores every `resources.limits` key outside
+ * cpu/memory. For a GPU that means the pod comes up healthy, both containers
+ * running, `/healthz` green — and the card is simply not there. The only
+ * escape hatch ServiceBay has is the `.container` Quadlet swap
+ * (`AddDevice=nvidia.com/gpu=all`, see `ServiceManager.reconcileContainerQuadletShadow`),
+ * and a `.container` unit is **one container per unit** — so it has no
+ * equivalent for a multi-container Pod.
+ *
+ * Rather than deploy a service that quietly runs on CPU, refuse the manifest
+ * and say what does work. Single-container pods are untouched: they are
+ * exactly the shape the `.container` escape hatch supports.
+ *
+ * Exported so the template-consistency suite can apply the same rule to
+ * shipped templates at PR time (one rule, two gates).
+ */
+const GPU_LIMIT_KEY = /gpu/i;
+
+function gpuLimitKeys(container: unknown): string[] {
+    const resources = (container as {
+        resources?: { limits?: Record<string, unknown>; requests?: Record<string, unknown> };
+    } | null)?.resources;
+    const keys = [
+        ...Object.keys(resources?.limits ?? {}),
+        ...Object.keys(resources?.requests ?? {}),
+    ];
+    return [...new Set(keys.filter(k => GPU_LIMIT_KEY.test(k)))];
+}
+
+export function findGpuMultiContainerError(pod: unknown): PodValidationError | null {
+    const spec = (pod as { spec?: { containers?: unknown; initContainers?: unknown } } | null)?.spec;
+    const containers = Array.isArray(spec?.containers) ? spec.containers : [];
+    const initContainers = Array.isArray(spec?.initContainers) ? spec.initContainers : [];
+    const total = containers.length + initContainers.length;
+    // A single-container pod can be swapped to a `.container` Quadlet, so the
+    // GPU limit is honourable there — leave it alone.
+    if (total <= 1) return null;
+
+    for (const c of [...containers, ...initContainers]) {
+        const keys = gpuLimitKeys(c);
+        if (keys.length === 0) continue;
+        const name = (c as { name?: string } | null)?.name ?? '?';
+        return {
+            path: `spec.containers[${name}].resources.limits[${keys[0]}]`,
+            message:
+                `container "${name}" requests a GPU (${keys.join(', ')}) but this pod declares ` +
+                `${total} containers. \`podman kube play\` silently drops resources.limits ` +
+                `outside cpu/memory, so this would deploy healthy and run on CPU with no error ` +
+                `anywhere. GPU passthrough only works for a SINGLE-container service, which ` +
+                `ServiceBay deploys as a \`.container\` Quadlet with \`AddDevice=nvidia.com/gpu=all\`. ` +
+                `Fix: move the GPU workload into its own single-container service and share data ` +
+                `with the others through a hostPath volume, or drop the GPU limit and run on CPU. ` +
+                `See docs/TEMPLATE_AUTHORING.md → "GPU passthrough (CDI)".`,
+        };
+    }
+    return null;
+}
+
+/**
  * Validate PVC documents in a multi-doc YAML. Basic shape only;
  * podman creates the volume on first deploy regardless of most fields.
  */
@@ -241,6 +301,14 @@ export function validatePodManifest(yamlContent: string): PodValidationResult {
     const portError = validatePortReachability(podResult.data);
     if (portError) {
         return { ok: false, error: portError };
+    }
+
+    // GPU: a multi-container pod can never receive one, and kube-play says
+    // nothing about it. Refuse loudly instead of deploying a CPU-only service
+    // that reports healthy (#2517).
+    const gpuError = findGpuMultiContainerError(podResult.data);
+    if (gpuError) {
+        return { ok: false, error: gpuError };
     }
 
     // PVC docs (if any)

--- a/packages/backend/src/lib/stackInstall/credentialsManifest.test.ts
+++ b/packages/backend/src/lib/stackInstall/credentialsManifest.test.ts
@@ -4,6 +4,9 @@ import {
   resolveCredentialUrl,
   isHttpUrl,
   buildBitwardenCsv,
+  isCredentialSecured,
+  markCredentialsSecured,
+  summarizeCredentialSecurity,
   type Credential,
   type CredentialUrlContext,
 } from './credentialsManifest';
@@ -130,5 +133,95 @@ describe('buildBitwardenCsv login_uri', () => {
     const line = csv.trim().split('\n')[1];
     // login_uri is the 8th column — empty for a non-URL value
     expect(line.split(',')[7]).toBe('""');
+  });
+});
+
+/**
+ * #2519 — the Vaultwarden hand-off state. "Secured" means the secret lives
+ * in the operator's vault and ServiceBay dropped its copy; the two must
+ * never be true at once, which is what these tests pin down.
+ */
+describe('credential security state (#2519)', () => {
+  const unsecured = (service: string, template?: string): Credential => cred(service, template);
+  const secured = (service: string, at: string, template?: string): Credential => ({
+    ...cred(service, template), password: '', securedAt: at,
+  });
+
+  it('treats a missing or empty securedAt as not secured', () => {
+    expect(isCredentialSecured(unsecured('lldap'))).toBe(false);
+    expect(isCredentialSecured({ securedAt: '' })).toBe(false);
+    expect(isCredentialSecured({ securedAt: '2026-08-13T00:00:00.000Z' })).toBe(true);
+  });
+
+  it('summarises how many entries ServiceBay still holds the secret for', () => {
+    const s = summarizeCredentialSecurity([
+      secured('lldap', '2026-08-10T00:00:00.000Z'),
+      secured('npm', '2026-08-12T00:00:00.000Z'),
+      unsecured('immich'),
+    ]);
+    expect(s).toEqual({
+      total: 3,
+      secured: 2,
+      unsecured: 1,
+      lastSecuredAt: '2026-08-12T00:00:00.000Z',
+    });
+  });
+
+  it('summarises an empty manifest without a last-sync timestamp', () => {
+    expect(summarizeCredentialSecurity([])).toEqual({
+      total: 0, secured: 0, unsecured: 0, lastSecuredAt: null,
+    });
+  });
+
+  it('drops the password in the same step that marks an entry secured', () => {
+    const at = '2026-08-13T12:00:00.000Z';
+    const out = markCredentialsSecured([unsecured('lldap'), unsecured('npm')], at);
+    expect(out.every(c => c.password === '')).toBe(true);
+    expect(out.every(c => c.securedAt === at)).toBe(true);
+    // The pointer survives — Settings still says *what* exists.
+    expect(out.map(c => c.service)).toEqual(['lldap', 'npm']);
+    expect(out[0].username).toBe('admin');
+  });
+
+  it('leaves an already-secured entry (and its original timestamp) untouched', () => {
+    const first = '2026-08-01T00:00:00.000Z';
+    const out = markCredentialsSecured([secured('lldap', first)], '2026-08-13T12:00:00.000Z');
+    expect(out[0].securedAt).toBe(first);
+  });
+
+  it('never leaves a secured entry that still carries a secret', () => {
+    const out = markCredentialsSecured(
+      [unsecured('lldap'), secured('npm', '2026-08-01T00:00:00.000Z')],
+      '2026-08-13T12:00:00.000Z',
+    );
+    expect(out.filter(c => isCredentialSecured(c)).every(c => c.password === '')).toBe(true);
+  });
+
+  it('excludes secured entries from the Bitwarden CSV', () => {
+    const csv = buildBitwardenCsv([
+      secured('lldap', '2026-08-01T00:00:00.000Z'),
+      unsecured('immich'),
+    ]);
+    const lines = csv.trim().split('\n');
+    expect(lines).toHaveLength(2); // header + the one unsecured row
+    expect(csv).toContain('immich');
+    expect(csv).not.toContain('lldap');
+  });
+
+  it('a re-install of a secured template resets it to not-yet-secured', () => {
+    // mergeCredentials replaces the deployed template's entries wholesale,
+    // so `securedAt` goes with them — the fresh secret is unsecured again.
+    const existing = [secured('lldap', '2026-08-01T00:00:00.000Z', 'auth')];
+    const fresh = [{ ...cred('lldap', 'auth'), password: 'ROTATED' }];
+    const merged = mergeCredentials(existing, fresh, ['auth']);
+    expect(merged).toHaveLength(1);
+    expect(isCredentialSecured(merged[0])).toBe(false);
+    expect(merged[0].password).toBe('ROTATED');
+  });
+
+  it('does not un-secure entries owned by templates this install did not touch', () => {
+    const existing = [secured('lldap', '2026-08-01T00:00:00.000Z', 'auth')];
+    const merged = mergeCredentials(existing, [cred('immich', 'immich')], ['immich']);
+    expect(isCredentialSecured(merged.find(c => c.service === 'lldap')!)).toBe(true);
   });
 });

--- a/packages/backend/src/lib/stackInstall/credentialsManifest.ts
+++ b/packages/backend/src/lib/stackInstall/credentialsManifest.ts
@@ -40,6 +40,21 @@ export interface Credential {
    * the captured template name).
    */
   template?: string;
+  /**
+   * ISO timestamp of when this entry was handed off to the operator's
+   * Vaultwarden vault (#2519). Once set, ServiceBay no longer keeps the
+   * secret: `password` is emptied and only the pointer (service / url /
+   * username / notes) remains, so Settings can still list *what* exists
+   * without being a second password manager.
+   *
+   * Absent ⇒ **not yet secured** — ServiceBay is still the only place
+   * this secret lives, and the UI says so. A re-install or rotation
+   * replaces the owning template's entries wholesale (see
+   * `mergeCredentials` / `capabilities/credentials.ts`), which drops
+   * `securedAt` with them — the fresh secret is unsecured again, by
+   * construction, because ServiceBay cannot know whether it changed.
+   */
+  securedAt?: string;
 }
 
 interface BuildOpts {
@@ -109,6 +124,54 @@ export function mergeCredentials(
   const deployed = new Set(deployedTemplates);
   const kept = existing.filter(c => !c.template || !deployed.has(c.template));
   return [...kept, ...fresh];
+}
+
+/**
+ * True once the entry has been handed off to Vaultwarden and ServiceBay
+ * dropped its own copy of the secret (#2519).
+ */
+export function isCredentialSecured(cred: Pick<Credential, 'securedAt'>): boolean {
+  return typeof cred.securedAt === 'string' && cred.securedAt.length > 0;
+}
+
+export interface CredentialSecuritySummary {
+  total: number;
+  /** Entries whose secret now lives only in Vaultwarden. */
+  secured: number;
+  /** Entries ServiceBay still holds the secret for — the risk surface. */
+  unsecured: number;
+  /** Newest `securedAt` across secured entries, or null when none. */
+  lastSecuredAt: string | null;
+}
+
+/** Roll a manifest up into the counts Settings renders instead of passwords. */
+export function summarizeCredentialSecurity(
+  creds: readonly Credential[],
+): CredentialSecuritySummary {
+  let secured = 0;
+  let lastSecuredAt: string | null = null;
+  for (const c of creds) {
+    if (!isCredentialSecured(c)) continue;
+    secured++;
+    if (!lastSecuredAt || c.securedAt! > lastSecuredAt) lastSecuredAt = c.securedAt!;
+  }
+  return { total: creds.length, secured, unsecured: creds.length - secured, lastSecuredAt };
+}
+
+/**
+ * Mark every not-yet-secured entry as handed off, **dropping ServiceBay's
+ * copy of the secret in the same step** (#2519).
+ *
+ * Emptying `password` is the point, not a side effect: "secured" and "we
+ * still hold it" must never be representable at the same time, so the two
+ * can't drift apart. Already-secured entries pass through untouched (their
+ * original `securedAt` is the honest one).
+ */
+export function markCredentialsSecured(
+  creds: readonly Credential[],
+  at: string,
+): Credential[] {
+  return creds.map(c => (isCredentialSecured(c) ? c : { ...c, password: '', securedAt: at }));
 }
 
 // #632 removed `formatCredentialsBanner` — the install runner no longer
@@ -205,7 +268,12 @@ export function resolveCredentialUrl(
  *  When a `ctx` is supplied, each row's `login_uri` is run through
  *  `resolveCredentialUrl` so loopback URLs become the admin-reachable
  *  public subdomain (#1626) — keeping the CSV import in lock-step with
- *  what the Saved-credentials table shows. */
+ *  what the Saved-credentials table shows.
+ *
+ *  Entries already secured in Vaultwarden are skipped (#2519) — their
+ *  `password` was dropped at hand-off, so exporting them would produce
+ *  rows that overwrite a real vault item with an empty one. The CSV is
+ *  exactly "what is still only on this box". */
 export function buildBitwardenCsv(manifest: Credential[], ctx: CredentialUrlContext = {}): string {
   const escape = (s: string) => `"${(s ?? '').replace(/"/g, '""')}"`;
   const header = [
@@ -214,7 +282,7 @@ export function buildBitwardenCsv(manifest: Credential[], ctx: CredentialUrlCont
     'login_uri', 'login_username', 'login_password', 'login_totp',
   ].join(',');
 
-  const rows = manifest.map(c => {
+  const rows = manifest.filter(c => !isCredentialSecured(c)).map(c => {
     const resolved = resolveCredentialUrl(c, ctx);
     return [
       escape('ServiceBay Home'),

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/CredentialsSection.tsx
@@ -1,16 +1,19 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Download, ExternalLink, Eye, EyeOff, Loader2, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Download, ExternalLink, Loader2, ShieldCheck, Trash2 } from 'lucide-react';
 import {
   buildBitwardenCsv,
+  isCredentialSecured,
   isHttpUrl,
   resolveCredentialUrl,
+  summarizeCredentialSecurity,
   type Credential,
+  type CredentialSecuritySummary,
   type CredentialUrlHost,
 } from '@servicebay/api-client';
 import { useToast } from '@/providers/ToastProvider';
-import { Button, DataTable } from '@/components/ui';
+import { Badge, Button, DataTable, type Column } from '@/components/ui';
 
 interface Manifest {
   savedAt: string;
@@ -46,27 +49,185 @@ function CredentialUrlCell({ cred, hosts, publicDomain }: {
   );
 }
 
+/** Vaultwarden deep link — an <a> (navigation), styled like a secondary Button. */
+function VaultLink({ href, title, children }: {
+  href: string;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={title}
+      className={'inline-flex items-center gap-2 px-4 py-2.5 bg-surface-2 hover:bg-surface-muted ' +
+        'text-text text-sm font-medium rounded-card border border-border transition-colors'}
+    >
+      <ExternalLink size={14} />
+      {children}
+    </a>
+  );
+}
+
+/** The line that replaced the password column: where these secrets live. */
+function SyncStatus({ summary, savedAt, vaultInstalled }: {
+  summary: CredentialSecuritySummary;
+  savedAt: string;
+  vaultInstalled: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      {summary.unsecured > 0 ? (
+        <p className="text-sm text-status-warn" data-testid="credentials-sync-status">
+          {summary.unsecured} of {summary.total} not yet secured — ServiceBay is still the only place
+          {summary.unsecured === 1 ? ' this password lives' : ' these passwords live'}.
+          {!vaultInstalled && ' Vaultwarden isn\'t installed on this box, so there is nowhere to hand them off to yet.'}
+        </p>
+      ) : (
+        <p className="text-sm text-status-ok" data-testid="credentials-sync-status">
+          All {summary.total} entries are in Vaultwarden
+          {summary.lastSecuredAt ? ` — last synced ${new Date(summary.lastSecuredAt).toLocaleString()}` : ''}.
+          ServiceBay no longer stores these passwords.
+        </p>
+      )}
+      <p className="text-xs text-text-muted">
+        Last updated {new Date(savedAt).toLocaleString()}. Passwords are never shown here — open the entry
+        in Vaultwarden.
+      </p>
+    </div>
+  );
+}
+
+/** Hand-off actions. Which ones apply depends entirely on `summary.unsecured`. */
+const TIP_CSV = 'Download the not-yet-secured credentials as a Vaultwarden-importable CSV.';
+const TIP_IMPORT = 'Opens the Vaultwarden web-vault import page in a new tab. Download the CSV first, then pick it there \u2014 it imports into your personal vault.';
+const TIP_CONFIRM = "Records the hand-off and deletes ServiceBay's copy of these passwords.";
+const TIP_WIPE = 'Remove the whole list from ServiceBay, secured entries included.';
+
+function CredentialActions({ summary, vaultBase, busy, onDownload, onConfirmSecured, onWipe }: {
+  summary: CredentialSecuritySummary;
+  vaultBase: string | null;
+  busy: 'wipe' | 'secure' | null;
+  onDownload: () => void;
+  onConfirmSecured: () => void;
+  onWipe: () => void;
+}) {
+  const pending = summary.unsecured > 0;
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {pending && (
+        <Button onClick={onDownload} variant="primary" size="md" title={TIP_CSV}>
+          <Download size={14} />
+          Download CSV
+        </Button>
+      )}
+      {vaultBase && pending && (
+        <VaultLink href={`${vaultBase}/#/tools/import`} title={TIP_IMPORT}>
+          Open Vaultwarden import
+        </VaultLink>
+      )}
+      {vaultBase && !pending && (
+        <VaultLink href={`${vaultBase}/#/vault`}>Open in Vaultwarden</VaultLink>
+      )}
+      {pending && (
+        <Button onClick={onConfirmSecured} disabled={busy === 'secure'} variant="secondary" size="md" title={TIP_CONFIRM}>
+          {busy === 'secure' ? <Loader2 size={14} className="animate-spin" /> : <ShieldCheck size={14} />}
+          They&apos;re in Vaultwarden — drop the local copy
+        </Button>
+      )}
+      <Button onClick={onWipe} disabled={busy === 'wipe'} variant="danger" size="md" title={TIP_WIPE}>
+        {busy === 'wipe' ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+        Forget entries
+      </Button>
+    </div>
+  );
+}
+
+function ServiceCell(c: Credential) {
+  return (
+    <div>
+      {c.service}
+      {c.importance === 'system' && (
+        <span className="ml-2 text-[10px] uppercase tracking-wide text-text-muted">system</span>
+      )}
+    </div>
+  );
+}
+
+function StoredInCell(c: Credential) {
+  if (!isCredentialSecured(c)) return <Badge variant="warn">Not yet secured</Badge>;
+  return (
+    <Badge variant="ok" title={`Handed off ${new Date(c.securedAt!).toLocaleString()}`}>
+      Vaultwarden
+    </Badge>
+  );
+}
+
+/** Explicit per-column widths (#2520): without them the browser's auto
+ *  table-layout hands the spare width to whichever column holds the longest
+ *  prose — Notes — and starves Service/URL/Username. These are preferred
+ *  widths, so a column still grows past its share rather than clipping; the
+ *  table's min-width makes a narrow viewport scroll instead of crushing them. */
+function credentialColumns(
+  proxyHosts: CredentialUrlHost[],
+  publicDomain: string | null,
+): Column<Credential>[] {
+  return [
+    { key: 'service', header: 'Service', className: 'w-[16%]', align: 'left', cell: ServiceCell },
+    {
+      key: 'url',
+      header: 'URL',
+      cell: (c) => <CredentialUrlCell cred={c} hosts={proxyHosts} publicDomain={publicDomain} />,
+      align: 'left',
+      className: 'w-[28%] font-mono text-xs',
+    },
+    {
+      key: 'username',
+      header: 'Username',
+      cell: (c) => c.username,
+      align: 'left',
+      className: 'w-[16%] font-mono text-xs',
+    },
+    // "Stored in" replaces the old Password column (#2519): where the secret
+    // lives, never the secret itself.
+    { key: 'status', header: 'Stored in', className: 'w-[18%]', align: 'left', cell: StoredInCell },
+    {
+      key: 'notes',
+      header: 'Notes',
+      cell: (c) => c.notes ?? '',
+      align: 'left',
+      className: 'w-[22%] text-xs text-text-muted',
+    },
+  ];
+}
+
 /**
- * Settings section that surfaces the encrypted credentials manifest
- * the install wizard persisted (#19 / A1). Encrypted at rest in
- * `config.json`; decrypted by the same admin session that's loading
- * this page.
+ * Settings → Saved credentials (#2519).
  *
- * Two affordances:
- *   - Per-row password reveal (default hidden) so the page doesn't
- *     leak secrets at a glance to anyone shoulder-surfing.
- *   - "Wipe from server" button that clears the manifest after the
- *     operator has stored credentials in their password manager —
- *     narrows the window during which plaintext-decryptable secrets
- *     sit in config.json.
+ * This section used to be a password table: a Password column with
+ * per-row reveal + copy, i.e. a second password manager next to the
+ * Vaultwarden ServiceBay itself deploys. It no longer renders secrets at
+ * all. What it shows instead is **where each credential lives**:
+ *
+ *   - "In Vaultwarden" — the hand-off happened and ServiceBay dropped its
+ *     copy of the password; only the pointer (service/URL/username) is left.
+ *   - "Not yet secured" — ServiceBay is still the only place this secret
+ *     exists. That is the state to act on, and it is called out at the top,
+ *     including when Vaultwarden isn't installed on this box at all.
+ *
+ * Hand-off is still operator-driven (CSV → import → confirm) because a
+ * server-side write into a *personal* Vaultwarden vault requires a
+ * vault-unlocking secret ServiceBay must not hold — see the issue thread.
+ * Confirming calls `/api/system/credentials/secured`, which records the
+ * hand-off and drops the local passwords in the same write.
  */
 export default function CredentialsSection() {
   const { addToast } = useToast();
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [proxyHosts, setProxyHosts] = useState<CredentialUrlHost[]>([]);
   const [publicDomain, setPublicDomain] = useState<string | null>(null);
-  const [busy, setBusy] = useState<'load' | 'wipe' | null>('load');
-  const [revealed, setRevealed] = useState<Record<number, boolean>>({});
+  const [busy, setBusy] = useState<'load' | 'wipe' | 'secure' | null>('load');
 
   useEffect(() => {
     fetch('/api/system/credentials')
@@ -81,22 +242,45 @@ export default function CredentialsSection() {
       .finally(() => setBusy(null));
   }, []);
 
+  const credentials = useMemo(() => manifest?.credentials ?? [], [manifest]);
+  const summary = useMemo(() => summarizeCredentialSecurity(credentials), [credentials]);
   const urlCtx = { hosts: proxyHosts, publicDomain: publicDomain ?? undefined };
 
-  // Vaultwarden import deep-link (#1627): only when vaultwarden is installed
-  // (has a proxy host) and a public domain is configured. Derive the domain
-  // from the proxy host so we don't hardcode `vault`/the public domain.
+  // Vaultwarden deep links (#1627/#2519): only when vaultwarden is installed
+  // (has a proxy host). Derive the domain from the proxy host so we don't
+  // hardcode `vault`/the public domain.
   const vaultHost = proxyHosts.find(h => h.service === 'vaultwarden');
-  const vaultwardenImportUrl =
-    publicDomain && vaultHost?.domain
-      ? `https://${vaultHost.domain}/#/tools/import`
-      : null;
+  const vaultBase = vaultHost?.domain ? `https://${vaultHost.domain}` : null;
+
+  const onConfirmSecured = async () => {
+    if (!window.confirm(
+      `Confirm ${summary.unsecured} credential(s) are now in Vaultwarden?\n\n` +
+      'ServiceBay deletes its own copy of these passwords immediately. The services keep running with the same passwords — but if they are not actually in your vault, the only way back is to reset them in each service.',
+    )) return;
+    setBusy('secure');
+    try {
+      const res = await fetch('/api/system/credentials/secured', { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        addToast('error', 'Could not record the hand-off', data.error || `HTTP ${res.status}`);
+        return;
+      }
+      const securedAt: string = data.securedAt ?? new Date().toISOString();
+      setManifest(m => (m ? {
+        savedAt: securedAt,
+        credentials: m.credentials.map(c =>
+          isCredentialSecured(c) ? c : { ...c, password: '', securedAt }),
+      } : m));
+      addToast('success', 'Vaultwarden is now the only copy', `${data.secured ?? summary.unsecured} password(s) dropped from ServiceBay.`);
+    } finally {
+      setBusy(null);
+    }
+  };
 
   const onWipe = async () => {
     if (!window.confirm(
-      'Wipe credentials from the server?\n\n' +
-      'Make sure you\'ve already saved them in your password manager — once wiped, you\'ll need to dig them out of running services manually (or reinstall) to recover.\n\n' +
-      'The credentials themselves remain in the running services; this only clears ServiceBay\'s saved copy.',
+      'Forget these entries entirely?\n\n' +
+      'This removes the whole list, including the not-yet-secured passwords — make sure you have them saved first. The credentials themselves remain in the running services; this only clears ServiceBay\'s record.',
     )) return;
     setBusy('wipe');
     try {
@@ -107,21 +291,21 @@ export default function CredentialsSection() {
         return;
       }
       setManifest(null);
-      addToast('success', 'Credentials wiped from server', 'The saved manifest is gone. Services keep running with the same passwords — they just aren\'t in ServiceBay\'s config anymore.');
+      addToast('success', 'Entries forgotten', 'Services keep running with the same passwords — they just aren\'t in ServiceBay\'s config anymore.');
     } finally {
       setBusy(null);
     }
   };
 
   const downloadCsv = () => {
-    if (!manifest || manifest.credentials.length === 0) return;
-    const blob = new Blob([buildBitwardenCsv(manifest.credentials, urlCtx)], { type: 'text/csv' });
+    if (summary.unsecured === 0) return;
+    const blob = new Blob([buildBitwardenCsv(credentials, urlCtx)], { type: 'text/csv' });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
     a.download = `servicebay-credentials-${new Date().toISOString().slice(0, 10)}.csv`;
     a.click();
     URL.revokeObjectURL(a.href);
-    addToast('success', 'Credentials CSV downloaded', 'Re-import it into Bitwarden/Vaultwarden, then consider wiping the server copy.');
+    addToast('success', 'Credentials CSV downloaded', 'Import it into Vaultwarden, then confirm below so ServiceBay drops its copy.');
   };
 
   if (busy === 'load') {
@@ -135,144 +319,37 @@ export default function CredentialsSection() {
 
   return (
     <>
-        {manifest && (
-          <p className="text-xs text-text-muted">
-            Persisted at {new Date(manifest.savedAt).toLocaleString()} — encrypted at rest, visible to logged-in admins.
-          </p>
-        )}
-        {manifest && manifest.credentials.length > 0 && (
-          <div className="flex items-center gap-2 flex-wrap">
-            <Button
-              onClick={downloadCsv}
-              variant="primary"
-              size="md"
-              title="Download the saved credentials as a Bitwarden/Vaultwarden-importable CSV."
-            >
-              <Download size={14} />
-              Download CSV
-            </Button>
-            {vaultwardenImportUrl && (
-              <a
-                href={vaultwardenImportUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-4 py-2.5 bg-surface-2 hover:bg-surface-muted text-text text-sm font-medium rounded-card border border-border transition-colors"
-                title="Opens the Vaultwarden web-vault import page in a new tab. Download the CSV first, then pick it there. Choose an Organization collection to share entries with other admins (folders are personal)."
-              >
-                <ExternalLink size={14} />
-                Open Vaultwarden import
-              </a>
-            )}
-            <Button
-              onClick={onWipe}
-              disabled={busy === 'wipe'}
-              variant="danger"
-              size="md"
-              title="Remove the saved credentials from the server. Useful once you've stored them safely in your password manager."
-            >
-              {busy === 'wipe' ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
-              Wipe from server
-            </Button>
-          </div>
-        )}
+      {summary.total > 0 && (
+        <SyncStatus summary={summary} savedAt={manifest!.savedAt} vaultInstalled={!!vaultBase} />
+      )}
+
+      {summary.total > 0 && (
+        <CredentialActions
+          summary={summary}
+          vaultBase={vaultBase}
+          busy={busy}
+          onDownload={downloadCsv}
+          onConfirmSecured={onConfirmSecured}
+          onWipe={onWipe}
+        />
+      )}
 
       <div>
-        {!manifest || manifest.credentials.length === 0 ? (
+        {summary.total === 0 ? (
           <p className="text-sm text-text-muted italic">
             Nothing saved yet. The install wizard writes here at the end of every successful run.
           </p>
         ) : (
-          // Explicit per-column widths (#2520): without them the browser's auto
-          // table-layout hands the spare width to whichever column holds the
-          // longest prose — Notes — and starves Service/URL/Username. These are
-          // preferred widths, so a column still grows past its share rather
-          // than clipping its content; the table's min-width makes a narrow
-          // viewport scroll instead of crushing them.
           <DataTable<Credential>
-            columns={[
-              {
-                key: 'service',
-                header: 'Service',
-                className: 'w-[16%]',
-                cell: (c) => (
-                  <div>
-                    {c.service}
-                    {c.importance === 'system' && (
-                      <span className="ml-2 text-[10px] uppercase tracking-wide text-text-muted">system</span>
-                    )}
-                  </div>
-                ),
-                align: 'left',
-              },
-              {
-                key: 'url',
-                header: 'URL',
-                cell: (c) => <CredentialUrlCell cred={c} hosts={proxyHosts} publicDomain={publicDomain} />,
-                align: 'left',
-                className: 'w-[28%] font-mono text-xs',
-              },
-              {
-                key: 'username',
-                header: 'Username',
-                cell: (c) => c.username,
-                align: 'left',
-                className: 'w-[16%] font-mono text-xs',
-              },
-              {
-                key: 'password',
-                header: 'Password',
-                className: 'w-[18%]',
-                cell: (c, i) => {
-                  const isRevealed = !!revealed[i];
-                  return (
-                    <div className="flex items-center gap-2">
-                      <code className="font-mono text-xs">{isRevealed ? c.password : '••••••••••'}</code>
-                      <Button
-                        onClick={() => setRevealed(s => ({ ...s, [i]: !s[i] }))}
-                        variant="ghost"
-                        className="!h-auto !p-1"
-                        title={isRevealed ? 'Hide password' : 'Reveal password'}
-                      >
-                        {isRevealed ? <EyeOff size={12} /> : <Eye size={12} />}
-                      </Button>
-                      {isRevealed && (
-                        <Button
-                          onClick={() => {
-                            navigator.clipboard.writeText(c.password).then(
-                              () => addToast('success', 'Copied to clipboard', `${c.service} password`),
-                              () => addToast('error', 'Copy failed', 'Browser refused clipboard access.'),
-                            );
-                          }}
-                          variant="ghost"
-                          className="!h-auto !p-1 text-[10px] uppercase tracking-wide"
-                        >
-                          copy
-                        </Button>
-                      )}
-                    </div>
-                  );
-                },
-                align: 'left',
-              },
-              {
-                key: 'notes',
-                header: 'Notes',
-                cell: (c) => c.notes ?? '',
-                align: 'left',
-                className: 'w-[22%] text-xs text-text-muted',
-              },
-            ]}
-            // Above the primitive's 5×8rem default: these five columns are all
-            // dense (a URL, an e-mail username, a masked password + two
-            // buttons, a sentence of notes), so a 40rem floor still stacks the
-            // notes 6 lines deep on a phone. 56rem keeps every row ~2 lines and
-            // lets the wrapper scroll instead.
+            columns={credentialColumns(proxyHosts, publicDomain)}
+            // Above the primitive's 5x8rem default: these five columns are all
+            // dense (a URL, an e-mail username, a status chip, a sentence of
+            // notes), so a 40rem floor still stacks the notes 6 lines deep on a
+            // phone. 56rem keeps every row ~2 lines and lets the wrapper scroll.
             minWidthClassName="min-w-[56rem]"
-            rows={manifest.credentials}
+            rows={credentials}
             rowKey={(c, i) => String(i)}
-            rowClassName={(c) =>
-              c.importance === 'critical' ? '' : 'opacity-80'
-            }
+            rowClassName={(c) => (c.importance === 'critical' ? '' : 'opacity-80')}
             empty="No credentials saved"
           />
         )}

--- a/packages/frontend/src/app/(dashboard)/settings/access/page.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/access/page.tsx
@@ -33,7 +33,7 @@ export default function AccessSettingsPage() {
         tier="essential"
         label="Saved credentials"
         icon={Key}
-        description="Credentials the install wizard persisted — encrypted at rest, visible to logged-in admins."
+        description="What the install wizard set up and where each password lives. Passwords aren't shown here — they belong in Vaultwarden."
       >
         <CredentialsSection />
       </SettingDisclosure>

--- a/packages/frontend/src/app/api/services/[name]/reconfigure-preview/route.test.ts
+++ b/packages/frontend/src/app/api/services/[name]/reconfigure-preview/route.test.ts
@@ -1,0 +1,225 @@
+/**
+ * GET /api/services/:name/reconfigure-preview — "Re-render from template" (#2537).
+ *
+ * The bug: the route built its render view from `templateSettings[name] ??
+ * meta.default ?? ''` and consulted neither `config.installedVariables` (#2531)
+ * nor `config.installedSecrets` (#615), so every operator-typed value and every
+ * generated secret came back as an EMPTY STRING in the YAML handed to the editor.
+ *
+ * These tests deliberately let the REAL `assembleManifest` /
+ * `applyVariableDefaults` / `savedSecrets` / `savedVariables` /
+ * `findEmptyYamlVars` / `renderPodYaml` run — only the registry, the config file
+ * and the API-handler gate are stubbed. That is the point: the assertion worth
+ * having is not "the route reads a store" but "the preview resolves what a
+ * deploy resolves", which only holds if the same code produces both.
+ *
+ * No real credentials here — every fixture value is an obvious placeholder.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VariableMeta } from '@/lib/registry';
+
+const mocks = vi.hoisted(() => ({
+  getTemplateYaml: vi.fn(),
+  getTemplateVariables: vi.fn(),
+  getTemplateConfigFiles: vi.fn(),
+  getTemplateAssetFiles: vi.fn(),
+  getTemplateSettingsSchema: vi.fn(),
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+}));
+
+vi.mock('@/lib/registry', () => ({
+  getTemplateYaml: mocks.getTemplateYaml,
+  getTemplateVariables: mocks.getTemplateVariables,
+  getTemplateConfigFiles: mocks.getTemplateConfigFiles,
+  getTemplateAssetFiles: mocks.getTemplateAssetFiles,
+  getTemplateSettingsSchema: mocks.getTemplateSettingsSchema,
+}));
+
+vi.mock('@/lib/config', () => ({
+  getConfig: mocks.getConfig,
+  updateConfig: mocks.updateConfig,
+}));
+
+vi.mock('@/lib/api/handler', () => ({
+  withApiHandlerParams:
+    (_opts: unknown, handler: (ctx: { params: { name: string } }) => Promise<Response>) =>
+      (_req: unknown, ctx: { params: { name: string } }) => handler({ params: ctx.params }),
+}));
+
+import { GET } from './route';
+import { assembleManifest, applyVariableDefaults } from '@/lib/install/manifestAssembler';
+import { authDynamicVars } from '@/lib/install/runner';
+import { renderPodYaml } from '@/lib/template/render';
+
+/** Minimal pod yaml with the given `env` entries, each `value: "{{VAR}}"`. */
+function podYaml(name: string, vars: string[]): string {
+  return `apiVersion: v1
+kind: Pod
+metadata:
+  name: ${name}
+  annotations:
+    servicebay.label: "${name}"
+spec:
+  containers:
+  - name: ${name}
+    image: example/${name}:latest
+    env:
+${vars.map(v => `      - name: ${v}\n        value: "{{${v}}}"`).join('\n')}
+`;
+}
+
+async function call(name: string): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await (GET as unknown as (
+    req: unknown,
+    ctx: { params: { name: string } },
+  ) => Promise<Response>)({}, { params: { name } });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+function setTemplate(name: string, vars: string[], meta: Record<string, VariableMeta>): void {
+  mocks.getTemplateYaml.mockResolvedValue(podYaml(name, vars));
+  mocks.getTemplateVariables.mockResolvedValue(meta);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getTemplateConfigFiles.mockResolvedValue([]);
+  mocks.getTemplateAssetFiles.mockResolvedValue([]);
+  mocks.getTemplateSettingsSchema.mockResolvedValue({});
+  mocks.getConfig.mockResolvedValue({ templateSettings: {} });
+  mocks.updateConfig.mockResolvedValue(undefined);
+});
+
+describe('reconfigure-preview — #2537 blanked values', () => {
+  it('keeps an operator-set non-secret value instead of rendering it empty', async () => {
+    // A `text` variable whose template default is empty — exactly the #2531
+    // shape. Pre-fix the view was `templateSettings ?? '' ?? ''` → `value: ""`.
+    setTemplate('solaris', ['VAPID_PUBLIC_KEY'], {
+      VAPID_PUBLIC_KEY: { type: 'text', default: '' },
+    });
+    mocks.getConfig.mockResolvedValue({
+      templateSettings: {},
+      installedVariables: [{ varName: 'VAPID_PUBLIC_KEY', value: 'operator-typed-public-key' }],
+    });
+
+    const { status, body } = await call('solaris');
+
+    expect(status).toBe(200);
+    expect(body.yamlContent).toContain('value: "operator-typed-public-key"');
+    expect(body.yamlContent).not.toContain('name: VAPID_PUBLIC_KEY\n        value: ""');
+    expect(body.unresolved).toEqual([]);
+  });
+
+  it('keeps a stored secret instead of rendering it empty', async () => {
+    // The worse half of #2537: the blanked value here is a live credential, so
+    // a re-render + save deploys the pod with no password.
+    setTemplate('auth', ['LLDAP_ADMIN_PASSWORD'], {
+      LLDAP_ADMIN_PASSWORD: { type: 'secret' },
+    });
+    mocks.getConfig.mockResolvedValue({
+      templateSettings: {},
+      installedSecrets: [{ varName: 'LLDAP_ADMIN_PASSWORD', password: 'PLACEHOLDER-not-a-real-secret' }],
+    });
+
+    const { status, body } = await call('auth');
+
+    expect(status).toBe(200);
+    expect(body.yamlContent).toContain('value: "PLACEHOLDER-not-a-real-secret"');
+    expect(body.unresolved).toEqual([]);
+  });
+
+  it('renders byte-for-byte what the deploy path would render', async () => {
+    // The criterion that matters: not "looks right" but "is the same bytes the
+    // install runner would write". Build the deploy view the way `deployItem`
+    // does — assembleManifest (no preview) → applyVariableDefaults → variables
+    // reduced to a view → authDynamicVars → renderPodYaml — and compare.
+    setTemplate('auth', ['LLDAP_ADMIN_PASSWORD', 'LLDAP_BASE_DN', 'PUBLIC_DOMAIN', 'LLDAP_FORCE_LDAP_USER_PASS_RESET'], {
+      LLDAP_ADMIN_PASSWORD: { type: 'secret' },
+      LLDAP_BASE_DN: { type: 'text', default: '' },
+      PUBLIC_DOMAIN: { type: 'text', default: '' },
+      LLDAP_FORCE_LDAP_USER_PASS_RESET: { type: 'text', default: 'false' },
+    });
+    mocks.getConfig.mockResolvedValue({
+      templateSettings: {},
+      reverseProxy: { publicDomain: 'example.test' },
+      installedSecrets: [{ varName: 'LLDAP_ADMIN_PASSWORD', password: 'PLACEHOLDER-not-a-real-secret' }],
+    });
+
+    const { status, body } = await call('auth');
+    expect(status).toBe(200);
+
+    const assembled = await assembleManifest({ items: [{ name: 'auth', checked: true }] });
+    const withDefaults = await applyVariableDefaults({
+      items: assembled.items,
+      variables: assembled.variables,
+      templateSource: 'Built-in',
+      host: 'localhost',
+      wipeMode: 'install',
+    });
+    const view: Record<string, string> = {};
+    for (const v of withDefaults.variables) view[v.name] = v.value;
+    Object.assign(view, authDynamicVars('auth'));
+    const deployed = renderPodYaml(assembled.items[0].yaml as string, view);
+
+    expect(body.yamlContent).toBe(deployed);
+    // And the dynamic var the runner injects is present, not a stale default —
+    // `assembleManifest` drops it from the variable set on purpose.
+    expect(body.yamlContent).toContain('name: LLDAP_FORCE_LDAP_USER_PASS_RESET\n        value: "always"');
+    expect(body.yamlContent).toContain('value: "example.test"');
+  });
+});
+
+describe('reconfigure-preview — no silent substitution (#2537)', () => {
+  it('refuses to render when a generated secret cannot be recovered, and writes nothing', async () => {
+    setTemplate('auth', ['LLDAP_ADMIN_PASSWORD'], {
+      LLDAP_ADMIN_PASSWORD: { type: 'secret' },
+    });
+    mocks.getConfig.mockResolvedValue({ templateSettings: {} });
+
+    const { status, body } = await call('auth');
+
+    expect(status).toBe(400);
+    expect(body.unresolvedSecrets).toEqual(['LLDAP_ADMIN_PASSWORD']);
+    expect(String(body.error)).toContain('LLDAP_ADMIN_PASSWORD');
+    // A read-only preview must neither mint a replacement credential nor
+    // persist one — that would diverge `installedSecrets` from the running pod.
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+    expect(body.yamlContent).toBeUndefined();
+  });
+
+  it('names a non-secret value it could not resolve rather than returning it quietly empty', async () => {
+    setTemplate('svc', ['OPTIONAL_TOKEN'], {
+      OPTIONAL_TOKEN: { type: 'text', default: '' },
+    });
+
+    const { status, body } = await call('svc');
+
+    expect(status).toBe(200);
+    expect(body.unresolved).toEqual(['OPTIONAL_TOKEN']);
+  });
+
+  it('lets an operator-supplied (noAutoGenerate) secret render empty, but reports it', async () => {
+    setTemplate('hass', ['HASS_TOKEN'], {
+      HASS_TOKEN: { type: 'secret', noAutoGenerate: true },
+    });
+
+    const { status, body } = await call('hass');
+
+    // Empty is this variable's legitimate resting state (the operator pastes it
+    // in later), so refusing would make re-render impossible — but it is still
+    // named rather than silently blank.
+    expect(status).toBe(200);
+    expect(body.unresolved).toEqual(['HASS_TOKEN']);
+  });
+
+  it('404s when the template is gone from the registry', async () => {
+    mocks.getTemplateYaml.mockResolvedValue(null);
+    mocks.getTemplateVariables.mockResolvedValue(null);
+
+    const { status, body } = await call('ghost');
+
+    expect(status).toBe(404);
+    expect(String(body.error)).toContain('ghost');
+  });
+});

--- a/packages/frontend/src/app/api/services/[name]/reconfigure-preview/route.ts
+++ b/packages/frontend/src/app/api/services/[name]/reconfigure-preview/route.ts
@@ -1,65 +1,168 @@
 import { NextResponse } from 'next/server';
-import { renderTemplate } from '@/lib/template/render';
-import { getConfig } from '@/lib/config';
-import { getTemplateYaml, getTemplateVariables } from '@/lib/registry';
+import { renderPodYaml } from '@/lib/template/render';
+import { assembleManifest, applyVariableDefaults } from '@/lib/install/manifestAssembler';
+import { authDynamicVars, findEmptyYamlVars } from '@/lib/install/runner';
+import type { JobInput } from '@/lib/install/jobStore';
+import type { VariableMeta } from '@/lib/registry';
 import { logger } from '@/lib/logger';
 import { withApiHandlerParams } from '@/lib/api/handler';
 
 export const dynamic = 'force-dynamic';
 
+/** Variable types whose value is a live credential. An empty one deploys a
+ *  service with no password — the #2537 blast radius (a re-render + save on
+ *  `auth` takes SSO out for the whole box). */
+const SECRET_TYPES = new Set(['secret', 'bcrypt', 'rsa-private']);
+
 /**
- * Re-render a service's kube YAML from the template using the
- * operator's current `templateSettings` (#421). Migrated to
+ * Re-render a service's kube YAML from the template (#421). Migrated to
  * withApiHandler in #603.
  *
- * Doesn't write or restart — returns the rendered YAML for the
- * editor to drop in; the existing save → restart flow handles the
- * rest.
+ * Doesn't write or restart — returns the rendered YAML for the editor to drop
+ * in; the existing save → restart flow handles the rest.
+ *
+ * #2537 — this used to build its render view from `templateSettings[name] ??
+ * meta.default ?? ''` and nothing else, so every variable that was neither a
+ * global Template Setting nor carried a `variables.json` default rendered as an
+ * EMPTY STRING. That silently blanked operator-typed values (`installedVariables`,
+ * #2531) and, worse, generated secrets (`installedSecrets`, #615) — the operator
+ * reviewed a diff whose blanked credentials had scrolled off screen, saved, and
+ * redeployed the service with empty passwords.
+ *
+ * The fix is not a third resolution idiom: the preview now runs the SAME
+ * `assembleManifest → applyVariableDefaults` pair that the wizard
+ * (`/api/install/assemble` + `/api/install/start`), the `install_template` MCP
+ * tool and `POST /napi/services/:name/upgrade` drive for a single service, then
+ * renders with the SAME `renderPodYaml` + `authDynamicVars` the install runner's
+ * `deployItem` uses. What you see is what a deploy resolves, by construction.
+ *
+ * The one deliberate difference is `preview: true`: a deploy MINTS a missing
+ * secret, a read-only GET must not (it would write `installedSecrets` and hand
+ * back YAML that silently rotates a live credential). So a secret the store
+ * cannot supply stays empty and is reported instead of substituted — 400 for a
+ * normally-generated one (the value is genuinely lost; refuse rather than
+ * deploy a blank credential), and listed in `unresolved` for anything else.
  */
+/** What a deploy of this one service would render with. `null` when the
+ *  template no longer resolves from any registry. */
+async function resolveDeployView(serviceName: string): Promise<{
+  yamlSource: string;
+  view: Record<string, string>;
+  metaByName: Map<string, VariableMeta | undefined>;
+} | null> {
+  const assembled = await assembleManifest({
+    items: [{ name: serviceName, checked: true }],
+    preview: true,
+  });
+  const yamlSource = assembled.items[0]?.yaml;
+  if (!yamlSource) return null;
+
+  // The same defaults/operator-value backfill `POST /api/install/start` runs
+  // over a JobInput before the runner ever sees it (#1297 / #2531).
+  const input: JobInput = {
+    items: assembled.items,
+    variables: assembled.variables,
+    templateSource: 'Built-in',
+    host: 'localhost',
+    wipeMode: 'install',
+  };
+  const withDefaults = await applyVariableDefaults(input);
+
+  // `deployItem`'s view, verbatim: variables reduced to name → value, plus the
+  // dynamic vars the runner injects (LLDAP_FORCE_LDAP_USER_PASS_RESET on `auth`,
+  // which `assembleManifest` deliberately drops from the variable set).
+  const view: Record<string, string> = {};
+  for (const v of withDefaults.variables) view[v.name] = v.value;
+  Object.assign(view, authDynamicVars(serviceName));
+
+  const metaByName = new Map(
+    withDefaults.variables.map(v => [v.name, v.meta as VariableMeta | undefined]),
+  );
+  return { yamlSource, view, metaByName };
+}
+
+/** Template refs the view cannot satisfy, split by how bad that is. `missing`
+ *  is a ref with no variable at all; `lostSecrets` is a normally-generated
+ *  credential that resolved EMPTY (refuse — saving it would deploy a service
+ *  with no password); `unresolved` is everything else that rendered empty and
+ *  is merely reported. */
+function findUnsatisfiedRefs(
+  yamlSource: string,
+  view: Record<string, string>,
+  metaByName: Map<string, VariableMeta | undefined>,
+): { missing: string[]; lostSecrets: string[]; unresolved: string[] } {
+  const refRe = /\{\{\s*[#^/{]?\s*([A-Z_][A-Z0-9_]*)\s*\}{1,3}/g;
+  const refs = new Set<string>();
+  for (const m of yamlSource.matchAll(refRe)) refs.add(m[1]);
+  const missing = [...refs].filter(r => !(r in view));
+
+  // Present in the view but EMPTY. This is the hole #2537 was about: the
+  // missing-ref check only ever caught ABSENT refs, so a blanked value walked
+  // straight through it. Same detector the runner warns with, so preview and
+  // deploy agree on what "rendered empty" means (section refs are optional).
+  const empty = findEmptyYamlVars(yamlSource, view);
+  const lostSecrets = empty.filter(n => {
+    const meta = metaByName.get(n);
+    return !!meta?.type && SECRET_TYPES.has(meta.type) && !meta.noAutoGenerate;
+  });
+  return { missing, lostSecrets, unresolved: empty.filter(n => !lostSecrets.includes(n)) };
+}
+
+/** The two conditions under which we hand back nothing rather than YAML the
+ *  operator would save over a working service. `null` = go ahead and render. */
+function refuseIfUnsatisfiable(missing: string[], lostSecrets: string[]): NextResponse | null {
+  if (missing.length > 0) {
+    return NextResponse.json(
+      {
+        error: `The template references variables that aren't in Settings → Template Variables: ${missing.join(', ')}. Set them there first, then try again.`,
+        missing,
+      },
+      { status: 400 },
+    );
+  }
+  if (lostSecrets.length > 0) {
+    const one = lostSecrets.length === 1;
+    return NextResponse.json(
+      {
+        error: `Refusing to re-render: the stored value for ${lostSecrets.join(', ')} couldn't be recovered, so ${one ? 'it' : 'they'} would render EMPTY and the re-rendered YAML would deploy this service with no credential. Nothing has been changed. Set ${one ? 'it' : 'them'} in Configure, or reinstall the service, before re-rendering.`,
+        unresolvedSecrets: lostSecrets,
+      },
+      { status: 400 },
+    );
+  }
+  return null;
+}
+
 export const GET = withApiHandlerParams<undefined, undefined, { name: string }>(
   {},
   async ({ params }) => {
     const serviceName = decodeURIComponent(params.name);
 
-    const yamlSource = await getTemplateYaml(serviceName);
-    if (!yamlSource) {
+    let resolved: Awaited<ReturnType<typeof resolveDeployView>>;
+    try {
+      resolved = await resolveDeployView(serviceName);
+    } catch (e) {
+      logger.warn('services:reconfigure-preview', `Assemble failed for ${serviceName}: ${e instanceof Error ? e.message : String(e)}`);
+      return NextResponse.json(
+        { error: `Couldn't resolve "${serviceName}" from its template: ${e instanceof Error ? e.message : String(e)}` },
+        { status: 500 },
+      );
+    }
+    if (!resolved) {
       return NextResponse.json(
         { error: `No template named "${serviceName}" found in the registry — can't re-render.` },
         { status: 404 },
       );
     }
+    const { yamlSource, view, metaByName } = resolved;
 
-    const variables = await getTemplateVariables(serviceName);
-    const config = await getConfig();
-    const templateSettings = config.templateSettings ?? {};
-
-    const view: Record<string, string> = {};
-    for (const [name, meta] of Object.entries(variables ?? {})) {
-      const value = templateSettings[name] ?? meta.default ?? '';
-      view[name] = String(value);
-    }
-
-    // Walk the raw yaml for {{VAR}} / {{#VAR}} references and refuse
-    // to render when one of them isn't present in the view. Mustache
-    // would silently substitute "" — that produces YAML that crashes
-    // on deploy. Fail closed with a useful message instead.
-    const refRe = /\{\{\s*[#^/{]?\s*([A-Z_][A-Z0-9_]*)\s*\}{1,3}/g;
-    const refs = new Set<string>();
-    for (const m of yamlSource.matchAll(refRe)) refs.add(m[1]);
-    const missing = [...refs].filter(r => !(r in view));
-    if (missing.length > 0) {
-      return NextResponse.json(
-        {
-          error: `The template references variables that aren't in Settings → Template Variables: ${missing.join(', ')}. Set them there first, then try again.`,
-          missing,
-        },
-        { status: 400 },
-      );
-    }
+    const { missing, lostSecrets, unresolved } = findUnsatisfiedRefs(yamlSource, view, metaByName);
+    const refusal = refuseIfUnsatisfiable(missing, lostSecrets);
+    if (refusal) return refusal;
 
     let rendered: string;
     try {
-      rendered = renderTemplate(yamlSource, view);
+      rendered = renderPodYaml(yamlSource, view);
     } catch (e) {
       logger.warn('services:reconfigure-preview', `Render failed for ${serviceName}: ${e instanceof Error ? e.message : String(e)}`);
       return NextResponse.json(
@@ -68,6 +171,8 @@ export const GET = withApiHandlerParams<undefined, undefined, { name: string }>(
       );
     }
 
-    return NextResponse.json({ yamlContent: rendered });
+    // Anything still empty is NAMED in the response so the operator sees it in
+    // the editor instead of discovering the blank after a save.
+    return NextResponse.json({ yamlContent: rendered, unresolved });
   },
 );

--- a/packages/frontend/src/app/api/system/credentials/route.ts
+++ b/packages/frontend/src/app/api/system/credentials/route.ts
@@ -25,6 +25,10 @@ const CredentialSchema = z.object({
   importance: z.enum(['critical', 'system']),
   notes: z.string().max(400).optional(),
   template: z.string().max(120).optional(),
+  // #2519 — hand-off marker. Round-tripped so a caller that reads the
+  // manifest and writes it back doesn't silently resurrect entries as
+  // "not yet secured".
+  securedAt: z.string().max(40).optional(),
 });
 
 const ManifestBody = z.object({

--- a/packages/frontend/src/app/api/system/credentials/secured/route.ts
+++ b/packages/frontend/src/app/api/system/credentials/secured/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { getConfig, saveConfig, type InstalledCredential, type InstallManifest } from '@/lib/config';
+import {
+  markCredentialsSecured,
+  summarizeCredentialSecurity,
+  type Credential,
+} from '@/lib/stackInstall/credentialsManifest';
+import { withApiHandler } from '@/lib/api/handler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Vaultwarden hand-off confirmation (#2519).
+ *
+ * POST — record that every not-yet-secured credential now lives in the
+ * operator's Vaultwarden vault, and **drop ServiceBay's copy of the
+ * secret in the same write**. The entry itself stays: service, URL,
+ * username and notes remain so Settings can still say *what* exists and
+ * link to the vault — only `password` goes.
+ *
+ * This is deliberately the ONLY way an entry becomes "secured", and it
+ * cannot be set without the drop happening (`markCredentialsSecured`
+ * empties `password` as part of the same map). "Secured" and "we still
+ * hold it" are therefore not simultaneously representable.
+ *
+ * Not the automated push the issue asks for — see the issue thread: a
+ * server-side write into a *personal* Vaultwarden vault needs a
+ * vault-unlocking secret, which ServiceBay must not hold. The state this
+ * route writes is the same state an automated push would write, so the
+ * push slice replaces the trigger without changing the model.
+ */
+export const POST = withApiHandler({}, async () => {
+  const config = await getConfig();
+  const existing = (config.installManifest?.credentials ?? []) as Credential[];
+  if (existing.length === 0) {
+    return NextResponse.json({ ok: true, secured: 0, summary: summarizeCredentialSecurity([]) });
+  }
+
+  const before = summarizeCredentialSecurity(existing);
+  if (before.unsecured === 0) {
+    return NextResponse.json({ ok: true, secured: 0, summary: before });
+  }
+
+  const securedAt = new Date().toISOString();
+  const next = markCredentialsSecured(existing, securedAt);
+  const manifest: InstallManifest = {
+    savedAt: securedAt,
+    credentials: next as unknown as InstalledCredential[],
+  };
+  await saveConfig({ ...config, installManifest: manifest });
+
+  return NextResponse.json({
+    ok: true,
+    secured: before.unsecured,
+    securedAt,
+    summary: summarizeCredentialSecurity(next),
+  });
+});

--- a/packages/frontend/src/components/ServiceForm.test.tsx
+++ b/packages/frontend/src/components/ServiceForm.test.tsx
@@ -13,8 +13,9 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
 }));
+const toastMocks = vi.hoisted(() => ({ addToast: vi.fn(), updateToast: vi.fn() }));
 vi.mock('@/providers/ToastProvider', () => ({
-  useToast: () => ({ addToast: vi.fn(), updateToast: vi.fn() }),
+  useToast: () => toastMocks,
 }));
 vi.mock('@/app/actions/system', () => ({ getNodes: () => Promise.resolve([]) }));
 // Keep the history panel out of the render.
@@ -68,5 +69,82 @@ describe('ServiceForm — rename modal Escape-to-close (#2188)', () => {
     // Escape must be ignored while the request is in flight.
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.getByRole('heading', { name: /rename service/i })).toBeTruthy();
+  });
+});
+
+/**
+ * "Re-render from template" — #2537. The route now names any variable it could
+ * not resolve instead of handing back quietly-blank YAML; the operator only
+ * benefits if the form SAYS so, because the blanked line is exactly what
+ * scrolls off screen in the diff they are reviewing.
+ */
+describe('ServiceForm — re-render reports unresolved values (#2537)', () => {
+  function renderForm() {
+    render(
+      <ServiceForm
+        isEdit
+        initialData={{
+          name: 'my-service',
+          yamlFileName: 'my-service.yml',
+          kubeContent: '',
+          yamlContent: '',
+        }}
+      />,
+    );
+  }
+
+  function stubPreview(payload: unknown, ok = true, status = 200) {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (String(url).includes('reconfigure-preview')) {
+        return { ok, status, json: async () => payload } as unknown as Response;
+      }
+      // The editor revalidates the YAML it was handed — irrelevant here.
+      return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+    }));
+  }
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    toastMocks.addToast.mockClear();
+    vi.stubGlobal('confirm', vi.fn(() => true));
+  });
+
+  it('warns, naming each variable that rendered empty', async () => {
+    stubPreview({ yamlContent: 'kind: Pod\n', unresolved: ['HASS_TOKEN'] });
+    renderForm();
+
+    fireEvent.click(screen.getByTitle(/Re-render this YAML/i));
+
+    await waitFor(() => expect(toastMocks.addToast).toHaveBeenCalled());
+    const [type, title, message] = toastMocks.addToast.mock.calls.at(-1) as string[];
+    expect(type).toBe('warning');
+    expect(title).toMatch(/empty/i);
+    expect(message).toContain('HASS_TOKEN');
+  });
+
+  it('reports plain success when everything resolved', async () => {
+    stubPreview({ yamlContent: 'kind: Pod\n', unresolved: [] });
+    renderForm();
+
+    fireEvent.click(screen.getByTitle(/Re-render this YAML/i));
+
+    await waitFor(() => expect(toastMocks.addToast).toHaveBeenCalled());
+    expect((toastMocks.addToast.mock.calls.at(-1) as string[])[0]).toBe('success');
+  });
+
+  it('surfaces the server refusal when a secret could not be recovered', async () => {
+    stubPreview(
+      { error: 'Refusing to re-render: the stored value for LLDAP_ADMIN_PASSWORD ...' },
+      false,
+      400,
+    );
+    renderForm();
+
+    fireEvent.click(screen.getByTitle(/Re-render this YAML/i));
+
+    await waitFor(() => expect(toastMocks.addToast).toHaveBeenCalled());
+    const [type, , message] = toastMocks.addToast.mock.calls.at(-1) as string[];
+    expect(type).toBe('error');
+    expect(message).toContain('LLDAP_ADMIN_PASSWORD');
   });
 });

--- a/packages/frontend/src/components/ServiceForm.tsx
+++ b/packages/frontend/src/components/ServiceForm.tsx
@@ -222,9 +222,10 @@ WantedBy=default.target`;
   const handleRerender = async () => {
     if (!name) return;
     if (!window.confirm(
-      'Re-render this service\'s YAML from its template using the current ' +
-      'Settings → Template Variables values? The editor below will be replaced ' +
-      'with the new YAML; nothing is saved or restarted until you click Save.',
+      'Re-render this service\'s YAML from its template, using the same values ' +
+      'a deploy would resolve (Template Settings, your saved variables and stored ' +
+      'secrets)? The editor below will be replaced with the new YAML; nothing is ' +
+      'saved or restarted until you click Save.',
     )) {
       return;
     }
@@ -238,7 +239,19 @@ WantedBy=default.target`;
       }
       if (typeof data.yamlContent === 'string') {
         handleYamlChange(data.yamlContent);
-        addToast('success', 'Re-rendered', 'Review the changes and click Save to apply.');
+        // #2537 — a variable the server could not resolve renders empty. Name it
+        // here rather than let the operator find the blank after a save; the
+        // blanked-value diff is exactly what scrolls off screen unnoticed.
+        const unresolved: string[] = Array.isArray(data.unresolved) ? data.unresolved : [];
+        if (unresolved.length > 0) {
+          addToast(
+            'warning',
+            'Re-rendered with empty values',
+            `${unresolved.join(', ')} could not be resolved and rendered empty. Check ${unresolved.length === 1 ? 'it' : 'them'} in the YAML before saving.`,
+          );
+        } else {
+          addToast('success', 'Re-rendered', 'Review the changes and click Save to apply.');
+        }
       }
     } catch (e) {
       addToast('error', 'Re-render failed', e instanceof Error ? e.message : String(e));
@@ -707,7 +720,7 @@ WantedBy=default.target`;
                                         variant="ghost"
                                         size="sm"
                                         className="p-1.5"
-                                        title="Re-render this YAML from its template using the current Settings → Template Variables values"
+                                        title="Re-render this YAML from its template, using the same values a deploy would resolve"
                                     >
                                         <RefreshCw size={14} className={rerendering ? 'animate-spin' : ''} />
                                     </Button>

--- a/scripts/bootstrap-service-repo.ts
+++ b/scripts/bootstrap-service-repo.ts
@@ -1,0 +1,101 @@
+/**
+ * Standards-bootstrap for a new service repo (#2513).
+ *
+ * The mechanics of "a new service repo's CLAUDE.md carries the
+ * get_service_standards pointer from day one" are deterministic, so they live in
+ * a script rather than in prose an agent re-interprets (CLAUDE.md § "Deterministic
+ * execution → scripts"). The block itself comes from
+ * packages/backend/src/lib/mcp/serviceRepoBootstrap.ts — the same source the
+ * `get_service_standards` MCP tool serves as its `repoBootstrap` block, so a
+ * pasted copy and a scripted copy can never disagree.
+ *
+ * Usage (from a mdopp/servicebay checkout):
+ *   npm run standards:bootstrap                      # print the block (stdout)
+ *   npm run standards:bootstrap -- --print
+ *   npm run standards:bootstrap -- --write <repo>    # insert/refresh <repo>/CLAUDE.md
+ *   npm run standards:bootstrap -- --check <repo>    # exit 1 if missing or drifted
+ *
+ * Exits 0 (ok / written), 1 (check failed), 2 (usage or I/O error).
+ */
+import { readFileSync, writeFileSync, existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+import {
+  BOOTSTRAP_MARKER_BEGIN,
+  applyStandardsPointer,
+  checkStandardsPointer,
+  renderStandardsPointerBlock,
+} from '../packages/backend/src/lib/mcp/serviceRepoBootstrap.js';
+
+type Mode = 'print' | 'write' | 'check';
+
+interface Args {
+  mode: Mode;
+  target: string;
+}
+
+export function parseArgs(argv: string[]): Args {
+  let mode: Mode = 'print';
+  let target = '';
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--print') mode = 'print';
+    else if (a === '--write' || a === '--check') {
+      mode = a === '--write' ? 'write' : 'check';
+      if (argv[i + 1] && !argv[i + 1].startsWith('--')) target = argv[++i];
+    } else if (!a.startsWith('--') && !target) target = a;
+  }
+  return { mode, target: target || '.' };
+}
+
+/** `<target>` may be the repo dir or the CLAUDE.md path itself. */
+export function resolveClaudeMd(target: string): string {
+  const abs = path.resolve(target);
+  if (existsSync(abs) && statSync(abs).isDirectory()) return path.join(abs, 'CLAUDE.md');
+  return abs;
+}
+
+function main() {
+  const { mode, target } = parseArgs(process.argv.slice(2));
+
+  if (mode === 'print') {
+    console.log(renderStandardsPointerBlock());
+    return;
+  }
+
+  const file = resolveClaudeMd(target);
+  const existing = existsSync(file) ? readFileSync(file, 'utf-8') : '';
+
+  if (mode === 'check') {
+    if (!existsSync(file)) {
+      console.error(`standards-bootstrap: ${file} does not exist — a service repo without a CLAUDE.md has no pointer into the standards catalog (#2513).`);
+      process.exit(1);
+    }
+    const { ok, problems } = checkStandardsPointer(existing);
+    if (ok) {
+      console.log(`standards-bootstrap: ${file} carries an up-to-date standards pointer.`);
+      return;
+    }
+    console.error(`standards-bootstrap: ${file} does not satisfy the bootstrap step.\n`);
+    for (const p of problems) console.error(`  · ${p}`);
+    process.exit(1);
+  }
+
+  const next = applyStandardsPointer(existing);
+  if (next === existing) {
+    console.log(`standards-bootstrap: ${file} already up to date.`);
+    return;
+  }
+  writeFileSync(file, next, 'utf-8');
+  const verb = existing.includes(BOOTSTRAP_MARKER_BEGIN) ? 'refreshed' : 'wrote';
+  console.log(`standards-bootstrap: ${verb} the standards pointer in ${file}.`);
+}
+
+// Run only as a CLI — parseArgs/resolveClaudeMd are imported by the test suite.
+if (/bootstrap-service-repo\.ts$/.test(process.argv[1] ?? '')) {
+  try {
+    main();
+  } catch (err) {
+    console.error('standards-bootstrap crashed:', err);
+    process.exit(2);
+  }
+}

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -720,6 +720,88 @@ async function checkCiRunsEveryCheckScript() {
 }
 
 // ---------------------------------------------------------------------------
+// 8b. The service-repo bootstrap step still consults the standards catalog.
+//
+// #2513: `get_service_standards` served an excellent index that nothing outside
+// an already-connected MCP session referenced, so a sibling repo picked its
+// stack, its CI and its storage before ever meeting the ADRs. The fix is a step
+// — step 1 of the `create-service` recipe — plus the generated CLAUDE.md pointer
+// the new repo carries from its first commit.
+//
+// A step that lives only in prose is a step an agent skips (CLAUDE.md
+// § "Deterministic execution → scripts"), and prose is also what silently rots:
+// re-order the recipe, drop the pointer block, and nothing complains. This check
+// is the ratchet — the recipe must still name the tool in its FIRST ordered
+// action, and must still carry a pointer block that references the tool, the
+// assist fetch, and the gap-reporting convention.
+// ---------------------------------------------------------------------------
+const CREATE_SERVICE_ASSIST = path.join(REPO_ROOT, 'assists', 'create-service.md');
+const BOOTSTRAP_BEGIN_RE = /<!-- BEGIN SERVICEBAY STANDARDS POINTER/;
+const BOOTSTRAP_END_RE = /<!-- END SERVICEBAY STANDARDS POINTER -->/;
+/** Every pointer block is worthless without these — same list as the module. */
+const BOOTSTRAP_POINTER_REFS = ['get_service_standards', 'get_assist', 'standards-gap'];
+
+/**
+ * Pure audit of the `create-service` recipe text. Returns one detail string per
+ * problem (empty = the bootstrap step is intact). Exported so the suite can
+ * exercise the RED path — a gate whose failure branch is never run is a gate
+ * nobody knows still works.
+ */
+export function auditServiceRepoBootstrap(doc: string): string[] {
+    const problems: string[] = [];
+
+    // The first entry of the "## Ordered actions" list must be the standards step.
+    const ordered = /\n## Ordered actions\n([\s\S]*?)(?:\n## |\s*$)/.exec(doc);
+    if (!ordered) {
+        problems.push('assists/create-service.md has no "## Ordered actions" section to carry the bootstrap step (#2513).');
+    } else {
+        const firstAction = /^1\.[\s\S]*?(?=^\d+\.\s)/m.exec(ordered[1])?.[0] ?? ordered[1];
+        if (!firstAction.includes('get_service_standards')) {
+            problems.push(
+                'assists/create-service.md — the FIRST ordered action no longer names `get_service_standards`. Consulting the catalog must come before the image/stack/CI choices, or a new repo is built past the ADRs again (#2513).',
+            );
+        }
+    }
+
+    const start = doc.search(BOOTSTRAP_BEGIN_RE);
+    const end = doc.search(BOOTSTRAP_END_RE);
+    if (start < 0 || end < 0) {
+        problems.push(
+            'assists/create-service.md no longer carries the generated CLAUDE.md standards-pointer block. Regenerate it with `npm run standards:bootstrap -- --print` (#2513).',
+        );
+        return problems;
+    }
+    const block = doc.slice(start, end);
+    for (const ref of BOOTSTRAP_POINTER_REFS) {
+        if (block.includes(ref)) continue;
+        problems.push(
+            `assists/create-service.md — the standards-pointer block no longer mentions \`${ref}\`, so a repo bootstrapped from it loses that link into the catalog (#2513).`,
+        );
+    }
+    return problems;
+}
+
+async function checkServiceRepoBootstrapStep() {
+    const check = 'service-repo-bootstrap-step';
+    let doc: string;
+    try {
+        doc = await readFile(CREATE_SERVICE_ASSIST, 'utf-8');
+    } catch {
+        violations.push({
+            check,
+            detail: 'assists/create-service.md is missing — it owns step 1 of the service-repo bootstrap (#2513).',
+        });
+        return;
+    }
+
+    const problems = auditServiceRepoBootstrap(doc);
+    for (const detail of problems) violations.push({ check, detail });
+    if (problems.length === 0) {
+        measurements.push('service-repo bootstrap: step 1 of assists/create-service.md consults get_service_standards, pointer block intact');
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 9. docs/ARCHITECTURE_INVARIANTS.md's numbers are generated, not typed.
 //
 // #2427: the doc carried a hand-maintained measurement table ("largest backend
@@ -816,6 +898,7 @@ async function main() {
         checkDurableStateAtomicWrites(),
         checkGatePathsResolve(),
         checkCiRunsEveryCheckScript(),
+        checkServiceRepoBootstrapStep(),
         syncOrCheckThresholdDoc(),
     ]);
 

--- a/templates/claude-dev/CHANGELOG.md
+++ b/templates/claude-dev/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Claude Dev — template changelog
+
+Tracks breaking changes to the `claude-dev` template's pod structure /
+variable shape (not the Claude Code CLI itself — that's versioned by the
+image tag). Each H2 corresponds to a value of `servicebay.schema-version`
+in `template.yml`.
+
+The ServiceBay update flow reads the section header(s) between the operator's
+installed schema-version and the current one and surfaces them in the re-deploy
+dialog. Each `(breaking)` section needs an explicit acknowledgement before the
+deploy can proceed.
+
+## v2 (breaking)
+
+**Moved off `hostNetwork` into an isolated network namespace (#2522).**
+
+The pod used to run `hostNetwork: true`, so sshd bound `CLAUDE_DEV_SSH_PORT`
+directly on the host. That also meant a session in this container — a general
+shell with a Claude Code session running unattended in it — could reach every
+other service port on the box, and ServiceBay's own control API, over
+`127.0.0.1`. `claude-dev` was never on ADR 0007's closed carve-out list; per
+[ADR 0007](../../docs/adr/0007-container-network-isolation-and-carveouts.md)
+Decision 1 it is migrated rather than added to it.
+
+**Your SSH access does not change.** The port is now published with an explicit
+`hostPort` on the *same* port number and with no `hostIP`, so podman binds it on
+`0.0.0.0` — the same reachability the `hostNetwork` bind had:
+
+- the router/FritzBox port-forward you already have keeps working, unchanged;
+- `ssh -p <port> <user>@<box>` on the LAN keeps working, unchanged;
+- the Claude Code mobile app connection keeps working, unchanged;
+- the SSH **host keys** live on the persistent `/workspace` volume, so there is
+  no `known_hosts` warning after the re-deploy.
+
+**LDAP login keeps working, over a different address.** The container binds
+LLDAP for SSH logins. LLDAP lives in the `auth` pod, which is a named
+`hostNetwork` carve-out, so it listens on the *host* — an isolated pod cannot
+reach it on `127.0.0.1`, and rootless podman refuses the host's own LAN IP. The
+bind target is therefore `host.containers.internal`, the name podman writes into
+every container's `/etc/hosts`. This is the same address Radicale's `ldap_uri`
+and the media stack's Jellyfin LDAP-Auth config already use.
+
+Nothing in the `auth` stack has to change first: LLDAP's raw LDAP port is
+deliberately left bound to every interface, and its LAN half is closed one layer
+down by the `blockLanAccess: true` nftables rule, which accepts traffic arriving
+on `lo` — where the pasta-proxied pod path lands — and drops physical interfaces
+(#2388). ADR 0007's *siblings first, consumer second* order is already satisfied.
+
+**Variable removed: `LLDAP_HOST`.** It is no longer a variable at all; the pod
+carries `host.containers.internal` as a literal. `LLDAP_HOST` is a shared
+variable owned by the `auth` stack, and ServiceBay's install assembler
+force-resolves it to `localhost` for every template — correct for the
+`hostNetwork` `auth` pod, but it would silently overwrite the value here and
+break every LDAP login. `LLDAP_LDAP_PORT`, `LLDAP_BASE_DN`,
+`LLDAP_ADMIN_PASSWORD` and `CLAUDE_DEV_LDAP_GROUP` are unchanged.
+
+**One behavioural difference worth knowing:** sshd now sees connections arriving
+from the pod's gateway address rather than the client's real LAN address, because
+the connection is proxied into the namespace. Nothing in this template
+authenticates or filters on source IP (logins are gated by SSH key, the LLDAP
+bind, an nslcd `memberof` filter and sshd `AllowGroups`), so no access rule
+changes — but `/var/log/auth.log` inside the container will show the gateway
+address instead of the client's.
+
+Required action: **re-deploy** the `claude-dev` service so podman recreates the
+pod from the v2 manifest. Nothing on disk moves — `/workspace` (git checkouts,
+`~/.claude` history, `gh` auth, per-user homes, SSH host keys) is untouched. The
+local `dev` break-glass account is unaffected and remains the fallback if the
+LDAP path ever misbehaves.

--- a/templates/claude-dev/README.md
+++ b/templates/claude-dev/README.md
@@ -39,7 +39,7 @@ homes under `/workspace/home/<user>` stay private (mode `700`).
 | `CLAUDE_DEV_SSH_AUTHORIZED_KEY` | Optional SSH public key for the `dev` user; enables key-based login (recommended when the box is reachable from outside the LAN). |
 | `LLDAP_ADMIN_PASSWORD` | LLDAP bind password. **Not asked for** — reused automatically from the value the `auth` stack generated. Empty ⇒ LDAP login off, `dev` only. |
 | `CLAUDE_DEV_LDAP_GROUP` | LLDAP group whose members may SSH in (default `admins`). |
-| `LLDAP_HOST` / `LLDAP_LDAP_PORT` / `LLDAP_BASE_DN` | LLDAP coordinates; default to the `auth` stack's (`localhost` / `3890` / the base DN derived from `PUBLIC_DOMAIN`). LDAP login is skipped when the base DN is blank. |
+| `LLDAP_LDAP_PORT` / `LLDAP_BASE_DN` | LLDAP coordinates; default to the `auth` stack's (`3890` / the base DN derived from `PUBLIC_DOMAIN`). LDAP login is skipped when the base DN is blank. The LLDAP *host* is not a variable — since template v2 the pod reaches it at `host.containers.internal` (see [CHANGELOG](CHANGELOG.md)). |
 
 ## Logging in as your own LDAP user
 
@@ -73,10 +73,14 @@ serves no `uidNumber`/`gidNumber`, and groups carry DN `member`s rather than
 
 ## Reaching it from a phone
 
-`sshd` binds `CLAUDE_DEV_SSH_PORT` directly on the host (the pod runs
-with `hostNetwork`). On the LAN, connect straight to
-`dev@<server-ip>:<port>`. From outside, add a FritzBox port-forward for
-that port and point the Claude Code mobile app's SSH connection at it.
+`CLAUDE_DEV_SSH_PORT` is published on the host via `hostPort` with no
+`hostIP`, so it answers on every interface. (Before template v2 the pod ran
+with `hostNetwork` and sshd bound the host directly — the reachability is the
+same, the blast radius is not; see [CHANGELOG](CHANGELOG.md) and
+[ADR 0007](../../docs/adr/0007-container-network-isolation-and-carveouts.md).)
+On the LAN, connect straight to `dev@<server-ip>:<port>`. From outside, add a
+FritzBox port-forward for that port and point the Claude Code mobile app's SSH
+connection at it.
 
 ## Starting a session
 

--- a/templates/claude-dev/migrations/v1-to-v2.py
+++ b/templates/claude-dev/migrations/v1-to-v2.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Migration: claude-dev v1 → v2 (#2522).
+
+What changed between v1 and v2: the pod dropped `hostNetwork: true` and now
+runs in its own network namespace (ADR 0007 Decision 1). sshd's port is
+published with an explicit `hostPort` on the SAME port number and with no
+`hostIP`, so podman binds it on 0.0.0.0 — the reachability the hostNetwork
+bind had. The operator's router port-forward, LAN `ssh -p <port> …@<box>`, and
+the Claude Code mobile app connection are all unaffected, and the SSH host keys
+persist on /workspace so `known_hosts` does not complain.
+
+The LLDAP bind target moved from `localhost` to `host.containers.internal` —
+the name podman writes into every container's /etc/hosts, and the only way an
+isolated pod reaches an on-box sibling. The `LLDAP_HOST` variable was removed
+(the value is a literal in the manifest now) because the install assembler
+force-resolves LLDAP_HOST to "localhost" for every template, which is correct
+for the hostNetwork `auth` pod that owns the variable but would silently
+overwrite it here.
+
+The rebind is structural: `podman play kube` recreates the pod from the v2
+manifest. Nothing on disk moves — /workspace (git checkouts, ~/.claude history,
+gh auth, per-user homes, host keys) is untouched.
+
+What this script does:
+  - Inform the operator that SSH reachability is unchanged and that nothing
+    on disk moves.
+  - Best-effort PREFLIGHT of the sibling precondition (ADR 0007 Decision 3,
+    "siblings first, consumer second"): if LDAP login is configured, check
+    that LLDAP's raw LDAP port is listening on something wider than the
+    loopback, since an isolated pod can only reach it that way. `auth` binds
+    it to 0.0.0.0 by design (its LAN half is closed by the `blockLanAccess`
+    nftables rule, #2388), so this normally passes silently.
+  - Exit 0 — ALWAYS. This is a warning, never an abort. Aborting would leave
+    the operator unable to re-deploy their own dev box, and a broken LDAP path
+    does not lock anyone out: the local `dev` break-glass account still works.
+    Anything unexpected while probing is swallowed for the same reason.
+
+This script is intentionally read-only and idempotent — it logs guidance and
+returns.
+
+Environment available (set by ServiceManager.runMigrationScript):
+  - OLD_SCHEMA_VERSION = 1
+  - NEW_SCHEMA_VERSION = 2
+  - OLD_DATA_DIR, NEW_DATA_DIR (defaults to DATA_DIR for both)
+  - Every wizard variable (CLAUDE_DEV_SSH_PORT, LLDAP_LDAP_PORT, …)
+  - SB_NODE, SB_API_URL, SB_API_TOKEN (for callbacks into ServiceBay)
+
+See docs/TEMPLATE_AUTHORING.md (Migrations section) for the contract.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def _loopback_only(port: str) -> bool:
+    """True only when we POSITIVELY see `port` listening on loopback alone.
+
+    Unknown, unreadable or absent → False, so an unclear reading never
+    produces a warning about a problem that may not exist.
+    """
+    try:
+        out = subprocess.run(
+            ["ss", "-H", "-ltn"],
+            capture_output=True, text=True, timeout=10, check=False,
+        ).stdout
+    except Exception:
+        return False
+    locals_ = []
+    for line in out.splitlines():
+        fields = line.split()
+        if len(fields) < 4:
+            continue
+        addr = fields[3]
+        host, _, listen_port = addr.rpartition(":")
+        if listen_port == port:
+            locals_.append(host.strip("[]"))
+    if not locals_:
+        return False
+    return all(h in ("127.0.0.1", "::1") for h in locals_)
+
+
+def main() -> int:
+    ssh_port = os.environ.get("CLAUDE_DEV_SSH_PORT", "2222")
+    ldap_port = os.environ.get("LLDAP_LDAP_PORT", "3890")
+    ldap_configured = bool(os.environ.get("LLDAP_ADMIN_PASSWORD"))
+
+    print("Claude Dev v1 → v2: the pod now runs in its own network namespace (#2522).")
+    print(f"  SSH is UNCHANGED: port {ssh_port} is published on the host with an")
+    print("  explicit hostPort and no hostIP, so it still answers on every")
+    print("  interface. Your router port-forward, LAN ssh and the Claude Code")
+    print("  mobile app connection all keep working exactly as before, and the")
+    print("  SSH host keys persist on /workspace so known_hosts is unaffected.")
+    print("  Nothing to move or transform on disk — /workspace (git checkouts,")
+    print("  ~/.claude history, gh auth, per-user homes) is untouched.")
+
+    if ldap_configured:
+        print(f"  LDAP logins now bind ldap://host.containers.internal:{ldap_port}")
+        print("  instead of localhost — an isolated pod cannot reach an on-box")
+        print("  sibling on 127.0.0.1. LLDAP is bound wide by design and its LAN")
+        print("  half is closed at the host firewall (blockLanAccess, #2388).")
+        if _loopback_only(ldap_port):
+            print("")
+            print(f"  WARNING — LLDAP's LDAP port {ldap_port} appears to be listening on")
+            print("  the LOOPBACK ONLY. An isolated pod cannot reach it there, so LDAP")
+            print("  logins will fail after this deploy. Fix the SIBLING first: the")
+            print("  `auth` stack must leave LLDAP_LDAP_HOST unset (0.0.0.0 bind) and")
+            print("  keep `blockLanAccess: true` on LLDAP_LDAP_PORT — re-deploy `auth`,")
+            print("  then re-deploy this service. The local `dev` break-glass account")
+            print("  keeps working meanwhile, so you are not locked out.")
+    else:
+        print("  LDAP login is not configured on this box (LLDAP_ADMIN_PASSWORD is")
+        print("  empty), so only the local `dev` account is affected — i.e. nothing.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/claude-dev/template.yml
+++ b/templates/claude-dev/template.yml
@@ -6,7 +6,12 @@ metadata:
     app: claude-dev
   annotations:
     servicebay.label: "Claude Dev (Claude Code CLI + toolchain)"
-    servicebay.schema-version: "1"
+    # v2 (#2522): the pod moved off `hostNetwork` into its own network
+    # namespace (ADR 0007 Decision 1). sshd's port is published with an
+    # explicit `hostPort` on the SAME port number, and the LLDAP bind target
+    # became `host.containers.internal` instead of the `LLDAP_HOST` variable.
+    # No data move; /workspace and the persisted SSH host keys are untouched.
+    servicebay.schema-version: "2"
     servicebay.ports: "{{CLAUDE_DEV_SSH_PORT}}/tcp"
     # LLDAP (the `auth` stack) provides the directory the SSH login binds
     # against, and installing auth first means claude-dev inherits the
@@ -15,7 +20,10 @@ metadata:
     servicebay.dependencies: "auth"
     # Continuous health probe (#628). A raw TCP connect to the SSH port
     # proves sshd accepted the listener — a dev box has no
-    # unauthenticated HTTP surface to probe.
+    # unauthenticated HTTP surface to probe. The poller runs in the HOST
+    # netns, so 127.0.0.1 reaches the `hostPort` published below exactly as
+    # it reached the hostNetwork bind before v2 (same call radicale's
+    # localhost health URL makes for its isolated pod).
     servicebay.healthcheck: |
       kind: tcp
       host: 127.0.0.1
@@ -24,10 +32,21 @@ metadata:
       timeout: 5s
       startup_timeout: 5m
 spec:
-  # hostNetwork so sshd binds {{CLAUDE_DEV_SSH_PORT}} directly on the
-  # host — the operator port-maps that on the FritzBox (or reaches it
-  # over the LAN) to drive a Claude Code session from the mobile app.
-  hostNetwork: true
+  # ADR 0007 Decision 1 (#2522): claude-dev runs in its OWN network
+  # namespace — deliberately NO `hostNetwork`. This container is a general
+  # shell with a Claude session running unattended in it, so host networking
+  # gave it 127.0.0.1 reach to every other service port on the box and to
+  # ServiceBay's own control API. It was never on the ADR's closed carve-out
+  # list; it is migrated rather than added to it.
+  #
+  #   - sshd is reachable on exactly the same port as before: the `hostPort`
+  #     below publishes {{CLAUDE_DEV_SSH_PORT}} on the host with NO `hostIP`,
+  #     so podman binds 0.0.0.0 — the same reachability hostNetwork gave it.
+  #     The operator's router port-forward, every `ssh -p <port> …@<box>`,
+  #     and the Claude Code mobile app connection all keep working unchanged,
+  #     and the SSH host keys persist on /workspace so known_hosts is happy.
+  #   - The one on-box sibling it consumes is LLDAP; it is reached via
+  #     `host.containers.internal` — see the LLDAP_HOST note below.
   containers:
   # Built from templates/claude-dev/Dockerfile and published by
   # .github/workflows/claude-dev-image.yml. The image carries Node 22,
@@ -48,8 +67,31 @@ spec:
       # mirror the `auth` template's variable names so LLDAP_ADMIN_PASSWORD is
       # reused from savedSecrets (the value auth generated) rather than asked
       # for again. Blank LLDAP_ADMIN_PASSWORD ⇒ LDAP off, local `dev` only.
+      #
+      # `host.containers.internal` is the name podman writes into every
+      # container's /etc/hosts for the host, and it is the ONLY way an
+      # isolated pod reaches an on-box sibling (ADR 0007 Decision 1). NOT
+      # `localhost` — since v2 that is this pod's own loopback, where no
+      # LDAP server listens — and NOT the LAN_IP placeholder, which rootless
+      # podman refuses outright.
+      #
+      # This is a LITERAL, deliberately not the LLDAP_HOST placeholder: the
+      # install assembler force-resolves LLDAP_HOST to "localhost" for EVERY
+      # (manifestAssembler.ts, "LLDAP_HOST is always localhost"), which is
+      # correct for the hostNetwork `auth` pod that owns the variable but
+      # would silently overwrite the value here and break every LDAP login.
+      # Radicale's `ldap_uri` and media's post-deploy hard-code the same host
+      # for the same reason.
+      #
+      # Sibling-first (ADR 0007 Decision 3) is already satisfied — `auth`
+      # needs no change for this migration. LLDAP's raw LDAP port is
+      # deliberately left on 0.0.0.0 (auth/template.yml: "DELIBERATELY NOT
+      # SET: LLDAP_LDAP_HOST") and its LAN half is closed one layer down by
+      # `blockLanAccess: true`, whose nftables rule accepts `iifname lo` —
+      # where the pasta-proxied pod path lands — and drops physical
+      # interfaces (#2388).
       - name: LLDAP_HOST
-        value: "{{LLDAP_HOST}}"
+        value: "host.containers.internal"
       - name: LLDAP_LDAP_PORT
         value: "{{LLDAP_LDAP_PORT}}"
       - name: LLDAP_BASE_DN
@@ -59,7 +101,15 @@ spec:
       - name: CLAUDE_DEV_LDAP_GROUP
         value: "{{CLAUDE_DEV_LDAP_GROUP}}"
     ports:
+      # No `hostIP` on purpose (contrast radicale #2357, which pins
+      # 127.0.0.1): podman publishes on 0.0.0.0, which is precisely the
+      # reachability the hostNetwork bind had. sshd is the service — it is
+      # authenticated by SSH key or LLDAP bind, nginx cannot proxy raw SSH,
+      # and the operator's router forwards this port straight to it. Pinning
+      # the loopback here would silently lock the owner out of their own dev
+      # box.
       - containerPort: {{CLAUDE_DEV_SSH_PORT}}
+        hostPort: {{CLAUDE_DEV_SSH_PORT}}
     volumeMounts:
       # Persistent home for the `dev` user: git checkouts, Claude Code
       # session history (~/.claude), gh auth and SSH host keys all live

--- a/templates/claude-dev/variables.json
+++ b/templates/claude-dev/variables.json
@@ -13,11 +13,6 @@
     "description": "Optional SSH public key (one line, e.g. `ssh-ed25519 AAAA... you@phone`). When set, key-based login is enabled for the `dev` user — recommended over the password for a box reachable from outside the LAN. Leave blank to use the password only.",
     "default": ""
   },
-  "LLDAP_HOST": {
-    "type": "text",
-    "description": "LLDAP host the SSH login binds against. Always localhost — the `auth` stack runs hostNetwork, so LLDAP's LDAP port is reachable on the loopback of this hostNetwork container.",
-    "default": "localhost"
-  },
   "LLDAP_LDAP_PORT": {
     "type": "text",
     "description": "LLDAP LDAP-protocol port. Must match the `auth` stack's LLDAP_LDAP_PORT.",

--- a/tests/backend/credentials_secured_route.test.ts
+++ b/tests/backend/credentials_secured_route.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * `/api/system/credentials/secured` (#2519).
+ *
+ * The route that ends ServiceBay's role as a second password manager: it
+ * records the Vaultwarden hand-off AND deletes the local copy of the
+ * secrets in the same write. The invariant worth a test is that those two
+ * cannot come apart — a persisted entry is never both "secured" and still
+ * carrying a password.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const state: { config: any } = { config: {} };
+
+vi.mock('@/lib/config', async () => {
+  const actual = await vi.importActual<any>('@/lib/config');
+  return {
+    ...actual,
+    getConfig: vi.fn(async () => state.config),
+    saveConfig: vi.fn(async (cfg: any) => { state.config = cfg; }),
+  };
+});
+
+vi.mock('@/lib/api/requireSession', () => ({
+  requireSession: vi.fn(async () => ({ user: 'test', expires: new Date(Date.now() + 60_000) })),
+}));
+
+import { POST } from '@/app/api/system/credentials/secured/route';
+
+const cred = (service: string, extra: Record<string, unknown> = {}) => ({
+  service,
+  url: `https://${service}.example`,
+  username: 'admin',
+  password: 'plaintext-secret',
+  importance: 'critical',
+  template: service,
+  ...extra,
+});
+
+const post = () =>
+  POST(new NextRequest('http://test/api/system/credentials/secured', { method: 'POST' }));
+
+beforeEach(() => {
+  state.config = {};
+});
+
+describe('POST /api/system/credentials/secured', () => {
+  it('drops every stored password and stamps the hand-off', async () => {
+    state.config = {
+      installManifest: { savedAt: '2026-08-12T00:00:00.000Z', credentials: [cred('immich'), cred('auth')] },
+    };
+    const res = await post();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.secured).toBe(2);
+
+    const saved = state.config.installManifest.credentials;
+    expect(saved).toHaveLength(2);
+    expect(saved.every((c: any) => c.password === '')).toBe(true);
+    expect(saved.every((c: any) => typeof c.securedAt === 'string')).toBe(true);
+    // The pointer survives — Settings still lists what exists.
+    expect(saved.map((c: any) => c.service).sort()).toEqual(['auth', 'immich']);
+    expect(saved[0].username).toBe('admin');
+    expect(body.summary).toEqual({ total: 2, secured: 2, unsecured: 0, lastSecuredAt: body.securedAt });
+  });
+
+  it('never persists an entry that is secured and still holds a secret', async () => {
+    state.config = {
+      installManifest: { savedAt: '2026-08-12T00:00:00.000Z', credentials: [cred('immich')] },
+    };
+    await post();
+    const saved = state.config.installManifest.credentials;
+    expect(saved.filter((c: any) => c.securedAt && c.password)).toEqual([]);
+  });
+
+  it('leaves an already-secured entry and its original timestamp alone', async () => {
+    const first = '2026-08-01T00:00:00.000Z';
+    state.config = {
+      installManifest: {
+        savedAt: first,
+        credentials: [cred('auth', { password: '', securedAt: first }), cred('immich')],
+      },
+    };
+    const body = await (await post()).json();
+    expect(body.secured).toBe(1);
+    const saved = state.config.installManifest.credentials;
+    expect(saved.find((c: any) => c.service === 'auth').securedAt).toBe(first);
+    expect(saved.find((c: any) => c.service === 'immich').securedAt).not.toBe(first);
+  });
+
+  it('is idempotent — a second call writes nothing new', async () => {
+    state.config = {
+      installManifest: { savedAt: '2026-08-12T00:00:00.000Z', credentials: [cred('immich')] },
+    };
+    await post();
+    const afterFirst = JSON.stringify(state.config.installManifest);
+    const body = await (await post()).json();
+    expect(body.secured).toBe(0);
+    expect(JSON.stringify(state.config.installManifest)).toBe(afterFirst);
+  });
+
+  it('no-ops on an empty manifest', async () => {
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ ok: true, secured: 0 });
+    expect(state.config.installManifest).toBeUndefined();
+  });
+});

--- a/tests/backend/mcp_service_repo_bootstrap.test.ts
+++ b/tests/backend/mcp_service_repo_bootstrap.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Service-repo bootstrap step (#2513).
+ *
+ * The gap this closes is not "no standard existed" — `get_service_standards` was
+ * already a good index. It is that **consulting it was not a step anywhere**, so
+ * a sibling repo chose its stack, CI and storage before ever meeting the ADRs.
+ *
+ * What must therefore hold, and is asserted here:
+ *   1. The tool serves a `repoBootstrap` block with the finished CLAUDE.md text
+ *      (both flavors — the repo that failed was bootstrapped with `generic`).
+ *   2. The pasteable copy in the `create-service` recipe is byte-identical to
+ *      the generator, so the three copies (module / tool / recipe) can't drift.
+ *   3. The `check`/`write` mechanics really fail a repo without the pointer —
+ *      including the RED path of the `check:arch` invariant.
+ *   4. The MCP initialize instructions name the tool, which is the one channel
+ *      that reaches a client before its first tool call.
+ *
+ * Pure file-system + parsing. No agent / network needed.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+  BOOTSTRAP_MARKER_BEGIN,
+  BOOTSTRAP_MARKER_END,
+  BOOTSTRAP_REQUIRED_REFERENCES,
+  BOOTSTRAP_STEP,
+  applyStandardsPointer,
+  checkStandardsPointer,
+  renderStandardsPointerBlock,
+} from '@/lib/mcp/serviceRepoBootstrap';
+import { buildServiceStandards } from '@/lib/mcp/serviceStandards';
+import { auditServiceRepoBootstrap } from '../../scripts/check-invariants';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const CREATE_SERVICE = path.join(REPO_ROOT, 'assists', 'create-service.md');
+
+describe('standards pointer block (#2513)', () => {
+  it('names the tool, the assist fetch and the gap-report convention', () => {
+    const block = renderStandardsPointerBlock();
+    for (const ref of BOOTSTRAP_REQUIRED_REFERENCES) {
+      expect(block, `pointer block mentions ${ref}`).toContain(ref);
+    }
+    expect(block.startsWith(BOOTSTRAP_MARKER_BEGIN)).toBe(true);
+    expect(block.endsWith(BOOTSTRAP_MARKER_END)).toBe(true);
+  });
+
+  it('tells an unconnected session to stop rather than guess', () => {
+    // The foundry-chronicle failure was invisible precisely because the session
+    // had no ServiceBay MCP and carried on regardless.
+    expect(renderStandardsPointerBlock()).toMatch(/not connected[\s\S]*stop and say so/i);
+    expect(BOOTSTRAP_STEP.ifMcpNotConnected).toMatch(/connect/i);
+  });
+
+  it('checkStandardsPointer rejects a CLAUDE.md with no pointer', () => {
+    const res = checkStandardsPointer('# My new service\n\nSome notes.\n');
+    expect(res.ok).toBe(false);
+    expect(res.problems.join(' ')).toMatch(/standards:bootstrap/);
+  });
+
+  it('checkStandardsPointer rejects an edited (drifted) block', () => {
+    const drifted = applyStandardsPointer('# repo\n').replace('flavor `servicebay`', 'whatever you like');
+    const res = checkStandardsPointer(drifted);
+    expect(res.ok).toBe(false);
+    expect(res.problems.join(' ')).toMatch(/drifted/);
+  });
+
+  it('applyStandardsPointer is idempotent and preserves the rest of the file', () => {
+    const original = '# My new service\n\nSome notes.\n';
+    const once = applyStandardsPointer(original);
+    expect(checkStandardsPointer(once).ok).toBe(true);
+    expect(once).toContain('Some notes.');
+    expect(applyStandardsPointer(once)).toBe(once);
+    // A file that already carries a stale block is refreshed in place, not doubled.
+    const stale = once.replace('Read first, design second', 'Read whenever');
+    const refreshed = applyStandardsPointer(stale);
+    expect(checkStandardsPointer(refreshed).ok).toBe(true);
+    expect(refreshed.split(BOOTSTRAP_MARKER_BEGIN).length - 1).toBe(1);
+  });
+
+  it('bootstraps an empty/absent CLAUDE.md', () => {
+    expect(checkStandardsPointer(applyStandardsPointer('')).ok).toBe(true);
+  });
+});
+
+describe('get_service_standards serves the bootstrap step (#2513)', () => {
+  it('servicebay flavor returns the finished CLAUDE.md block, not an instruction to write one', async () => {
+    const s = await buildServiceStandards('servicebay');
+    const rb = s.repoBootstrap as { claudeMdBlock: string; commands: string[]; step: string; ifMcpNotConnected: string };
+    expect(rb).toBeDefined();
+    expect(rb.claudeMdBlock).toBe(renderStandardsPointerBlock());
+    expect(rb.commands.join(' ')).toContain('standards:bootstrap');
+    expect(rb.step).toMatch(/before/i);
+    expect(rb.ifMcpNotConnected).toBeTruthy();
+  });
+
+  it('generic flavor carries the ServiceBay-target detection step', async () => {
+    // The repo that shipped past the ADRs was bootstrapped with the GENERIC
+    // standards — a generic flavor with no route to the platform flavor is a
+    // dead end for exactly the case that failed.
+    const s = await buildServiceStandards('generic');
+    const rb = s.repoBootstrap as { ifServiceBayTarget: string };
+    expect(rb).toBeDefined();
+    expect(rb.ifServiceBayTarget).toContain('get_service_standards');
+    expect(rb.ifServiceBayTarget).toContain('servicebay');
+    // …without smuggling the platform ADR list into the generic flavor (#2323).
+    expect(s.mustRespectAdrs).toBeUndefined();
+    expect(JSON.stringify(s)).not.toContain('docs/adr');
+  });
+});
+
+describe('the pasteable copies cannot drift (#2513)', () => {
+  it('the create-service recipe embeds the generated block byte-for-byte', () => {
+    const doc = fs.readFileSync(CREATE_SERVICE, 'utf-8');
+    const start = doc.indexOf(BOOTSTRAP_MARKER_BEGIN);
+    const end = doc.indexOf(BOOTSTRAP_MARKER_END);
+    expect(start, 'create-service.md carries the pointer block').toBeGreaterThanOrEqual(0);
+    expect(doc.slice(start, end + BOOTSTRAP_MARKER_END.length)).toBe(renderStandardsPointerBlock());
+  });
+
+  it('check:arch passes on the real recipe', () => {
+    expect(auditServiceRepoBootstrap(fs.readFileSync(CREATE_SERVICE, 'utf-8'))).toEqual([]);
+  });
+
+  it('check:arch fails when the bootstrap step is demoted or the block deleted', () => {
+    const doc = fs.readFileSync(CREATE_SERVICE, 'utf-8');
+
+    // Someone re-orders the recipe so "Image" is step 1 again.
+    const demoted = doc.replace(
+      /\n## Ordered actions\n[\s\S]*?(?=\n## )/,
+      '\n## Ordered actions\n1. **Image** — build + push it.\n2. **Install** — go.\n',
+    );
+    expect(auditServiceRepoBootstrap(demoted).join(' ')).toMatch(/FIRST ordered action/);
+
+    // Someone drops the pointer block.
+    const stripped = doc.replace(BOOTSTRAP_MARKER_BEGIN, 'x').replace(BOOTSTRAP_MARKER_END, 'x');
+    expect(auditServiceRepoBootstrap(stripped).join(' ')).toMatch(/no longer carries/);
+  });
+});
+
+// The initialize-handshake half of the loop is asserted end-to-end through the
+// SDK in packages/backend/src/lib/mcp/server.test.ts ("tells a new-project
+// session to call get_service_standards first").

--- a/tests/backend/mcp_service_standards.test.ts
+++ b/tests/backend/mcp_service_standards.test.ts
@@ -129,6 +129,45 @@ describe('get_service_standards — servicebay flavor (#2323)', () => {
   });
 });
 
+describe('UI language & state design is a standard (#2514)', () => {
+  it('is reachable through get_service_standards and resolves', async () => {
+    // The sibling frontend that shipped CLI commands as status texts had read
+    // every standard the catalog served — none of them covered what the UI SAYS.
+    const s = await buildServiceStandards('servicebay');
+    const ids = (s.assistsToRead as { ids: { id: string; why: string }[] }).ids;
+    const entry = ids.find(i => i.id === 'service-ui-user-language');
+    expect(entry, 'assistsToRead surfaces service-ui-user-language').toBeDefined();
+    expect(entry!.why).toMatch(/language/i);
+    expect(await getAssist('service-ui-user-language')).not.toBeNull();
+  });
+
+  it('references the existing UX philosophy instead of restating it', async () => {
+    const body = (await getAssist('service-ui-user-language')) ?? '';
+    // Prior art in this repo — the standard points at it, it is not a parallel
+    // second version of the same principle.
+    expect(body).toContain('docs/UX_PHILOSOPHY.md');
+    expect(body).toContain('docs/UX_DECISIONS.md');
+    expect(fs.existsSync(path.join(REPO_ROOT, 'docs', 'UX_PHILOSOPHY.md'))).toBe(true);
+    expect(fs.existsSync(path.join(REPO_ROOT, 'docs', 'UX_DECISIONS.md'))).toBe(true);
+  });
+
+  it('carries the rules the sibling frontend violated, incl. test enforcement', async () => {
+    const body = (await getAssist('service-ui-user-language')) ?? '';
+    // Every rejection from the #2514 review maps to a rule here.
+    expect(body, 'CLI/env/header names banned in rendered HTML').toMatch(/env-var names/i);
+    expect(body).toMatch(/header names/i);
+    expect(body, 'the ban is test-enforced, not a review habit').toMatch(/test-enforced|not a review habit/i);
+    expect(body, 'an untriggerable named action is a product gap').toMatch(/product gap/i);
+    expect(body, 'onboarding shows while its condition holds').toMatch(/condition the wizard resolves|not only on virgin state/i);
+    expect(body, 'settings group by user questions').toMatch(/group by user questions|Settings group by/i);
+  });
+
+  it('is cross-linked from the design standard, which was the doc that was silent', async () => {
+    const design = (await getAssist('service-ui-design-standard')) ?? '';
+    expect(design).toContain('service-ui-user-language');
+  });
+});
+
 describe('get_service_standards — generic flavor (#2323)', () => {
   it('returns platform-agnostic standards', async () => {
     const s = await buildServiceStandards('generic');

--- a/tests/backend/pod_schema.test.ts
+++ b/tests/backend/pod_schema.test.ts
@@ -203,3 +203,114 @@ metadata:
         expect(r.error?.path).toMatch(/PVC/);
     });
 });
+
+// ─── GPU passthrough is single-container-only (#2517) ───────────────────────
+// `podman kube play` silently drops resources.limits outside cpu/memory, and
+// the `.container` Quadlet escape hatch is one container per unit. The
+// daggerheart-chronik shape (chronik + bot sharing hostPath volumes) deployed
+// healthy and ran on CPU with no error anywhere — that is what must now fail.
+describe('validatePodManifest: GPU in a multi-container pod (#2517)', () => {
+    const MULTI_GPU = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: daggerheart-chronik
+spec:
+  hostNetwork: true
+  containers:
+  - name: chronik
+    image: ghcr.io/example/chronik:latest
+    resources:
+      limits:
+        nvidia.com/gpu: "1"
+    volumeMounts:
+    - mountPath: /data
+      name: data
+  - name: bot
+    image: ghcr.io/example/bot:latest
+    volumeMounts:
+    - mountPath: /data
+      name: data
+  volumes:
+  - name: data
+    hostPath:
+      path: /mnt/data/daggerheart-chronik
+      type: DirectoryOrCreate
+`;
+
+    const SINGLE_GPU = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ollama
+spec:
+  hostNetwork: true
+  containers:
+  - name: ollama
+    image: docker.io/ollama/ollama:latest
+    resources:
+      limits:
+        nvidia.com/gpu: "1"
+`;
+
+    it('rejects the two-container pod that requests a GPU', () => {
+        const r = validatePodManifest(MULTI_GPU);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toBe('spec.containers[chronik].resources.limits[nvidia.com/gpu]');
+    });
+
+    it('names the working alternative, not just the prohibition', () => {
+        const msg = validatePodManifest(MULTI_GPU).error?.message ?? '';
+        // Actionable: single-container service + `.container` Quadlet + where to read more.
+        expect(msg).toMatch(/SINGLE-container/);
+        expect(msg).toMatch(/\.container.*Quadlet/);
+        expect(msg).toMatch(/AddDevice=nvidia\.com\/gpu=all/);
+        expect(msg).toMatch(/hostPath volume/);
+        expect(msg).toMatch(/TEMPLATE_AUTHORING\.md/);
+    });
+
+    it('accepts a single-container pod that requests a GPU (the ollama shape)', () => {
+        expect(validatePodManifest(SINGLE_GPU).ok).toBe(true);
+    });
+
+    it('accepts a multi-container pod with no GPU limit', () => {
+        const yaml = MULTI_GPU.replace(/    resources:\n      limits:\n        nvidia\.com\/gpu: "1"\n/, '');
+        expect(yaml).not.toMatch(/nvidia/);
+        expect(validatePodManifest(yaml).ok).toBe(true);
+    });
+
+    it('accepts a multi-container pod with plain cpu/memory limits', () => {
+        const yaml = MULTI_GPU.replace('        nvidia.com/gpu: "1"', '        cpu: "2"\n        memory: 512Mi');
+        expect(validatePodManifest(yaml).ok).toBe(true);
+    });
+
+    it('catches a non-NVIDIA vendor GPU key too', () => {
+        const yaml = MULTI_GPU.replace('nvidia.com/gpu', 'amd.com/gpu');
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toContain('amd.com/gpu');
+    });
+
+    it('counts an initContainer toward the multi-container rule', () => {
+        const yaml = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: withinit
+spec:
+  hostNetwork: true
+  initContainers:
+  - name: prep
+    image: docker.io/library/busybox:latest
+  containers:
+  - name: app
+    image: docker.io/example/app:latest
+    resources:
+      limits:
+        nvidia.com/gpu: "1"
+`;
+        const r = validatePodManifest(yaml);
+        expect(r.ok).toBe(false);
+        expect(r.error?.path).toBe('spec.containers[app].resources.limits[nvidia.com/gpu]');
+    });
+});

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -27,6 +27,7 @@ import path from 'path';
 import Mustache from 'mustache';
 import yaml from 'js-yaml';
 import { describe, it, expect } from 'vitest';
+import { findGpuMultiContainerError } from '@/lib/services/podSchema';
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const TEMPLATES_DIR = path.join(REPO_ROOT, 'templates');
@@ -377,12 +378,11 @@ describe('Template variable defaults carry no concrete domain', () => {
   });
 });
 
-// ─── 3. Each template renders to a valid Pod ────────────────────────────────
-describe('Templates render to valid Pod manifests', () => {
-  /** Build a Mustache view that supplies a value for every variable referenced
-   *  by any template. Defaults from variables.json win; otherwise stub strings.
-   *  For section blocks (`{{#X}}...`) Mustache reads the value's truthiness;
-   *  defaults like '' would skip the block, which matches reality. */
+/** Build a Mustache view that supplies a value for every variable referenced
+ *  by any template. Defaults from variables.json win; otherwise stub strings.
+ *  For section blocks (`{{#X}}...`) Mustache reads the value's truthiness;
+ *  defaults like '' would skip the block, which matches reality. */
+function buildTemplateRenderView(): Record<string, string> {
   const view: Record<string, string> = {};
   for (const v of catalogVars) {
     // Stub fallbacks first; per-template defaults (if present) overwrite.
@@ -407,13 +407,19 @@ describe('Templates render to valid Pod manifests', () => {
       if (typeof def === 'string') view[name] = def;
     }
   }
+  // RSA private key is multi-line and pre-indented in the real wizard. Just
+  // give it a plausible single-line stub for parse-time validation.
+  view.AUTHELIA_OIDC_RSA_PRIVATE_KEY = '          -----BEGIN STUB-----\n          stub\n          -----END STUB-----';
+  return view;
+}
+
+// ─── 3. Each template renders to a valid Pod ────────────────────────────────
+describe('Templates render to valid Pod manifests', () => {
+  const view = buildTemplateRenderView();
   // ZWAVE_DEVICE acts as a section gate — when truthy, the home-assistant
   // template emits the Z-Wave container. Setting it to a fake path exercises
   // *more* of the YAML in the test, which is what we want.
   view.ZWAVE_DEVICE = '/dev/serial/by-id/stub-zwave';
-  // RSA private key is multi-line and pre-indented in the real wizard. Just
-  // give it a plausible single-line stub for parse-time validation.
-  view.AUTHELIA_OIDC_RSA_PRIVATE_KEY = '          -----BEGIN STUB-----\n          stub\n          -----END STUB-----';
 
   for (const t of templates) {
     it(`${t.name}: template.yml renders to a parseable Pod with ≥1 container`, () => {
@@ -461,6 +467,37 @@ describe('Templates render to valid Pod manifests', () => {
           }
         }
       }
+    });
+  }
+});
+
+// ─── 3a2. GPU passthrough is single-container-only (#2517) ──────────────────
+// `podman kube play` silently drops `resources.limits` outside cpu/memory, and
+// the escape hatch (a `.container` Quadlet with `AddDevice=nvidia.com/gpu=all`,
+// #1026) is one container per unit — so a multi-container pod can never get a
+// GPU, it just deploys healthy and runs on CPU with no error anywhere.
+//
+// The runtime gate is `validatePodManifest` (POST/PUT /api/services), which
+// covers every install regardless of which registry the template came from.
+// This is the PR-time half: a template shipped from THIS repo can't introduce
+// the shape in the first place, and the author sees it in `npm test` rather
+// than on the box. Same rule, same function — one source of truth.
+describe('GPU passthrough: shipped templates stay single-container (#2517)', () => {
+  // Model "the operator opted into GPU, everything else at defaults": force
+  // only the GPU section gates truthy. Forcing *every* section on would report
+  // containers a real GPU deploy would never emit (e.g. the Z-Wave container).
+  const gpuView = buildTemplateRenderView();
+  for (const v of catalogVars) {
+    if (/GPU/.test(v)) gpuView[v] = 'yes';
+  }
+
+  for (const t of templates) {
+    it(`${t.name}: no GPU limit in a multi-container pod`, () => {
+      const rendered = Mustache.render(t.yamlContent, gpuView);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pod = (yaml.loadAll(rendered) as any[]).find(d => d?.kind === 'Pod');
+      const err = findGpuMultiContainerError(pod);
+      expect(err, err ? `${t.name}: ${err.path} — ${err.message}` : '').toBeNull();
     });
   }
 });

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -710,11 +710,11 @@ describe('hostNetwork templates: every declared TCP port is guarded (#2416)', ()
       why: 'The Authelia portal itself — it IS the login surface, so gating it '
         + 'behind itself is circular. Every app redirects here.',
     },
-    'claude-dev:2222': {
-      policy: 'lan-exposed',
-      why: 'sshd. Authenticated by SSH key / LLDAP bind, not by the proxy; '
-        + 'nginx cannot proxy raw SSH.',
-    },
+    // NOTE: `claude-dev:2222` used to live here. It is gone because the
+    // template no longer runs hostNetwork (#2522) — this policy map is only
+    // consulted for hostNetwork pods, so the entry had become dead code. The
+    // equivalent reasoning for its (still deliberate) 0.0.0.0 hostPort now
+    // lives in the dedicated claude-dev suite further down this file.
     'file-share:22000': {
       policy: 'lan-exposed',
       why: 'Syncthing sync protocol. Peers connect device-to-device over TLS '
@@ -1196,6 +1196,115 @@ describe('Media template: Audiobookshelf retired for fresh installs (#1725)', ()
     // The migration must NOT delete/move the ABS data dirs — it only informs.
     expect(mig).not.toMatch(/shutil\.(move|rmtree)|os\.remove|\.unlink\(|\.rename\(/);
     expect(mig).toMatch(/UNTOUCHED|preserved/i);
+  });
+});
+
+// ─── 3d. claude-dev runs isolated, and SSH stays reachable (#2522) ──────────
+describe('Claude Dev template: isolated netns, SSH reachability preserved (#2522)', () => {
+  const claudeDev = templates.find(t => t.name === 'claude-dev')!;
+  const auth = templates.find(t => t.name === 'auth')!;
+
+  const view: Record<string, string> = {};
+  for (const v of catalogVars) view[v] = `stub-${v.toLowerCase()}`;
+  for (const [name, meta] of Object.entries(claudeDev.variables)) {
+    if (meta && typeof meta === 'object' && 'default' in meta && typeof meta.default === 'string') {
+      view[name] = meta.default;
+    }
+  }
+  view.CLAUDE_DEV_SSH_PORT = '2222';
+  view.LLDAP_LDAP_PORT = '3890';
+  view.DATA_DIR = '/mnt/data/stacks';
+  view.LAN_IP = '192.168.1.10';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pod = (): any =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    yaml.loadAll(Mustache.render(claudeDev.yamlContent, view)).find((d: any) => d?.kind === 'Pod');
+
+  const sshEnv = (): Record<string, string> => {
+    const c = pod().spec.containers.find((x: { name: string }) => x.name === 'claude-dev');
+    const out: Record<string, string> = {};
+    for (const e of c.env ?? []) out[e.name] = String(e.value);
+    return out;
+  };
+
+  it('no longer runs hostNetwork', () => {
+    // ADR 0007 Decision 1. claude-dev was never on the ADR's closed carve-out
+    // list, so it is migrated rather than granted an exemption.
+    expect(pod().spec.hostNetwork).toBeUndefined();
+  });
+
+  it('publishes sshd on the SAME port, on every interface — the lockout guard', () => {
+    // This is the criterion an operator feels: their router port-forward and
+    // `ssh -p 2222 …@<box>` must keep working with nothing changed on their
+    // side. That needs hostPort == containerPort AND no `hostIP` (a
+    // `hostIP: 127.0.0.1` pin like radicale's #2357 would make the box
+    // reachable only from the box itself — i.e. lock the owner out).
+    const c = pod().spec.containers.find((x: { name: string }) => x.name === 'claude-dev');
+    expect(c.ports).toHaveLength(1);
+    expect(c.ports[0].containerPort).toBe(2222);
+    expect(c.ports[0].hostPort).toBe(2222);
+    expect(c.ports[0].hostIP).toBeUndefined();
+  });
+
+  it('reaches LLDAP via host.containers.internal — never localhost or LAN_IP', () => {
+    // An isolated pod cannot reach an on-box sibling on 127.0.0.1 (that is now
+    // its OWN loopback), and rootless podman refuses the host's LAN IP
+    // outright (ADR 0007 Context). host.containers.internal is the only path.
+    expect(sshEnv().LLDAP_HOST).toBe('host.containers.internal');
+    expect(sshEnv().LLDAP_HOST).not.toMatch(/localhost|127\.0\.0\.1|192\.168\./);
+  });
+
+  it('hard-codes the LLDAP host instead of taking the LLDAP_HOST variable', () => {
+    // manifestAssembler force-resolves LLDAP_HOST to "localhost" for EVERY
+    // template ("LLDAP_HOST is always localhost") — correct for the
+    // hostNetwork `auth` pod that owns the variable, but it would silently
+    // overwrite the value here and break every LDAP login with no error.
+    expect(claudeDev.yamlContent).not.toMatch(/\{\{LLDAP_HOST\}\}/);
+    expect(claudeDev.variables.LLDAP_HOST).toBeUndefined();
+  });
+
+  it('the sibling precondition it depends on is actually in place (ADR 0007 order)', () => {
+    // "Siblings first, consumer second." The consumer above is only correct
+    // because `auth` leaves LLDAP's raw LDAP port bound wider than loopback
+    // and closes the LAN half at the host firewall instead (#2388). If a
+    // future change loopback-binds that port, this consumer breaks — so pin
+    // the precondition here, at the consumer, not only in the auth suite.
+    expect(auth.yamlContent).not.toMatch(/name:\s*LLDAP_LDAP_HOST/);
+    expect(auth.variables.LLDAP_LDAP_PORT.blockLanAccess).toBe(true);
+  });
+
+  it('is NOT added to ADR 0007 carve-out list', () => {
+    // The list was closed in #2518/#2523. Migrating the consumer is the
+    // decision; growing the list again would hollow that out.
+    const adr = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'docs', 'adr',
+        '0007-container-network-isolation-and-carveouts.md'), 'utf-8',
+    );
+    const decision2 = adr.slice(
+      adr.indexOf('2. **These stay on `hostNetwork` deliberately'),
+      adr.indexOf('3. **Consuming a loopback-bound sibling'),
+    );
+    expect(decision2.length).toBeGreaterThan(100);
+    expect(decision2).not.toMatch(/claude-dev/);
+  });
+
+  it('schema-version is bumped to 2 with a CHANGELOG section and a v1-to-v2 migration', () => {
+    expect(claudeDev.yamlContent).toMatch(/servicebay\.schema-version:\s*"2"/);
+    const changelog = fs.readFileSync(
+      path.join(TEMPLATES_DIR, 'claude-dev', 'CHANGELOG.md'), 'utf-8',
+    );
+    expect(changelog).toMatch(/##\s*v2\b.*\(breaking\)/);
+    const mig = fs.readFileSync(
+      path.join(TEMPLATES_DIR, 'claude-dev', 'migrations', 'v1-to-v2.py'), 'utf-8',
+    );
+    // Structural hop — nothing on /workspace may be moved, renamed or deleted.
+    expect(mig).not.toMatch(/shutil\.(move|rmtree)|os\.remove|\.unlink\(|\.rename\(/);
+    expect(mig).toMatch(/untouched/i);
+    // And it must never abort the deploy: a non-zero exit would leave the
+    // operator unable to re-deploy their own dev box, while a broken LDAP
+    // path does not lock anyone out (the local `dev` account still works).
+    expect(mig).not.toMatch(/return\s+[1-9]|sys\.exit\([1-9]/);
   });
 });
 

--- a/tests/frontend/CredentialsSection.test.tsx
+++ b/tests/frontend/CredentialsSection.test.tsx
@@ -1,0 +1,164 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Settings → Saved credentials (#2519).
+ *
+ * The acceptance criterion this file encodes: the section must stop being
+ * a password table. No Password column, no reveal, no copy — a sync-status
+ * line plus a Vaultwarden deep link instead, and an explicit "not yet
+ * secured" marking whenever ServiceBay is still the only copy (including
+ * the Vaultwarden-not-installed case).
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import CredentialsSection from '@/app/(dashboard)/settings/_lib/sections/CredentialsSection';
+
+vi.mock('@/providers/ToastProvider', () => {
+  const addToast = vi.fn();
+  return { useToast: () => ({ addToast }) };
+});
+
+const VAULT_HOST = { service: 'vaultwarden', domain: 'vault.dopp.cloud' };
+
+const UNSECURED = {
+  service: 'Immich',
+  url: 'http://localhost:2283',
+  username: 'admin@dopp.cloud',
+  password: 'sup3r-s3cret-value',
+  importance: 'critical' as const,
+  template: 'immich',
+};
+const SECURED = {
+  service: 'LLDAP',
+  url: 'https://ldap.dopp.cloud',
+  username: 'admin',
+  password: '',
+  importance: 'critical' as const,
+  template: 'auth',
+  securedAt: '2026-08-12T09:00:00.000Z',
+};
+
+interface FetchHandler {
+  pattern: RegExp;
+  responder: (init?: RequestInit) => Promise<Response>;
+}
+
+function jsonRes(body: any, status = 200): Promise<Response> {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response);
+}
+
+function installFetch(handlers: FetchHandler[]) {
+  global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    for (const h of handlers) {
+      if (h.pattern.test(url)) return h.responder(init);
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as any;
+}
+
+function manifestFetch(credentials: any[], proxyHosts = [VAULT_HOST]) {
+  installFetch([
+    {
+      pattern: /\/api\/system\/credentials\/secured$/,
+      responder: () => jsonRes({ ok: true, secured: 1, securedAt: '2026-08-13T12:00:00.000Z' }),
+    },
+    {
+      pattern: /\/api\/system\/credentials$/,
+      responder: () => jsonRes({
+        manifest: { savedAt: '2026-08-12T08:00:00.000Z', credentials },
+        proxyHosts,
+        publicDomain: 'dopp.cloud',
+      }),
+    },
+  ]);
+}
+
+beforeEach(() => {
+  vi.spyOn(window, 'confirm').mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CredentialsSection (#2519)', () => {
+  it('renders no password column and never puts a stored secret in the DOM', async () => {
+    manifestFetch([UNSECURED, SECURED]);
+    const { container } = render(<CredentialsSection />);
+    await waitFor(() => expect(screen.getByText('Immich')).toBeTruthy());
+
+    expect(screen.queryByRole('columnheader', { name: /password/i })).toBeNull();
+    expect(container.textContent).not.toContain('sup3r-s3cret-value');
+    // The old reveal/copy affordances are gone with the column.
+    expect(screen.queryByTitle(/reveal password/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /^copy$/i })).toBeNull();
+    // …replaced by a "where does this live" column.
+    expect(screen.getByRole('columnheader', { name: /stored in/i })).toBeTruthy();
+  });
+
+  it('marks entries ServiceBay still holds as not yet secured', async () => {
+    manifestFetch([UNSECURED, SECURED]);
+    const { container } = render(<CredentialsSection />);
+    await waitFor(() => expect(screen.getByText('Immich')).toBeTruthy());
+
+    expect(screen.getByTestId('credentials-sync-status').textContent)
+      .toMatch(/1 of 2 not yet secured/i);
+    // Per-row chips: one warn ("Not yet secured"), one ok ("Vaultwarden").
+    const warn = container.querySelectorAll('[data-variant="warn"]');
+    const ok = container.querySelectorAll('[data-variant="ok"]');
+    expect(warn).toHaveLength(1);
+    expect(warn[0].textContent).toMatch(/not yet secured/i);
+    expect(ok).toHaveLength(1);
+    expect(ok[0].textContent).toBe('Vaultwarden');
+  });
+
+  it('shows the sync status and a Vaultwarden deep link once everything is secured', async () => {
+    manifestFetch([SECURED]);
+    render(<CredentialsSection />);
+    await waitFor(() => expect(screen.getByText('LLDAP')).toBeTruthy());
+
+    const status = screen.getByTestId('credentials-sync-status');
+    expect(status.textContent).toMatch(/All 1 entries are in Vaultwarden/i);
+    expect(status.textContent).toMatch(/no longer stores these passwords/i);
+    const link = screen.getByRole('link', { name: /open in vaultwarden/i }) as HTMLAnchorElement;
+    expect(link.href).toContain('vault.dopp.cloud');
+    // Nothing left to hand off.
+    expect(screen.queryByRole('button', { name: /download csv/i })).toBeNull();
+  });
+
+  it('says so when Vaultwarden is not installed — the failure path stays visibly unsecured', async () => {
+    manifestFetch([UNSECURED], []);
+    render(<CredentialsSection />);
+    await waitFor(() => expect(screen.getByText('Immich')).toBeTruthy());
+
+    const status = screen.getByTestId('credentials-sync-status');
+    expect(status.textContent).toMatch(/not yet secured/i);
+    expect(status.textContent).toMatch(/Vaultwarden isn't installed/i);
+    expect(screen.queryByRole('link', { name: /vaultwarden/i })).toBeNull();
+    // The CSV escape hatch stays, so the operator is not stuck.
+    expect(screen.getByRole('button', { name: /download csv/i })).toBeTruthy();
+  });
+
+  it('drops the local copy when the hand-off is confirmed', async () => {
+    manifestFetch([UNSECURED]);
+    const { container } = render(<CredentialsSection />);
+    await waitFor(() => expect(screen.getByText('Immich')).toBeTruthy());
+    expect(container.textContent).toMatch(/not yet secured/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /drop the local copy/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('credentials-sync-status').textContent)
+        .toMatch(/All 1 entries are in Vaultwarden/i));
+    expect(container.textContent).not.toMatch(/not yet secured/i);
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/system/credentials/secured',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/tests/scripts/bootstrap-service-repo.test.ts
+++ b/tests/scripts/bootstrap-service-repo.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `npm run standards:bootstrap` CLI (#2513).
+ *
+ * The bootstrap step is only real if its mechanics are a command that fails
+ * loudly — prose an agent re-interprets is the thing that broke (CLAUDE.md
+ * § "Deterministic execution → scripts"). So the exit codes are the contract:
+ * `--check` exits 1 on a repo whose CLAUDE.md has no pointer into the standards
+ * catalog, and `--write` makes it exit 0.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { parseArgs, resolveClaudeMd } from '../../scripts/bootstrap-service-repo';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'bootstrap-service-repo.ts');
+
+/** Run the CLI; returns `{ code, out }` instead of throwing on a non-zero exit. */
+function run(args: string[]): { code: number; out: string } {
+  try {
+    const out = execFileSync('npx', ['tsx', SCRIPT, ...args], { cwd: REPO_ROOT, encoding: 'utf-8', stdio: 'pipe' });
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return { code: err.status ?? -1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+describe('standards:bootstrap argument parsing', () => {
+  it('defaults to printing the block', () => {
+    expect(parseArgs([])).toEqual({ mode: 'print', target: '.' });
+  });
+
+  it('takes the target after --write/--check, and bare', () => {
+    expect(parseArgs(['--write', '/tmp/repo'])).toEqual({ mode: 'write', target: '/tmp/repo' });
+    expect(parseArgs(['--check', '/tmp/repo'])).toEqual({ mode: 'check', target: '/tmp/repo' });
+    expect(parseArgs(['--check'])).toEqual({ mode: 'check', target: '.' });
+  });
+
+  it('accepts a repo dir or the CLAUDE.md path itself', () => {
+    expect(resolveClaudeMd(REPO_ROOT)).toBe(path.join(REPO_ROOT, 'CLAUDE.md'));
+    expect(resolveClaudeMd(path.join(REPO_ROOT, 'CLAUDE.md'))).toBe(path.join(REPO_ROOT, 'CLAUDE.md'));
+  });
+});
+
+describe('standards:bootstrap CLI on a fresh service repo', () => {
+  let repo: string;
+  beforeEach(() => {
+    repo = mkdtempSync(path.join(tmpdir(), 'sb-bootstrap-'));
+  });
+  afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+  it('--check fails a repo with no CLAUDE.md at all', () => {
+    const { code, out } = run(['--check', repo]);
+    expect(code).toBe(1);
+    expect(out).toMatch(/does not exist/);
+  });
+
+  it('--check fails, --write fixes it, --check then passes', () => {
+    writeFileSync(path.join(repo, 'CLAUDE.md'), '# chronicle\n\nHouse rules.\n', 'utf-8');
+    expect(run(['--check', repo]).code).toBe(1);
+
+    const written = run(['--write', repo]);
+    expect(written.code).toBe(0);
+    const md = readFileSync(path.join(repo, 'CLAUDE.md'), 'utf-8');
+    expect(md).toContain('House rules.');
+    expect(md).toContain('get_service_standards');
+
+    expect(run(['--check', repo]).code).toBe(0);
+  });
+
+  it('--print emits the block without touching the tree', () => {
+    const { code, out } = run(['--print']);
+    expect(code).toBe(0);
+    expect(out).toContain('get_service_standards');
+    expect(existsSync(path.join(repo, 'CLAUDE.md'))).toBe(false);
+  });
+}, 60_000);

--- a/tools/sb/internal/build/assets/fedora-coreos.bu
+++ b/tools/sb/internal/build/assets/fedora-coreos.bu
@@ -313,7 +313,27 @@ storage:
             # For nvme disks the partition is e.g. /dev/nvme0n1p1
             [[ -e "$PART" ]] || PART="${RAID_DISK}p1"
 
-            # Create degraded RAID1 (second disk missing)
+            # Create the data array as a 2-member RAID1 with the literal
+            # keyword `missing` in slot 1. This is DELIBERATE, not a bug —
+            # do not "fix" it by dropping to --raid-devices=1 or by adding
+            # a second device here (see #1666, #2526):
+            #
+            #   * Most boxes ship with one data disk. Declaring 2 members
+            #     now means a mirror can be added later with a plain
+            #     `mdadm --manage /dev/md/data --add /dev/<part>` — no
+            #     backup, reshape or reformat of live data.
+            #   * There is no second disk to name at this point in first
+            #     boot: the loop above picked the single largest non-OS
+            #     disk, and anything else present is the OS disk or
+            #     removable.
+            #
+            # The cost is real and must stay visible: the array runs
+            # degraded ([2/1] [U_]) with NO redundancy until an operator
+            # adds a member, and that state is indistinguishable from a
+            # failed disk when read from /proc/mdstat alone. The `raid`
+            # diagnose probe (packages/backend/src/lib/diagnose/probes/
+            # raidDegraded.ts) surfaces it and explains the difference —
+            # keep the two in sync if this line ever changes.
             mdadm --create /dev/md/data --level=1 --raid-devices=2 --metadata=1.2 \
               --run "$PART" missing
 


### PR DESCRIPTION
Batch `2026-08-13a` — 7 commits. Two silent-data-loss fixes, two things the box could not tell the operator, one enforcement gap, one ADR migration, and one blocked design reported honestly.

## Silent data loss

**#2537 — "Re-render from template" blanked operator values *and secrets*.** `reconfigure-preview` built its view from `templateSettings ?? default ?? ''` and consulted neither store shipped in 5.11.19. The preview now resolves through the **same** `assembleManifest → applyVariableDefaults` pair the wizard, `install_template` and the runner use, and renders with the same `renderPodYaml` + `authDynamicVars` as `deployItem`. A new `preview` flag skips the three generation branches so a read-only GET never mints or persists credential material.

Preview-matches-deploy is established by a **byte-for-byte equality test** against a deploy view built exactly as `deployItem` builds it — pre-fix that diff showed the secret, the operator value, `PUBLIC_DOMAIN` and `LLDAP_BASE_DN` as `value: ""` and a stale `"false"` for the dynamic var. 7 tests failed before, 12 pass after. Unresolvable values are refused (400, secrets) or named in `unresolved[]` with a warning, never left quietly empty. Filed **#2544** for two further un-wired consumers found in the sweep, rather than chaining them in.

## Things the box could not tell you

**#2526 — a degraded RAID array was invisible.** New `raidDegraded` probe reads `/proc/mdstat`, and distinguishes a kernel-marked `(F)` failure (`fail`) from a merely-absent member (`warn`, with a hint explaining the deliberate `missing` placeholder) so nobody attempts an impossible repair. Surfaces on the `/diagnose` "Storage & backups" card, the Health row `Self-diagnose: RAID array`, and the Home dashboard card via `summarizeDiagnoseRows`. The `mdadm --create` line is unchanged (#1666 not re-litigated); the provisioning site gains a comment so the `missing` member does not read as a bug.

**#2527 — disk monitoring watched only `/mnt/data`.** Detection moved out of `runDiagnose.ts` into a pure `diskFill` probe running one `df -P -B1` per watched path, so a *missing* partition returns an empty row instead of vanishing. Thresholds are per-filesystem and justified in source, because a percentage tuned for a 2 TB array is meaningless on a 384 MiB `/boot`:

- `/boot` — **absolute headroom only**: warn < 128 MiB (≈ one vmlinuz + initramfs, what `rpm-ostree` must write to stage the next deployment — the band where the operator can still act), fail < 64 MiB (under half a kernel image; the update cannot write a boot entry and a half-finished update leaves the box unbootable).
- `/` — warn < 5 GiB or ≥ 90%, fail < 1 GiB.
- `/mnt/data` — percentage only, ≥ 90%, unchanged, so the already-watched filesystem gets no noisier.

Measured read-only on the reference box: `/boot` 350 MiB usable, 91%, **55.8 MiB free** — now reported as `fail` where it was silent. `/boot` and `/` rows carry `actionIds: []` and a hint stating ServiceBay will not delete kernels.

## Enforcement gaps

**#2517 — GPU limits silently dropped in multi-container pods.** `podman kube play` drops `resources.limits.nvidia.com/gpu`; the caveat was documented but nothing enforced it. Now refused by `findGpuMultiContainerError` at **both** load-bearing points: runtime (`validatePodManifest`, HTTP 400 before the agent write on POST and PUT — so wizard installs, MCP `deploy_service`/`update_service_yaml`, and bundle import) *and* PR time in `template_consistency.test.ts`. Both, deliberately: sibling-repo registry templates never reach this repo's CI, and a CI-only gate tells a template author nothing while they write. The error names the alternative that works (single-container service on a `.container` Quadlet with `AddDevice=nvidia.com/gpu=all`) rather than only prohibiting.

**#2513 + #2514 — the standards catalog was unreachable and incomplete.** Not one root cause: #2513 is *reach* (the catalog was never consulted at repo creation), #2514 is *coverage* (no standard said a service UI must speak the user's language). A consumer is now made to read it at three non-prose points: the MCP `initialize` instructions name `get_service_standards` as step 0 for a new project; `npm run standards:bootstrap -- --write|--check <repo>` writes/verifies the pointer block and exits 1 on drift; and a `service-repo-bootstrap-step` invariant under `check:arch` fails if `create-service`'s first ordered action stops naming the tool. The new `assists/service-ui-user-language.md` references `docs/UX_PHILOSOPHY.md` §5 and the locked `UX_DECISIONS` entries rather than restating a parallel version.

## ADR 0007 migration

**#2522 — `claude-dev` ran `hostNetwork` without being on the carve-out list.** Migrated to isolated netns + `hostPort`; the list stays closed (ADR untouched, one day after PR #2523 closed it). The sibling precondition was **already met** — `templates/auth` deliberately leaves LLDAP's raw LDAP port on `0.0.0.0` (only the web UI is loopback-bound, #2380) with its LAN half closed by `blockLanAccess`, and radicale + media already bind LLDAP from isolated pods.

One sharp edge caught en route: `manifestAssembler.ts:510` force-resolves `LLDAP_HOST='localhost'` for **every** template, which would have silently broken every LDAP login — i.e. SSH access to the box — after the migration. The variable is removed from `claude-dev`'s `variables.json` and the pod carries the literal. `claude-dev:2222` dropped from `HOST_NETWORK_PORT_POLICY` as now-dead code.

On-box SSH and LDAP reachability are owed to box-verify (`gate: verify`).

## Reported, not worked around

**#2519 — automated push into a *personal* Vaultwarden vault is not buildable.** An API key authenticates but leaves the vault locked (`bw login --apikey` → `bw unlock`); items are encrypted with a master-password-derived user key, `/admin` cannot create ciphers, `templates/vaultwarden/` sets no `ADMIN_TOKEN`, and SSO has no Key Connector. Designing around that would have meant storing or deriving the owner's master password — replacing one credential-hoarding problem with a worse one, which is the thing this issue exists to remove.

So the issue stays **open** and the identity decision is parked on `needs_refinement[]`. What shipped is the slice that needs no master password: a `Credential.securedAt` state model, `POST /api/system/credentials/secured` which records the hand-off **and drops the local passwords in the same write**, the Settings password column replaced by a "Stored in: Vaultwarden / Not yet secured" chip plus sync status and deep link, CSV export limited to unsecured entries, and `securedAt` cleared on re-install. Plus `assists/footgun-vaultwarden-personal-vault-write.md` so the next agent does not re-derive this.

## Gates

`npm run lint` 0 errors (460 warnings, unchanged) · `typecheck` clean · `check:arch` ratchet held at baseline · `npm test` **5362 passed / 1 skipped**.

`#2537` and `#2522` are `gate: verify` → box-verify owed before release.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
