### PR TITLE
fix: stop the disk probe crying wolf on the OS root, and make container auto-updates actually run

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/disk.ts
+++ b/packages/backend/src/lib/diagnose/probes/disk.ts
@@ -2,9 +2,9 @@
  * `disk` probe action — registers the `show_largest_dirs` handler so
  * the operator can find what's eating /mnt/data when the probe says
  * "above 90%". The detection lives in `diskFill.ts` (which watches
- * /mnt/data, /boot and / — see #2527); this file only contributes the
- * action, and only /mnt/data offers it: the other two are reclaimed by
- * deleting kernels and images, which ServiceBay deliberately won't do.
+ * /mnt/data, /boot, /var and / — see #2527, #2564); this file only
+ * contributes the action, and only /mnt/data offers it: the others are
+ * reclaimed by deleting kernels and images, which ServiceBay won't do.
  *
  * Returns the top 10 directories under /mnt/data sorted by size as
  * multi-line `details`, which the UI renders as a code block under

--- a/packages/backend/src/lib/diagnose/probes/diskFill.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/diskFill.test.ts
@@ -1,106 +1,244 @@
 /**
- * `disk` probe (#2527).
+ * `disk` probe (#2527, corrected by #2564).
  *
- * Every fixture is real `df -P -B1` output shape, and the byte counts in the
- * NEAR_FULL one are the numbers measured on the box that filed the issue:
- * a 350 MiB usable /boot at 91% with ~56 MiB free, a 2 TB data array at 64%,
- * and a 238 GiB root at 14%. That combination is the whole point of the
- * change — the only filesystem that was watched before is the only one that
- * is fine.
+ * Every fixture is real `df -P -B1` + `/proc/self/mounts` output shape, and
+ * the byte counts are the ones measured on the reference Fedora CoreOS box:
+ * a read-only composefs `/` of 12.7 MiB at 100% (by construction, on every
+ * healthy box), `/var` on xfs with ~206 GiB free, a 350 MiB `/boot` at 91%
+ * with 32.6 MiB free — and `/boot` mounted `ro`, which is why "read-only" on
+ * its own may never excuse a filesystem from being judged.
  */
 import { describe, it, expect } from 'vitest';
 import {
   parseDiskFill,
+  parseMountTable,
+  isImmutableImage,
   evaluateDiskFill,
   formatBytes,
   MONITORED_FILESYSTEMS,
   DISK_FILL_COMMAND,
+  DISK_FILL_MOUNTS_MARKER,
 } from './diskFill';
 
-/** The reference box: /boot critically low, everything else healthy. */
-const NEAR_FULL_BOOT = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 308402176 58467328 91% /boot
-/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+const MiB = 1024 * 1024;
+
+/** Glue the two halves of the probe's output together, as the box does. */
+function probeOutput(df: string, mounts: string): string {
+  return `${df}${DISK_FILL_MOUNTS_MARKER}\n${mounts}`;
+}
+
+/**
+ * The reference box's mount table, trimmed to the lines that matter. Note
+ * `/boot` is `ro` and `/sysroot` is `ro` — only `/var` and `/etc` are `rw`.
+ */
+const FCOS_MOUNTS = `composefs / overlay ro,seclabel,relatime,lowerdir+=/run/ostree/.private/cfsroot-lower,datadir+=/sysroot/ostree/repo/objects,redirect_dir=on,metacopy=on 0 0
+/dev/nvme1n1p4 /etc xfs rw,seclabel,relatime,inode64,logbufs=8,logbsize=32k,prjquota 0 0
+/dev/nvme1n1p4 /sysroot xfs ro,seclabel,relatime,inode64,logbufs=8,logbsize=32k,prjquota 0 0
+/dev/nvme1n1p4 /var xfs rw,seclabel,relatime,inode64,logbufs=8,logbsize=32k,prjquota 0 0
+/dev/nvme1n1p3 /boot ext4 ro,seclabel,nosuid,nodev,relatime 0 0
+/dev/md127 /var/mnt/data xfs rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,prjquota 0 0
 `;
+
+/** A box with one ordinary writable root and no separate /var. */
+const PLAIN_MOUNTS = `/dev/nvme1n1p4 / xfs rw,relatime,seclabel,inode64 0 0
+/dev/nvme1n1p3 /boot ext4 rw,relatime,seclabel 0 0
+/dev/md127 /var/mnt/data xfs rw,relatime,seclabel 0 0
+`;
+
+/** The reference box as it stands today: /boot critical, everything else fine. */
+const FCOS_BOOT_CRITICAL = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 308402176 34141184 91% /boot
+/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
+/|composefs 13340672 13340672 0 100% /
+`,
+  FCOS_MOUNTS,
+);
 
 /** The same box after `rpm-ostree cleanup -bm` reclaimed one deployment. */
-const HEALTHY = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
-/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-`;
+const FCOS_HEALTHY = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 157154304 209715200 43% /boot
+/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
+/|composefs 13340672 13340672 0 100% /
+`,
+  FCOS_MOUNTS,
+);
 
-/** /boot in the early-warning band: one kernel image no longer fits. */
-const BOOT_TIGHT = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/** The writable filesystem genuinely full — 625 MiB left on /var. */
+const FCOS_VAR_CRITICAL = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 157154304 209715200 43% /boot
+/var|/dev/nvme1n1p4 255455465472 254800000000 655465472 99% /var
+/|composefs 13340672 13340672 0 100% /
+`,
+  FCOS_MOUNTS,
+);
+
+/** /boot at 129 MiB free: one measured deployment (~143 MiB) no longer fits. */
+const FCOS_BOOT_UNDER_ONE_PAYLOAD = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 231603200 135266304 63% /boot
+/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
+/|composefs 13340672 13340672 0 100% /
+`,
+  FCOS_MOUNTS,
+);
+
+/** /boot in the failing band: not even a vmlinuz plus a slice of initramfs. */
+const FCOS_BOOT_TIGHT = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
 /boot|/dev/nvme1n1p3 366869504 261000000 105869504 71% /boot
+/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
+/|composefs 13340672 13340672 0 100% /
+`,
+  FCOS_MOUNTS,
+);
+
+/** A plain writable root, healthy: /var is not its own filesystem, so `df`
+ *  answers for it with the root row. */
+const PLAIN_HEALTHY = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
+/var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 /|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-`;
+`,
+  PLAIN_MOUNTS,
+);
 
 /** No /boot partition at all — a container/dev target. `df` prints nothing
  *  for it, so the line comes back with an empty right-hand side. */
-const NO_BOOT_PARTITION = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+const NO_BOOT_PARTITION = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
 /boot|
+/var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 /|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-`;
-
-/** /boot exists as a plain directory on the root filesystem — `df` answers
- *  with the root row, same device. */
-const BOOT_ON_ROOT = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
-/boot|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-`;
+`,
+  PLAIN_MOUNTS,
+);
 
 /** The array never assembled — the pre-existing "not mounted yet" case. */
-const NO_DATA_MOUNT = `/mnt/data|
+const NO_DATA_MOUNT = probeOutput(
+  `/mnt/data|
 /boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
+/var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 /|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-`;
+`,
+  PLAIN_MOUNTS,
+);
 
-/** Root nearly gone: image pulls and journald are about to fail. */
-const ROOT_CRITICAL = `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/** Writable root nearly gone on a plain box: /var folds into it. */
+const PLAIN_ROOT_CRITICAL = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
 /boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
+/var|/dev/nvme1n1p4 255455465472 254800000000 655465472 99% /
 /|/dev/nvme1n1p4 255455465472 254800000000 655465472 99% /
-`;
+`,
+  PLAIN_MOUNTS,
+);
 
 /** Data array full, boot and root fine — the pre-#2527 behaviour, unchanged. */
-const DATA_FULL = `/mnt/data|/dev/md127 1999285899264 1899321604300 99964294964 95% /var/mnt/data
+const DATA_FULL = probeOutput(
+  `/mnt/data|/dev/md127 1999285899264 1899321604300 99964294964 95% /var/mnt/data
 /boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
+/var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 /|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-`;
+`,
+  PLAIN_MOUNTS,
+);
 
 describe('DISK_FILL_COMMAND', () => {
-  it('asks about all three filesystems, in exact bytes', () => {
+  it('asks about all four filesystems, in exact bytes', () => {
     expect(DISK_FILL_COMMAND).toContain('/mnt/data');
     expect(DISK_FILL_COMMAND).toContain('/boot');
+    // /var is where the writable system state lives on an ostree box (#2564).
+    expect(DISK_FILL_COMMAND).toContain('/var');
     // -B1 not -h: on /boot the whole signal is an absolute byte count that
     // -h would have rounded away.
     expect(DISK_FILL_COMMAND).toContain('-B1');
     expect(DISK_FILL_COMMAND).toContain('-P');
   });
+
+  it('also reads the mount table, because df does not print mount options', () => {
+    expect(DISK_FILL_COMMAND).toContain('/proc/self/mounts');
+    expect(DISK_FILL_COMMAND).toContain(DISK_FILL_MOUNTS_MARKER);
+  });
+});
+
+describe('parseMountTable', () => {
+  it('reads the filesystem type and whether the mount is read-only', () => {
+    const mounts = parseMountTable(FCOS_MOUNTS);
+    expect(mounts.get('/')).toEqual({ fstype: 'overlay', readOnly: true });
+    expect(mounts.get('/var')).toEqual({ fstype: 'xfs', readOnly: false });
+    // Both true on the reference box, and both matter: /sysroot is the same
+    // filesystem as /var but mounted ro, which is why /var is what we watch.
+    expect(mounts.get('/sysroot')!.readOnly).toBe(true);
+    expect(mounts.get('/boot')!.readOnly).toBe(true);
+  });
+
+  it('does not mistake an option ending in "ro" for read-only', () => {
+    const mounts = parseMountTable('/dev/sda1 / ext4 rw,relatime,errors=remount-ro 0 0\n');
+    expect(mounts.get('/')!.readOnly).toBe(false);
+  });
+
+  it('lets a later mount over the same point win, as the kernel does', () => {
+    const mounts = parseMountTable(
+      '/dev/sda1 /var ext4 ro,relatime 0 0\n/dev/sdb1 /var xfs rw,relatime 0 0\n',
+    );
+    expect(mounts.get('/var')).toEqual({ fstype: 'xfs', readOnly: false });
+  });
+
+  it('decodes the octal escapes /proc uses in mount paths', () => {
+    const mounts = parseMountTable('/dev/sdb1 /mnt/my\\040disk xfs rw,relatime 0 0\n');
+    expect(mounts.get('/mnt/my disk')!.fstype).toBe('xfs');
+  });
+
+  it('survives garbage without throwing', () => {
+    expect(() => parseMountTable('nonsense\n\n   \n')).not.toThrow();
+    expect(parseMountTable('nonsense').size).toBe(0);
+  });
 });
 
 describe('parseDiskFill', () => {
   it('parses a df row into exact byte counts', () => {
-    const rows = parseDiskFill(NEAR_FULL_BOOT);
-    expect(rows).toHaveLength(3);
+    const rows = parseDiskFill(FCOS_BOOT_CRITICAL);
+    expect(rows).toHaveLength(4);
     const boot = rows.find(r => r.path === '/boot')!;
     expect(boot.present).toBe(true);
     expect(boot.device).toBe('/dev/nvme1n1p3');
     expect(boot.totalBytes).toBe(366869504);
     expect(boot.usedBytes).toBe(308402176);
-    expect(boot.freeBytes).toBe(58467328);
+    expect(boot.freeBytes).toBe(34141184);
     expect(boot.usedPct).toBe(91);
     expect(boot.mountpoint).toBe('/boot');
   });
 
+  it('joins each row to the mount table by mountpoint', () => {
+    const rows = parseDiskFill(FCOS_BOOT_CRITICAL);
+    const root = rows.find(r => r.path === '/')!;
+    expect(root.device).toBe('composefs');
+    expect(root.fstype).toBe('overlay');
+    expect(root.readOnly).toBe(true);
+    const varRow = rows.find(r => r.path === '/var')!;
+    expect(varRow.fstype).toBe('xfs');
+    expect(varRow.readOnly).toBe(false);
+  });
+
+  it('treats a row with no mount-table entry as writable, so it stays judged', () => {
+    const rows = parseDiskFill('/|/dev/sda1 100 90 10 90% /');
+    expect(rows[0].readOnly).toBe(false);
+    expect(rows[0].fstype).toBe('');
+  });
+
   it('keeps the requested path distinct from the mountpoint (CoreOS symlinks /mnt to /var/mnt)', () => {
-    const data = parseDiskFill(NEAR_FULL_BOOT).find(r => r.path === '/mnt/data')!;
+    const data = parseDiskFill(FCOS_BOOT_CRITICAL).find(r => r.path === '/mnt/data')!;
     expect(data.mountpoint).toBe('/var/mnt/data');
     expect(data.present).toBe(true);
   });
 
   it('marks a path df returned nothing for as absent instead of dropping it', () => {
     const rows = parseDiskFill(NO_BOOT_PARTITION);
-    expect(rows.map(r => r.path)).toEqual(['/mnt/data', '/boot', '/']);
+    expect(rows.map(r => r.path)).toEqual(['/mnt/data', '/boot', '/var', '/']);
     expect(rows.find(r => r.path === '/boot')!.present).toBe(false);
   });
 
@@ -110,12 +248,33 @@ describe('parseDiskFill', () => {
   });
 });
 
-describe('formatBytes', () => {
-  it('renders the sizes an operator has to compare', () => {
-    expect(formatBytes(58467328)).toBe('55.8 MiB');
-    expect(formatBytes(128 * 1024 * 1024)).toBe('128 MiB');
-    expect(formatBytes(221072547840)).toBe('206 GiB');
-    expect(formatBytes(1999285899264)).toBe('1.8 TiB');
+describe('isImmutableImage — the rule that keeps a read-only image out of the judgement', () => {
+  const rowsOf = (raw: string) => new Map(parseDiskFill(raw).map(r => [r.path, r]));
+
+  it('is true for a composefs root: read-only, nothing free, nothing to free', () => {
+    expect(isImmutableImage(rowsOf(FCOS_BOOT_CRITICAL).get('/')!)).toBe(true);
+  });
+
+  it('is false for /boot even though /boot is also mounted read-only', () => {
+    // The half that stops the rule from swallowing the most dangerous
+    // filesystem on the box: rpm-ostree remounts /boot rw to stage a kernel,
+    // and it has slack, so its free space is a real resource.
+    const boot = rowsOf(FCOS_BOOT_CRITICAL).get('/boot')!;
+    expect(boot.readOnly).toBe(true);
+    expect(isImmutableImage(boot)).toBe(false);
+  });
+
+  it('is false for a genuinely full writable filesystem', () => {
+    // The other half: 0 B free alone must never excuse a filesystem.
+    const full = parseDiskFill(
+      probeOutput('/var|/dev/sda1 1000000 1000000 0 100% /var\n', '/dev/sda1 /var xfs rw 0 0\n'),
+    )[0];
+    expect(full.freeBytes).toBe(0);
+    expect(isImmutableImage(full)).toBe(false);
+  });
+
+  it('is false for an absent row', () => {
+    expect(isImmutableImage(parseDiskFill('/boot|')[0])).toBe(false);
   });
 });
 
@@ -124,14 +283,31 @@ describe('evaluateDiskFill — thresholds match what each filesystem is for', ()
     const boot = MONITORED_FILESYSTEMS.find(f => f.path === '/boot')!;
     const data = MONITORED_FILESYSTEMS.find(f => f.path === '/mnt/data')!;
     // /boot is judged on absolute headroom only — a percentage on a 350 MiB
-    // partition is meaningless.
+    // partition is meaningless. 192 MiB (not the 128 MiB of #2527) because a
+    // measured deployment payload on the reference box is ~143 MiB: the warn
+    // has to sit ABOVE one payload, or it fires after staging already became
+    // impossible (#2564).
     expect(boot.warnUsedPct).toBeNull();
-    expect(boot.warnFreeBytes).toBe(128 * 1024 * 1024);
-    expect(boot.failFreeBytes).toBe(64 * 1024 * 1024);
+    expect(boot.warnFreeBytes).toBe(192 * MiB);
+    expect(boot.warnFreeBytes!).toBeGreaterThan(143 * MiB);
+    // The failing band is unchanged from #2527 on purpose.
+    expect(boot.failFreeBytes).toBe(64 * MiB);
     // /mnt/data is judged on percentage only — a byte floor on a 2 TB array
     // would either never fire or fire constantly.
     expect(data.warnFreeBytes).toBeNull();
     expect(data.warnUsedPct).toBe(90);
+  });
+
+  it('watches the writable system state, with a GiB floor and a percentage backstop', () => {
+    const state = MONITORED_FILESYSTEMS.find(f => f.path === '/var')!;
+    expect(state.warnFreeBytes).toBe(5 * 1024 * MiB);
+    expect(state.failFreeBytes).toBe(1024 * MiB);
+    expect(state.warnUsedPct).toBe(90);
+    // Same numbers on `/`, which IS the writable state on a box whose root is
+    // an ordinary filesystem.
+    const root = MONITORED_FILESYSTEMS.find(f => f.path === '/')!;
+    expect(root.warnFreeBytes).toBe(state.warnFreeBytes);
+    expect(root.failFreeBytes).toBe(state.failFreeBytes);
   });
 
   it('offers a fix button only where ServiceBay may safely act', () => {
@@ -139,65 +315,121 @@ describe('evaluateDiskFill — thresholds match what each filesystem is for', ()
     expect(byPath['/mnt/data']).toEqual(['show_largest_dirs']);
     // Reclaiming these means deleting kernels / images — operator decisions.
     expect(byPath['/boot']).toEqual([]);
+    expect(byPath['/var']).toEqual([]);
     expect(byPath['/']).toEqual([]);
   });
 });
 
-describe('evaluateDiskFill — near-full /boot', () => {
-  const result = evaluateDiskFill(NEAR_FULL_BOOT, 0);
-
-  it('fails rather than staying silent on the box that filed the issue', () => {
-    // 55.8 MiB free is under half a kernel image: the next rpm-ostree
-    // upgrade cannot stage a boot entry from here.
-    expect(result.status).toBe('fail');
+describe('evaluateDiskFill — a composefs root is never judged by free space (#2564)', () => {
+  it('leaves a healthy ostree box completely quiet', () => {
+    const result = evaluateDiskFill(FCOS_HEALTHY, 0);
+    expect(result.status).toBe('ok');
+    expect(result.hint).toBeUndefined();
+    expect(result.items).toBeUndefined();
   });
 
-  it('names the consequence, not just the number', () => {
-    expect(result.detail).toContain('/boot');
-    expect(result.detail).toContain('91% used');
-    expect(result.detail).toContain('55.8 MiB free');
+  it('reports the root as the image it is, instead of predicting failures that cannot happen', () => {
+    const result = evaluateDiskFill(FCOS_HEALTHY, 0);
+    expect(result.detail).toContain('/ — a read-only image of 12.7 MiB');
+    expect(result.detail).toContain('100% used by construction');
+    expect(result.detail).toContain('composefs');
+    // The exact false alarm this issue is about.
+    expect(result.detail).not.toContain('below the 1.0 GiB floor');
+    expect(result.detail).not.toMatch(/Container image pulls, system logs and OS updates all fail/);
+  });
+
+  it('is a structural rule, not a match on the word "composefs"', () => {
+    // Same shape, a squashfs image on a loop device, no ostree anywhere.
+    const squashfs = probeOutput(
+      `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 157154304 209715200 43% /boot
+/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
+/|/dev/loop0 4194304 4194304 0 100% /
+`,
+      `/dev/loop0 / squashfs ro,relatime 0 0
+/dev/nvme1n1p4 /var xfs rw,relatime 0 0
+/dev/nvme1n1p3 /boot ext4 ro,relatime 0 0
+/dev/md127 /var/mnt/data xfs rw,relatime 0 0
+`,
+    );
+    const result = evaluateDiskFill(squashfs, 0);
+    expect(result.status).toBe('ok');
+    expect(result.detail).toContain('a read-only image of 4.0 MiB');
+  });
+
+  it('still fails the box when the writable filesystem is the one running out', () => {
+    const result = evaluateDiskFill(FCOS_VAR_CRITICAL, 0);
+    expect(result.status).toBe('fail');
+    expect(result.items!.map(i => i.id)).toEqual(['/var']);
+    expect(result.detail).toContain('/var — 99% used, 625 MiB free');
+    expect(result.detail).toMatch(/Container image pulls, system logs and OS updates all fail/);
+    expect(result.hint).toContain('podman image prune');
+  });
+
+  it('judges an ordinary writable root exactly as before', () => {
+    const result = evaluateDiskFill(PLAIN_ROOT_CRITICAL, 0);
+    expect(result.status).toBe('fail');
+    expect(result.items!.map(i => i.id)).toEqual(['/']);
+    // /var is not its own filesystem there, so it is counted once, under /.
+    expect(result.detail).toContain('/var is not a separate partition');
+  });
+});
+
+describe('evaluateDiskFill — /boot keeps absolute headroom, warned earlier', () => {
+  it('fails the reference box, and blames only /boot', () => {
+    const result = evaluateDiskFill(FCOS_BOOT_CRITICAL, 0);
+    expect(result.status).toBe('fail');
+    // The whole point of #2564: one honest finding, not one honest and one false.
+    expect(result.items!.map(i => i.id)).toEqual(['/boot']);
+    expect(result.detail).toContain('32.6 MiB free');
     expect(result.detail).toMatch(/next OS update will fail/);
     expect(result.detail).toMatch(/unable to boot/);
   });
 
-  it('tells the operator what to do, and that ServiceBay will not do it', () => {
-    expect(result.hint).toContain('rpm-ostree cleanup -bm');
-    expect(result.hint).toMatch(/ServiceBay will not delete kernels/);
+  it('judges /boot on free space even though it is mounted read-only', () => {
+    // Regression guard for the obvious over-correction: excusing every ro
+    // mount would have silenced the one real finding on this box.
+    const boot = parseDiskFill(FCOS_BOOT_CRITICAL).find(r => r.path === '/boot')!;
+    expect(boot.readOnly).toBe(true);
+    expect(evaluateDiskFill(FCOS_BOOT_CRITICAL, 0).items!.map(i => i.id)).toContain('/boot');
   });
 
-  it('surfaces /boot as its own row with no one-click fix', () => {
-    expect(result.items).toHaveLength(1);
-    const [item] = result.items!;
-    expect(item.id).toBe('/boot');
-    expect(item.status).toBe('fail');
-    expect(item.actionIds).toEqual([]);
+  it('warns once one deployment no longer fits — where 128 MiB said nothing', () => {
+    // 129 MiB free. A measured payload is ~143 MiB, so an upgrade can no
+    // longer be staged here; the old 128 MiB threshold called this ok.
+    const result = evaluateDiskFill(FCOS_BOOT_UNDER_ONE_PAYLOAD, 0);
+    expect(result.status).toBe('warn');
+    expect(result.items!.map(i => i.id)).toEqual(['/boot']);
+    expect(result.hint).toContain('rpm-ostree cleanup -bm');
+  });
+
+  it('stays quiet at 200 MiB free, where a deployment still fits with room', () => {
+    expect(evaluateDiskFill(FCOS_HEALTHY, 0).status).toBe('ok');
+  });
+
+  it('warns between one payload and the failing floor, and says ServiceBay will not delete kernels', () => {
+    const result = evaluateDiskFill(FCOS_BOOT_TIGHT, 0);
+    expect(result.status).toBe('warn');
+    expect(result.hint).toContain('rpm-ostree cleanup -bm');
+    expect(result.hint).toMatch(/ServiceBay will not delete kernels/);
+    expect(result.items!.map(i => i.status)).toEqual(['warn']);
+    expect(result.items![0].actionIds).toEqual([]);
   });
 
   it('leads with the unhealthy filesystem so it is not below the fold', () => {
-    expect(result.detail.split('\n')[0]).toContain('/boot');
+    expect(evaluateDiskFill(FCOS_BOOT_CRITICAL, 0).detail.split('\n')[0]).toContain('/boot');
   });
 
   it('does not drag the healthy filesystems into the warning', () => {
+    const result = evaluateDiskFill(FCOS_BOOT_CRITICAL, 0);
     expect(result.items!.map(i => i.id)).not.toContain('/mnt/data');
     expect(result.detail).toContain('/mnt/data — 64% used');
-    expect(result.detail).toContain('/ — 14% used');
-  });
-});
-
-describe('evaluateDiskFill — the early-warning band', () => {
-  it('warns while the operator can still act, before the failing band', () => {
-    // ~101 MiB free: under one kernel image (warn) but above the 64 MiB
-    // floor (fail). This is the window the issue says has to exist.
-    const result = evaluateDiskFill(BOOT_TIGHT, 0);
-    expect(result.status).toBe('warn');
-    expect(result.detail).toContain('/boot');
-    expect(result.hint).toContain('rpm-ostree cleanup -bm');
-    expect(result.items!.map(i => i.status)).toEqual(['warn']);
+    expect(result.detail).toContain('/var — 14% used');
   });
 });
 
 describe('evaluateDiskFill — healthy partitions produce no noise', () => {
-  const result = evaluateDiskFill(HEALTHY, 0);
+  const result = evaluateDiskFill(PLAIN_HEALTHY, 0);
 
   it('is ok with no hint and no items', () => {
     expect(result.status).toBe('ok');
@@ -214,8 +446,8 @@ describe('evaluateDiskFill — healthy partitions produce no noise', () => {
   it('does not warn about a 91%-shaped /mnt/data threshold applied to /boot', () => {
     // 42% on /boot is 204 MiB free — above the headroom floor. A naive
     // percentage rule would agree here; the point is that it also has to
-    // agree at 71% (BOOT_TIGHT), where it does not.
-    expect(evaluateDiskFill(BOOT_TIGHT, 0).status).not.toBe('ok');
+    // agree at 63% (FCOS_BOOT_UNDER_ONE_PAYLOAD), where it does not.
+    expect(evaluateDiskFill(FCOS_BOOT_UNDER_ONE_PAYLOAD, 0).status).not.toBe('ok');
   });
 });
 
@@ -233,12 +465,37 @@ describe('evaluateDiskFill — missing partitions', () => {
   });
 
   it('counts a /boot that shares the root filesystem under / instead of judging it by kernel-sized rules', () => {
-    const result = evaluateDiskFill(BOOT_ON_ROOT, 0);
+    const bootOnRoot = probeOutput(
+      `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
+/boot|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+/var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
+`,
+      '/dev/nvme1n1p4 / xfs rw,relatime 0 0\n/dev/md127 /var/mnt/data xfs rw,relatime 0 0\n',
+    );
+    const result = evaluateDiskFill(bootOnRoot, 0);
     expect(['warn', 'fail']).not.toContain(result.status);
     expect(result.detail).toContain('/boot is not a separate partition');
     expect(result.detail).toContain('counted under / below');
     // The root's own 14%/206 GiB row is what gets judged, and it is healthy.
     expect(result.items).toBeUndefined();
+  });
+
+  it('does not fold a real filesystem into a root that is only an image', () => {
+    // Contrived: a filesystem whose df device string collides with the image
+    // root's. Folding it under `/` would stop measuring it entirely, because
+    // `/` is never judged.
+    const collide = probeOutput(
+      `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 157154304 209715200 43% /boot
+/var|composefs 255455465472 254800000000 655465472 99% /var
+/|composefs 13340672 13340672 0 100% /
+`,
+      FCOS_MOUNTS,
+    );
+    const result = evaluateDiskFill(collide, 0);
+    expect(result.status).toBe('fail');
+    expect(result.items!.map(i => i.id)).toEqual(['/var']);
   });
 
   it('keeps the pre-existing "data array not mounted" warning', () => {
@@ -256,15 +513,16 @@ describe('evaluateDiskFill — missing partitions', () => {
   });
 });
 
-describe('evaluateDiskFill — the other two filesystems', () => {
-  it('fails a root filesystem with under a GiB left', () => {
-    const result = evaluateDiskFill(ROOT_CRITICAL, 0);
-    expect(result.status).toBe('fail');
-    expect(result.items!.map(i => i.id)).toEqual(['/']);
-    expect(result.detail).toMatch(/Container image pulls, system logs and OS updates all fail/);
-    expect(result.hint).toContain('podman image prune');
+describe('formatBytes', () => {
+  it('renders the sizes an operator has to compare', () => {
+    expect(formatBytes(34141184)).toBe('32.6 MiB');
+    expect(formatBytes(192 * MiB)).toBe('192 MiB');
+    expect(formatBytes(221072547840)).toBe('206 GiB');
+    expect(formatBytes(1999285899264)).toBe('1.8 TiB');
   });
+});
 
+describe('evaluateDiskFill — the data array', () => {
   it('keeps the /mnt/data 90% behaviour it had before, with its fix button', () => {
     const result = evaluateDiskFill(DATA_FULL, 0);
     expect(result.status).toBe('warn');

--- a/packages/backend/src/lib/diagnose/probes/diskFill.ts
+++ b/packages/backend/src/lib/diagnose/probes/diskFill.ts
@@ -10,7 +10,48 @@
  * entry. `/mnt/data` running out costs you writes; `/boot` running out can
  * cost you the box.
  *
- * ## Why the thresholds are not one number
+ * ## Free space is only a signal where free space can move (#2564)
+ *
+ * The first cut of this probe watched `/` and judged it by free space. On an
+ * ostree box that is a **false alarm by construction**: Fedora CoreOS mounts
+ * `/` as a read-only composefs image whose size *is* its content
+ * (`composefs / overlay ro,...`, 12.7 MiB, 0 B free, 100% used on every
+ * healthy box from first boot). Nothing can be written to it and nothing can
+ * be freed from it, so "1.0 GiB free or it fails" fires forever and predicts
+ * failures that never happen — while the writable state it *meant* to watch
+ * sits on a different filesystem entirely.
+ *
+ * So a filesystem is judged by free space only when free space is a resource
+ * on it. The rule is structural, not a name match on "composefs" (a squashfs,
+ * an EROFS image, an ISO or a loopback mount would all be misjudged the same
+ * way) — see {@link isImmutableImage}:
+ *
+ *   > **read-only mount + zero available + used == total ⇒ an image, not a
+ *   > store.** Read-only means nothing on the box can consume the space;
+ *   > used == total with nothing available means there is nothing to consume
+ *   > and nothing to reclaim. Both directions are dead, so the number carries
+ *   > no information about the box's health.
+ *
+ * Both halves are load-bearing. Read-only *alone* is not enough: `/boot` on
+ * this same box is mounted `ro` too (rpm-ostree remounts it rw to stage a
+ * kernel), and it is the filesystem whose exhaustion is most dangerous.
+ * Zero-free *alone* is not enough either: a genuinely full writable disk also
+ * reports 0 available, and that must still fail loudly.
+ *
+ * Read-only detection needs the mount options, which `df` does not print, so
+ * the read appends `/proc/self/mounts` and rows are matched to it by
+ * mountpoint (see `DISK_FILL_COMMAND`).
+ *
+ * ## Which filesystems, and why the thresholds are not one number
+ *
+ * The writable system state on an ostree box lives on **`/var`** — verified
+ * on the reference box, not assumed: `/var` is `/dev/nvme1n1p4 ... rw` with
+ * ~206 GiB free, and it is where container images (`/var/lib/containers`),
+ * the journal (`/var/log`) and every service's data (`/mnt/data` is a symlink
+ * to `/var/mnt/data`) actually land. `/etc` and `/sysroot` are the same xfs
+ * filesystem, so measuring `/var` measures all of it — and unlike them `/var`
+ * is the one mounted `rw` (`/sysroot` is `ro`). On a box with no separate
+ * `/var` the row folds into `/`, which there is an ordinary writable root.
  *
  * A percentage tuned for a multi-terabyte array is meaningless on a
  * fingernail-sized partition. On the reference box `/boot` is a **350 MiB**
@@ -22,45 +63,57 @@
  * So each filesystem is measured against what it is *for*:
  *
  *   * `/boot` — **absolute headroom only.** What matters is whether one more
- *     kernel + initramfs pair fits, and that cost is a fixed ~100-150 MiB
+ *     kernel + initramfs pair fits, and that cost is a fixed ~140-150 MiB
  *     regardless of how big the partition is.
- *   * `/` — **absolute headroom, with a percentage backstop.** It carries the
- *     ostree repo, container images and journals; the things that fail are
- *     GB-scale, but the root partition size varies enough between installs
- *     that a percentage is still worth keeping as a slow-growth signal.
+ *   * `/var` (or `/` where the root is writable) — **absolute headroom, with
+ *     a percentage backstop.** It carries the ostree repo, container images
+ *     and journals; the things that fail are GB-scale, but the partition size
+ *     varies enough between installs that a percentage is still worth keeping
+ *     as a slow-growth signal.
  *   * `/mnt/data` — **percentage.** It is a bulk store whose whole job is to
  *     be mostly full; the operator cares about the trend, not a byte count,
  *     and nothing is bricked by it filling.
  *
  * Detection is a plain `df` read (see `DISK_FILL_COMMAND`). The parse and the
- * verdict are pure functions so every shape — near-full, healthy, and a
- * partition that isn't there — is unit-testable without a host. **This probe
- * only reports; it never frees space.** Reclaiming `/boot` means deleting
- * kernels (`rpm-ostree cleanup -bm`), which is an operator decision, so the
- * rows here carry no one-click fix — the same call the `raid` probe makes.
+ * verdict are pure functions so every shape — near-full, healthy, an image
+ * root, and a partition that isn't there — is unit-testable without a host.
+ * **This probe only reports; it never frees space.** Reclaiming `/boot` means
+ * deleting kernels (`rpm-ostree cleanup -bm`), which is an operator decision,
+ * so the rows here carry no one-click fix — the same call the `raid` probe
+ * makes.
  */
 
 import type { ProbeItem } from '../actions';
 
 export const PROBE_ID = 'disk';
-export const PROBE_LABEL = 'Storage (/mnt/data, /boot, /)';
+export const PROBE_LABEL = 'Storage (/mnt/data, /boot, /var, /)';
 
 const MiB = 1024 * 1024;
 const GiB = 1024 * MiB;
 
 export type DiskProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
 
+/** Separates the `df` rows from the mount table in the probe's output. */
+export const DISK_FILL_MOUNTS_MARKER = '---mounts---';
+
 /**
  * One `df` invocation per watched path, each line prefixed with the path we
- * asked about. The prefix is what makes a *missing* partition legible: `df`
- * writes its complaint to stderr and prints no row, so the line comes back
- * as a bare `"/boot|"` rather than silently vanishing into a shorter list.
- * `-P` pins the POSIX one-line-per-filesystem layout and `-B1` gives exact
- * bytes, because the whole point on `/boot` is an absolute number that `-h`
- * would have already rounded away.
+ * asked about, then the kernel's mount table.
+ *
+ * The prefix is what makes a *missing* partition legible: `df` writes its
+ * complaint to stderr and prints no row, so the line comes back as a bare
+ * `"/boot|"` rather than silently vanishing into a shorter list. `-P` pins
+ * the POSIX one-line-per-filesystem layout and `-B1` gives exact bytes,
+ * because the whole point on `/boot` is an absolute number that `-h` would
+ * have already rounded away.
+ *
+ * `/proc/self/mounts` is appended because `df` does not print mount options,
+ * and read-only is half of the "is this an image or a store?" test (#2564).
+ * It is a kernel file, always present on Linux, and costs one `cat`.
  */
 export const DISK_FILL_COMMAND =
-  'for p in /mnt/data /boot /; do echo "$p|$(df -P -B1 "$p" 2>/dev/null | tail -1)"; done';
+  'for p in /mnt/data /boot /var /; do echo "$p|$(df -P -B1 "$p" 2>/dev/null | tail -1)"; done; ' +
+  `echo "${DISK_FILL_MOUNTS_MARKER}"; cat /proc/self/mounts 2>/dev/null`;
 
 /** What we watch, why, and the numbers — with the reasoning attached. */
 export interface MonitoredFilesystem {
@@ -118,20 +171,26 @@ export const MONITORED_FILESYSTEMS: MonitoredFilesystem[] = [
     // tight", it is less than one kernel image.
     //
     // The unit that matters is a single deployment's boot payload — a vmlinuz
-    // (~15 MiB) plus its initramfs (~100-140 MiB), so call it ~150 MiB. That
-    // is the amount `rpm-ostree` must be able to write before it can stage
-    // the next update.
+    // plus its initramfs. MEASURED on the reference box (#2564), not guessed:
+    // the two retained deployments under /boot/ostree are 140.6 MiB and
+    // 142.8 MiB (initramfs ~123-125 MiB + vmlinuz ~17.6-17.8 MiB), 294 MiB of
+    // a 350 MiB partition. That is what `rpm-ostree` must be able to write
+    // before it can stage the next update.
     //
-    //   warn  < 128 MiB free — under roughly one kernel image. The next
-    //     update has no room to stage, but the box is still running fine and
-    //     the operator has time to reclaim space. This is deliberately the
-    //     *early* warning: it has to arrive while acting is still possible,
-    //     because by the time an update fails it is too late to have been
-    //     warned about it.
-    //   fail  < 64 MiB free — under half a kernel image. `rpm-ostree upgrade`
-    //     cannot write a new boot entry from here, and an update that dies
-    //     partway through is how a box ends up unbootable.
-    warnFreeBytes: 128 * MiB,
+    //   warn  < 192 MiB free — was 128 MiB, which was BELOW a real payload:
+    //     at 130 MiB free the probe said "ok" while an upgrade needing
+    //     ~143 MiB could no longer be staged, so the early warning arrived
+    //     after the thing it was warning about. The warning has to fire while
+    //     acting is still possible, so it now sits above one measured payload
+    //     (~143 MiB) plus room for the next initramfs to grow. This is
+    //     deliberately the *early* warning: by the time an update fails it is
+    //     too late to have been warned about it.
+    //   fail  < 64 MiB free — kept exactly as shipped in #2527, on purpose.
+    //     "The next update cannot be staged" is now the warn band's job; fail
+    //     is reserved for the harsher state where not even a vmlinuz (~18 MiB)
+    //     and a fraction of its initramfs fit, i.e. an update attempted from
+    //     here dies partway through — which is how a box ends up unbootable.
+    warnFreeBytes: 192 * MiB,
     failFreeBytes: 64 * MiB,
     warnUsedPct: null,
     consequence:
@@ -144,17 +203,39 @@ export const MONITORED_FILESYSTEMS: MonitoredFilesystem[] = [
     absentDetail: '/boot is not a separate partition on this box, so there is nothing to run out.',
   },
   {
-    path: '/',
-    purpose: 'the OS root — the ostree repo, container images, and system logs',
-    // Absolute floor first, percentage as a backstop. What fills / is
+    path: '/var',
+    purpose:
+      'the writable system state — container images, the ostree repo, system logs and service data',
+    // THIS is the filesystem the previous `/` entry was reaching for (#2564).
+    // Absolute floor first, percentage as a backstop. What fills it is
     // GB-scale (a container image pull, a staged ostree deployment, journald),
     // so the floor is expressed in GiB:
     //   warn  < 5 GiB free — an ostree deployment plus an image pull no longer
     //     comfortably fit; still plenty of time to act.
     //   fail  < 1 GiB free — podman pulls, journald writes and OS updates all
     //     start failing at around this point.
-    // The 90% backstop catches slow growth on a small root, where 5 GiB free
-    // would still be a large share of the disk.
+    // The 90% backstop catches slow growth on a small disk, where 5 GiB free
+    // would still be a large share of it.
+    warnFreeBytes: 5 * GiB,
+    failFreeBytes: 1 * GiB,
+    warnUsedPct: 90,
+    consequence:
+      'Container image pulls, system logs and OS updates all fail once the writable filesystem fills.',
+    remedy:
+      'Reclaim it from a shell on the box: `podman image prune -a` drops unused images, `journalctl --vacuum-size=200M` trims logs, and `sudo rpm-ostree cleanup -bm` drops staged deployments.',
+    actionIds: [],
+    // /var exists on every Linux box; when it is not its own filesystem the
+    // row folds into `/` below instead of landing here.
+    absentStatus: 'info',
+    absentDetail: 'Could not read /var, so the writable filesystem\'s fill level is unknown.',
+  },
+  {
+    path: '/',
+    purpose: 'the OS root',
+    // Same numbers as /var, and for the same reason: on a box whose root is
+    // an ordinary writable filesystem, this row IS the writable state (/var
+    // folds into it). On an ostree box the root is a read-only image and is
+    // reported but never judged — see isImmutableImage.
     warnFreeBytes: 5 * GiB,
     failFreeBytes: 1 * GiB,
     warnUsedPct: 90,
@@ -185,6 +266,68 @@ export interface DfRow {
    *  symlink (`/mnt/data` → `/var/mnt/data` on CoreOS) or not its own
    *  filesystem at all. */
   mountpoint: string;
+  /** Filesystem type from the mount table (`xfs`, `overlay`, …); '' if the
+   *  mount table could not be read. */
+  fstype: string;
+  /** Mounted `ro`, per the mount table. Half of the image-vs-store test. */
+  readOnly: boolean;
+}
+
+/** What the mount table says about one mountpoint. */
+interface MountInfo {
+  fstype: string;
+  readOnly: boolean;
+}
+
+/** The kernel's mount table escapes these four characters in path fields. */
+function unescapeMountPath(value: string): string {
+  return value
+    .replace(/\\040/g, ' ')
+    .replace(/\\011/g, '\t')
+    .replace(/\\012/g, '\n')
+    .replace(/\\134/g, '\\');
+}
+
+/**
+ * `<device> <mountpoint> <fstype> <options> <dump> <pass>` per line. Keyed by
+ * mountpoint with **last one winning**, which is what the kernel does: a
+ * later mount over the same point shadows the earlier one, and `df` reports
+ * the shadowing mount.
+ */
+export function parseMountTable(raw: string): Map<string, MountInfo> {
+  const mounts = new Map<string, MountInfo>();
+  for (const line of (raw ?? '').split('\n')) {
+    const fields = line.trim().split(/\s+/);
+    if (fields.length < 4) continue;
+    mounts.set(unescapeMountPath(fields[1]), {
+      fstype: fields[2],
+      readOnly: fields[3].split(',').includes('ro'),
+    });
+  }
+  return mounts;
+}
+
+/**
+ * An **image, not a store**: free space on it is not a resource, so judging
+ * it by free space says nothing about the box (#2564).
+ *
+ * Read-only means nothing on the box can consume the space; `used == total`
+ * with nothing available means there is nothing to consume and nothing to
+ * reclaim. Both conditions are required, and each rules out a case the other
+ * would get wrong:
+ *
+ *   * read-only alone would excuse `/boot`, which Fedora CoreOS also mounts
+ *     `ro` (rpm-ostree remounts it rw to stage a kernel) and whose exhaustion
+ *     is the most dangerous of all;
+ *   * zero-free alone would excuse a genuinely full writable disk, which must
+ *     keep failing loudly.
+ *
+ * This is deliberately a structural test rather than a match on "composefs":
+ * a squashfs, an EROFS image, an ISO or a read-only loopback mount are all
+ * the same shape and would all be misjudged the same way.
+ */
+export function isImmutableImage(row: DfRow): boolean {
+  return row.present && row.readOnly && row.freeBytes === 0 && row.usedBytes >= row.totalBytes;
 }
 
 /** `<device> <total> <used> <avail> <pct>% <mountpoint>` — the `df -P` row. */
@@ -197,8 +340,10 @@ const DF_ROW = /^(.+?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+(.+)$/;
  * diagnose run (same call as the `raid` probe).
  */
 export function parseDiskFill(raw: string): DfRow[] {
+  const [dfSection = '', mountSection = ''] = (raw ?? '').split(DISK_FILL_MOUNTS_MARKER);
+  const mounts = parseMountTable(mountSection);
   const rows: DfRow[] = [];
-  for (const line of (raw ?? '').split('\n')) {
+  for (const line of dfSection.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     const sep = trimmed.indexOf('|');
@@ -214,12 +359,19 @@ export function parseDiskFill(raw: string): DfRow[] {
       freeBytes: 0,
       usedPct: 0,
       mountpoint: '',
+      fstype: '',
+      readOnly: false,
     };
     const m = DF_ROW.exec(trimmed.slice(sep + 1).trim());
     if (!m) {
       rows.push(absent);
       continue;
     }
+    const mountpoint = m[6].trim();
+    // No mount-table entry (unreadable /proc, or a shape we did not parse) →
+    // treated as a writable store, i.e. judged. Failing to judge is the worse
+    // error: that is the regression #2564 fixed.
+    const mount = mounts.get(mountpoint);
     rows.push({
       path,
       present: true,
@@ -228,7 +380,9 @@ export function parseDiskFill(raw: string): DfRow[] {
       usedBytes: Number.parseInt(m[3], 10),
       freeBytes: Number.parseInt(m[4], 10),
       usedPct: Number.parseInt(m[5], 10),
-      mountpoint: m[6].trim(),
+      mountpoint,
+      fstype: mount?.fstype ?? '',
+      readOnly: mount?.readOnly ?? false,
     });
   }
   return rows;
@@ -267,6 +421,23 @@ function worst(a: DiskProbeStatus, b: DiskProbeStatus): DiskProbeStatus {
 function verdictFor(spec: MonitoredFilesystem, row: DfRow | undefined): DiskFilesystemVerdict {
   if (!row || !row.present) {
     return { spec, row: null, status: spec.absentStatus, detail: spec.absentDetail };
+  }
+
+  // An image is reported, never judged — and `ok`, not `info`, because this
+  // is the *healthy* state of an ostree root: it is 100% used by construction
+  // on every box from first boot, and a permanently non-green card is the
+  // same "train the operator to ignore it" failure in a quieter colour.
+  if (isImmutableImage(row)) {
+    const kind = [row.device, row.fstype].filter(Boolean).join(', ');
+    return {
+      spec,
+      row,
+      status: 'ok',
+      detail:
+        `${spec.path} — a read-only image of ${formatBytes(row.totalBytes)}, 100% used by ` +
+        `construction (${kind}). Nothing can be written to it and nothing can be freed from ` +
+        `it, so free space here is not a measure of anything.`,
+    };
   }
 
   const numbers =
@@ -314,7 +485,11 @@ export function evaluateDiskFill(raw: string, execCode: number | undefined): Dis
   }
 
   const byPath = new Map(rows.map(r => [r.path, r]));
-  const rootDevice = byPath.get('/')?.device;
+  // Only fold a path into `/` when `/` is itself judged. On an ostree box the
+  // root is an image, so folding a real filesystem into it would silently
+  // stop measuring it (#2564).
+  const rootRow = byPath.get('/');
+  const rootDevice = rootRow?.present && !isImmutableImage(rootRow) ? rootRow.device : undefined;
 
   const verdicts = MONITORED_FILESYSTEMS.map(spec => {
     const row = byPath.get(spec.path);
@@ -327,7 +502,8 @@ export function evaluateDiskFill(raw: string, execCode: number | undefined): Dis
       return {
         spec,
         row,
-        status: 'info' as DiskProbeStatus,
+        // `ok`, not `info`: the path is covered, just measured once under `/`.
+        status: 'ok' as DiskProbeStatus,
         detail: `${spec.path} is not a separate partition — it lives on the root filesystem, counted under / below.`,
       };
     }

--- a/packages/backend/src/lib/updateWindow.test.ts
+++ b/packages/backend/src/lib/updateWindow.test.ts
@@ -1,0 +1,224 @@
+/**
+ * #2515 — `AutoUpdate=registry` never fired because the update window
+ * enabled the SYSTEM `podman-auto-update.timer` while every ServiceBay
+ * container is a ROOTLESS Quadlet owned by the user manager.
+ *
+ * These tests deliberately do NOT assert "some command string was issued".
+ * They model systemd's two managers (system vs. user) and their unit search
+ * paths, then check **reachability**: the manager that owns the units
+ * carrying `AutoUpdate=registry` must be the same manager that runs the
+ * timer we enable, and must be the same manager that reads our drop-in.
+ * `podman auto-update` only ever sees the container store of the user it
+ * runs as, so same-manager is exactly the property that makes the label
+ * effective.
+ */
+import os from 'os';
+import path from 'path';
+import { describe, it, expect, vi } from 'vitest';
+import type { Executor } from './interfaces';
+import type { AppConfig } from './config';
+import { applyUpdateWindow, applyLocks } from './updateWindow';
+import { getLocalSystemdDir } from './dirs';
+import { generateBundleStackArtifacts, type ServiceBundle } from './unmanaged/bundleShared';
+
+type Scope = 'user' | 'system';
+
+const HOME = os.homedir();
+
+function expand(p: string): string {
+  return p.startsWith('~/') ? path.join(HOME, p.slice(2)) : p;
+}
+
+/**
+ * systemd's unit search paths, per manager. A drop-in is only merged into a
+ * unit if it sits under the search path of the manager that loaded it.
+ * (`man systemd.unit`, "Table 1/2 — Load path".)
+ */
+const UNIT_SEARCH_PATH: Record<Scope, string[]> = {
+  user: [expand('~/.config/systemd/user'), expand('~/.local/share/systemd/user'), '/etc/systemd/user', '/usr/lib/systemd/user'],
+  system: ['/etc/systemd/system', '/run/systemd/system', '/usr/lib/systemd/system'],
+};
+
+/**
+ * Quadlet's generator directories, per manager (`man quadlet`). A `.kube`
+ * unit dropped here is turned into a `.service` by the generator of THAT
+ * manager, and its containers land in THAT user's podman store.
+ */
+const QUADLET_DIRS: Record<Scope, string[]> = {
+  user: [expand('~/.config/containers/systemd'), expand('~/.local/share/containers/systemd')],
+  system: ['/etc/containers/systemd', '/usr/share/containers/systemd'],
+};
+
+function scopeOf(dirs: Record<Scope, string[]>, target: string): Scope | null {
+  const abs = expand(target);
+  for (const scope of ['user', 'system'] as Scope[]) {
+    if (dirs[scope].some(d => abs === d || abs.startsWith(`${d}/`))) return scope;
+  }
+  return null;
+}
+
+interface SystemctlCall {
+  scope: Scope;
+  verb: string;
+  unit: string | undefined;
+  raw: string;
+}
+
+/** Parse the `systemctl …` tail of a recorded shell command. */
+function parseSystemctl(raw: string): SystemctlCall | null {
+  const idx = raw.indexOf('systemctl ');
+  if (idx === -1) return null;
+  const tokens = raw.slice(idx).trim().split(/\s+/);
+  const rest = tokens.slice(1);
+  const scope: Scope = rest[0] === '--user' ? 'user' : 'system';
+  const args = rest.filter(t => !t.startsWith('--'));
+  return { scope, verb: args[0], unit: args[1], raw };
+}
+
+function makeExecutor() {
+  const commands: string[] = [];
+  const writes: Array<{ path: string; content: string }> = [];
+  const executor: Executor = {
+    exec: vi.fn(async (command: string) => {
+      commands.push(command);
+      return { stdout: '', stderr: '' };
+    }),
+    execArgv: vi.fn(async (argv: string[]) => {
+      commands.push(argv.join(' '));
+      return { stdout: '', stderr: '' };
+    }),
+    spawn: vi.fn(),
+    readFile: vi.fn(async () => ''),
+    writeFile: vi.fn(async (p: string, content: string) => {
+      writes.push({ path: p, content });
+    }),
+    exists: vi.fn(async () => true),
+    mkdir: vi.fn(async () => undefined),
+    readdir: vi.fn(async () => []),
+    rm: vi.fn(async () => undefined),
+    rename: vi.fn(async () => undefined),
+  } as unknown as Executor;
+  const calls = () => commands.map(parseSystemctl).filter((c): c is SystemctlCall => c !== null);
+  const timerCalls = () => calls().filter(c => c.unit === 'podman-auto-update.timer');
+  return { executor, commands, writes, timerCalls };
+}
+
+const WINDOW: NonNullable<AppConfig['updateWindow']> = {
+  enabled: true,
+  days: ['Sat', 'Sun'],
+  startTime: '03:00',
+  lengthMinutes: 120,
+  applyTo: { os: true, containers: true, servicebay: false },
+};
+
+const BUNDLE: ServiceBundle = {
+  id: 'bundle-001',
+  displayName: 'Example App',
+  derivedName: 'example-app',
+  nodeName: 'Local',
+  severity: 'info',
+  hints: [],
+  validations: [],
+  services: [],
+  containers: [{ id: 'abc123', name: 'api', image: 'ghcr.io/example/api:latest', ports: [] }],
+  ports: [],
+  assets: [],
+  graph: [],
+};
+
+/** The manager that owns every unit ServiceBay stamps `AutoUpdate=registry` into. */
+const AUTO_UPDATE_UNIT_SCOPE = scopeOf(QUADLET_DIRS, getLocalSystemdDir());
+
+describe('podman auto-update reachability (#2515)', () => {
+  it('installs AutoUpdate=registry units into the rootless (user) quadlet scope', () => {
+    // Real generator, same `[Kube]` body install/runner.ts writes.
+    const { kubeUnit } = generateBundleStackArtifacts(BUNDLE, 'demo');
+    expect(kubeUnit).toContain('AutoUpdate=registry');
+    expect(AUTO_UPDATE_UNIT_SCOPE).toBe('user');
+  });
+
+  it('enables the timer in the SAME manager that owns those units', async () => {
+    const { executor, timerCalls } = makeExecutor();
+    await applyUpdateWindow(executor, WINDOW);
+
+    const enables = timerCalls().filter(c => c.verb === 'enable');
+    expect(enables).toHaveLength(1);
+    // The reachability assertion: `podman auto-update` run by this manager
+    // queries this user's container store, which is where the units above
+    // put their containers. A system-scope enable would query root's store.
+    expect(enables[0].scope).toBe(AUTO_UPDATE_UNIT_SCOPE);
+    expect(timerCalls().some(c => c.verb === 'enable' && c.scope === 'system')).toBe(false);
+  });
+
+  it('writes the window drop-in into the user manager unit search path', async () => {
+    const { executor, writes } = makeExecutor();
+    await applyUpdateWindow(executor, WINDOW);
+
+    const dropIn = writes.find(w => w.path.includes('podman-auto-update.timer.d'));
+    expect(dropIn).toBeDefined();
+    expect(scopeOf(UNIT_SEARCH_PATH, path.dirname(dropIn!.path))).toBe(AUTO_UPDATE_UNIT_SCOPE);
+    expect(path.basename(path.dirname(dropIn!.path))).toBe('podman-auto-update.timer.d');
+    expect(dropIn!.content).toContain('OnCalendar=Sat,Sun *-*-* 03:00:00 UTC');
+    // The zeroing line is what stops the packaged daily schedule surviving.
+    expect(dropIn!.content).toContain('\nOnCalendar=\n');
+  });
+
+  it('exports XDG_RUNTIME_DIR for every user-scope systemctl call', async () => {
+    const { executor, commands } = makeExecutor();
+    await applyUpdateWindow(executor, WINDOW);
+    const userCalls = commands.filter(c => c.includes('systemctl --user'));
+    expect(userCalls.length).toBeGreaterThan(0);
+    for (const c of userCalls) expect(c).toContain('XDG_RUNTIME_DIR');
+  });
+});
+
+describe('lockPodmanTimer acts at the level it enables (#2515)', () => {
+  it('disables and masks the timer in the same scope the window enables it', async () => {
+    const enabling = makeExecutor();
+    await applyUpdateWindow(enabling.executor, WINDOW);
+    const enableScope = enabling.timerCalls().find(c => c.verb === 'enable')!.scope;
+
+    const locking = makeExecutor();
+    await applyLocks(locking.executor);
+    const lockVerbs = locking.timerCalls().filter(c => c.scope === enableScope).map(c => c.verb);
+
+    expect(lockVerbs).toContain('disable');
+    expect(lockVerbs).toContain('mask');
+    // Nothing is left running: no enable anywhere on the lock path.
+    expect(locking.timerCalls().some(c => c.verb === 'enable')).toBe(false);
+    // And the drop-in that carried our schedule is removed from the same
+    // search path it was written to, so an unmask later can't resurrect it.
+    expect(locking.commands.some(c => /^rm -f .*podman-auto-update\.timer\.d/.test(c))).toBe(true);
+  });
+
+  it('locks the same scope when the window opts containers out', async () => {
+    const { executor, timerCalls } = makeExecutor();
+    await applyUpdateWindow(executor, { ...WINDOW, applyTo: { os: true, containers: false, servicebay: false } });
+    const inScope = timerCalls().filter(c => c.scope === AUTO_UPDATE_UNIT_SCOPE);
+    expect(inScope.map(c => c.verb)).toContain('disable');
+    expect(inScope.map(c => c.verb)).toContain('mask');
+    expect(inScope.some(c => c.verb === 'enable')).toBe(false);
+  });
+});
+
+describe('the legacy system-scope timer is retired, not maintained (#2515)', () => {
+  async function assertRetired(run: (e: Executor) => Promise<void>) {
+    const { executor, commands, timerCalls, writes } = makeExecutor();
+    await run(executor);
+
+    expect(commands).toContain('sudo rm -f /etc/systemd/system/podman-auto-update.timer.d/55-servicebay-window.conf');
+    const system = timerCalls().filter(c => c.scope === 'system');
+    expect(system.map(c => c.verb)).toContain('disable');
+    expect(system.some(c => c.verb === 'enable')).toBe(false);
+    // Nothing ServiceBay-owned is written under the system search path.
+    expect(writes.some(w => scopeOf(UNIT_SEARCH_PATH, path.dirname(w.path)) === 'system')).toBe(false);
+  }
+
+  it('removes the old /etc drop-in and disables the root timer when a window is applied', async () => {
+    await assertRetired(e => applyUpdateWindow(e, WINDOW));
+  });
+
+  it('removes the old /etc drop-in and disables the root timer when locks are applied', async () => {
+    await assertRetired(e => applyLocks(e));
+  });
+});

--- a/packages/backend/src/lib/updateWindow.ts
+++ b/packages/backend/src/lib/updateWindow.ts
@@ -27,8 +27,40 @@ const ZINCATI_PATH = `${ZINCATI_DIR}/55-servicebay-window.toml`;
 const ZINCATI_LOCK_PATH = `${ZINCATI_DIR}/55-servicebay-lock.toml`;
 const ZINCATI_TMP = '/tmp/55-servicebay-zincati.toml';
 
-const PODMAN_TIMER_DROPIN = '/etc/systemd/system/podman-auto-update.timer.d/55-servicebay-window.conf';
-const PODMAN_TIMER_TMP = '/tmp/55-servicebay-podman-timer.conf';
+/**
+ * The podman auto-update timer is driven at the **user** (rootless) level,
+ * because that is the only level ServiceBay's containers exist at: every
+ * service is a Quadlet under `~/.config/containers/systemd/` (`dirs.ts:
+ * getLocalSystemdDir`) driven by `systemctl --user` (`serviceLifecycle.ts`),
+ * and `install/runner.ts` stamps `AutoUpdate=registry` into those user
+ * `.kube` units. The root systemd manager only ever sees root-owned
+ * containers, of which ServiceBay creates none — so a system-scope
+ * `podman-auto-update.timer` had nothing to act on and the `AutoUpdate=`
+ * label was never evaluated (#2515).
+ *
+ * The drop-in therefore has to land in the *user* unit search path, so the
+ * same manager that loads `podman-auto-update.timer` loads our override.
+ */
+const PODMAN_TIMER_UNIT = 'podman-auto-update.timer';
+const PODMAN_USER_TIMER_DROPIN = `~/.config/systemd/user/${PODMAN_TIMER_UNIT}.d/55-servicebay-window.conf`;
+
+/**
+ * Where ServiceBay *used* to write the drop-in, back when it drove the
+ * system-scope timer. Kept only so both paths can clean it up — see
+ * `retireSystemPodmanTimer`. Never written to again.
+ */
+const LEGACY_SYSTEM_TIMER_DROPIN = `/etc/systemd/system/${PODMAN_TIMER_UNIT}.d/55-servicebay-window.conf`;
+
+/**
+ * A `systemctl --user` invocation needs the user bus. The agent process is
+ * launched with `XDG_RUNTIME_DIR` exported (`agent/handler.ts`), but the
+ * value is re-derived here so a locally-spawned or re-parented executor is
+ * never left without a bus address. Lingering is provisioned for the host
+ * user in `fedora-coreos.bu`, so the user manager is up without a login.
+ */
+function userSystemctl(args: string): string {
+  return `export XDG_RUNTIME_DIR="\${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"; systemctl --user ${args}`;
+}
 
 type Window = NonNullable<AppConfig['updateWindow']>;
 
@@ -112,11 +144,32 @@ async function writeZincatiLock(executor: Executor): Promise<void> {
   await execIgnoringFailure(executor, 'sudo systemctl restart zincati', 'restart zincati');
 }
 
+/**
+ * One-shot migration, run from BOTH podman paths so it self-heals whichever
+ * way the operator flips the switch: undo the system-scope state older
+ * ServiceBay versions left behind (our drop-in, the enablement, the mask)
+ * and hand the unit back to its distro default (`preset: disabled`).
+ *
+ * ServiceBay does not manage root-owned containers, so it has no business
+ * owning a root-scope timer — leaving it enabled "just in case" would keep a
+ * second, invisible schedule for the same operator switch.
+ */
+async function retireSystemPodmanTimer(executor: Executor): Promise<void> {
+  await execIgnoringFailure(executor, `sudo rm -f ${LEGACY_SYSTEM_TIMER_DROPIN}`, 'rm legacy system dropin');
+  await execIgnoringFailure(executor, `sudo systemctl unmask ${PODMAN_TIMER_UNIT}`, 'unmask legacy system timer');
+  await execIgnoringFailure(executor, 'sudo systemctl daemon-reload', 'system daemon-reload');
+  await execIgnoringFailure(executor, `sudo systemctl disable --now ${PODMAN_TIMER_UNIT}`, 'disable legacy system timer');
+}
+
 async function writePodmanTimerWindow(executor: Executor, window: Window): Promise<void> {
-  await writeRoot(executor, PODMAN_TIMER_TMP, PODMAN_TIMER_DROPIN, renderPodmanTimerDropin(window));
-  await execIgnoringFailure(executor, 'sudo systemctl daemon-reload', 'daemon-reload');
-  await execIgnoringFailure(executor, 'sudo systemctl unmask podman-auto-update.timer', 'unmask podman timer');
-  await execIgnoringFailure(executor, 'sudo systemctl enable --now podman-auto-update.timer', 'enable podman timer');
+  // User-owned path — no sudo, no /tmp staging. `write_file` expands `~`
+  // and creates the `.d` directory, so the drop-in lands directly in the
+  // user unit search path.
+  await executor.writeFile(PODMAN_USER_TIMER_DROPIN, renderPodmanTimerDropin(window));
+  await execIgnoringFailure(executor, userSystemctl('daemon-reload'), 'user daemon-reload');
+  await execIgnoringFailure(executor, userSystemctl(`unmask ${PODMAN_TIMER_UNIT}`), 'unmask user podman timer');
+  await execIgnoringFailure(executor, userSystemctl(`enable --now ${PODMAN_TIMER_UNIT}`), 'enable user podman timer');
+  await retireSystemPodmanTimer(executor);
 }
 
 async function lockPodmanTimer(executor: Executor): Promise<void> {
@@ -124,10 +177,15 @@ async function lockPodmanTimer(executor: Executor): Promise<void> {
   // it can't be started by accident, only an explicit unmask brings
   // it back. We also remove our drop-in so a future operator who
   // unmasks manually doesn't get our schedule by surprise.
-  await execIgnoringFailure(executor, `sudo rm -f ${PODMAN_TIMER_DROPIN}`, 'rm podman dropin');
-  await execIgnoringFailure(executor, 'sudo systemctl daemon-reload', 'daemon-reload');
-  await execIgnoringFailure(executor, 'sudo systemctl disable --now podman-auto-update.timer', 'stop podman timer');
-  await execIgnoringFailure(executor, 'sudo systemctl mask podman-auto-update.timer', 'mask podman timer');
+  //
+  // This MUST act at the same level `writePodmanTimerWindow` enables at
+  // (user), or switching the window off would leave the rootless timer
+  // running on our schedule with nothing left to turn it off (#2515).
+  await execIgnoringFailure(executor, `rm -f ${PODMAN_USER_TIMER_DROPIN}`, 'rm user podman dropin');
+  await execIgnoringFailure(executor, userSystemctl('daemon-reload'), 'user daemon-reload');
+  await execIgnoringFailure(executor, userSystemctl(`disable --now ${PODMAN_TIMER_UNIT}`), 'stop user podman timer');
+  await execIgnoringFailure(executor, userSystemctl(`mask ${PODMAN_TIMER_UNIT}`), 'mask user podman timer');
+  await retireSystemPodmanTimer(executor);
 }
 
 /**


### PR DESCRIPTION
Batch `2026-08-14a` — 2 units. One is a regression we shipped yesterday; the other is a bug that had been silently true for months.

## Closes #2564 — the disk probe cried wolf on the OS root

`d7204edf` (#2527, released in 5.12.0) extended the probe from `/mnt/data` to `/boot` and `/`. The `/boot` half was right; the `/` half was not. On Fedora CoreOS the root is a **composefs** — a read-only image whose size *is* its metadata (13.3 MB, used == total, 0 free, on every healthy box from first boot). A "1 GiB free or it fails" floor on that is a permanent, confident false alarm predicting failures that cannot happen.

**Now watched: `/var`**, established on the box by one read-only read (`df -P -B1` + `/proc/self/mounts` + `du /boot/ostree/*`), not by assumption: `/` is `composefs / overlay ro` with 0 free, while `/var` is `/dev/nvme1n1p4 xfs rw` with 206 GiB free. The same xfs also appears at `/etc` (rw) and `/sysroot` (**ro**) — `/var` is its writable view.

**The read-only rule is structural, not a name match:** *mounted read-only* **and** *0 bytes free* **and** *used ≥ total* ⇒ an image, report it but never judge it. Both halves are load-bearing and both are tested, because `/boot` on this host is **also** mounted `ro` (so read-only alone would have silenced the one genuine finding) and a genuinely full writable disk also reports 0 free (so zero-free alone would have excused it). `df` prints no mount options, so the probe now joins its rows against `/proc/self/mounts` by mountpoint.

**`/boot` warn threshold 128 → 192 MiB**, measured rather than guessed: `du -sb /boot/ostree/*` gives 140.6 and 142.8 MiB per deployment (294 of 350 MiB used). At 130 MiB free the old threshold still said "ok" while a ~143 MiB payload could no longer stage — the warning arrived after the point it was meant to prevent. Fail stays at 64 MiB; the absolute-headroom approach from #2527 is untouched.

Verified against the verbatim live-box output: overall `fail` with `/boot` as the only item, `/` reported as "a read-only image of 12.7 MiB … free space here is not a measure of anything", `/var` at "14% used, 206 GiB free".

## Closes #2515 — container auto-updates had never run

An earlier triage dismissed this claiming no update window was configured. Both halves of that were wrong, checked against the live config:

1. The window **is** configured — `enabled: true`, Sat/Sun 03:00, 120 minutes, `applyTo.containers: true`.
2. `updateWindow.ts` enabled the **wrong timer**: a drop-in under `/etc/systemd/system/…` plus `sudo systemctl unmask` / `enable --now`, i.e. system systemd throughout, with no `systemctl --user` anywhere in the file.

Every service is a **rootless** Quadlet under `~/.config/containers/systemd/` driven by `systemctl --user`. The system timer runs as root and sees only root-owned containers, of which ServiceBay creates none. So the `AutoUpdate=registry` line `runner.ts:728` writes into every `.kube` unit has **never** been acted on — silently, while the config and the UI both said otherwise.

The drop-in now goes to `~/.config/systemd/user/podman-auto-update.timer.d/` and is enabled with `systemctl --user` and `XDG_RUNTIME_DIR` exported. **`lockPodmanTimer` acts at the same level it enables** — otherwise switching the window *off* would leave a live timer firing outside the operator's chosen hours, which is worse than the bug being fixed.

**Verdict on the system-scope timer: dead code, so it is retired rather than maintained.** A new `retireSystemPodmanTimer` runs from *both* paths to remove the legacy `/etc/systemd/system` drop-in and unmask+disable the root timer, so no box keeps a second invisible schedule behind one operator switch.

Reachability is proven by modelling systemd's two managers and their unit search paths, asserting `scope(units carrying AutoUpdate=registry) == scope(enabled timer) == scope(drop-in)` — not by matching command strings. 6 of 8 tests fail against the pre-fix file.

## Gates

`npm run lint` 0 errors (452 warnings, unchanged) · `typecheck` clean · `check:arch` ratchet held at baseline · `npm test` 551/551 files, 5524 passed / 1 skipped.

Both units are `gate: verify`; on-box confirmation of the timer and the probe is owed to a real run.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
