### PR TITLE
fix(diagnose): stop watching /boot, and describe the rpm-ostree flags correctly

### DIFF
--- a/packages/backend/src/lib/diagnose/probes/disk.ts
+++ b/packages/backend/src/lib/diagnose/probes/disk.ts
@@ -2,9 +2,10 @@
  * `disk` probe action — registers the `show_largest_dirs` handler so
  * the operator can find what's eating /mnt/data when the probe says
  * "above 90%". The detection lives in `diskFill.ts` (which watches
- * /mnt/data, /boot, /var and / — see #2527, #2564); this file only
- * contributes the action, and only /mnt/data offers it: the others are
- * reclaimed by deleting kernels and images, which ServiceBay won't do.
+ * /mnt/data and /var, and reports / — see #2527, #2564, #2567); this file
+ * only contributes the action, and only /mnt/data offers it: /var is
+ * reclaimed by deleting container images and logs, which ServiceBay won't
+ * decide for you.
  *
  * Returns the top 10 directories under /mnt/data sorted by size as
  * multi-line `details`, which the UI renders as a code block under

--- a/packages/backend/src/lib/diagnose/probes/diskFill.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/diskFill.test.ts
@@ -1,12 +1,15 @@
 /**
- * `disk` probe (#2527, corrected by #2564).
+ * `disk` probe (#2527, corrected by #2564, narrowed by #2567).
  *
  * Every fixture is real `df -P -B1` + `/proc/self/mounts` output shape, and
  * the byte counts are the ones measured on the reference Fedora CoreOS box:
  * a read-only composefs `/` of 12.7 MiB at 100% (by construction, on every
- * healthy box), `/var` on xfs with ~206 GiB free, a 350 MiB `/boot` at 91%
- * with 32.6 MiB free — and `/boot` mounted `ro`, which is why "read-only" on
- * its own may never excuse a filesystem from being judged.
+ * healthy box) and `/var` on xfs with ~206 GiB free.
+ *
+ * `/boot` is no longer watched (#2567) — rpm-ostree keeps two deployments on
+ * a ~350 MiB partition, so near-full is that partition's healthy steady state
+ * and a threshold there fires on every box. What remains here about `/boot`
+ * is the guard that keeps it removed, not a threshold.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -18,6 +21,7 @@ import {
   MONITORED_FILESYSTEMS,
   DISK_FILL_COMMAND,
   DISK_FILL_MOUNTS_MARKER,
+  PROBE_LABEL,
 } from './diskFill';
 
 const MiB = 1024 * 1024;
@@ -29,36 +33,24 @@ function probeOutput(df: string, mounts: string): string {
 
 /**
  * The reference box's mount table, trimmed to the lines that matter. Note
- * `/boot` is `ro` and `/sysroot` is `ro` — only `/var` and `/etc` are `rw`.
+ * `/sysroot` is `ro` while `/var` — the same filesystem — is `rw`, which is
+ * why `/var` is the one watched.
  */
 const FCOS_MOUNTS = `composefs / overlay ro,seclabel,relatime,lowerdir+=/run/ostree/.private/cfsroot-lower,datadir+=/sysroot/ostree/repo/objects,redirect_dir=on,metacopy=on 0 0
 /dev/nvme1n1p4 /etc xfs rw,seclabel,relatime,inode64,logbufs=8,logbsize=32k,prjquota 0 0
 /dev/nvme1n1p4 /sysroot xfs ro,seclabel,relatime,inode64,logbufs=8,logbsize=32k,prjquota 0 0
 /dev/nvme1n1p4 /var xfs rw,seclabel,relatime,inode64,logbufs=8,logbsize=32k,prjquota 0 0
-/dev/nvme1n1p3 /boot ext4 ro,seclabel,nosuid,nodev,relatime 0 0
 /dev/md127 /var/mnt/data xfs rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,prjquota 0 0
 `;
 
 /** A box with one ordinary writable root and no separate /var. */
 const PLAIN_MOUNTS = `/dev/nvme1n1p4 / xfs rw,relatime,seclabel,inode64 0 0
-/dev/nvme1n1p3 /boot ext4 rw,relatime,seclabel 0 0
 /dev/md127 /var/mnt/data xfs rw,relatime,seclabel 0 0
 `;
 
-/** The reference box as it stands today: /boot critical, everything else fine. */
-const FCOS_BOOT_CRITICAL = probeOutput(
-  `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 308402176 34141184 91% /boot
-/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
-/|composefs 13340672 13340672 0 100% /
-`,
-  FCOS_MOUNTS,
-);
-
-/** The same box after `rpm-ostree cleanup -bm` reclaimed one deployment. */
+/** The reference box in its normal state: everything the probe watches is fine. */
 const FCOS_HEALTHY = probeOutput(
   `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 157154304 209715200 43% /boot
 /var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
 /|composefs 13340672 13340672 0 100% /
 `,
@@ -68,28 +60,7 @@ const FCOS_HEALTHY = probeOutput(
 /** The writable filesystem genuinely full — 625 MiB left on /var. */
 const FCOS_VAR_CRITICAL = probeOutput(
   `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 157154304 209715200 43% /boot
 /var|/dev/nvme1n1p4 255455465472 254800000000 655465472 99% /var
-/|composefs 13340672 13340672 0 100% /
-`,
-  FCOS_MOUNTS,
-);
-
-/** /boot at 129 MiB free: one measured deployment (~143 MiB) no longer fits. */
-const FCOS_BOOT_UNDER_ONE_PAYLOAD = probeOutput(
-  `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 231603200 135266304 63% /boot
-/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
-/|composefs 13340672 13340672 0 100% /
-`,
-  FCOS_MOUNTS,
-);
-
-/** /boot in the failing band: not even a vmlinuz plus a slice of initramfs. */
-const FCOS_BOOT_TIGHT = probeOutput(
-  `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 261000000 105869504 71% /boot
-/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
 /|composefs 13340672 13340672 0 100% /
 `,
   FCOS_MOUNTS,
@@ -99,28 +70,16 @@ const FCOS_BOOT_TIGHT = probeOutput(
  *  answers for it with the root row. */
 const PLAIN_HEALTHY = probeOutput(
   `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
 /var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 /|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 `,
   PLAIN_MOUNTS,
 );
 
-/** No /boot partition at all — a container/dev target. `df` prints nothing
- *  for it, so the line comes back with an empty right-hand side. */
-const NO_BOOT_PARTITION = probeOutput(
-  `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
-/boot|
-/var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-`,
-  PLAIN_MOUNTS,
-);
-
-/** The array never assembled — the pre-existing "not mounted yet" case. */
+/** The array never assembled — the pre-existing "not mounted yet" case, and
+ *  the shape `df` produces for a path it could not stat at all. */
 const NO_DATA_MOUNT = probeOutput(
   `/mnt/data|
-/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
 /var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 /|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 `,
@@ -130,17 +89,15 @@ const NO_DATA_MOUNT = probeOutput(
 /** Writable root nearly gone on a plain box: /var folds into it. */
 const PLAIN_ROOT_CRITICAL = probeOutput(
   `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
 /var|/dev/nvme1n1p4 255455465472 254800000000 655465472 99% /
 /|/dev/nvme1n1p4 255455465472 254800000000 655465472 99% /
 `,
   PLAIN_MOUNTS,
 );
 
-/** Data array full, boot and root fine — the pre-#2527 behaviour, unchanged. */
+/** Data array full, everything else fine — the pre-#2527 behaviour, unchanged. */
 const DATA_FULL = probeOutput(
   `/mnt/data|/dev/md127 1999285899264 1899321604300 99964294964 95% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 152043520 214825984 42% /boot
 /var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 /|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
 `,
@@ -148,13 +105,12 @@ const DATA_FULL = probeOutput(
 );
 
 describe('DISK_FILL_COMMAND', () => {
-  it('asks about all four filesystems, in exact bytes', () => {
+  it('asks about the filesystems it watches, in exact bytes', () => {
     expect(DISK_FILL_COMMAND).toContain('/mnt/data');
-    expect(DISK_FILL_COMMAND).toContain('/boot');
     // /var is where the writable system state lives on an ostree box (#2564).
     expect(DISK_FILL_COMMAND).toContain('/var');
-    // -B1 not -h: on /boot the whole signal is an absolute byte count that
-    // -h would have rounded away.
+    // -B1 not -h: the GiB floors on /var are compared against a real number,
+    // not one -h already rounded.
     expect(DISK_FILL_COMMAND).toContain('-B1');
     expect(DISK_FILL_COMMAND).toContain('-P');
   });
@@ -165,15 +121,50 @@ describe('DISK_FILL_COMMAND', () => {
   });
 });
 
+describe('/boot is deliberately not watched (#2567)', () => {
+  it('has no /boot row at all', () => {
+    // Removed, not disabled: rpm-ostree keeps two deployments on a ~350 MiB
+    // partition, so 91% used is the healthy steady state there and any
+    // threshold on it fires on every box — the same false-alarm class #2564
+    // removed from the composefs root.
+    expect(MONITORED_FILESYSTEMS.map(f => f.path)).toEqual(['/mnt/data', '/var', '/']);
+  });
+
+  it('does not even ask df about /boot', () => {
+    expect(DISK_FILL_COMMAND).not.toContain('/boot');
+  });
+
+  it('stays silent about a /boot at 91% — the measured healthy steady state', () => {
+    // 32.6 MiB free of 350 MiB, two retained deployments (140.6 + 142.8 MiB).
+    // Even handed the row, the probe neither reports nor judges it.
+    const withBoot = probeOutput(
+      `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
+/boot|/dev/nvme1n1p3 366869504 308402176 34141184 91% /boot
+/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
+/|composefs 13340672 13340672 0 100% /
+`,
+      `${FCOS_MOUNTS}/dev/nvme1n1p3 /boot ext4 ro,seclabel,nosuid,nodev,relatime 0 0\n`,
+    );
+    const result = evaluateDiskFill(withBoot, 0);
+    expect(result.status).toBe('ok');
+    expect(result.detail).not.toContain('/boot');
+    expect(result.items).toBeUndefined();
+    expect(result.hint).toBeUndefined();
+  });
+
+  it('does not advertise /boot in the probe label either', () => {
+    expect(PROBE_LABEL).toBe('Storage (/mnt/data, /var, /)');
+  });
+});
+
 describe('parseMountTable', () => {
   it('reads the filesystem type and whether the mount is read-only', () => {
     const mounts = parseMountTable(FCOS_MOUNTS);
     expect(mounts.get('/')).toEqual({ fstype: 'overlay', readOnly: true });
     expect(mounts.get('/var')).toEqual({ fstype: 'xfs', readOnly: false });
-    // Both true on the reference box, and both matter: /sysroot is the same
-    // filesystem as /var but mounted ro, which is why /var is what we watch.
+    // /sysroot is the same filesystem as /var but mounted ro, which is why
+    // /var is the one we watch.
     expect(mounts.get('/sysroot')!.readOnly).toBe(true);
-    expect(mounts.get('/boot')!.readOnly).toBe(true);
   });
 
   it('does not mistake an option ending in "ro" for read-only', () => {
@@ -201,20 +192,20 @@ describe('parseMountTable', () => {
 
 describe('parseDiskFill', () => {
   it('parses a df row into exact byte counts', () => {
-    const rows = parseDiskFill(FCOS_BOOT_CRITICAL);
-    expect(rows).toHaveLength(4);
-    const boot = rows.find(r => r.path === '/boot')!;
-    expect(boot.present).toBe(true);
-    expect(boot.device).toBe('/dev/nvme1n1p3');
-    expect(boot.totalBytes).toBe(366869504);
-    expect(boot.usedBytes).toBe(308402176);
-    expect(boot.freeBytes).toBe(34141184);
-    expect(boot.usedPct).toBe(91);
-    expect(boot.mountpoint).toBe('/boot');
+    const rows = parseDiskFill(FCOS_HEALTHY);
+    expect(rows).toHaveLength(3);
+    const varRow = rows.find(r => r.path === '/var')!;
+    expect(varRow.present).toBe(true);
+    expect(varRow.device).toBe('/dev/nvme1n1p4');
+    expect(varRow.totalBytes).toBe(255455465472);
+    expect(varRow.usedBytes).toBe(34435706880);
+    expect(varRow.freeBytes).toBe(221019758592);
+    expect(varRow.usedPct).toBe(14);
+    expect(varRow.mountpoint).toBe('/var');
   });
 
   it('joins each row to the mount table by mountpoint', () => {
-    const rows = parseDiskFill(FCOS_BOOT_CRITICAL);
+    const rows = parseDiskFill(FCOS_HEALTHY);
     const root = rows.find(r => r.path === '/')!;
     expect(root.device).toBe('composefs');
     expect(root.fstype).toBe('overlay');
@@ -231,20 +222,20 @@ describe('parseDiskFill', () => {
   });
 
   it('keeps the requested path distinct from the mountpoint (CoreOS symlinks /mnt to /var/mnt)', () => {
-    const data = parseDiskFill(FCOS_BOOT_CRITICAL).find(r => r.path === '/mnt/data')!;
+    const data = parseDiskFill(FCOS_HEALTHY).find(r => r.path === '/mnt/data')!;
     expect(data.mountpoint).toBe('/var/mnt/data');
     expect(data.present).toBe(true);
   });
 
   it('marks a path df returned nothing for as absent instead of dropping it', () => {
-    const rows = parseDiskFill(NO_BOOT_PARTITION);
-    expect(rows.map(r => r.path)).toEqual(['/mnt/data', '/boot', '/var', '/']);
-    expect(rows.find(r => r.path === '/boot')!.present).toBe(false);
+    const rows = parseDiskFill(NO_DATA_MOUNT);
+    expect(rows.map(r => r.path)).toEqual(['/mnt/data', '/var', '/']);
+    expect(rows.find(r => r.path === '/mnt/data')!.present).toBe(false);
   });
 
   it('survives garbage without throwing', () => {
-    expect(() => parseDiskFill('nonsense\n|\n/boot|not a df row')).not.toThrow();
-    expect(parseDiskFill('/boot|not a df row')[0].present).toBe(false);
+    expect(() => parseDiskFill('nonsense\n|\n/var|not a df row')).not.toThrow();
+    expect(parseDiskFill('/var|not a df row')[0].present).toBe(false);
   });
 });
 
@@ -252,16 +243,21 @@ describe('isImmutableImage — the rule that keeps a read-only image out of the 
   const rowsOf = (raw: string) => new Map(parseDiskFill(raw).map(r => [r.path, r]));
 
   it('is true for a composefs root: read-only, nothing free, nothing to free', () => {
-    expect(isImmutableImage(rowsOf(FCOS_BOOT_CRITICAL).get('/')!)).toBe(true);
+    expect(isImmutableImage(rowsOf(FCOS_HEALTHY).get('/')!)).toBe(true);
   });
 
-  it('is false for /boot even though /boot is also mounted read-only', () => {
-    // The half that stops the rule from swallowing the most dangerous
-    // filesystem on the box: rpm-ostree remounts /boot rw to stage a kernel,
-    // and it has slack, so its free space is a real resource.
-    const boot = rowsOf(FCOS_BOOT_CRITICAL).get('/boot')!;
-    expect(boot.readOnly).toBe(true);
-    expect(isImmutableImage(boot)).toBe(false);
+  it('is false for a read-only mount that still has slack', () => {
+    // The half that stops the rule from swallowing a filesystem that is only
+    // ro *right now*: Fedora CoreOS mounts /sysroot and /boot ro and remounts
+    // them rw to write, so their free space is a real, movable resource.
+    const roWithSlack = parseDiskFill(
+      probeOutput(
+        '/var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var\n',
+        '/dev/nvme1n1p4 /var xfs ro,relatime 0 0\n',
+      ),
+    )[0];
+    expect(roWithSlack.readOnly).toBe(true);
+    expect(isImmutableImage(roWithSlack)).toBe(false);
   });
 
   it('is false for a genuinely full writable filesystem', () => {
@@ -274,27 +270,17 @@ describe('isImmutableImage — the rule that keeps a read-only image out of the 
   });
 
   it('is false for an absent row', () => {
-    expect(isImmutableImage(parseDiskFill('/boot|')[0])).toBe(false);
+    expect(isImmutableImage(parseDiskFill('/var|')[0])).toBe(false);
   });
 });
 
 describe('evaluateDiskFill — thresholds match what each filesystem is for', () => {
   it('the numbers are per-filesystem, not one global percentage', () => {
-    const boot = MONITORED_FILESYSTEMS.find(f => f.path === '/boot')!;
     const data = MONITORED_FILESYSTEMS.find(f => f.path === '/mnt/data')!;
-    // /boot is judged on absolute headroom only — a percentage on a 350 MiB
-    // partition is meaningless. 192 MiB (not the 128 MiB of #2527) because a
-    // measured deployment payload on the reference box is ~143 MiB: the warn
-    // has to sit ABOVE one payload, or it fires after staging already became
-    // impossible (#2564).
-    expect(boot.warnUsedPct).toBeNull();
-    expect(boot.warnFreeBytes).toBe(192 * MiB);
-    expect(boot.warnFreeBytes!).toBeGreaterThan(143 * MiB);
-    // The failing band is unchanged from #2527 on purpose.
-    expect(boot.failFreeBytes).toBe(64 * MiB);
     // /mnt/data is judged on percentage only — a byte floor on a 2 TB array
     // would either never fire or fire constantly.
     expect(data.warnFreeBytes).toBeNull();
+    expect(data.failFreeBytes).toBeNull();
     expect(data.warnUsedPct).toBe(90);
   });
 
@@ -313,11 +299,54 @@ describe('evaluateDiskFill — thresholds match what each filesystem is for', ()
   it('offers a fix button only where ServiceBay may safely act', () => {
     const byPath = Object.fromEntries(MONITORED_FILESYSTEMS.map(f => [f.path, f.actionIds]));
     expect(byPath['/mnt/data']).toEqual(['show_largest_dirs']);
-    // Reclaiming these means deleting kernels / images — operator decisions.
-    expect(byPath['/boot']).toEqual([]);
+    // Reclaiming these means deleting container images and logs — operator
+    // decisions.
     expect(byPath['/var']).toEqual([]);
     expect(byPath['/']).toEqual([]);
   });
+});
+
+/**
+ * #2566. The shipped hint said `rpm-ostree cleanup -bm` "drops the pending
+ * and rollback ones" — plausible prose, and wrong: `-b` clears leftovers from
+ * interrupted operations and `-m` clears cached rpm metadata, while `-p` and
+ * `-r` are what remove deployments. A test that asserted merely that *some*
+ * hint existed waved it through review and into 5.12.0, so these pin each
+ * flag against its documented effect instead.
+ */
+describe('the rpm-ostree cleanup hint describes the flags it recommends (#2566)', () => {
+  /** `rpm-ostree cleanup(1)`, flag by flag — the text has to agree with this. */
+  const DOCUMENTED_EFFECT: [string, RegExp][] = [
+    ['-b', /clears leftovers from interrupted rpm-ostree operations \(-b\)/],
+    ['-m', /the cached rpm metadata \(-m\)/],
+    ['-p', /-p \(the pending one\)/],
+    ['-r', /-r \(the rollback one\)/],
+  ];
+
+  const advised = MONITORED_FILESYSTEMS.filter(f => f.remedy.includes('rpm-ostree cleanup'));
+
+  it('is offered exactly where -bm frees something — the filesystems holding that data', () => {
+    expect(advised.map(f => f.path)).toEqual(['/var', '/']);
+  });
+
+  for (const fs of advised) {
+    describe(fs.path, () => {
+      it('recommends -bm', () => {
+        expect(fs.remedy).toContain('sudo rpm-ostree cleanup -bm');
+      });
+
+      it.each(DOCUMENTED_EFFECT)('describes %s as what it actually does', (_flag, effect) => {
+        expect(fs.remedy).toMatch(effect);
+      });
+
+      it('does not claim -bm removes deployments', () => {
+        // The exact false sentence that shipped, and its near neighbours.
+        expect(fs.remedy).not.toMatch(/-bm`? drops/i);
+        expect(fs.remedy).not.toMatch(/drops (the pending|staged deployments)/i);
+        expect(fs.remedy).toMatch(/-bm does not remove deployments/);
+      });
+    });
+  }
 });
 
 describe('evaluateDiskFill — a composefs root is never judged by free space (#2564)', () => {
@@ -342,13 +371,11 @@ describe('evaluateDiskFill — a composefs root is never judged by free space (#
     // Same shape, a squashfs image on a loop device, no ostree anywhere.
     const squashfs = probeOutput(
       `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 157154304 209715200 43% /boot
 /var|/dev/nvme1n1p4 255455465472 34435706880 221019758592 14% /var
 /|/dev/loop0 4194304 4194304 0 100% /
 `,
       `/dev/loop0 / squashfs ro,relatime 0 0
 /dev/nvme1n1p4 /var xfs rw,relatime 0 0
-/dev/nvme1n1p3 /boot ext4 ro,relatime 0 0
 /dev/md127 /var/mnt/data xfs rw,relatime 0 0
 `,
     );
@@ -366,65 +393,22 @@ describe('evaluateDiskFill — a composefs root is never judged by free space (#
     expect(result.hint).toContain('podman image prune');
   });
 
+  it('leads with the unhealthy filesystem so it is not below the fold', () => {
+    expect(evaluateDiskFill(FCOS_VAR_CRITICAL, 0).detail.split('\n')[0]).toContain('/var');
+  });
+
+  it('does not drag the healthy filesystems into the warning', () => {
+    const result = evaluateDiskFill(FCOS_VAR_CRITICAL, 0);
+    expect(result.items!.map(i => i.id)).not.toContain('/mnt/data');
+    expect(result.detail).toContain('/mnt/data — 64% used');
+  });
+
   it('judges an ordinary writable root exactly as before', () => {
     const result = evaluateDiskFill(PLAIN_ROOT_CRITICAL, 0);
     expect(result.status).toBe('fail');
     expect(result.items!.map(i => i.id)).toEqual(['/']);
     // /var is not its own filesystem there, so it is counted once, under /.
     expect(result.detail).toContain('/var is not a separate partition');
-  });
-});
-
-describe('evaluateDiskFill — /boot keeps absolute headroom, warned earlier', () => {
-  it('fails the reference box, and blames only /boot', () => {
-    const result = evaluateDiskFill(FCOS_BOOT_CRITICAL, 0);
-    expect(result.status).toBe('fail');
-    // The whole point of #2564: one honest finding, not one honest and one false.
-    expect(result.items!.map(i => i.id)).toEqual(['/boot']);
-    expect(result.detail).toContain('32.6 MiB free');
-    expect(result.detail).toMatch(/next OS update will fail/);
-    expect(result.detail).toMatch(/unable to boot/);
-  });
-
-  it('judges /boot on free space even though it is mounted read-only', () => {
-    // Regression guard for the obvious over-correction: excusing every ro
-    // mount would have silenced the one real finding on this box.
-    const boot = parseDiskFill(FCOS_BOOT_CRITICAL).find(r => r.path === '/boot')!;
-    expect(boot.readOnly).toBe(true);
-    expect(evaluateDiskFill(FCOS_BOOT_CRITICAL, 0).items!.map(i => i.id)).toContain('/boot');
-  });
-
-  it('warns once one deployment no longer fits — where 128 MiB said nothing', () => {
-    // 129 MiB free. A measured payload is ~143 MiB, so an upgrade can no
-    // longer be staged here; the old 128 MiB threshold called this ok.
-    const result = evaluateDiskFill(FCOS_BOOT_UNDER_ONE_PAYLOAD, 0);
-    expect(result.status).toBe('warn');
-    expect(result.items!.map(i => i.id)).toEqual(['/boot']);
-    expect(result.hint).toContain('rpm-ostree cleanup -bm');
-  });
-
-  it('stays quiet at 200 MiB free, where a deployment still fits with room', () => {
-    expect(evaluateDiskFill(FCOS_HEALTHY, 0).status).toBe('ok');
-  });
-
-  it('warns between one payload and the failing floor, and says ServiceBay will not delete kernels', () => {
-    const result = evaluateDiskFill(FCOS_BOOT_TIGHT, 0);
-    expect(result.status).toBe('warn');
-    expect(result.hint).toContain('rpm-ostree cleanup -bm');
-    expect(result.hint).toMatch(/ServiceBay will not delete kernels/);
-    expect(result.items!.map(i => i.status)).toEqual(['warn']);
-    expect(result.items![0].actionIds).toEqual([]);
-  });
-
-  it('leads with the unhealthy filesystem so it is not below the fold', () => {
-    expect(evaluateDiskFill(FCOS_BOOT_CRITICAL, 0).detail.split('\n')[0]).toContain('/boot');
-  });
-
-  it('does not drag the healthy filesystems into the warning', () => {
-    const result = evaluateDiskFill(FCOS_BOOT_CRITICAL, 0);
-    expect(result.items!.map(i => i.id)).not.toContain('/mnt/data');
-    expect(result.detail).toContain('/mnt/data — 64% used');
-    expect(result.detail).toContain('/var — 14% used');
   });
 });
 
@@ -439,45 +423,16 @@ describe('evaluateDiskFill — healthy partitions produce no noise', () => {
 
   it('still reports every filesystem it looked at', () => {
     expect(result.detail).toContain('/mnt/data — 64% used');
-    expect(result.detail).toContain('/boot — 42% used');
     expect(result.detail).toContain('/ — 14% used');
-  });
-
-  it('does not warn about a 91%-shaped /mnt/data threshold applied to /boot', () => {
-    // 42% on /boot is 204 MiB free — above the headroom floor. A naive
-    // percentage rule would agree here; the point is that it also has to
-    // agree at 63% (FCOS_BOOT_UNDER_ONE_PAYLOAD), where it does not.
-    expect(evaluateDiskFill(FCOS_BOOT_UNDER_ONE_PAYLOAD, 0).status).not.toBe('ok');
   });
 });
 
 describe('evaluateDiskFill — missing partitions', () => {
-  it('treats an absent /boot as information, not a problem', () => {
-    const result = evaluateDiskFill(NO_BOOT_PARTITION, 0);
-    // `info`, not `warn`/`fail` — diagnoseStatusToCheckStatus collapses it to
-    // a passing check, so a box with no /boot never nags. Same call the raid
-    // probe makes for a box with no md array.
-    expect(result.status).toBe('info');
+  it('counts a /var that shares the root filesystem under / instead of twice', () => {
+    const result = evaluateDiskFill(PLAIN_HEALTHY, 0);
     expect(['warn', 'fail']).not.toContain(result.status);
-    expect(result.detail).toContain('/boot is not a separate partition');
-    expect(result.items).toBeUndefined();
-    expect(result.hint).toBeUndefined();
-  });
-
-  it('counts a /boot that shares the root filesystem under / instead of judging it by kernel-sized rules', () => {
-    const bootOnRoot = probeOutput(
-      `/mnt/data|/dev/md127 1999285899264 1269934231552 729351667712 64% /var/mnt/data
-/boot|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-/var|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-/|/dev/nvme1n1p4 255455465472 34382917632 221072547840 14% /
-`,
-      '/dev/nvme1n1p4 / xfs rw,relatime 0 0\n/dev/md127 /var/mnt/data xfs rw,relatime 0 0\n',
-    );
-    const result = evaluateDiskFill(bootOnRoot, 0);
-    expect(['warn', 'fail']).not.toContain(result.status);
-    expect(result.detail).toContain('/boot is not a separate partition');
+    expect(result.detail).toContain('/var is not a separate partition');
     expect(result.detail).toContain('counted under / below');
-    // The root's own 14%/206 GiB row is what gets judged, and it is healthy.
     expect(result.items).toBeUndefined();
   });
 
@@ -487,7 +442,6 @@ describe('evaluateDiskFill — missing partitions', () => {
     // `/` is never judged.
     const collide = probeOutput(
       `/mnt/data|/dev/md127 1999285899264 1276953501696 722332397568 64% /var/mnt/data
-/boot|/dev/nvme1n1p3 366869504 157154304 209715200 43% /boot
 /var|composefs 255455465472 254800000000 655465472 99% /var
 /|composefs 13340672 13340672 0 100% /
 `,
@@ -516,7 +470,7 @@ describe('evaluateDiskFill — missing partitions', () => {
 describe('formatBytes', () => {
   it('renders the sizes an operator has to compare', () => {
     expect(formatBytes(34141184)).toBe('32.6 MiB');
-    expect(formatBytes(192 * MiB)).toBe('192 MiB');
+    expect(formatBytes(655465472)).toBe('625 MiB');
     expect(formatBytes(221072547840)).toBe('206 GiB');
     expect(formatBytes(1999285899264)).toBe('1.8 TiB');
   });

--- a/packages/backend/src/lib/diagnose/probes/diskFill.ts
+++ b/packages/backend/src/lib/diagnose/probes/diskFill.ts
@@ -1,14 +1,37 @@
 /**
- * `disk` probe (#2527) — how full is every filesystem the box actually
- * depends on, not just the data array.
+ * `disk` probe (#2527, corrected by #2564 and #2567) — how full is every
+ * filesystem whose exhaustion the operator can actually do something about.
  *
- * Until now this probe read `df -h /mnt/data` and nothing else, so the two
- * filesystems whose exhaustion is *unrecoverable* were unwatched. `/boot`
- * filled to 91% (~33 MB free) on a live CoreOS box and nothing said a word:
- * a `/boot` too full to stage the next kernel leaves `rpm-ostree upgrade`
- * failing, and a failure partway through leaves the box without a bootable
- * entry. `/mnt/data` running out costs you writes; `/boot` running out can
- * cost you the box.
+ * Watched and judged: **`/mnt/data`** (the array) and **`/var`** (all
+ * writable system state). `/` is read and reported, but judged only where
+ * the root is an ordinary writable filesystem — see the next section.
+ *
+ * ## Why `/boot` is deliberately NOT watched (#2567)
+ *
+ * #2527 added a `/boot` row with an absolute free-space threshold. It was
+ * taken back out, and this note exists so it does not come back next quarter:
+ *
+ *   * `rpm-ostree` manages `/boot` itself. It keeps two deployments by
+ *     default and prunes the oldest when it stages a new one, so a nearly
+ *     full partition is the *healthy steady state* rather than a symptom.
+ *     Measured on the reference box: exactly two deployments, 140.6 MiB and
+ *     142.8 MiB of a 350 MiB partition — 91% used, and nothing wrong with it.
+ *   * A threshold on that fires on **every healthy box** at this partition
+ *     size. That is the same false-alarm class #2564 had just removed from
+ *     `/` (a composefs root is 100% used by construction), and a permanently
+ *     red card is how an operator learns to ignore the card.
+ *   * Whether a tight `/boot` actually blocks staging an update was never
+ *     established — it turns on whether rpm-ostree prunes before or after it
+ *     writes, which nobody measured. A threshold resting on an unproven
+ *     assumption is noise, not monitoring.
+ *
+ * Not overstated, on purpose: "rpm-ostree keeps `/boot` tidy" is the design,
+ * not a measurement of any particular box. On the reference box `/boot` fell
+ * from 55.8 to 32.6 MiB free in ~15 hours with **no OS update in between**,
+ * and a tidy steady state does not shrink. That observation is recorded and
+ * still open as **#2568**. If it turns out to have a real mechanism, what
+ * comes back is a rule about *that* mechanism — not a percentage threshold on
+ * a partition that is supposed to be full.
  *
  * ## Free space is only a signal where free space can move (#2564)
  *
@@ -32,11 +55,12 @@
  *   > and nothing to reclaim. Both directions are dead, so the number carries
  *   > no information about the box's health.
  *
- * Both halves are load-bearing. Read-only *alone* is not enough: `/boot` on
- * this same box is mounted `ro` too (rpm-ostree remounts it rw to stage a
- * kernel), and it is the filesystem whose exhaustion is most dangerous.
- * Zero-free *alone* is not enough either: a genuinely full writable disk also
- * reports 0 available, and that must still fail loudly.
+ * Both halves are load-bearing. Read-only *alone* is not enough: a mount can
+ * be `ro` at this instant and still be a store — Fedora CoreOS mounts both
+ * `/sysroot` and `/boot` `ro` and remounts them rw to write, so their free
+ * space is a real, movable resource. Zero-free *alone* is not enough either:
+ * a genuinely full writable disk also reports 0 available, and that must
+ * still fail loudly.
  *
  * Read-only detection needs the mount options, which `df` does not print, so
  * the read appends `/proc/self/mounts` and rows are matched to it by
@@ -53,18 +77,11 @@
  * is the one mounted `rw` (`/sysroot` is `ro`). On a box with no separate
  * `/var` the row folds into `/`, which there is an ordinary writable root.
  *
- * A percentage tuned for a multi-terabyte array is meaningless on a
- * fingernail-sized partition. On the reference box `/boot` is a **350 MiB**
- * usable ext4 partition (Fedora CoreOS lays down 384 MiB), so 91% there is
- * ~33-56 MiB — **less than a single kernel image**. "Warn at 90%" would have
- * fired only once the box was already past saving, while "warn at 80%" on a
- * 2 TB `/mnt/data` would page someone about 400 GB of free space.
+ * A percentage tuned for a multi-terabyte array is meaningless on a small
+ * partition, and an absolute floor tuned for a small partition is meaningless
+ * on a 2 TB array — "warn at 80%" there would page someone about 400 GB of
+ * free space. So each filesystem is measured against what it is *for*:
  *
- * So each filesystem is measured against what it is *for*:
- *
- *   * `/boot` — **absolute headroom only.** What matters is whether one more
- *     kernel + initramfs pair fits, and that cost is a fixed ~140-150 MiB
- *     regardless of how big the partition is.
  *   * `/var` (or `/` where the root is writable) — **absolute headroom, with
  *     a percentage backstop.** It carries the ostree repo, container images
  *     and journals; the things that fail are GB-scale, but the partition size
@@ -77,16 +94,14 @@
  * Detection is a plain `df` read (see `DISK_FILL_COMMAND`). The parse and the
  * verdict are pure functions so every shape — near-full, healthy, an image
  * root, and a partition that isn't there — is unit-testable without a host.
- * **This probe only reports; it never frees space.** Reclaiming `/boot` means
- * deleting kernels (`rpm-ostree cleanup -bm`), which is an operator decision,
- * so the rows here carry no one-click fix — the same call the `raid` probe
- * makes.
+ * **This probe only reports; it never frees space** beyond the one read-only
+ * `du` behind `/mnt/data`'s fix button — the same call the `raid` probe makes.
  */
 
 import type { ProbeItem } from '../actions';
 
 export const PROBE_ID = 'disk';
-export const PROBE_LABEL = 'Storage (/mnt/data, /boot, /var, /)';
+export const PROBE_LABEL = 'Storage (/mnt/data, /var, /)';
 
 const MiB = 1024 * 1024;
 const GiB = 1024 * MiB;
@@ -102,17 +117,21 @@ export const DISK_FILL_MOUNTS_MARKER = '---mounts---';
  *
  * The prefix is what makes a *missing* partition legible: `df` writes its
  * complaint to stderr and prints no row, so the line comes back as a bare
- * `"/boot|"` rather than silently vanishing into a shorter list. `-P` pins
- * the POSIX one-line-per-filesystem layout and `-B1` gives exact bytes,
- * because the whole point on `/boot` is an absolute number that `-h` would
- * have already rounded away.
+ * `"/mnt/data|"` rather than silently vanishing into a shorter list. `-P`
+ * pins the POSIX one-line-per-filesystem layout and `-B1` gives exact bytes,
+ * so the GiB floors on `/var` are compared against a real number rather than
+ * one `-h` already rounded.
+ *
+ * `/boot` is deliberately absent from this list (#2567) — see the module
+ * header: rpm-ostree keeps it near-full by design, so there is nothing here
+ * to judge.
  *
  * `/proc/self/mounts` is appended because `df` does not print mount options,
  * and read-only is half of the "is this an image or a store?" test (#2564).
  * It is a kernel file, always present on Linux, and costs one `cat`.
  */
 export const DISK_FILL_COMMAND =
-  'for p in /mnt/data /boot /var /; do echo "$p|$(df -P -B1 "$p" 2>/dev/null | tail -1)"; done; ' +
+  'for p in /mnt/data /var /; do echo "$p|$(df -P -B1 "$p" 2>/dev/null | tail -1)"; done; ' +
   `echo "${DISK_FILL_MOUNTS_MARKER}"; cat /proc/self/mounts 2>/dev/null`;
 
 /** What we watch, why, and the numbers — with the reasoning attached. */
@@ -161,47 +180,10 @@ export const MONITORED_FILESYSTEMS: MonitoredFilesystem[] = [
     absentDetail:
       '/mnt/data is not mounted — first-boot RAID setup may still be running, or the array failed to assemble.',
   },
-  {
-    path: '/boot',
-    purpose: 'the kernels and initramfs images the box boots from',
-    // ABSOLUTE ONLY, and small. Fedora CoreOS gives /boot a 384 MiB partition
-    // (~350 MiB usable) and keeps two deployments on it, so the numbers here
-    // are in the tens of megabytes and a percentage says nothing useful:
-    // the reference box sat at 91% with 56 MiB free, which is not "a bit
-    // tight", it is less than one kernel image.
-    //
-    // The unit that matters is a single deployment's boot payload — a vmlinuz
-    // plus its initramfs. MEASURED on the reference box (#2564), not guessed:
-    // the two retained deployments under /boot/ostree are 140.6 MiB and
-    // 142.8 MiB (initramfs ~123-125 MiB + vmlinuz ~17.6-17.8 MiB), 294 MiB of
-    // a 350 MiB partition. That is what `rpm-ostree` must be able to write
-    // before it can stage the next update.
-    //
-    //   warn  < 192 MiB free — was 128 MiB, which was BELOW a real payload:
-    //     at 130 MiB free the probe said "ok" while an upgrade needing
-    //     ~143 MiB could no longer be staged, so the early warning arrived
-    //     after the thing it was warning about. The warning has to fire while
-    //     acting is still possible, so it now sits above one measured payload
-    //     (~143 MiB) plus room for the next initramfs to grow. This is
-    //     deliberately the *early* warning: by the time an update fails it is
-    //     too late to have been warned about it.
-    //   fail  < 64 MiB free — kept exactly as shipped in #2527, on purpose.
-    //     "The next update cannot be staged" is now the warn band's job; fail
-    //     is reserved for the harsher state where not even a vmlinuz (~18 MiB)
-    //     and a fraction of its initramfs fit, i.e. an update attempted from
-    //     here dies partway through — which is how a box ends up unbootable.
-    warnFreeBytes: 192 * MiB,
-    failFreeBytes: 64 * MiB,
-    warnUsedPct: null,
-    consequence:
-      'There is not enough room to stage the next kernel, so the next OS update will fail — and an update that fails partway through can leave the box unable to boot.',
-    remedy:
-      'Reclaim /boot from a shell on the box: `rpm-ostree status` shows the retained deployments, `sudo rpm-ostree cleanup -bm` drops the pending and rollback ones, and any kernel left behind by a past failed update has to go too. ServiceBay will not delete kernels for you — getting that wrong is what makes a box unbootable.',
-    // Read-only on purpose: the fix deletes boot entries.
-    actionIds: [],
-    absentStatus: 'info',
-    absentDetail: '/boot is not a separate partition on this box, so there is nothing to run out.',
-  },
+  // NOTE: there is deliberately no `/boot` entry (#2567). rpm-ostree keeps
+  // two deployments on a ~350 MiB partition, so near-full IS the healthy
+  // state and any threshold here fires on every box — see the module header,
+  // including the still-open #2568 observation that keeps this honest.
   {
     path: '/var',
     purpose:
@@ -222,7 +204,7 @@ export const MONITORED_FILESYSTEMS: MonitoredFilesystem[] = [
     consequence:
       'Container image pulls, system logs and OS updates all fail once the writable filesystem fills.',
     remedy:
-      'Reclaim it from a shell on the box: `podman image prune -a` drops unused images, `journalctl --vacuum-size=200M` trims logs, and `sudo rpm-ostree cleanup -bm` drops staged deployments.',
+      'Reclaim it from a shell on the box: `podman image prune -a` drops unused images, `journalctl --vacuum-size=200M` trims logs, and `sudo rpm-ostree cleanup -bm` clears leftovers from interrupted rpm-ostree operations (-b) and the cached rpm metadata (-m), both of which live here. Note that -bm does not remove deployments — that is -p (the pending one) and -r (the rollback one), and what those free is /boot, not this filesystem.',
     actionIds: [],
     // /var exists on every Linux box; when it is not its own filesystem the
     // row folds into `/` below instead of landing here.
@@ -242,7 +224,7 @@ export const MONITORED_FILESYSTEMS: MonitoredFilesystem[] = [
     consequence:
       'Container image pulls, system logs and OS updates all fail once the root filesystem fills.',
     remedy:
-      'Reclaim it from a shell on the box: `podman image prune -a` drops unused images, `journalctl --vacuum-size=200M` trims logs, and `sudo rpm-ostree cleanup -bm` drops staged deployments.',
+      'Reclaim it from a shell on the box: `podman image prune -a` drops unused images, `journalctl --vacuum-size=200M` trims logs, and `sudo rpm-ostree cleanup -bm` clears leftovers from interrupted rpm-ostree operations (-b) and the cached rpm metadata (-m), both of which live here. Note that -bm does not remove deployments — that is -p (the pending one) and -r (the rollback one), and what those free is /boot, not this filesystem.',
     actionIds: [],
     // `/` always exists; an absent row here means the read itself failed.
     absentStatus: 'info',
@@ -316,9 +298,9 @@ export function parseMountTable(raw: string): Map<string, MountInfo> {
  * reclaim. Both conditions are required, and each rules out a case the other
  * would get wrong:
  *
- *   * read-only alone would excuse `/boot`, which Fedora CoreOS also mounts
- *     `ro` (rpm-ostree remounts it rw to stage a kernel) and whose exhaustion
- *     is the most dangerous of all;
+ *   * read-only alone would excuse a mount that is `ro` right now but is
+ *     still a store — Fedora CoreOS mounts `/sysroot` and `/boot` `ro` and
+ *     remounts them rw to write, and both have real, movable slack;
  *   * zero-free alone would excuse a genuinely full writable disk, which must
  *     keep failing loudly.
  *
@@ -494,10 +476,9 @@ export function evaluateDiskFill(raw: string, execCode: number | undefined): Dis
   const verdicts = MONITORED_FILESYSTEMS.map(spec => {
     const row = byPath.get(spec.path);
     // A path that is not its own partition lives on the root filesystem, so
-    // the root's thresholds are the ones that apply to it — measuring a
-    // 350 MiB-sized `/boot` rule against a 250 GB root would either never
-    // fire or fire on a box that is perfectly healthy. Report it as covered
-    // and evaluate it once, under `/`.
+    // the root's thresholds are the ones that apply to it — and counting it
+    // twice would report one filling disk as two separate problems. Report it
+    // as covered and evaluate it once, under `/`.
     if (spec.path !== '/' && row?.present && rootDevice && row.device === rootDevice) {
       return {
         spec,

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -411,9 +411,10 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     exec('systemctl --user --failed --no-legend --no-pager 2>&1', 5000),
     exec('ss -ltn 2>/dev/null | tail -n +2 | awk \'{print $4}\' | awk -F: \'{print $NF}\' | sort -nu', 4000),
     exec('ls -la /dev/serial/by-id/ 2>/dev/null | grep -v "^total" | awk \'{print $NF}\' | grep -v "^$"', 3000),
-    // Fill level of every filesystem the box depends on, not just the data
-    // array (#2527). `/boot` used to be unwatched, and a `/boot` too full to
-    // stage the next kernel is how a box ends up unbootable after an update.
+    // Fill level of every filesystem whose exhaustion the operator can act on
+    // (#2527): the data array and the writable system state. `/boot` is
+    // deliberately not among them (#2567) — rpm-ostree keeps it near-full by
+    // design, so a threshold there fires on every healthy box.
     exec(DISK_FILL_COMMAND, 3000),
     // The kernel's own view of every md array (#2526). `df` above only
     // proves the filesystem mounts — it says nothing about whether the
@@ -577,10 +578,10 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     detail: serialDevices.length === 0 ? 'No USB serial devices (no Z-Wave / Zigbee stick plugged in).' : serialDevices.join('\n'),
   });
 
-  // 7) Fill level of /mnt/data, /boot and / (#2527). Each filesystem is
-  //    judged against what it is for — see the threshold rationale in
-  //    probes/diskFill.ts. Reporting only: the probe never frees space,
-  //    because reclaiming /boot means deleting kernels.
+  // 7) Fill level of /mnt/data, /var and / (#2527, #2564, #2567). Each
+  //    filesystem is judged against what it is for — see the threshold
+  //    rationale in probes/diskFill.ts, including why `/` is reported but
+  //    not judged on an ostree box and why `/boot` is not watched at all.
   const diskFill = evaluateDiskFill(disk.stdout ?? '', disk.code);
   probes.push({
     id: DISK_PROBE_ID,

--- a/tests/backend/logger_retention.test.ts
+++ b/tests/backend/logger_retention.test.ts
@@ -53,9 +53,19 @@ function open(): InstanceType<typeof Database> {
   return d;
 }
 
+// #2558/#2571: insert inside ONE transaction. Row-by-row, each `stmt.run` is
+// its own implicit transaction and commits to disk, so seeding the 20 000 rows
+// the freelist cases need took whole seconds and blew vitest's 5 s default —
+// twice, on two different tests in this file, and the second time only after
+// the first had been "fixed" with a bigger timeout. The cost was never the
+// VACUUM; it was the seeding both tests share. One transaction commits once,
+// which removes the flake at its source instead of budgeting around it.
 function seed(d: InstanceType<typeof Database>, when: Date, count = 1) {
   const stmt = d.prepare('INSERT INTO logs (timestamp, level, tag, message) VALUES (?, ?, ?, ?)');
-  for (let i = 0; i < count; i++) stmt.run(ts(when), 'info', 'test', `msg-${i}`);
+  const insertAll = d.transaction((n: number) => {
+    for (let i = 0; i < n; i++) stmt.run(ts(when), 'info', 'test', `msg-${i}`);
+  });
+  insertAll(count);
 }
 
 function rowCount(d: InstanceType<typeof Database>): number {
@@ -136,14 +146,13 @@ describe('pruneLogsDb (#1869)', () => {
     // VACUUM rewrote the DB: page count collapsed and the freelist is empty.
     expect(pageCount(db)).toBeLessThan(before / 10);
     expect(freelist(db)).toBe(0);
-    // #2558: 30s, not the 5s default. This is the one case in the file that
-    // pays a real VACUUM — the sibling above seeds the same 20 000 rows and
-    // stays fast precisely because it skips it. Rewriting the file took 10.9s
-    // on a loaded machine and timed out CI, so the default is simply the wrong
-    // budget for the work; the seed size stays at 20 000 because both
-    // assertions depend on it (`before > 100` pages, and a collapse to under a
-    // tenth). Raising the ceiling does not weaken what the test proves.
-  }, 30_000);
+    // The 30s budget #2558 put here is gone: it rested on the VACUUM being the
+    // expensive part, and it wasn't — the sibling that skips the VACUUM timed
+    // out next. With `seed` batched into one transaction the whole file runs in
+    // ~0.6s, so the default applies again. The seed size stays at 20 000
+    // because both assertions depend on it (`before > 100` pages, and a
+    // collapse to under a tenth).
+  });
 
   it('does not delete when nothing is old (no-op prune leaves the DB untouched)', () => {
     seed(db, NOW, 5000);


### PR DESCRIPTION
Batch `2026-08-14b` — 1 unit, 2 issues. Takes back a piece of yesterday's work on the owner's call.

## Closes #2567 — the `/boot` watch is removed again

`#2527` added `/boot` to the disk probe in 5.12.0. Taking it back out, because the premise was wrong: **`rpm-ostree` manages `/boot` itself.** It keeps two deployments and prunes the oldest when staging a new one. Measured on the reference box: exactly two, 140.6 and 142.8 MiB, on a 350 MiB partition. So **91% used is the healthy steady state at that size** — a threshold on it fires on every healthy box.

That is the same false-alarm class as the composefs root #2564 fixed the day before. And whether a tight `/boot` actually blocks staging was never established; a threshold resting on an unproven assumption is noise, not monitoring.

Removed: the row, its 192/64 MiB thresholds, its hint, `/boot` from `DISK_FILL_COMMAND` and from `PROBE_LABEL` (now `Storage (/mnt/data, /var, /)`), and every `/boot` fixture — **removed, not skipped**, and replaced by three removal guards including a behavioural one asserting that a real 91%-full `/boot` row yields no finding.

Kept: `/var` and `/mnt/data` thresholds unchanged, the read-only rule from #2564 intact (its doc/test example just moved off `/boot` onto a synthetic read-only-with-slack row), and `/` still *reported* without being judged.

**Not risk-free, and the code says so rather than claiming tidiness:** `/boot` on the reference box fell 55.8 → 32.6 MiB free in about 15 hours with no OS update in between. A tidy steady state does not shrink. That observation is filed as **#2568** and referenced in-source, so a future reader knows it was seen and left open rather than missed.

## Closes #2566 — the rpm-ostree hint described the wrong flags

The remediation text claimed `sudo rpm-ostree cleanup -bm` "drops the pending and rollback ones". It does not: `-b` clears leftovers from interrupted operations and `-m` the cached rpm metadata; `-p` and `-r` are what remove deployments. So the hint recommended a command that could not fix what was reported — the failure mode where an operator follows the advice, sees nothing happen, and concludes the warning is broken.

The `/boot` occurrence left with the row above. The same wrong description also sat on `/var` and `/mnt/data`, where `-bm` *is* the right command and only the wording was false; that now reads "clears leftovers from interrupted rpm-ostree operations (`-b`) and the cached rpm metadata (`-m`), both of which live here… `-bm` does not remove deployments — that is `-p` (the pending one) and `-r` (the rollback one)".

A new `DOCUMENTED_EFFECT` per-flag regex table pins every rpm-ostree remedy against its documented effect — 10 cases fail against the shipped wording. A test asserting merely that *some* hint exists would not have caught this, which is how it passed review and shipped.

## Gates

`npm run lint` 0 errors (452 warnings, unchanged) · `typecheck` clean · `check:arch` ratchet held at baseline · `npm test` 5534 passed / 1 skipped.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
