### PR TITLE
feat(templates): add beets with a reachable UI and operator-triggered imports

### DIFF
--- a/packages/backend/src/lib/externalBackup/serviceManifest.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.ts
@@ -390,6 +390,22 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     ],
     exclude: [],
   },
+  {
+    // Beets (#2581) — the tagger's own state, NOT the music it tags. Two small
+    // files under `beets/config/`: `config.yaml` is hand-tuned (plugin list, an
+    // AcoustID key, and the import safety settings that decide whether an
+    // import relocates files), and `musiclibrary.db` is what beets knows about
+    // the collection — crucially which directories it has already imported, so
+    // a restored box doesn't re-walk and re-tag the whole library. Everything
+    // else in that dir is disposable: `.cache`, the resume `state.pickle`, and
+    // the `<db>-before-<schema-change>.bak` copies beets writes on every
+    // database migration. The music and audiobooks are on the file-share
+    // volumes and are never backed up (EXCLUDED_BULK_VOLUMES).
+    service: 'beets',
+    dataSubdir: 'beets/config',
+    include: ['config.yaml', 'musiclibrary.db'],
+    exclude: [],
+  },
 ];
 
 /**
@@ -414,6 +430,8 @@ export const EXCLUDED_BULK_VOLUMES: Readonly<Record<string, string>> = {
   JELLYFIN_MEDIA_PATH: 'The media library itself — multi-TB, lives on the RAID.',
   'immich/upload': 'Immich photo/video library — multi-GB blobs, RAID-resident.',
   'file-share/data': 'The shared household files — bulk user data on the RAID.',
+  BEETS_MUSIC_PATH: 'The music library beets tags — the file-share bulk tree under another name, RAID-resident.',
+  BEETS_AUDIOBOOKS_PATH: 'The audiobook library — same file-share bulk tree, RAID-resident.',
   // Postgres data dirs: credential-coupled, reconciled by rekey (#2165), not
   // restored from a NAS tarball.
   'immich/pgdata': 'Immich Postgres data dir — RAID-resident, rekey-reconciled, not NAS-restored.',

--- a/packages/backup-worker/src/engine/serviceManifest.ts
+++ b/packages/backup-worker/src/engine/serviceManifest.ts
@@ -203,6 +203,15 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     ],
     exclude: [],
   },
+  {
+    // Beets (#2581): the tagger's config and its library database — which
+    // directories it has already imported — NOT the music itself (that lives on
+    // the file-share bulk tree, excluded below).
+    service: 'beets',
+    dataSubdir: 'beets/config',
+    include: ['config.yaml', 'musiclibrary.db'],
+    exclude: [],
+  },
 ];
 
 /**
@@ -223,6 +232,8 @@ export const EXCLUDED_BULK_VOLUMES: Readonly<Record<string, string>> = {
   JELLYFIN_MEDIA_PATH: 'The media library itself — multi-TB, lives on the RAID.',
   'immich/upload': 'Immich photo/video library — multi-GB blobs, RAID-resident.',
   'file-share/data': 'The shared household files — bulk user data on the RAID.',
+  BEETS_MUSIC_PATH: 'The music library beets tags — the file-share bulk tree under another name, RAID-resident.',
+  BEETS_AUDIOBOOKS_PATH: 'The audiobook library — same file-share bulk tree, RAID-resident.',
   'immich/pgdata': 'Immich Postgres data dir — RAID-resident, rekey-reconciled, not NAS-restored.',
 };
 

--- a/stacks/cloud/README.md
+++ b/stacks/cloud/README.md
@@ -10,6 +10,7 @@ that handle private data the household relies on.
 - [x] file-share — Syncthing + Samba + FileBrowser (LDAP/SSO‑wired)
 - [x] media — Jellyfin streaming + Audiobookshelf for podcasts/books
 - [x] radicale — CalDAV/CardDAV (calendar + contacts), LDAP-bound
+- [ ] beets — Music tagger for the file-share music folder (LAN-only UI; imports are operator-triggered)
 
 ## Why a single stack
 

--- a/templates/beets/CHANGELOG.md
+++ b/templates/beets/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Beets — changelog
+
+## v2 (breaking)
+
+**Required action, if `beets` was installed from a local (file-dropped)
+template:** delete `DATA_DIR/local-templates/templates/beets` before
+re-deploying, otherwise that copy keeps overriding this one — local templates
+win over built-ins by name. Removing the directory does not touch the running
+service; the deployed unit is independent of the template it was rendered from.
+
+**Then check `DATA_DIR/beets/config/config.yaml` before you run an import.**
+This template never rewrites an existing config. A config carried over from an
+earlier install commonly has `move: yes` under `import:` plus a `paths:` rename
+scheme — with those set, *any* import moves and renames every file it touches,
+across your whole music library. Set `move: no` and `copy: no` first unless
+relocating the collection is genuinely what you want. `post-deploy.py` prints a
+warning in the install log when it finds this.
+
+What v2 changes (#2581):
+
+- **The web UI is reachable.** v1 declared no ports at all — not even a
+  `containerPort` — so `beet web` answered only on a container-internal
+  address. v2 publishes it on the host via `hostPort`, LAN-only: no subdomain,
+  no SSO, because beets' web plugin has no authentication of any kind and this
+  UI fronts a service that can rewrite a music library.
+- **The container runs as UID 0 instead of PUID/PGID 1000.** Under rootless
+  podman, UID 1000 in the container maps to a sub-UID with no write access to
+  the `core`-owned music files, so v1 could not have written a single tag even
+  if an import had been triggered. `migrations/v1-to-v2.py` re-owns
+  `DATA_DIR/beets/config` accordingly (`podman unshare chown -R 0:0`) — nothing
+  is moved or deleted, and the music library is not touched.
+- **A safe config is seeded when there isn't one** (`copy: no`, `move: no`,
+  `write: yes`, `web.readonly: yes`), by an initContainer that leaves any
+  existing config alone.
+- **A health check that goes red on an empty library** is registered, so a
+  beets that is running but has never imported anything stops looking green.
+- **Still no automatic import.** v1 shipped a nightly-import helper that never
+  ran; had it worked it would have restructured the whole collection
+  unattended. v2 does not replace it — imports are operator-triggered, one
+  documented command. The reasoning is in `README.md`.
+
+Data paths are unchanged from v1 (`DATA_DIR/beets/config`, the file-share
+music and audiobook folders), so the library database and your music stay
+exactly where they are.
+
+## v1
+
+Initial release — local template. Ran `beet web` with no published ports, no
+import trigger, and a UID that could not write to the music library.

--- a/templates/beets/README.md
+++ b/templates/beets/README.md
@@ -1,0 +1,128 @@
+# Beets — music tagger
+
+[beets](https://beets.io) reads the audio files in your music folder, looks
+each album up in MusicBrainz, and writes proper tags back into the files —
+artist, album, track number, year, cover art. A media server such as Jellyfin
+then has something to build a library from instead of guessing from filenames.
+
+The service runs beets' **web UI**, a browser for what is already in the beets
+library, published on your LAN. Tagging itself is something **you trigger**;
+this template does not run it for you. The rest of this file explains why, and
+how to trigger it.
+
+## Why nothing is imported automatically
+
+`beet import` is not a read-only operation. It edits the tags inside your audio
+files, and — depending on configuration — it also **moves and renames** them
+into a folder scheme of its own. When it can't tell which release an album is,
+beets normally asks. Running unattended it can only do one of two things:
+stop and wait forever, or pick the first plausible answer and write it.
+
+Neither is something that should happen to somebody's music collection at
+03:00 without them knowing. So the choice here was between three options:
+
+| Option | Verdict |
+|---|---|
+| **Import on a schedule** | No. A silent nightly job that rewrites files is the failure mode we are trying to avoid, not a feature. If it guesses wrong you find out months later. |
+| **Watch a drop folder** | No, for now. It is the safer shape of automation — only *new* arrivals get touched, never the existing library — but it needs a staging folder that is separate from the library, and there isn't one yet. Worth revisiting when there is. |
+| **Operable, you trigger it** | **Yes.** The UI is reachable, the defaults are safe, and the import command is one line. The decision about your own music collection stays with you. |
+
+There is a concrete reason to be careful rather than a theoretical one. Before
+this template existed, this service was installed from a hand-written local
+copy that carried a "nightly import" helper script. That script would have run
+a quiet, unattended import over the whole library every night, against a config
+that had **`import: move: yes`** and a `paths:` rename scheme — in other words,
+it would have restructured and renamed the entire collection overnight. It
+never actually ran (its shell variables came out empty, and the location it was
+dropped into is no longer executed by the base image), so nobody noticed. A
+quiet import that fails silently is bad. A quiet import that *succeeds*
+unnoticed is worse.
+
+## What you get instead
+
+- **A reachable web UI** at `http://<your-box>:8337` — the library browser, so
+  you can see what beets actually knows about. LAN-only, on purpose (below).
+- **Safe defaults.** On a fresh install `post-deploy.py` seeds
+  `/config/config.yaml` with `import.copy: no`, `import.move: no`,
+  `import.write: yes`: beets writes tags into your files where they already
+  are and never relocates or renames anything. `web.readonly: yes` keeps the
+  browser a browser.
+- **A health check that tells the truth.** Alongside the normal "is it up"
+  probe, the install registers a second check that goes **red when the beets
+  library is empty**. A service that is running but has never been given
+  anything to do no longer looks green.
+- **An import you can run in one line**, below.
+
+## Running an import
+
+Interactive — beets asks you about anything it isn't sure of. This is the one
+to use the first time:
+
+```bash
+podman exec -it beets-beets beet import /music
+```
+
+Unattended-safe bulk pass — applies only matches beets is confident about and
+**skips** everything ambiguous instead of guessing. `-i` (incremental) means
+re-running it only looks at directories it hasn't seen:
+
+```bash
+podman exec beets-beets beet import -q -i /music
+```
+
+Look before you leap:
+
+```bash
+podman exec beets-beets beet stats      # how much is in the library
+podman exec beets-beets beet ls -a      # which albums
+```
+
+Skipped albums are listed in beets' import log so you can come back and handle
+them interactively.
+
+> **Check the config before the first import**, especially if this service was
+> installed before and you have a `/config/config.yaml` from then. `post-deploy.py`
+> never overwrites an existing config — it only warns. If yours has `move: yes`
+> or `copy: yes` under `import:`, an import **will relocate and rename** every
+> file it touches, whichever command above you use. Set them to `no` first
+> unless that is genuinely what you want.
+
+## Why it is LAN-only, with no subdomain and no SSO
+
+beets' web plugin has **no authentication at all** — no login, no token,
+nothing. Exposing it on a public hostname would mean the only thing between the
+internet and this UI is Authelia forward-auth on the proxy host, and this is a
+UI that fronts a service capable of rewriting a music library. That is a worse
+trade than for a read-only dashboard, and there is no use case for reaching a
+music tagger from outside the house.
+
+So: a plain `hostPort` on the LAN, no `type: subdomain` variable, no `nginx` or
+`auth` dependency. Per ADR 0007 the pod runs in its own network namespace — it
+is not on the closed `hostNetwork` carve-out list and has no reason to be.
+
+## Permissions, and why the pod runs as container UID 0
+
+Under rootless podman, container UID 0 maps to the host user that runs podman
+(`core`), which owns the file-share data tree. A container running as UID 1000
+maps to a *sub*-UID that has no write access to those files at all — so beets
+would fail to write a single tag, silently, on every import. `securityContext:
+runAsUser: 0` plus `PUID`/`PGID` of `0` is the same arrangement file-share's
+own containers use for the same reason.
+
+## Upgrading from a local copy of this template
+
+If `beets` was installed from a local (file-dropped) template, that copy still
+**wins over this one** — local templates override built-ins by name. To hand
+the service over:
+
+1. Remove the local directory: `DATA_DIR/local-templates/templates/beets`
+   (inside the ServiceBay container: `/app/data/local-templates/templates/beets`).
+   This does **not** touch the running service — the deployed unit and its data
+   are independent of the template it was rendered from.
+2. Re-deploy `beets` from the wizard. The volume paths are unchanged, so the
+   library database, the config, and the music all stay exactly where they are.
+
+`migrations/v1-to-v2.py` handles the one thing that does have to change: the
+`/config` directory was written by a container running as UID 1000, so it is
+owned by a sub-UID that the new UID-0 container cannot write. The migration
+re-owns it. See `CHANGELOG.md`.

--- a/templates/beets/migrations/v1-to-v2.py
+++ b/templates/beets/migrations/v1-to-v2.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Migration: beets v1 → v2 (#2581).
+
+v2 is the first version of this template that ships from the ServiceBay
+repo. v1 was a hand-written local template that ran the container as
+PUID/PGID 1000. Under rootless podman that maps to a *sub*-UID on the
+host (subuid base + 999), so everything beets wrote into its /config bind
+mount — `musiclibrary.db` above all — is owned by that sub-UID.
+
+v2 runs the container as UID 0, which under rootless podman maps to the
+host user running podman. That is the only way beets can write tags into
+the `core`-owned music files (as v1 could not: it would have failed on
+every single file, silently, if an import had ever been triggered). The
+side effect is that the new container cannot write the OLD /config
+contents until they are re-owned.
+
+`podman unshare` runs a command inside the podman user namespace, where
+the invoking user is UID 0 and the sub-UIDs are addressable — so a
+`chown -R 0:0` in there hands the directory back to the host podman user
+without any privilege on the host.
+
+NOTHING IS MOVED OR DELETED. The library database, the config file and
+the import state stay exactly where they are; only their owner changes.
+The music library is not touched at all.
+
+Idempotent: the ownership scan short-circuits when everything already
+belongs to the invoking user (fresh install, or a re-run).
+
+Exits 0 even when the chown fails — a permissions fixup is not the kind
+of half-completed data migration that justifies aborting a deploy, and
+the operator gets the exact manual command in the log.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def log(msg: str) -> None:
+    print(msg)
+    sys.stdout.flush()
+
+
+def config_dir() -> str:
+    data_dir = os.environ.get("OLD_DATA_DIR") or os.environ.get("DATA_DIR") or "/mnt/data"
+    return os.path.join(data_dir, "beets", "config")
+
+
+def foreign_owned_entries(root: str, wanted_uid: int) -> list[str]:
+    """Paths under `root` (inclusive) not owned by `wanted_uid`."""
+    out: list[str] = []
+    try:
+        if os.stat(root).st_uid != wanted_uid:
+            out.append(root)
+    except OSError:
+        return out
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in list(dirnames) + list(filenames):
+            full = os.path.join(dirpath, name)
+            try:
+                if os.lstat(full).st_uid != wanted_uid:
+                    out.append(full)
+            except OSError:
+                continue
+    return out
+
+
+def main() -> int:
+    path = config_dir()
+    if not os.path.isdir(path):
+        log(f"v1→v2: no beets config directory at {path}; nothing to re-own.")
+        return 0
+
+    wanted = os.getuid()
+    foreign = foreign_owned_entries(path, wanted)
+    if not foreign:
+        log(f"v1→v2: {path} is already owned by the podman user (uid {wanted}); nothing to do.")
+        return 0
+
+    log(f"v1→v2: {len(foreign)} entrie(s) under {path} are owned by a container")
+    log("   sub-UID left behind by the previous PUID=1000 container (e.g.")
+    log(f"   {os.path.basename(foreign[0])}). The v2 container runs as UID 0 —")
+    log("   the host podman user — so it must own these to write the library")
+    log("   database. Re-owning them now. No file is moved or deleted.")
+
+    try:
+        result = subprocess.run(
+            ["podman", "unshare", "chown", "-R", "0:0", path],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        result = None
+        log(f"   ⚠️ Could not run `podman unshare chown`: {exc}")
+
+    if result is not None and result.returncode == 0:
+        remaining = foreign_owned_entries(path, wanted)
+        if not remaining:
+            log(f"   ✅ {path} now belongs to the podman user.")
+            return 0
+        log(f"   ⚠️ {len(remaining)} entrie(s) still foreign-owned after the chown.")
+    elif result is not None:
+        stderr = (result.stderr or "").strip()
+        log(f"   ⚠️ `podman unshare chown` exited {result.returncode}: {stderr}")
+
+    log("   beets will start, but it may not be able to write its library")
+    log("   database until this is fixed. Run it by hand on the box:")
+    log(f"     podman unshare chown -R 0:0 {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/beets/post-deploy.py
+++ b/templates/beets/post-deploy.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+beets post-deploy (#2581).
+
+This script deliberately does NOT import anything. See README.md for why:
+`beet import` rewrites the operator's music files, and on an ambiguous
+album it either stalls waiting for an answer or guesses one. Triggering it
+is the operator's call, so all this script does is make that call an
+informed one:
+
+  1. Inspect an EXISTING /config/config.yaml (never write it — the pod's
+     `seed-config` initContainer owns the "no config yet" case) and warn
+     loudly if it is configured to move or copy files, because then an
+     import relocates and renames the collection.
+  2. Register a health check that goes RED while the beets library is
+     empty, so "running but has never been given anything to do" stops
+     looking green — the #2581 complaint that a service waiting for a
+     command nobody gives should not count as healthy.
+  3. Print the commands that actually trigger an import.
+
+Exit 0 unconditionally: everything here is advisory, and post-deploy
+failures don't roll back a deploy anyway.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+CONTAINER = "beets-beets"
+DEFAULT_PORT = "8337"
+
+
+def log(msg: str) -> None:
+    print(msg)
+    sys.stdout.flush()
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default) or default
+
+
+def config_path() -> str:
+    """Host path of beets' config, mirroring template.yml's /config volume."""
+    return os.path.join(env("DATA_DIR", "/mnt/data"), "beets", "config", "config.yaml")
+
+
+def relocating_import_settings(config_text: str) -> list[str]:
+    """Return the `import:` keys in this config that make beets RELOCATE files.
+
+    Deliberately a small line scanner rather than a YAML parse: PyYAML is not
+    guaranteed on the host, and the question is narrow — is `move` or `copy`
+    turned on inside the top-level `import:` block. Anything not clearly off
+    counts as on, because the whole point is to err towards warning.
+    """
+    off = {"no", "false", "off", "0", "none"}
+    found: list[str] = []
+    in_import = False
+    for raw in config_text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent == 0:
+            # A new top-level key ends the import block.
+            in_import = line.strip().startswith("import:")
+            continue
+        if not in_import:
+            continue
+        stripped = line.strip()
+        for key in ("move", "copy"):
+            prefix = key + ":"
+            if stripped.startswith(prefix):
+                value = stripped[len(prefix):].strip().strip("'\"").lower()
+                if value and value not in off:
+                    found.append(f"{key}: {value}")
+    return found
+
+
+def warn_about_existing_config() -> None:
+    path = config_path()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except FileNotFoundError:
+        # The initContainer seeds a safe config when there isn't one; if it
+        # is missing here the pod hasn't written its volume yet, which the
+        # health check below will surface.
+        log(f"   (note) No config at {path} yet — the pod seeds one on start.")
+        return
+    except OSError as exc:
+        log(f"   (note) Could not read {path}: {exc}. Skipping the config check.")
+        return
+
+    hits = relocating_import_settings(text)
+    if not hits:
+        log("✅ beets config: imports write tags in place — no move/copy, "
+            "so an import will not relocate or rename your files.")
+        return
+
+    log("")
+    log("⚠️  BEETS CONFIG WILL RELOCATE YOUR MUSIC ON THE NEXT IMPORT")
+    log(f"   {path} has under `import:`  →  {', '.join(hits)}")
+    log("   With that setting, ANY `beet import` — including the quiet one in")
+    log("   the README — moves every file it touches into beets' own folder")
+    log("   scheme and renames it. This template never turns that on itself;")
+    log("   it is carried over from an earlier install.")
+    log("   If you want tags written in place instead, set `move: no` and")
+    log("   `copy: no` under `import:` BEFORE running an import.")
+    log("")
+
+
+def register_empty_library_check(sb_api: str, port: str) -> None:
+    """Health check: red while the beets library holds zero items.
+
+    `beet web`'s /stats answers `{"items": N, "albums": M}`. A body match on a
+    non-zero item count turns "beets is up but has never imported anything"
+    into a visible red check instead of a green pod. Registered here rather
+    than as the template's `servicebay.healthcheck` annotation on purpose:
+    that annotation gates install settleWait, and a fresh install legitimately
+    has an empty library — it must not block the deploy.
+    """
+    payload = {
+        "id": "beets-library-populated",
+        "name": "Beets library populated",
+        "type": "http",
+        "target": f"http://127.0.0.1:{port}/stats",
+        "interval": 300,
+        "enabled": True,
+        "httpConfig": {
+            "expectedStatus": 200,
+            "bodyMatch": r'"items"\s*:\s*[1-9]',
+            "bodyMatchType": "regex",
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    token = env("SB_API_TOKEN")
+    if token:
+        headers["X-SB-Internal-Token"] = token
+    req = urllib.request.Request(
+        f"{sb_api}/api/health/checks", data=body, headers=headers, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if resp.status == 200:
+                log("✅ Registered health check 'beets-library-populated' — it stays")
+                log("   RED until an import has actually put something in the library.")
+                return
+            log(f"⚠️ Health-check registration returned HTTP {resp.status}. "
+                "The auto-created service:beets check still applies.")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as exc:
+        log(f"⚠️ Could not register the library health check: {exc}. "
+            "The auto-created service:beets check still applies.")
+
+
+def print_import_instructions(port: str) -> None:
+    log("")
+    log("🎵 beets is running. It does NOT import anything on its own — that is")
+    log("   deliberate; an unattended import rewrites your music files. See the")
+    log("   template README for the reasoning.")
+    log(f"   Web UI (library browser, LAN only): http://<this-box>:{port}")
+    log("")
+    log("   Tag your library when you're ready:")
+    log(f"     podman exec -it {CONTAINER} beet import /music      # asks you about anything unclear")
+    log(f"     podman exec {CONTAINER} beet import -q -i /music    # only confident matches, skips the rest")
+    log(f"     podman exec {CONTAINER} beet stats                  # what's in the library right now")
+    log("")
+
+
+def main() -> int:
+    port = env("BEETS_PORT", DEFAULT_PORT)
+    warn_about_existing_config()
+    register_empty_library_check(env("SB_API_URL", "http://localhost:3000"), port)
+    print_import_instructions(port)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/beets/template.yml
+++ b/templates/beets/template.yml
@@ -1,0 +1,204 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: beets
+  labels:
+    app: beets
+    servicebay.role: media
+  annotations:
+    servicebay.label: "Beets (Music Tagger)"
+    # v2 (#2581): supersedes the hand-rolled LOCAL template that shipped
+    # this service before. See CHANGELOG.md — the bump exists so an
+    # operator upgrading off that local copy sees the breaking-change
+    # acknowledgement, and so migrations/v1-to-v2.py runs.
+    servicebay.schema-version: "2"
+    servicebay.ports: "{{BEETS_PORT}}/tcp"
+    # The music/audiobook trees this pod mounts are file-share's data
+    # volume, so file-share must be installed and settled first.
+    servicebay.dependencies: "file-share"
+    # Continuous health probe (#628). `beet web`'s /stats returns
+    # `{"items": N, "albums": M}` — a 200 there proves more than "the
+    # process is up": it proves the web plugin loaded AND the library
+    # database opened. A pod that starts but can't read its DB answers
+    # 500 here. post-deploy.py registers a SECOND, stricter check
+    # (`beets-library-populated`) against the same URL that also asserts
+    # the item count is non-zero, which is what makes "beets is running
+    # but has never imported anything" visible instead of green (#2581).
+    servicebay.healthcheck: |
+      url: http://localhost:{{BEETS_PORT}}/stats
+      interval: 60s
+      timeout: 5s
+      startup_timeout: 5m
+    # Disable SELinux relabelling on this pod's bind mounts, for exactly
+    # the reason templates/media/template.yml documents: /music and
+    # /audiobooks point INTO the shared, multi-writer
+    # file-share/data tree. The default kube recursive relabel walks that
+    # whole tree calling `lsetxattr` on every entry, and one root-owned
+    # stray makes the rootless relabel fail `operation not permitted` and
+    # crash-loop the pod on a routine restart. The tree already carries
+    # `container_file_t` from its long-lived consumers.
+    io.podman.annotations.label/beets: "disable"
+spec:
+  # ADR 0007: beets runs in its own network namespace — no `hostNetwork`.
+  # It is not on the closed carve-out list and has no reason to be: it
+  # talks to nothing over the network except its own web UI, and it
+  # reaches the music through a bind mount, not a socket. The web UI is
+  # published to the host with a plain `hostPort` below.
+  #
+  # Deliberately LAN-only: NO `type: subdomain` variable, no nginx/auth
+  # dependency, no public hostname. `beet web` ships with no
+  # authentication of any kind — the only thing standing between a
+  # request and the library would be Authelia forward-auth on the proxy
+  # host, and this UI fronts a service that can rewrite a music
+  # collection. A music tagger has no business being reachable from
+  # outside the house, so it is reachable from the LAN and nowhere else.
+  # (The seeded config also pins `web.readonly: true` — see below.)
+  initContainers:
+  # Seed /config/config.yaml ONLY when there isn't one, before beets
+  # starts. Two reasons this is an initContainer rather than a companion
+  # `config.yaml.mustache` or a host-side write in post-deploy.py:
+  #
+  #   1. A `*.mustache` config file is re-rendered and written on EVERY
+  #      deploy, unconditionally. beets' config is a file operators tune
+  #      by hand (plugins, an AcoustID key, a `paths:` scheme), so
+  #      overwriting it on redeploy would silently discard their work —
+  #      and ADR 0004 says installs are non-destructive.
+  #   2. post-deploy.py runs AFTER the unit is up, which loses a race the
+  #      base image actually wins: started with an empty /config, this
+  #      image writes its OWN default config and beets is already serving
+  #      on it before post-deploy gets a turn (verified by running the
+  #      image bare — it opens `/config/musiclibrary.blb`, its default
+  #      library path, not ours). An initContainer runs before the beets
+  #      container exists, so the `test -e` answer is the real one, and
+  #      the image then leaves the file we wrote alone.
+  #
+  # Idempotent by construction: existing file → touch nothing. The
+  # defaults it writes are the safety property this template promises —
+  # `copy: false` + `move: false` means an import writes tags into the files
+  # where they already are and never relocates or renames them. No
+  # `paths:` scheme is seeded for the same reason.
+  - name: seed-config
+    image: docker.io/linuxserver/beets:latest
+    # Same UID-0 reasoning as the beets container below — /config is a
+    # host bind mount owned by the rootless podman user.
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        if [ -e /config/config.yaml ]; then
+          echo "beets: /config/config.yaml already exists — leaving it untouched."
+          echo "beets: (post-deploy.py checks it for move/copy settings and warns.)"
+          exit 0
+        fi
+        echo "beets: no /config/config.yaml — seeding safe defaults."
+        cat > /config/config.yaml <<'EOF'
+        # Seeded by ServiceBay's beets template on first deploy.
+        # Yours to edit — this file is written only when it does not exist.
+        # Booleans are spelled true/false rather than beets' more common
+        # yes/no: both mean the same thing to beets' YAML 1.1 parser, but
+        # yes/no is a plain STRING to a YAML 1.2 parser, so the safety
+        # settings below cannot be misread by whatever else looks at this file.
+        directory: /music
+        library: /config/musiclibrary.db
+
+        plugins:
+          - web
+
+        web:
+          host: 0.0.0.0
+          # Fixed: the pod publishes this on the host via hostPort, so the
+          # host-side port can be changed without touching this file.
+          port: 8337
+          # This UI has no login of any kind. Keep it a browser, not an editor.
+          readonly: true
+
+        import:
+          # SAFETY — the whole point. beets writes tags into the files where
+          # they already are and never copies, moves or renames them. There is
+          # deliberately no `paths:` scheme here: with copy+move off it would
+          # do nothing, and its presence invites turning move back on.
+          copy: false
+          move: false
+          write: true
+          # With `beet import -q`, apply only confident matches and SKIP
+          # anything ambiguous rather than guessing at it.
+          quiet_fallback: skip
+          # Re-runs only look at directories not already imported.
+          incremental: true
+        EOF
+    volumeMounts:
+      - mountPath: /config
+        name: beets-config
+  containers:
+  - name: beets
+    # Same image reference the pre-v2 local template used, deliberately:
+    # switching registries (lscr.io) on an in-place takeover would force a
+    # fresh pull and re-point AutoUpdate=registry for no benefit.
+    image: docker.io/linuxserver/beets:latest
+    # Run as container UID 0. Under rootless podman that maps to the host
+    # user running podman (`core`, uid 1000), which OWNS the file-share
+    # data tree — the same reasoning file-share's own filebrowser/samba
+    # containers document. The pre-v2 local template used PUID/PGID 1000,
+    # which maps to a sub-UID (subuid base + 999) with NO write access to
+    # `core`-owned music files: beets could not have written a single tag
+    # even if an import had ever been triggered. This is the third half of
+    # the #2581 bug and the reason v1-to-v2.py has to re-own /config.
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+    env:
+      - name: TZ
+        value: "{{TZ}}"
+      # The linuxserver entrypoint runs `usermod` from these; keeping them
+      # at 0 stops s6 from dropping back to uid 1000 after the
+      # securityContext above put us at 0 (same trap file-share's
+      # syncthing container documents).
+      - name: PUID
+        value: "0"
+      - name: PGID
+        value: "0"
+      # beets reads its config + library from $BEETSDIR. Setting it
+      # explicitly means an operator's `podman exec` (the documented way to
+      # trigger an import) picks up the same config the web UI uses,
+      # without having to pass `-c` every time.
+      - name: BEETSDIR
+        value: "/config"
+    ports:
+      # The container side is FIXED at 8337 — it must agree with the
+      # `web.port` in /config/config.yaml, which post-deploy.py seeds and
+      # the operator may have carried over. BEETS_PORT is purely the
+      # host-side publication, so an operator can move the service off
+      # 8337 on the LAN without editing beets' own config.
+      #
+      # No `hostIP` (unlike radicale's loopback bind): there is no reverse
+      # proxy in front of this, so binding loopback-only would make the UI
+      # unreachable from the operator's laptop — i.e. exactly the #2581
+      # symptom, reintroduced.
+      - containerPort: 8337
+        hostPort: {{BEETS_PORT}}
+    volumeMounts:
+      - mountPath: /config
+        name: beets-config
+      # Read-WRITE, unlike jellyfin's /media mount. Writing tags into the
+      # files in place IS the job. What it will never do on a fresh
+      # install is move or rename them — `import.copy: false` +
+      # `import.move: false` in the seeded config, see README.md.
+      - mountPath: /music
+        name: music-data
+      - mountPath: /audiobooks
+        name: audiobooks-data
+  volumes:
+  - name: beets-config
+    hostPath:
+      path: {{DATA_DIR}}/beets/config
+      type: DirectoryOrCreate
+  - name: music-data
+    hostPath:
+      path: {{BEETS_MUSIC_PATH}}
+      type: DirectoryOrCreate
+  - name: audiobooks-data
+    hostPath:
+      path: {{BEETS_AUDIOBOOKS_PATH}}
+      type: DirectoryOrCreate

--- a/templates/beets/variables.json
+++ b/templates/beets/variables.json
@@ -1,0 +1,22 @@
+{
+  "TZ": {
+    "type": "text",
+    "description": "Timezone. beets stamps `added` dates and writes them into the library database with it.",
+    "default": "Europe/Berlin"
+  },
+  "BEETS_PORT": {
+    "type": "text",
+    "description": "Host port for the beets web UI (library browser). LAN-only — beets' web plugin has no login of any kind, so this service deliberately gets no public subdomain and no SSO. Inside the container beets always serves 8337; this is only where it is published on the host.",
+    "default": "8337"
+  },
+  "BEETS_MUSIC_PATH": {
+    "type": "text",
+    "description": "Host path mounted at /music, read-write. Defaults to the file-share music folder, so anything dropped into the Samba/Syncthing share is what beets tags. beets writes tags into these files in place; on a fresh install it never moves or renames them.",
+    "default": "/mnt/data/stacks/file-share/data/music"
+  },
+  "BEETS_AUDIOBOOKS_PATH": {
+    "type": "text",
+    "description": "Host path mounted at /audiobooks, read-write. Same file-share tree as the music folder. Audiobooks are NOT part of any import beets runs by default — the mount exists so an operator can point an import at it deliberately.",
+    "default": "/mnt/data/stacks/file-share/data/audiobooks"
+  }
+}

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -1495,6 +1495,198 @@ describe('Mosquitto template: mandatory credentials, LAN reach, persistence (#25
   });
 });
 
+// ─── 3i. Beets: the acceptance criteria of #2581, encoded ───────────────────
+//
+// beets shipped for three weeks as a local template that ran, looked healthy,
+// and did literally nothing: no `command:` so the image default `beet web`
+// ran, no ports at all so that UI answered only on a container-internal
+// address, and PUID 1000 so it could not have written a tag even if an import
+// had been triggered. Every one of those is invisible in a green deploy, which
+// is exactly why they get assertions rather than a code comment.
+describe('Beets template: reachable UI, in-place imports, no unattended rewrite (#2581)', () => {
+  const beets = templates.find(t => t.name === 'beets')!;
+
+  const view: Record<string, string> = {};
+  for (const v of catalogVars) view[v] = `stub-${v.toLowerCase()}`;
+  for (const [name, meta] of Object.entries(beets.variables)) {
+    if (meta && typeof meta === 'object' && 'default' in meta && typeof meta.default === 'string') {
+      view[name] = meta.default;
+    }
+  }
+  view.DATA_DIR = '/mnt/data/stacks';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pod = (): any =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    yaml.loadAll(renderPodYaml(beets.yamlContent, view)).find((d: any) => d?.kind === 'Pod');
+
+  /** The shell body of the config-seeding initContainer. */
+  const initScript = (): string => String(pod().spec.initContainers[0].args[0]);
+
+  /** The beets config that initContainer writes, parsed. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const seededConfig = (): any => {
+    const m = initScript().match(/<<'EOF'\n([\s\S]*?)\nEOF/);
+    expect(m, 'seed-config initContainer must write a heredoc config').toBeTruthy();
+    return yaml.load(m![1]);
+  };
+
+  const readme = () => fs.readFileSync(path.join(TEMPLATES_DIR, 'beets', 'README.md'), 'utf-8');
+
+  it('publishes the web UI on the host — the #2581 "no ports at all" regression', () => {
+    const c = pod().spec.containers.find((x: { name: string }) => x.name === 'beets');
+    expect(c.ports, 'beets must declare a port; v1 declared none').toHaveLength(1);
+    // The container side is pinned to 8337 because the seeded config's
+    // `web.port` says 8337 — the two must agree or the hostPort forwards to
+    // nothing. Only the host side is operator-configurable.
+    expect(c.ports[0].containerPort).toBe(8337);
+    expect(c.ports[0].hostPort).toBe(8337);
+    // No `hostIP` pin: there is no reverse proxy in front, so a loopback-only
+    // bind would reproduce the original "UI unreachable" symptom exactly.
+    expect(c.ports[0].hostIP).toBeUndefined();
+    expect(seededConfig().web.port).toBe(c.ports[0].containerPort);
+    expect(seededConfig().web.host).toBe('0.0.0.0');
+  });
+
+  it('runs isolated and is NOT added to the closed ADR 0007 carve-out list', () => {
+    expect(pod().spec.hostNetwork).toBeUndefined();
+    const adr = fs.readFileSync(
+      path.join(REPO_ROOT, 'docs', 'adr', '0007-container-network-isolation-and-carveouts.md'),
+      'utf-8',
+    );
+    const decision2 = adr.slice(
+      adr.indexOf('2. **These stay on `hostNetwork` deliberately'),
+      adr.indexOf('3. **Consuming a loopback-bound sibling'),
+    );
+    expect(decision2.length).toBeGreaterThan(100);
+    expect(decision2).not.toMatch(/beets/);
+  });
+
+  it('stays LAN-local: no subdomain, no SSO, because the UI has no login', () => {
+    // `beet web` ships no authentication whatsoever, and it fronts a service
+    // that can rewrite a music library — so it deliberately gets no public
+    // hostname and therefore no nginx/auth dependency to register one with.
+    const subdomainVars = Object.entries(beets.variables)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .filter(([, meta]) => (meta as any)?.type === 'subdomain')
+      .map(([name]) => name);
+    expect(subdomainVars, 'beets must not expose a public subdomain').toEqual([]);
+    const deps = String(pod().metadata.annotations['servicebay.dependencies'] ?? '');
+    expect(deps).not.toMatch(/nginx|auth/);
+    // The UI is a browser, not an editor — the one lever that limits what an
+    // unauthenticated LAN request can do.
+    expect(seededConfig().web.readonly).toBe(true);
+    expect(readme()).toMatch(/no authentication/i);
+  });
+
+  it('never moves, copies or renames files on a fresh install', () => {
+    // The criterion the whole unit turns on: an import writes tags into the
+    // files where they already are. `move`/`copy` on would relocate and
+    // rename the operator's entire collection.
+    const cfg = seededConfig();
+    expect(cfg.import.move, 'import.move must be off').toBe(false);
+    expect(cfg.import.copy, 'import.copy must be off').toBe(false);
+    expect(cfg.import.write, 'import.write is the point — tags in place').toBe(true);
+    // A `paths:` scheme only takes effect when moving/copying; shipping one
+    // would be a loaded gun for whoever flips move back on.
+    expect(cfg.paths, 'no rename scheme may be seeded').toBeUndefined();
+    // `-q` must skip what it cannot match confidently rather than guess.
+    expect(cfg.import.quiet_fallback).toBe('skip');
+  });
+
+  it('never overwrites an existing config — it probes first', () => {
+    const script = initScript();
+    expect(script).toMatch(/if \[ -e \/config\/config\.yaml \]; then/);
+    expect(script).toMatch(/exit 0/);
+    // A companion `*.mustache` config would be re-rendered and written on
+    // EVERY deploy, silently discarding an operator's hand-tuned beets
+    // config (plugins, an AcoustID key). That is why there isn't one.
+    expect(
+      Object.keys(beets.configs),
+      'beets must not ship a *.mustache config — it would clobber the operator config on redeploy',
+    ).toEqual([]);
+  });
+
+  it('triggers no import on its own, and says so in plain language', () => {
+    // Neither the pod nor its init script may invoke `beet import`. An
+    // unattended import over somebody's music collection is a decision, not
+    // a default — README.md carries the reasoning.
+    // Comments may *mention* `beet import`; no line may RUN it. Strip
+    // comments (both YAML's and the init script's are `#`-led) first.
+    const executable = renderPodYaml(beets.yamlContent, view)
+      .split('\n')
+      .filter(l => !l.trim().startsWith('#'))
+      .join('\n');
+    expect(executable).not.toMatch(/beet\s+import/);
+    const doc = readme();
+    expect(doc).toMatch(/Why nothing is imported automatically/);
+    expect(doc).toMatch(/moves? and renames?/i);
+    // …and it must still be operable: a documented one-line trigger.
+    expect(doc).toMatch(/podman exec -it beets-beets beet import \/music/);
+  });
+
+  it('runs as container UID 0 so it can actually write to the music files', () => {
+    // Under rootless podman, container UID 0 maps to the host podman user
+    // that owns the file-share tree; UID 1000 (what v1 used) maps to a
+    // sub-UID with no write access at all.
+    const c = pod().spec.containers.find((x: { name: string }) => x.name === 'beets');
+    expect(c.securityContext).toEqual({ runAsUser: 0, runAsGroup: 0 });
+    const puid = c.env.find((e: { name: string }) => e.name === 'PUID');
+    const pgid = c.env.find((e: { name: string }) => e.name === 'PGID');
+    expect(puid.value).toBe('0');
+    expect(pgid.value).toBe('0');
+    // The initContainer writes into the same host-owned bind mount.
+    expect(pod().spec.initContainers[0].securityContext).toEqual({ runAsUser: 0, runAsGroup: 0 });
+    // /music must be writable — writing tags IS the job (unlike jellyfin's
+    // read-only /media mount).
+    const music = c.volumeMounts.find((v: { mountPath: string }) => v.mountPath === '/music');
+    expect(music.readOnly).toBeUndefined();
+  });
+
+  it('keeps the volume paths the previous local install already used', () => {
+    // The takeover is in-place: same service name, same host paths, so the
+    // library database and the music stay exactly where they are.
+    const byName = Object.fromEntries(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pod().spec.volumes.map((v: any) => [v.name, v.hostPath.path]),
+    );
+    expect(byName['beets-config']).toBe('/mnt/data/stacks/beets/config');
+    expect(byName['music-data']).toBe('/mnt/data/stacks/file-share/data/music');
+    expect(byName['audiobooks-data']).toBe('/mnt/data/stacks/file-share/data/audiobooks');
+  });
+
+  it('ships schema-version 2 with a breaking CHANGELOG entry and the v1→v2 migration', () => {
+    expect(beets.yamlContent).toMatch(/servicebay\.schema-version:\s*"2"/);
+    const changelog = fs.readFileSync(path.join(TEMPLATES_DIR, 'beets', 'CHANGELOG.md'), 'utf-8');
+    // Breaking, so the wizard gates the deploy on an acknowledgement — the
+    // right place for "this will touch your music" to reach a human.
+    expect(changelog).toMatch(/^## v2 \(breaking\)$/m);
+    // The two things the operator must actually do.
+    expect(changelog).toMatch(/local-templates\/templates\/beets/);
+    expect(changelog).toMatch(/move: no/);
+    expect(
+      fs.existsSync(path.join(TEMPLATES_DIR, 'beets', 'migrations', 'v1-to-v2.py')),
+      'v2 needs its migration: the old /config is owned by a container sub-UID',
+    ).toBe(true);
+  });
+
+  it('declares a healthcheck that proves the library opened, not just the process', () => {
+    const hc = String(pod().metadata.annotations['servicebay.healthcheck']);
+    expect(hc).toMatch(/\/stats/);
+    // The stricter "library is not empty" probe is registered from
+    // post-deploy.py, NOT here: this annotation gates install settleWait and
+    // a fresh install legitimately has an empty library.
+    const postDeploy = fs.readFileSync(path.join(TEMPLATES_DIR, 'beets', 'post-deploy.py'), 'utf-8');
+    expect(postDeploy).toMatch(/beets-library-populated/);
+    expect(postDeploy).toMatch(/"bodyMatchType": "regex"/);
+  });
+
+  it('is offered by a stack, unchecked — it rewrites files, so it is opt-in', () => {
+    const stack = fs.readFileSync(path.join(REPO_ROOT, 'stacks', 'cloud', 'README.md'), 'utf-8');
+    expect(stack).toMatch(/^- \[ \] beets —/m);
+  });
+});
+
 // ─── 4. Subdomain proxyPort references resolve ──────────────────────────────
 describe('Subdomain proxyPort references', () => {
   for (const t of templates) {

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -3163,5 +3163,189 @@ class VerbatimScriptBodies(unittest.TestCase):
         self.assertNotEqual(scope["FMT"].strip("'"), "|")
 
 
+class BeetsScript(unittest.TestCase):
+    """#2581 — beets post-deploy never imports; it makes the decision informed.
+
+    The property under test is the config warning: an operator carrying a
+    config over from an earlier install commonly has `import: move: yes`, and
+    with that set ANY import relocates and renames their whole music library.
+    The script must never rewrite that config, but it must never let it pass
+    unremarked either.
+    """
+
+    HEALTH_OK = {"/api/health/checks": {"status": 200, "body": {"ok": True}}}
+
+    def _run(self, config_text: str | None) -> tuple[int, str]:
+        import tempfile
+
+        module = load_script("beets")
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_dir = Path(tmp) / "beets" / "config"
+            cfg_dir.mkdir(parents=True)
+            if config_text is not None:
+                (cfg_dir / "config.yaml").write_text(config_text, encoding="utf-8")
+            env = {
+                "DATA_DIR": tmp,
+                "BEETS_PORT": "8337",
+                "SB_API_URL": "http://localhost:3000",
+                "SB_API_TOKEN": "t",
+            }
+            with run_with_env(env), mock.patch(
+                "urllib.request.urlopen", fake_urlopen_factory(self.HEALTH_OK)
+            ):
+                rc, out = capture_main(module)
+            # The script must never write or alter the config.
+            after = (cfg_dir / "config.yaml").read_text(encoding="utf-8") if config_text is not None else None
+            self.assertEqual(after, config_text, "post-deploy must not touch config.yaml")
+        return rc, out
+
+    def test_warns_when_a_carried_over_config_will_relocate_files(self):
+        rc, out = self._run(
+            "directory: /music\n"
+            "import:\n"
+            "  move: yes\n"
+            "  write: yes\n"
+            "paths:\n"
+            "  default: $artist/$album/$track $title\n"
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("RELOCATE YOUR MUSIC", out)
+        self.assertIn("move: yes", out)
+
+    def test_quiet_when_the_config_writes_tags_in_place(self):
+        rc, out = self._run(
+            "directory: /music\nimport:\n  copy: false\n  move: false\n  write: true\n"
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("in place", out)
+        self.assertNotIn("RELOCATE YOUR MUSIC", out)
+
+    def test_move_under_another_top_level_key_is_not_a_false_positive(self):
+        # Only the `import:` block decides whether files get relocated — a
+        # `move` key belonging to some other plugin must not trip the warning.
+        rc, out = self._run(
+            "import:\n  move: false\n"
+            "somepluginn:\n  move: yes\n"
+        )
+        self.assertEqual(rc, 0)
+        self.assertNotIn("RELOCATE YOUR MUSIC", out)
+
+    def test_missing_config_is_not_an_error(self):
+        rc, out = self._run(None)
+        self.assertEqual(rc, 0)
+        self.assertIn("seeds one on start", out)
+
+    def test_registers_the_empty_library_check_and_prints_the_trigger(self):
+        rc, out = self._run("import:\n  move: false\n")
+        self.assertEqual(rc, 0)
+        self.assertIn("beets-library-populated", out)
+        # The service must be genuinely operable: the command is in the log.
+        self.assertIn("beet import /music", out)
+        self.assertIn("beet import -q -i /music", out)
+
+    def test_health_check_registration_failure_is_not_fatal(self):
+        module = load_script("beets")
+        import tempfile
+        import urllib.error
+
+        def boom(*_a, **_kw):
+            raise urllib.error.URLError("down")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "beets" / "config").mkdir(parents=True)
+            with run_with_env({"DATA_DIR": tmp, "BEETS_PORT": "8337"}), mock.patch(
+                "urllib.request.urlopen", boom
+            ):
+                rc, out = capture_main(module)
+        self.assertEqual(rc, 0)
+        self.assertIn("service:beets check still applies", out)
+
+
+class BeetsV1ToV2Migration(unittest.TestCase):
+    """#2581 — the v1→v2 migration re-owns /config and moves nothing."""
+
+    def _load(self):
+        path = TEMPLATES_DIR / "beets" / "migrations" / "v1-to-v2.py"
+        spec = importlib.util.spec_from_file_location("_beets_v1_to_v2", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_noop_when_the_config_dir_is_already_owned_by_the_podman_user(self):
+        import tempfile
+
+        module = self._load()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "beets" / "config"
+            cfg.mkdir(parents=True)
+            (cfg / "musiclibrary.db").write_bytes(b"db")
+            with run_with_env({"DATA_DIR": tmp}), mock.patch(
+                "subprocess.run", side_effect=AssertionError("must not shell out")
+            ):
+                rc, out = capture_main(module)
+        self.assertEqual(rc, 0)
+        self.assertIn("nothing to do", out)
+
+    def test_noop_when_there_is_no_config_dir_at_all(self):
+        import tempfile
+
+        module = self._load()
+        with tempfile.TemporaryDirectory() as tmp:
+            with run_with_env({"DATA_DIR": tmp}):
+                rc, out = capture_main(module)
+        self.assertEqual(rc, 0)
+        self.assertIn("nothing to re-own", out)
+
+    def test_chowns_foreign_owned_entries_and_leaves_the_data_in_place(self):
+        import subprocess
+        import tempfile
+
+        module = self._load()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "beets" / "config"
+            cfg.mkdir(parents=True)
+            db = cfg / "musiclibrary.db"
+            db.write_bytes(b"library")
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, **_kw):
+                calls.append(list(cmd))
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+
+            # Report the db as owned by a container sub-UID on the first scan
+            # and as re-owned on the verification scan.
+            scans = iter([[str(db)], []])
+            with run_with_env({"DATA_DIR": tmp}), mock.patch.object(
+                module, "foreign_owned_entries", lambda *_a: next(scans)
+            ), mock.patch("subprocess.run", fake_run):
+                rc, out = capture_main(module)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, [["podman", "unshare", "chown", "-R", "0:0", str(cfg)]])
+        self.assertIn("No file is moved or deleted", out)
+
+    def test_a_failed_chown_warns_but_never_aborts_the_deploy(self):
+        import subprocess
+        import tempfile
+
+        module = self._load()
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "beets" / "config"
+            cfg.mkdir(parents=True)
+            (cfg / "musiclibrary.db").write_bytes(b"library")
+            with run_with_env({"DATA_DIR": tmp}), mock.patch.object(
+                module, "foreign_owned_entries", lambda *_a: [str(cfg / "musiclibrary.db")]
+            ), mock.patch(
+                "subprocess.run",
+                return_value=subprocess.CompletedProcess([], 1, "", "chown: denied"),
+            ):
+                rc, out = capture_main(module)
+        # Migrations are fail-fast by contract, but a permissions fixup is not
+        # a half-completed data migration — it must not strand the operator.
+        self.assertEqual(rc, 0)
+        self.assertIn("podman unshare chown -R 0:0", out)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Batch `2026-08-17a` — 1 unit.

## Closes #2581 — beets becomes a real template, and stops pretending to work

`beets` had been installed on the owner's box since 2026-07-25 from a **local** template and had done **nothing** in three weeks. Not a fault in the running container — the template never asked it to do anything:

- started `linuxserver/beets` with **no `command:`/`args:`**, so the image default `beet web` ran and nothing else. No schedule, no watch folder, no `beet import`. The container log held only startup lines.
- declared **no ports at all**, so even the UI was container-internal (`http://10.89.0.31:8337`) and unreachable.

The cost showed up elsewhere: the music stayed untagged, and Jellyfin's LrcLib plugin re-queried every track on each library scan, aborting on missing artist/album tags thousands of times a minute — **286 % CPU with nobody watching**.

The owner spotted it from the symptom alone: beets had been installed a long time, the load kept coming back, so something was not running as assumed. It wasn't.

## Two further defects found while building

**A nightly import script that would have restructured the whole collection.** The prior local install carried one — broken, never executed — alongside a config with `import: move: yes`. Had it ever run, it would have moved and renamed the owner's entire music library. It doing nothing is what prevented that.

**It could not have written anyway.** The pod ran with `PUID 1000`, which under rootless podman maps to sub-UID 525287 — no write access to the `core`-owned music tree. Fixed via `runAsUser: 0` / `PUID=0`, verified on the box that linuxserver's s6 init accepts it.

## What ships

**Operator-triggered imports only — no schedule, no watch folder.** `beet import` rewrites: it can relocate and rename, and it guesses on ambiguous matches. Running that unattended over someone's music collection is a larger risk than untagged files. What ships instead is genuine operability: `containerPort 8337` + `hostPort`, a seeded config that tags **in place** (`copy/move: false`, no `paths:`, `web.readonly`), and a documented one-line trigger.

**LAN-only, deliberately no subdomain or SSO** — `beet web` carries no authentication of its own, so putting it on a public subdomain would expose a library-rewriting UI.

**A health check that goes red while the library is empty.** This is the part that matters beyond beets: the old service looked healthy in every view — pod running, no failed unit, no crash — while doing nothing for three weeks. A service waiting for a command that never comes should not read as fine.

Also: `templates/beets/` with the contract's files (template.yml, variables.json, README.md, CHANGELOG.md, post-deploy.py, `migrations/v1-to-v2.py`), an unchecked opt-in line in `stacks/cloud/README.md`, backup-manifest and bulk-exclude entries in both `serviceManifest.ts` copies, plus 11 criteria tests in `template_consistency.test.ts` and 10 in `test_post_deploy.py`.

## Transition from the local template

In place: identical service name and all three host paths, matched against the **live** pod spec. The config is never overwritten — an initContainer probes for it, and there are deliberately no `*.mustache` files, which would clobber operator edits on every redeploy. `v1-to-v2.py` re-owns `DATA_DIR/beets/config` via `podman unshare chown`, moving and deleting nothing.

**One operator step remains:** the local template at `DATA_DIR/local-templates/templates/beets` has to be deleted, because Local overrides Built-in. That is stated in the breaking `## v2` CHANGELOG section and the README.

## Gates

`npm run lint` 0 errors (452 warnings, unchanged) · `typecheck` clean · `check:arch` clean after adding the required backup-coverage entries · `npm test` 552/552 files, 5580 passed / 1 skipped.

Owed to box-verify: the real redeploy over the running local install.

<!-- sb-ai-comment -->
🤖 _AI-generated, acting for @mdopp._
