### PR TITLE
fix: device-safe secrets, HA trusted proxies + MQTT auto-connect, DNS probe timeouts, beets coverage check

### DIFF
--- a/assists/recipe-connect-mqtt-device-to-home-assistant.md
+++ b/assists/recipe-connect-mqtt-device-to-home-assistant.md
@@ -102,6 +102,24 @@ Work outside-in; each step rules out everything before it.
 
 ## The traps
 
+- **The device says the credentials are wrong — and they are right.** A
+  device reporting "wrong username or password" has told you only that the
+  broker turned it away; the broker log says *why*, and it is frequently not
+  what the device implies. Read it (`get_logs` on the broker) before
+  retyping anything:
+  - `disconnected: not authorised` while **Home Assistant connects with the
+    very same credentials** ⇒ the credentials are fine and the *device* is
+    mangling them. The usual culprit is a length cap on the device's
+    credential field: it keeps a prefix, sends that, and blames you. Try a
+    shorter password — ~24 alphanumeric characters is ~142 bits, plenty —
+    before suspecting anything else.
+  - no log line at all for the device's client ID ⇒ it never reached the
+    broker. That is host/port/firewall, not credentials, and retyping the
+    password cannot help.
+  This is why generated credentials should stay letters-and-digits and take
+  their strength from length: symbols are exactly where firmware, vendor
+  apps and copy-paste go wrong, and the failure surfaces as an accusation
+  against the operator rather than as a bug.
 - **`localhost` from inside a container.** It is the container. Use
   `host.containers.internal` for container→host, and the box's LAN address for
   device→box. The two are different answers to the same-sounding question.

--- a/assists/recipe-rotate-a-service-secret.md
+++ b/assists/recipe-rotate-a-service-secret.md
@@ -42,6 +42,16 @@ integration on the old password shows up in the service log as a rejected
 connection (mosquitto: `Client <id> disconnected: not authorised`), not as an
 error on the ServiceBay side.
 
+**Unless a post-deploy carries it over.** A template whose post-deploy owns the
+consumer side updates it in the same deploy — mosquitto's does this for Home
+Assistant's MQTT integration (#2578), through HA's own config-flow API rather
+than by editing its files. That only covers a connection ServiceBay created (or
+recognised as pointing at this very service); one the operator built by hand is
+deliberately left alone, so it is still on the rotate-the-consumers list. If you
+wire a new cross-service credential, the same pattern belongs in the
+*producing* template's post-deploy: it is the only place that has the new value
+at the moment it changes.
+
 ## Gotchas
 
 - **Never send back a read-masked value.** Reads mask secrets as `<redacted>`; a

--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -151,6 +151,7 @@ Map of variable name to metadata. Recognized fields:
       "scopes": ["openid", "profile", "email"],
       "clientSecretVar": "MY_SSO_SECRET"  // optional — env-wired SSO
     },
+    "deviceSafe": true,      // type=secret only — value gets typed INTO a device
     "bcryptSource": "ADMIN_PASSWORD",  // for type=bcrypt — name of the var to hash
     "blockLanAccess": true   // port vars only — refuse LAN access at the host firewall
   }
@@ -161,7 +162,17 @@ What each `type` does generically (no per-template code needed):
 
 - **`text` / `select` / `device`** — rendered as a form input.
 - **`password` / `secret`** — auto-generated random string, shown
-  read-only with a regenerate button.
+  read-only with a regenerate button. Generated secrets are **always
+  alphanumeric** (`SECRET_CHARS`, `lib/stackInstall/randomSecret.ts`) —
+  strength comes from length, never from punctuation, because these
+  values get pasted into shells, config files and device firmware.
+- **`deviceSafe` on a `secret` var** — the value is carried *into a
+  device* (an IoT credential field, a vendor app's setup form). It is
+  then generated at 24 characters instead of 32 (~142 bits, still far
+  past reach). Set it whenever an operator will retype the value on
+  hardware: consumer firmware caps that field and silently keeps the
+  prefix, and the device reports the truncated value as "wrong
+  password" (#2577).
 - **`rsa-private`** — auto-generated PEM, hidden from the UI.
 - **`bcrypt`** — hash of `bcryptSource`'s value, hidden from the UI.
   Use this when you need both the plaintext (in env) and the hash

--- a/packages/api-client/src/install.ts
+++ b/packages/api-client/src/install.ts
@@ -41,10 +41,15 @@ export const InstallStatusResponseSchema = z.object({
 // random secret using the same alphabet/length the install flow has
 // used since #19. Optional `length` lets callers override the default
 // 32 (currently nothing does, but keeps the schema flexible).
+//
+// `deviceSafe` (#2577) asks for the profile used by a value the operator
+// carries into a device's own credential field — the length policy stays
+// server-side, so the browser never has to know the number.
 // ---------------------------------------------------------------------------
 
 export const GenerateSecretRequestSchema = z.object({
   length: z.number().int().positive().max(256).optional(),
+  deviceSafe: z.boolean().optional(),
 });
 
 export const GenerateSecretResponseSchema = z.object({

--- a/packages/backend/src/lib/diagnose/probes/domainResolvesToBox.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainResolvesToBox.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LanResolveResult } from '@/lib/router/lanResolver';
 
 const getConfig = vi.fn();
 const resolve4 = vi.fn();
@@ -11,14 +12,23 @@ vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
-// The probe now resolves via the LAN path (AdGuard) rather than the OS
-// resolver — mock that helper. The mock returns A-records by hostname so
-// the per-call assertions below still pin which domains were looked up.
+// The probe resolves via the LAN path (AdGuard) rather than the OS resolver
+// — mock that helper. The mock returns an outcome by hostname so the
+// per-call assertions below still pin which domains were looked up.
 vi.mock('@/lib/router/lanResolver', () => ({
-  resolve4ViaLan: (h: string) => resolve4(h),
+  resolve4ViaLanDetailed: (h: string, ip: string) => resolve4(h, ip),
 }));
 
 import { checkDomainResolvesToBox } from './domainResolvesToBox';
+
+/** The old `string[] | null` shape, lifted to the outcome the resolver now
+ *  reports, so the existing cases read the same. */
+const ok = (...addresses: string[]): LanResolveResult => ({ outcome: 'ok', addresses });
+const noAnswer = (): LanResolveResult => ({ outcome: 'no-answer', addresses: null, code: 'ENOTFOUND' });
+const timeout = (): LanResolveResult => ({ outcome: 'timeout', addresses: null, code: 'ETIMEOUT' });
+
+/** No real waiting in the retry path. */
+const NO_WAIT = { retryDelayMs: 0 };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -27,14 +37,14 @@ beforeEach(() => {
 describe('domain_resolves_to_box', () => {
   it('info when no LAN IP is recorded', async () => {
     getConfig.mockResolvedValue({ reverseProxy: { publicDomain: 'dopp.cloud' } });
-    const r = await checkDomainResolvesToBox();
+    const r = await checkDomainResolvesToBox(NO_WAIT);
     expect(r.status).toBe('info');
     expect(r.detail).toContain('No LAN IP');
   });
 
   it('info when no public domains are configured', async () => {
     getConfig.mockResolvedValue({ reverseProxy: { lanIp: '192.168.178.100' } });
-    const r = await checkDomainResolvesToBox();
+    const r = await checkDomainResolvesToBox(NO_WAIT);
     expect(r.status).toBe('info');
     expect(resolve4).not.toHaveBeenCalled();
   });
@@ -47,25 +57,24 @@ describe('domain_resolves_to_box', () => {
         hosts: [{ domain: 'vault.dopp.cloud', exposure: 'public' }],
       },
     });
-    resolve4.mockResolvedValue(['192.168.178.100']);
-    const r = await checkDomainResolvesToBox();
+    resolve4.mockResolvedValue(ok('192.168.178.100'));
+    const r = await checkDomainResolvesToBox(NO_WAIT);
     expect(r.status).toBe('ok');
     // ldap. + auth. + the one public host = 3 lookups.
     expect(resolve4).toHaveBeenCalledTimes(3);
-    expect(resolve4).toHaveBeenCalledWith('ldap.dopp.cloud');
-    expect(resolve4).toHaveBeenCalledWith('auth.dopp.cloud');
-    expect(resolve4).toHaveBeenCalledWith('vault.dopp.cloud');
+    expect(resolve4).toHaveBeenCalledWith('ldap.dopp.cloud', '192.168.178.100');
+    expect(resolve4).toHaveBeenCalledWith('auth.dopp.cloud', '192.168.178.100');
+    expect(resolve4).toHaveBeenCalledWith('vault.dopp.cloud', '192.168.178.100');
   });
 
-  it('fail (blocking) when a core domain does not resolve at all', async () => {
+  it('fail (blocking) when a core domain answers NXDOMAIN', async () => {
     getConfig.mockResolvedValue({
       reverseProxy: { publicDomain: 'dopp.cloud', lanIp: '192.168.178.100', hosts: [] },
     });
-    // resolve4ViaLan swallows resolver errors and returns null — mirror that.
-    resolve4.mockResolvedValue(null);
-    const r = await checkDomainResolvesToBox();
+    resolve4.mockResolvedValue(noAnswer());
+    const r = await checkDomainResolvesToBox(NO_WAIT);
     expect(r.status).toBe('fail');
-    expect(r.detail).toContain('does not resolve');
+    expect(r.detail).toContain('no such name');
     expect(r.hint).toContain('Pattern A');
   });
 
@@ -73,28 +82,21 @@ describe('domain_resolves_to_box', () => {
     getConfig.mockResolvedValue({
       reverseProxy: { publicDomain: 'dopp.cloud', lanIp: '192.168.178.100', hosts: [] },
     });
-    resolve4.mockResolvedValue(['203.0.113.7']);
-    const r = await checkDomainResolvesToBox();
+    resolve4.mockResolvedValue(ok('203.0.113.7'));
+    const r = await checkDomainResolvesToBox(NO_WAIT);
     expect(r.status).toBe('fail');
     expect(r.detail).toContain('expected 192.168.178.100');
     expect(r.hint).toContain('DHCP DNS');
   });
 
   it('resolves via the LAN/AdGuard path (not the OS resolver) — passes the box lanIp through', async () => {
-    const lanSpy = vi.fn().mockResolvedValue(['192.168.178.100']);
-    const mod = await import('@/lib/router/lanResolver');
-    const orig = mod.resolve4ViaLan;
-    // Re-point the mocked helper to a spy that records the (host, lanIp) pair.
-    (resolve4 as unknown as { mockImplementation: (f: (h: string) => unknown) => void }).mockImplementation(
-      (h: string) => lanSpy(h, '192.168.178.100'),
-    );
     getConfig.mockResolvedValue({
       reverseProxy: { publicDomain: 'dopp.cloud', lanIp: '192.168.178.100', hosts: [] },
     });
-    const r = await checkDomainResolvesToBox();
+    resolve4.mockResolvedValue(ok('192.168.178.100'));
+    const r = await checkDomainResolvesToBox(NO_WAIT);
     expect(r.status).toBe('ok');
-    expect(lanSpy).toHaveBeenCalledWith('auth.dopp.cloud', '192.168.178.100');
-    void orig;
+    expect(resolve4).toHaveBeenCalledWith('auth.dopp.cloud', '192.168.178.100');
   });
 
   it('skips LAN-only hosts (resolved via AdGuard rewrites, not the box resolver)', async () => {
@@ -108,10 +110,94 @@ describe('domain_resolves_to_box', () => {
         ],
       },
     });
-    resolve4.mockResolvedValue(['192.168.178.100']);
-    await checkDomainResolvesToBox();
+    resolve4.mockResolvedValue(ok('192.168.178.100'));
+    await checkDomainResolvesToBox(NO_WAIT);
     const looked = resolve4.mock.calls.map(c => c[0]);
     expect(looked).toContain('photos.dopp.cloud');
     expect(looked).not.toContain('nas.home.arpa');
+  });
+});
+
+/**
+ * #2579 — the probe stood red for 37 runs naming domains that resolve fine.
+ * Cause: the tail of its own 21-query burst was dropped by AdGuard's
+ * per-client rate limit, timed out, and was reported as NXDOMAIN.
+ */
+describe('a query that got no answer is not a DNS misconfiguration (#2579)', () => {
+  const config = {
+    reverseProxy: {
+      publicDomain: 'dopp.cloud',
+      lanIp: '192.168.178.100',
+      hosts: [
+        { domain: 'paperless.dopp.cloud', exposure: 'internal' },
+        { domain: 'daggerheart.dopp.cloud', exposure: 'public' },
+      ],
+    },
+  };
+
+  beforeEach(() => getConfig.mockResolvedValue(config));
+
+  it('retries a timed-out lookup once, and reports ok when the retry answers', async () => {
+    // Exactly the observed shape: the tail of the burst is dropped, and the
+    // same names answer immediately when asked again.
+    const dropped = new Set(['paperless.dopp.cloud', 'daggerheart.dopp.cloud']);
+    resolve4.mockImplementation(async (host: string) => {
+      if (dropped.delete(host)) return timeout();
+      return ok('192.168.178.100');
+    });
+
+    const r = await checkDomainResolvesToBox(NO_WAIT);
+    expect(r.status).toBe('ok');
+    // 4 domains, 2 of them asked twice.
+    expect(resolve4).toHaveBeenCalledTimes(6);
+  });
+
+  it('warns — never fails — when a lookup times out twice, and says so in the words of a timeout', async () => {
+    resolve4.mockImplementation(async (host: string) =>
+      host === 'paperless.dopp.cloud' ? timeout() : ok('192.168.178.100'),
+    );
+
+    const r = await checkDomainResolvesToBox(NO_WAIT);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('paperless.dopp.cloud');
+    expect(r.detail).toContain('no answer');
+    // The timeout hint must NOT send the operator off to reconfigure DHCP —
+    // that is the fix for a different fault.
+    expect(r.hint).not.toContain('Pattern A');
+    expect(r.hint).toContain('rate limit');
+    // And it must not claim the name doesn't exist.
+    expect(r.detail).not.toContain('NXDOMAIN');
+  });
+
+  it('a resolver error is inconclusive too, not a failure', async () => {
+    resolve4.mockImplementation(async (host: string) =>
+      host === 'daggerheart.dopp.cloud'
+        ? ({ outcome: 'error', addresses: null, code: 'ESERVFAIL' } satisfies LanResolveResult)
+        : ok('192.168.178.100'),
+    );
+    const r = await checkDomainResolvesToBox(NO_WAIT);
+    expect(r.status).toBe('warn');
+    expect(r.detail).toContain('ESERVFAIL');
+  });
+
+  it('does not retry a definitive negative answer — the second ask would say the same', async () => {
+    resolve4.mockResolvedValue(noAnswer());
+    await checkDomainResolvesToBox(NO_WAIT);
+    // 4 domains, each asked exactly once.
+    expect(resolve4).toHaveBeenCalledTimes(4);
+  });
+
+  it('a real misconfiguration still fails, and unanswered domains ride along unjudged', async () => {
+    resolve4.mockImplementation(async (host: string) => {
+      if (host === 'paperless.dopp.cloud') return timeout();
+      if (host === 'daggerheart.dopp.cloud') return noAnswer();
+      return ok('192.168.178.100');
+    });
+    const r = await checkDomainResolvesToBox(NO_WAIT);
+    expect(r.status).toBe('fail');
+    expect(r.detail).toContain('daggerheart.dopp.cloud');
+    expect(r.detail).toContain('not judged');
+    expect(r.detail).toContain('paperless.dopp.cloud');
+    expect(r.hint).toContain('Pattern A');
   });
 });

--- a/packages/backend/src/lib/diagnose/probes/domainResolvesToBox.ts
+++ b/packages/backend/src/lib/diagnose/probes/domainResolvesToBox.ts
@@ -20,25 +20,72 @@
  *     / .local) are excluded — those resolve through AdGuard rewrites,
  *     not the box's container resolver, so checking them here is a false
  *     negative (see the `domain_unreachable` header).
- *   - For each, `dns.resolve4` against the OS resolver and confirm the
- *     A-record set contains the box's LAN IP.
- *   - Any core domain that doesn't resolve to the box → `fail`
+ *   - For each, resolve A-records over the LAN path (AdGuard, see
+ *     `lib/router/lanResolver.ts`) and confirm the set contains the box's
+ *     LAN IP.
+ *   - A core domain that answers with something other than the box's LAN
+ *     IP, or answers *negatively* (NXDOMAIN / no A data), → `fail`
  *     (blocking). This is the gate for the box-verify release hook
  *     (#1561): a reinstall must not be declared green while core service
  *     domains don't resolve to the box.
+ *   - A lookup that merely got **no answer** (timeout / resolver error) is
+ *     `warn`, never `fail` — see below.
  *
  * On failure the hint points at the stable DNS setup — Pattern A
  * (FritzBox distributes AdGuard directly as DHCP DNS), now the
  * recommended default (memory `user_dns_topology`, reversed 2026-06-02:
  * the old public-fallback Pattern B silently broke all SSO logins on
  * reinstall, #1559).
+ *
+ * ## Why a timeout is not a failure (#2579)
+ *
+ * This probe stood red for 37 consecutive runs on the reference box,
+ * naming domains that resolve perfectly (`getent`/`dig` both answer with
+ * the box IP, and `adguard_rewrites_missing` confirms the `*.<domain>`
+ * rewrite). Measured on the box, the named domains were **the tail of this
+ * probe's own query list**, and the tail grew from 2 to 8 under load —
+ * decisive against any per-domain theory. The cause is that AdGuard Home
+ * ships `ratelimit: 20` queries/sec/client with an empty
+ * `ratelimit_whitelist`, and enforces it by *dropping* the excess. Firing
+ * all ~21 core domains at once from one source IP therefore loses the last
+ * few queries of the burst to a self-inflicted timeout, which
+ * `resolve4ViaLan` used to flatten to `null` and this probe rendered as
+ * "does not resolve (NXDOMAIN / no answer)".
+ *
+ * Two changes follow from that, and both matter:
+ *   1. **Retry an inconclusive lookup once.** A dropped query re-sent a
+ *      moment later is far under the limit and answers immediately.
+ *   2. **Never report an inconclusive lookup as a failure.** Only a
+ *      *definitive* negative answer or a *wrong* address is evidence that
+ *      DNS is misconfigured. A timeout is evidence of nothing about DNS
+ *      configuration, so it warns and says why — the fix for a slow
+ *      resolver is not the fix for a wrong DHCP handout.
+ *
+ * ## Relationship to the `domain:<host>` health checks
+ *
+ * These two do **not** check the same fact, so they don't share (and
+ * shouldn't share) a resolution path — the apparent contradiction in #2579
+ * was this probe overclaiming, not two answers to one question:
+ *   - `domain:<host>` (`lib/health/probes/domain.ts`) deliberately avoids
+ *     DNS for routing: it fetches `http://<lanIp>:80/` with a `Host:`
+ *     header, and for *public* hosts adds a DoH lookup of **public** DNS.
+ *   - this probe asks the one thing neither of those covers: does the name
+ *     resolve **to the box on the LAN path (AdGuard)**.
+ * A green `domain:` row plus a red row here is a coherent state (public DNS
+ * fine, LAN DNS broken) and is exactly what this probe exists to surface.
+ * What was incoherent was claiming NXDOMAIN on the strength of silence.
  */
 
 import { getConfig, type ProxyHostEntry, type AppConfig } from '@/lib/config';
 import { logger } from '@/lib/logger';
-import { resolve4ViaLan } from '@/lib/router/lanResolver';
+import { resolve4ViaLanDetailed, type LanResolveResult } from '@/lib/router/lanResolver';
 
 const PROBE_ID = 'domain_resolves_to_box';
+
+/** Pause before re-sending a lookup that got no answer. Long enough to leave
+ *  the resolver's 1-second rate-limit window, short enough that a 21-domain
+ *  probe stays well inside a diagnose run. */
+const RETRY_DELAY_MS = 1200;
 
 /** SSO-precondition subdomains under `publicDomain` that always need to
  *  resolve to the box, whether or not a proxy host is recorded for them
@@ -54,10 +101,19 @@ export interface DomainResolvesToBoxResult {
 
 interface DomainResolution {
   domain: string;
-  /** Resolved A-records, or null when resolution failed entirely. */
+  /** Resolved A-records, or null when nothing was resolved. */
   addresses: string[] | null;
+  /** Why the lookup ended as it did — see `LanResolveOutcome`. */
+  outcome: LanResolveResult['outcome'];
+  code?: string;
   /** True when `addresses` contains the box's LAN IP. */
   resolvesToBox: boolean;
+}
+
+/** An outcome that says nothing about whether the name resolves — the query
+ *  never got an answer, so the probe must not draw a DNS conclusion from it. */
+function isInconclusive(outcome: LanResolveResult['outcome']): boolean {
+  return outcome === 'timeout' || outcome === 'error';
 }
 
 function isLanDomain(domain: string): boolean {
@@ -81,7 +137,36 @@ function buildCoreDomains(config: AppConfig): string[] {
   return Array.from(new Set(domains));
 }
 
-export async function checkDomainResolvesToBox(): Promise<DomainResolvesToBoxResult> {
+export interface DomainResolvesToBoxDeps {
+  /** Injectable for tests; defaults to the real AdGuard-bound lookup. */
+  resolve?: (host: string, lanIp: string) => Promise<LanResolveResult>;
+  /** Injectable for tests so the retry path doesn't cost real seconds. */
+  retryDelayMs?: number;
+}
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/** One lookup, retried once when it produced no answer at all. A dropped
+ *  query (rate limit) or a momentarily-loaded resolver answers fine on the
+ *  second try; a name that genuinely doesn't resolve answers negatively both
+ *  times, so the retry costs nothing in the failure case (#2579). */
+async function resolveWithRetry(
+  domain: string,
+  lanIp: string,
+  resolve: (host: string, lanIp: string) => Promise<LanResolveResult>,
+  retryDelayMs: number,
+): Promise<LanResolveResult> {
+  const first = await resolve(domain, lanIp);
+  if (!isInconclusive(first.outcome)) return first;
+  await sleep(retryDelayMs);
+  return resolve(domain, lanIp);
+}
+
+export async function checkDomainResolvesToBox(
+  deps: DomainResolvesToBoxDeps = {},
+): Promise<DomainResolvesToBoxResult> {
+  const resolve = deps.resolve ?? resolve4ViaLanDetailed;
+  const retryDelayMs = deps.retryDelayMs ?? RETRY_DELAY_MS;
   const config = await getConfig();
   const lanIp = config.reverseProxy?.lanIp;
   if (!lanIp) {
@@ -105,33 +190,65 @@ export async function checkDomainResolvesToBox(): Promise<DomainResolvesToBoxRes
       // resolver may carry a public fallback that answers with the box's
       // PUBLIC IP (split-horizon the LAN doesn't see), false-reding a box
       // whose LAN clients all resolve correctly through AdGuard (#1672/#1675).
-      const addresses = await resolve4ViaLan(domain, lanIp);
+      const { outcome, addresses, code } = await resolveWithRetry(domain, lanIp, resolve, retryDelayMs);
       return {
         domain,
         addresses,
+        outcome,
+        ...(code ? { code } : {}),
         resolvesToBox: !!addresses && addresses.includes(lanIp),
       };
     }),
   );
 
-  const broken = resolutions.filter(r => !r.resolvesToBox);
-  if (broken.length === 0) {
+  return summarise(resolutions, lanIp);
+}
+
+/** Turn the per-domain outcomes into the probe row. Split out so the check
+ *  itself stays about *gathering* the answers. */
+function summarise(resolutions: DomainResolution[], lanIp: string): DomainResolvesToBoxResult {
+  const total = resolutions.length;
+  const plural = total === 1 ? '' : 's';
+  // A definitive negative answer, or an answer pointing somewhere else, is
+  // evidence that DNS is misconfigured. Silence is not (#2579).
+  const misconfigured = resolutions.filter(r => !r.resolvesToBox && !isInconclusive(r.outcome));
+  const unanswered = resolutions.filter(r => !r.resolvesToBox && isInconclusive(r.outcome));
+
+  if (misconfigured.length === 0 && unanswered.length === 0) {
     return {
       status: 'ok',
-      detail: `All ${domains.length} core service domain${domains.length === 1 ? '' : 's'} resolve to ServiceBay (${lanIp}).`,
+      detail: `All ${total} core service domain${plural} resolve to ServiceBay (${lanIp}).`,
     };
   }
 
-  const lines = broken.map(b =>
-    b.addresses === null
-      ? `${b.domain} → does not resolve (NXDOMAIN / no answer)`
-      : `${b.domain} → ${b.addresses.join(', ')} (expected ${lanIp})`,
-  );
+  if (misconfigured.length > 0) {
+    const lines = misconfigured.map(b =>
+      b.addresses === null
+        ? `${b.domain} → no such name (${b.code ?? 'NXDOMAIN'}) — the resolver answered, and the answer was "this name does not exist here"`
+        : `${b.domain} → ${b.addresses.join(', ')} (expected ${lanIp})`,
+    );
+    if (unanswered.length > 0) {
+      lines.push(
+        `(${unanswered.length} further domain${unanswered.length === 1 ? '' : 's'} gave no answer at all and ${unanswered.length === 1 ? 'was' : 'were'} not judged: ${unanswered.map(u => u.domain).join(', ')})`,
+      );
+    }
+    return {
+      status: 'fail',
+      detail: `${misconfigured.length} of ${total} core service domain${plural} don't resolve to ServiceBay (${lanIp}):\n${lines.join('\n')}`,
+      hint:
+        'DNS misconfigured — DHCP DNS must point at ServiceBay (Pattern A). The most stable setup is to have the FritzBox hand out ServiceBay\'s IP as the DNS server via DHCP (option 6) so every LAN device resolves *.<your-domain> to the box through AdGuard. Open the "Router DNS routing" probe and click "Configure DHCP to ServiceBay", then re-run this check after devices renew their lease (restart Wi-Fi for an immediate refresh).',
+    };
+  }
+
+  // Only inconclusive lookups left: the resolver went quiet, twice. That is a
+  // resolver-health question, not a DNS-configuration one — say so, and don't
+  // send the operator off to reconfigure DHCP for it.
+  const lines = unanswered.map(u => `${u.domain} → no answer within the timeout (${u.outcome === 'timeout' ? 'timed out' : `resolver error ${u.code ?? 'unknown'}`}), twice`);
   return {
-    status: 'fail',
-    detail: `${broken.length} of ${domains.length} core service domain${domains.length === 1 ? '' : 's'} don't resolve to ServiceBay (${lanIp}):\n${lines.join('\n')}`,
+    status: 'warn',
+    detail: `${unanswered.length} of ${total} core service domain${plural} could not be checked — the LAN resolver gave no answer, which is not the same as the name not resolving:\n${lines.join('\n')}`,
     hint:
-      'DNS misconfigured — DHCP DNS must point at ServiceBay (Pattern A). The most stable setup is to have the FritzBox hand out ServiceBay\'s IP as the DNS server via DHCP (option 6) so every LAN device resolves *.<your-domain> to the box through AdGuard. Open the "Router DNS routing" probe and click "Configure DHCP to ServiceBay", then re-run this check after devices renew their lease (restart Wi-Fi for an immediate refresh).',
+      'Nothing here says DNS is misconfigured — the lookups simply got no reply, so these domains are unjudged rather than broken. The usual cause is the resolver dropping queries: AdGuard Home enforces a per-client rate limit (Settings → DNS settings → "Limit of requests per second", 20 by default) by discarding the excess, and it applies to the box\'s own bursts too. Raising that limit, or waiting for a moment when the box is not under heavy load, makes the check conclusive. If it stays quiet, check that AdGuard is running and listening on :53.',
   };
 }
 

--- a/packages/backend/src/lib/externalBackup/restore.ts
+++ b/packages/backend/src/lib/externalBackup/restore.ts
@@ -291,9 +291,9 @@ export async function restoreServiceBackup(
  * After this runs, `autoRestoreServiceOnReinstall` re-seeds CONFIG from the NAS
  * (the wiped CONFIG paths are gone, so the restore re-creates them over the
  * kept DATA). ServiceBay-managed bits stamped into the restored
- * `configuration.yaml` (HA `http: trusted_proxies`, the OIDC client secret) are
- * re-applied by the existing post-deploy self-heal hooks (serviceLifecycle's
- * trusted_proxies append + the #989 OIDC dispatcher), which run on every deploy
+ * `configuration.yaml` (the OIDC client secret) are
+ * re-applied by the existing post-deploy self-heal hooks (the #989 OIDC
+ * dispatcher, plus the #2573 trust-list step), which run on every deploy
  * regardless of the restore — so the documented caveat is honoured without a
  * second stamping path here.
  *

--- a/packages/backend/src/lib/install/manifestAssembler.test.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.test.ts
@@ -40,6 +40,10 @@ vi.mock('./savedVariables', () => ({
 }));
 
 import { assembleManifest, deriveLdapBaseDn } from './manifestAssembler';
+import {
+  DEFAULT_SECRET_LENGTH,
+  DEVICE_SAFE_SECRET_LENGTH,
+} from '@/lib/stackInstall/randomSecret';
 
 /** Minimal pod yaml carrying the dependency annotation + a `{{VAR}}`. */
 function tmplYaml(name: string, deps: string[], extra = ''): string {
@@ -315,6 +319,28 @@ describe('assembleManifest', () => {
     const secret = r.variables.find(v => v.name === 'SVC_SECRET')!;
     expect(secret.value).toMatch(/.{16,}/);
     expect(persistSingleSecret).toHaveBeenCalledWith('SVC_SECRET', secret.value);
+  });
+
+  // #2577 — a value the operator carries into a device's own credential field
+  // is generated shorter, because consumer firmware caps that field and keeps
+  // the prefix; the device then reports a correct password as "wrong".
+  it('generates a deviceSafe secret at the device-safe length, still alphanumeric', async () => {
+    getTemplateYaml.mockResolvedValue(tmplYaml('svc', []));
+    getTemplateVariables.mockResolvedValue({
+      MQTT_PASSWORD: { type: 'secret', deviceSafe: true },
+      SVC_SECRET: { type: 'secret' },
+    });
+    const r = await assembleManifest({
+      items: [{ name: 'svc', checked: true }],
+      templateSource: 'Built-in',
+    });
+    const device = r.variables.find(v => v.name === 'MQTT_PASSWORD')!.value;
+    const normal = r.variables.find(v => v.name === 'SVC_SECRET')!.value;
+    expect(device).toHaveLength(DEVICE_SAFE_SECRET_LENGTH);
+    expect(device).toMatch(/^[a-zA-Z0-9]+$/);
+    // The flag changes ONLY the length — the alphabet is platform-wide.
+    expect(normal).toHaveLength(DEFAULT_SECRET_LENGTH);
+    expect(normal).toMatch(/^[a-zA-Z0-9]+$/);
   });
 
   it('reuses a saved secret instead of generating a new one', async () => {

--- a/packages/backend/src/lib/install/manifestAssembler.ts
+++ b/packages/backend/src/lib/install/manifestAssembler.ts
@@ -34,7 +34,7 @@ import {
 } from '@/lib/registry';
 import { parseTemplateDependencies } from '@/lib/stackInstall/dependencies';
 import { readManifestAnnotations } from '@/lib/template/contract';
-import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
+import { DEVICE_SAFE_SECRET_LENGTH, generateRandomSecret } from '@/lib/stackInstall/randomSecret';
 import { getConfig } from '@/lib/config';
 import { loadSavedSecrets, persistSingleSecret } from './savedSecrets';
 import { loadSavedVariables } from './savedVariables';
@@ -555,7 +555,12 @@ export async function assembleManifest(
         // post-deploy must handle absent values gracefully.
         value = '';
       } else {
-        value = generateRandomSecret();
+        // #2577 — a `deviceSafe` secret is one the operator retypes into a
+        // device's own credential field, which commonly caps its length and
+        // keeps the prefix; the device then reports a perfectly correct
+        // password as "wrong". Generate it shorter (still alphanumeric, like
+        // every other secret) so it survives the trip.
+        value = generateRandomSecret(meta.deviceSafe ? DEVICE_SAFE_SECRET_LENGTH : undefined);
         newlyGenerated.push({ name, value });
       }
     }

--- a/packages/backend/src/lib/registry.ts
+++ b/packages/backend/src/lib/registry.ts
@@ -849,6 +849,20 @@ export interface VariableMeta {
    */
   noAutoGenerate?: boolean;
   /**
+   * #2577 — For `type: secret`: this value ends up **inside a device**
+   * (an IoT firmware credential field, a device app's setup form), not
+   * only in a container's env. Generate it at
+   * `DEVICE_SAFE_SECRET_LENGTH` (24) instead of the 32-char default.
+   *
+   * The *alphabet* needs no flag: every generated secret is alphanumeric
+   * platform-wide (`SECRET_CHARS` in stackInstall/randomSecret.ts), so a
+   * template that forgets this flag still gets a symbol-free value — it
+   * just gets a longer one. The flag exists only for the length, because
+   * consumer firmware caps its credential field and silently keeps the
+   * prefix, which the device then reports as "wrong password".
+   */
+  deviceSafe?: boolean;
+  /**
    * Concrete example value shown next to the input in the Configure
    * step (small grey hint text). Use for fields whose `description`
    * tells the user *what* but not what a *valid value looks like* —

--- a/packages/backend/src/lib/router/lanResolver.test.ts
+++ b/packages/backend/src/lib/router/lanResolver.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #2579 — the LAN resolver used to flatten "the resolver said no such name"
+ * and "nothing came back" into the same `null`, and its one caller that
+ * reports to a human then told the operator DNS was misconfigured whenever a
+ * query was merely dropped. These pin the distinction.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { resolve4ViaLan, resolve4ViaLanDetailed } from './lanResolver';
+
+const LAN_IP = '192.168.178.100';
+
+/** A resolver factory whose `resolve4` does whatever the test says. */
+function factory(resolve4: (h: string) => Promise<string[]>) {
+  return () => ({ resolve4: vi.fn(resolve4) });
+}
+
+function withCode(code: string): Promise<never> {
+  return Promise.reject(Object.assign(new Error(code), { code }));
+}
+
+describe('resolve4ViaLanDetailed', () => {
+  it('binds to AdGuard on loopback first, then the box LAN IP', async () => {
+    const seen: string[][] = [];
+    await resolve4ViaLanDetailed('auth.dopp.cloud', LAN_IP, servers => {
+      seen.push(servers);
+      return { resolve4: async () => [LAN_IP] };
+    });
+    expect(seen).toEqual([['127.0.0.1', LAN_IP]]);
+  });
+
+  it('ok with the A-records when the resolver answers', async () => {
+    const r = await resolve4ViaLanDetailed('auth.dopp.cloud', LAN_IP, factory(async () => [LAN_IP]));
+    expect(r).toEqual({ outcome: 'ok', addresses: [LAN_IP] });
+  });
+
+  it('NXDOMAIN is a definitive negative answer, not silence', async () => {
+    const r = await resolve4ViaLanDetailed('nope.dopp.cloud', LAN_IP, factory(() => withCode('ENOTFOUND')));
+    expect(r.outcome).toBe('no-answer');
+    expect(r.code).toBe('ENOTFOUND');
+  });
+
+  it('an empty A-set is a negative answer too — the resolver did reply', async () => {
+    const r = await resolve4ViaLanDetailed('empty.dopp.cloud', LAN_IP, factory(async () => []));
+    expect(r.outcome).toBe('no-answer');
+    expect(r.addresses).toBeNull();
+  });
+
+  it('a timeout is its own outcome — it says nothing about the name', async () => {
+    const r = await resolve4ViaLanDetailed('slow.dopp.cloud', LAN_IP, factory(() => withCode('ETIMEOUT')));
+    expect(r.outcome).toBe('timeout');
+  });
+
+  it('a resolver failure (SERVFAIL / REFUSED) is an error, not a missing name', async () => {
+    const r = await resolve4ViaLanDetailed('sf.dopp.cloud', LAN_IP, factory(() => withCode('ESERVFAIL')));
+    expect(r.outcome).toBe('error');
+    expect(r.code).toBe('ESERVFAIL');
+  });
+
+  it('a query that never settles times out rather than hanging the probe', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = resolve4ViaLanDetailed('hang.dopp.cloud', LAN_IP, factory(() => new Promise<string[]>(() => {})));
+      await vi.advanceTimersByTimeAsync(3100);
+      await expect(pending).resolves.toMatchObject({ outcome: 'timeout' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('resolve4ViaLan (the null-returning wrapper single-lookup callers use)', () => {
+  it('returns the addresses on success', async () => {
+    await expect(resolve4ViaLan('auth.dopp.cloud', LAN_IP, factory(async () => [LAN_IP]))).resolves.toEqual([LAN_IP]);
+  });
+
+  it('still collapses every non-answer to null', async () => {
+    await expect(resolve4ViaLan('x.dopp.cloud', LAN_IP, factory(() => withCode('ENOTFOUND')))).resolves.toBeNull();
+    await expect(resolve4ViaLan('x.dopp.cloud', LAN_IP, factory(() => withCode('ETIMEOUT')))).resolves.toBeNull();
+  });
+});

--- a/packages/backend/src/lib/router/lanResolver.ts
+++ b/packages/backend/src/lib/router/lanResolver.ts
@@ -14,11 +14,63 @@
  * We bind a Node `dns.Resolver` to AdGuard's listeners (`127.0.0.1` and the
  * box's LAN IP, both on :53). No fallback to the system resolver — the
  * point is to bypass any public fallback entirely.
+ *
+ * ## Why the outcome is typed and not just `string[] | null` (#2579)
+ *
+ * "No answer arrived" and "the answer was: this name does not exist" are
+ * different facts with different causes and different fixes, and collapsing
+ * both into `null` made `domain_resolves_to_box` report a *permanent DNS
+ * misconfiguration* every time a query merely got dropped. On the reference
+ * box that happened on every single run: AdGuard Home ships
+ * `ratelimit: 20` (queries per second per client, `ratelimit_whitelist: []`)
+ * and it enforces the limit by **silently dropping** the excess packets, so a
+ * caller that fans out 21 lookups at once loses the tail of its own burst to
+ * a timeout it caused itself.
+ *
+ * `resolve4ViaLanDetailed` therefore reports *which* of the two happened;
+ * `resolve4ViaLan` keeps the old `string[] | null` shape for callers that do a
+ * single lookup and genuinely don't care (`router_dns_not_pointing`).
  */
 
 import { Resolver } from 'dns/promises';
 
 const DNS_TIMEOUT_MS = 3000;
+
+/** Why a LAN-path lookup ended the way it did.
+ *  - `ok` — the resolver answered with at least one A-record.
+ *  - `no-answer` — the resolver answered *negatively* (NXDOMAIN / no A data).
+ *    This is a definitive "that name does not resolve here".
+ *  - `timeout` — nothing came back in time. Says nothing about the name;
+ *    a dropped packet (AdGuard rate limit), a loaded box, or a wedged
+ *    resolver all look like this.
+ *  - `error` — the resolver failed the query (SERVFAIL, REFUSED, connection
+ *    refused …). Also inconclusive about the name itself. */
+export type LanResolveOutcome = 'ok' | 'no-answer' | 'timeout' | 'error';
+
+export interface LanResolveResult {
+  outcome: LanResolveOutcome;
+  /** A-records when `outcome === 'ok'`, otherwise null. */
+  addresses: string[] | null;
+  /** Underlying resolver error code (`ENOTFOUND`, `ESERVFAIL`, …) when known. */
+  code?: string;
+}
+
+/** c-ares codes that are a *definitive negative answer* about the name. */
+const NEGATIVE_ANSWER_CODES = new Set(['ENOTFOUND', 'ENODATA', 'NXDOMAIN', 'ENONAME']);
+/** c-ares codes that mean "no answer arrived in time". */
+const TIMEOUT_CODES = new Set(['ETIMEOUT', 'ETIMEDOUT']);
+
+/** The only thing this module needs from a resolver — narrower than
+ *  `Resolver` so a test can hand in a plain object without reproducing
+ *  node's overloaded `resolve4` signature. `Resolver` satisfies it. */
+export interface LanResolverLike {
+  resolve4(hostname: string): Promise<string[]>;
+}
+
+function errorCode(err: unknown): string | undefined {
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === 'string' ? code : undefined;
+}
 
 /** AdGuard listens on :53 on both loopback and the box's LAN IP. We try
  *  loopback first (always present on the node), then the LAN IP. */
@@ -29,26 +81,58 @@ function adguardServers(lanIp: string): string[] {
 }
 
 /** Resolve a hostname's A-records via AdGuard (the LAN path) with a hard
+ *  timeout, reporting *why* it ended as it did — see `LanResolveOutcome`.
+ *  Callers that must not confuse "dropped/slow" with "does not exist" (the
+ *  `domain_resolves_to_box` probe, #2579) use this instead of the
+ *  null-returning wrapper below.
+ *
+ *  `resolverFactory` is injectable for tests; defaults to a fresh
+ *  AdGuard-bound `Resolver`. */
+export async function resolve4ViaLanDetailed(
+  hostname: string,
+  lanIp: string,
+  resolverFactory: (servers: string[]) => LanResolverLike = defaultLanResolver,
+): Promise<LanResolveResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const resolver = resolverFactory(adguardServers(lanIp));
+    const records = await Promise.race([
+      resolver.resolve4(hostname),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(Object.assign(new Error('dns timeout'), { code: 'ETIMEOUT' })), DNS_TIMEOUT_MS);
+      }),
+    ]);
+    // An empty A-set is the resolver answering "nothing here" — a negative
+    // answer, not a missing one.
+    if (records.length > 0) return { outcome: 'ok', addresses: records };
+    return { outcome: 'no-answer', addresses: null, code: 'ENODATA' };
+  } catch (err) {
+    const code = errorCode(err);
+    if (code && TIMEOUT_CODES.has(code)) return { outcome: 'timeout', addresses: null, code };
+    if (code && NEGATIVE_ANSWER_CODES.has(code)) return { outcome: 'no-answer', addresses: null, code };
+    return { outcome: 'error', addresses: null, ...(code ? { code } : {}) };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Resolve a hostname's A-records via AdGuard (the LAN path) with a hard
  *  timeout. Returns null on NXDOMAIN / SERVFAIL / timeout / any error —
  *  the caller treats null as "does not resolve via the LAN path".
+ *
+ *  Only for callers doing a **single** lookup where the distinction doesn't
+ *  change the verdict. Anything that reports the reason to a human wants
+ *  `resolve4ViaLanDetailed` (#2579).
  *
  *  `resolverFactory` is injectable for tests; defaults to a fresh
  *  AdGuard-bound `Resolver`. */
 export async function resolve4ViaLan(
   hostname: string,
   lanIp: string,
-  resolverFactory: (servers: string[]) => Pick<Resolver, 'resolve4'> = defaultLanResolver,
+  resolverFactory: (servers: string[]) => LanResolverLike = defaultLanResolver,
 ): Promise<string[] | null> {
-  try {
-    const resolver = resolverFactory(adguardServers(lanIp));
-    const records = await Promise.race([
-      resolver.resolve4(hostname),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('dns timeout')), DNS_TIMEOUT_MS)),
-    ]);
-    return records.length > 0 ? records : null;
-  } catch {
-    return null;
-  }
+  const { addresses } = await resolve4ViaLanDetailed(hostname, lanIp, resolverFactory);
+  return addresses;
 }
 
 function defaultLanResolver(servers: string[]): Resolver {

--- a/packages/backend/src/lib/services/serviceLifecycle.homeAssistantHook.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.homeAssistantHook.test.ts
@@ -72,7 +72,7 @@ const DIR = '/mnt/data/home-assistant/homeassistant';
 describe('runHomeAssistantHook (#1687 config-survival self-heal)', () => {
     beforeEach(() => vi.clearAllMocks());
 
-    it('re-adds http: + the 3 includes after a restore brought back a bare user config', async () => {
+    it('re-adds the 3 includes after a restore brought back a bare user config', async () => {
         // Simulate a restored user configuration.yaml: user content, but none
         // of ServiceBay's wiring and no automation/script/scene includes.
         const agent = makeHaAgent({ [CFG]: 'default_config:\n\nfrontend:\n' });
@@ -81,8 +81,6 @@ describe('runHomeAssistantHook (#1687 config-survival self-heal)', () => {
 
         const out = agent.files[CFG];
         expect(out).toContain('frontend:');                 // user content preserved
-        expect(out).toMatch(/^http:/m);                     // trusted_proxies re-added
-        expect(out).toContain('use_x_forwarded_for: true');
         expect(out).toMatch(/^automation: !include automations\.yaml$/m);
         expect(out).toMatch(/^script: !include scripts\.yaml$/m);
         expect(out).toMatch(/^scene: !include scenes\.yaml$/m);
@@ -91,6 +89,36 @@ describe('runHomeAssistantHook (#1687 config-survival self-heal)', () => {
         expect(agent.files[`${DIR}/automations.yaml`]).toBe('[]\n');
         expect(agent.files[`${DIR}/scripts.yaml`]).toBe('{}\n');
         expect(agent.files[`${DIR}/scenes.yaml`]).toBe('[]\n');
+    });
+
+    it('#2573: never writes an http: block — HA 2026.8 owns that setting now', async () => {
+        // Same bare restored config as above. Before #2573 this hook appended a
+        // trusted_proxies block on every deploy, which re-triggered HA's
+        // "HTTP YAML configuration is ignored after migration" repair issue
+        // however often the operator removed it. The hook runs BEFORE HA
+        // starts, so it cannot tell which HA era the box is on; the trust list
+        // is post-deploy.py's job now.
+        const agent = makeHaAgent({ [CFG]: 'default_config:\n\nfrontend:\n' });
+
+        await ServiceLifecycle.runHomeAssistantHook(agent as never, CFG);
+
+        expect(agent.files[CFG]).not.toMatch(/^http:/m);
+        expect(agent.files[CFG]).not.toContain('use_x_forwarded_for');
+        expect(agent.files[CFG]).not.toContain('trusted_proxies');
+        // …and it never even probed for the key, so no command can re-add it.
+        expect(agent.calls.some((c) => c.includes("grep -E '^http:'"))).toBe(false);
+    });
+
+    it('#2573: leaves an operator/legacy http: block in place — removal is post-deploy.py\'s call', async () => {
+        // The hook must not delete it either: only a running HA can confirm the
+        // setting has been migrated into `.storage/http` first.
+        const withHttp = 'default_config:\n\nhttp:\n  use_x_forwarded_for: true\n';
+        const agent = makeHaAgent({ [CFG]: withHttp });
+
+        await ServiceLifecycle.runHomeAssistantHook(agent as never, CFG);
+
+        expect(agent.files[CFG]).toContain('http:');
+        expect(agent.files[CFG]).toContain('use_x_forwarded_for: true');
     });
 
     it('is idempotent: a config that already has everything is left untouched', async () => {

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -1431,7 +1431,7 @@ export class ServiceLifecycle {
 
     /**
      * Append `block` to `cfgFile` (heredoc) only when `topKey` (an
-     * unindented YAML key, e.g. `http:` / `automation:`) is absent. Returns
+     * unindented YAML key, e.g. `automation:` / `script:`) is absent. Returns
      * true iff the block was appended. Shared by the HA self-heal hook so
      * each managed key is re-added independently after a backup-restore
      * brings back a user `configuration.yaml` without it. Idempotent: a
@@ -1467,17 +1467,25 @@ export class ServiceLifecycle {
      * Home Assistant configuration.yaml self-healing hook.
      *
      * A HA backup-restore replaces ServiceBay's base `configuration.yaml`
-     * with the snapshot's own — which carries the user's content but NONE of
-     * ServiceBay's required wiring (the `http:` trusted-proxies block, the
-     * `auth_oidc:` SSO block) and, on a pre-#1687 box, NOT the
-     * `automation:` / `script:` / `scene:` includes either. Without the
-     * includes a restored `automations.yaml` never loads (every automation
-     * `unavailable`); without `http:`/`auth_oidc:` the proxy + SSO break.
+     * with the snapshot's own — which carries the user's content but, on a
+     * pre-#1687 box, NOT the `automation:` / `script:` / `scene:` includes.
+     * Without those a restored `automations.yaml` never loads (every
+     * automation `unavailable`).
      *
      * We re-add each managed key independently when it's missing, and ensure
      * the three include target files exist (empty is fine — restore overwrote
      * them with real content), so a restored user config keeps all of the
      * user's own settings AND ServiceBay's needs are present again.
+     *
+     * The `http:` trusted-proxies block used to be re-added here too. It is
+     * NOT any more (#2573): HA 2026.8 moved that setting into its own store
+     * and raises a permanent repair issue for as long as an `http:` block is
+     * left in the YAML, so re-appending it every deploy meant the operator
+     * could never clear the warning. This hook runs BEFORE HA starts, so it
+     * cannot tell which HA era the box is on; `templates/home-assistant/
+     * post-deploy.py` owns the trust list now, where HA is running and can be
+     * asked. The `auth_oidc:` block was likewise already owned there, because
+     * it needs rendered variable values this hook does not have.
      *
      * Public for unit testing (`serviceLifecycle.homeAssistantHook.test.ts`);
      * the production caller is `runPreStartHooks`.
@@ -1492,22 +1500,6 @@ export class ServiceLifecycle {
         // (including post-restore), the file is there and we get to fix it.
         const exists = await agent.sendCommand('exec', { command: `test -f ${cfgFile} && echo yes` });
         if (exists.stdout?.trim() !== 'yes') return;
-
-        const trustedProxiesBlock = [
-            '',
-            '# Re-added by ServiceBay: NPM forwards X-Forwarded-For; HA needs',
-            '# trusted_proxies to accept proxied requests. Safe to edit, but',
-            '# ServiceBay will re-append this block on every deploy when the',
-            '# `http:` key is missing (e.g. after a HA backup-restore).',
-            'http:',
-            '  use_x_forwarded_for: true',
-            '  trusted_proxies:',
-            '    - 127.0.0.1',
-            '    - 192.168.0.0/16',
-            '    - 10.0.0.0/8',
-            '    - 172.16.0.0/12',
-        ].join('\n');
-        await ServiceLifecycle.appendYamlKeyIfMissing(agent, cfgFile, 'http:', trustedProxiesBlock, 'http: trusted_proxies block');
 
         // UI-editable automations/scripts/scenes only load when their
         // `!include` line is in configuration.yaml. A backup-restore brings
@@ -1671,7 +1663,8 @@ export class ServiceLifecycle {
                 for (const container of containers) {
                     const image = container.image || '';
 
-                    // Home Assistant self-healing trusted_proxies hook.
+                    // Home Assistant configuration.yaml self-healing hook
+                    // (the automation/script/scene includes + integrity guard).
                     if (image.includes('home-assistant') && container.name !== 'matter-server' && container.name !== 'zwave-js') {
                         const configMount = (container.volumeMounts || []).find(
                             (m: PodLikeVolumeMount) => m.mountPath === '/config'

--- a/packages/backend/src/lib/stackInstall/randomSecret.test.ts
+++ b/packages/backend/src/lib/stackInstall/randomSecret.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { generateRandomSecret, unbiasedCharIndex } from './randomSecret';
+import {
+  DEFAULT_SECRET_LENGTH,
+  DEVICE_SAFE_SECRET_LENGTH,
+  SECRET_CHARS,
+  generateRandomSecret,
+  unbiasedCharIndex,
+} from './randomSecret';
 
 // #2260 — the install-flow secret pre-fill must use an UNBIASED cryptographic
 // mapping (js/biased-cryptographic-random). Old `byte % 62` skewed the picks.
@@ -38,5 +44,53 @@ describe('generateRandomSecret (#2260 unbiased)', () => {
       expect(c).toBeGreaterThan(expected * 0.75);
       expect(c).toBeLessThan(expected * 1.25);
     }
+  });
+});
+
+// #2577 — the alphabet is a CONTRACT, not an accident: generated secrets are
+// pasted into IoT firmware credential fields, device apps and shell one-liners.
+// A symbol that any of those mangles surfaces as "wrong username or password"
+// at the device, which points the operator at themselves. These cases exist so
+// a future "make secrets stronger by adding punctuation" edit fails here first.
+describe('device-safe generation (#2577)', () => {
+  it('the alphabet is exactly the 62 alphanumerics — no symbol can drift in', () => {
+    expect(SECRET_CHARS).toBe(CHARS);
+    expect(SECRET_CHARS).toHaveLength(62);
+    expect(SECRET_CHARS).toMatch(/^[a-zA-Z0-9]+$/);
+    // No duplicates — a repeated char would silently skew the distribution.
+    expect(new Set(SECRET_CHARS).size).toBe(SECRET_CHARS.length);
+    // Spelled out, because these are the exact classes that broke a device:
+    // quotes/backslash (shell + YAML), whitespace (form trimming), and the
+    // punctuation URL/HTTP-Basic encoders like to transform.
+    for (const bad of ['"', "'", '\\', '`', '$', '@', ':', '/', '%', '#', '&', '!', '+', '=', ' ']) {
+      expect(SECRET_CHARS).not.toContain(bad);
+    }
+    // …and the generator only ever emits from it.
+    expect(generateRandomSecret(512)).toMatch(/^[a-zA-Z0-9]{512}$/);
+  });
+
+  it('carries strength in length: the device-safe profile is shorter but still ~142 bits', () => {
+    expect(DEFAULT_SECRET_LENGTH).toBe(32);
+    expect(DEVICE_SAFE_SECRET_LENGTH).toBe(24);
+
+    const bits = (len: number) => len * Math.log2(SECRET_CHARS.length);
+    // Shown, not claimed: both profiles are astronomically past any
+    // brute-force reach against a hashed, network-rate-limited credential.
+    expect(bits(DEFAULT_SECRET_LENGTH)).toBeGreaterThan(190);
+    expect(bits(DEVICE_SAFE_SECRET_LENGTH)).toBeGreaterThan(142);
+    // A floor, so nobody "fixes" a fussy device by shrinking this to 8.
+    expect(bits(DEVICE_SAFE_SECRET_LENGTH)).toBeGreaterThan(128);
+    // Adding the 33 ASCII symbols to a 24-char value would buy ~15 bits —
+    // less than adding 3 more alphanumeric characters, at the cost of
+    // devices that cannot accept it. That is the whole trade in one line.
+    expect(bits(DEVICE_SAFE_SECRET_LENGTH + 3)).toBeGreaterThan(
+      (DEVICE_SAFE_SECRET_LENGTH) * Math.log2(95),
+    );
+  });
+
+  it('generates the device-safe profile at the requested length', () => {
+    const s = generateRandomSecret(DEVICE_SAFE_SECRET_LENGTH);
+    expect(s).toHaveLength(24);
+    expect(s).toMatch(/^[a-zA-Z0-9]{24}$/);
   });
 });

--- a/packages/backend/src/lib/stackInstall/randomSecret.ts
+++ b/packages/backend/src/lib/stackInstall/randomSecret.ts
@@ -12,7 +12,52 @@
  * StackInstallFlow consumer (#341) share one implementation
  * instead of three near-copies.
  */
-const SECRET_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+/**
+ * The alphabet every generated secret is drawn from: ASCII letters and
+ * digits, **no symbols and no whitespace** (#2577).
+ *
+ * This has been the de-facto alphabet since #19; it is now a stated
+ * contract rather than an accident, because generated secrets are typed
+ * and pasted into places that are far less forgiving than a browser: IoT
+ * firmware credential fields, device apps, shell one-liners, config files
+ * with their own quoting rules. A symbol that one of those mangles turns
+ * into "wrong username or password" at the device, which points the
+ * operator at themselves instead of at the generator.
+ *
+ * Strength is carried by LENGTH, not by symbol variety — see
+ * `DEFAULT_SECRET_LENGTH` / `DEVICE_SAFE_SECRET_LENGTH` below. Pinned by
+ * `randomSecret.test.ts`; do not add punctuation here.
+ */
+export const SECRET_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+/**
+ * Default generated length. 32 × log2(62) ≈ **190 bits** — far past any
+ * offline-brute-force concern, and the length secrets have had since #19,
+ * so nothing an operator already memorised changes shape.
+ */
+export const DEFAULT_SECRET_LENGTH = 32;
+
+/**
+ * Length for a secret an operator has to carry INTO a device (#2577).
+ *
+ * Proven at a real device on 2026-08-16: a Nuki Smart Lock Pro was
+ * rejected by mosquitto (`disconnected: not authorised`) with the
+ * generated 32-character value — pasted, so complete — while Home
+ * Assistant accepted the very same credentials; a 24-character
+ * alphanumeric value connected on the first try. The alphabet was
+ * already alphanumeric in both cases (see `SECRET_CHARS`), so the only
+ * property that differed was the length: consumer firmware routinely caps
+ * its credential field and silently keeps the prefix, and a truncated
+ * password fails as "credentials wrong".
+ *
+ * 24 × log2(62) ≈ **142 bits**. That is fewer bits than the 190-bit
+ * default and still absurdly beyond reach — the broker stores a hash and
+ * a network-facing guess rate is a few per second, so the gap between
+ * 2^142 and 2^190 is the difference between two impossibilities. The
+ * strength that actually changed here is at the device: a value the
+ * firmware truncates authenticates NOTHING, which is 0 bits.
+ */
+export const DEVICE_SAFE_SECRET_LENGTH = 24;
 
 /**
  * One uniform index into `SECRET_CHARS` via rejection sampling: draw a random
@@ -33,7 +78,7 @@ export function unbiasedCharIndex(len: number = SECRET_CHARS.length): number {
   return byte % len;
 }
 
-export function generateRandomSecret(length = 32): string {
+export function generateRandomSecret(length = DEFAULT_SECRET_LENGTH): string {
   let out = '';
   for (let i = 0; i < length; i++) {
     out += SECRET_CHARS[unbiasedCharIndex()];

--- a/packages/frontend/src/app/api/install/generate-secret/route.ts
+++ b/packages/frontend/src/app/api/install/generate-secret/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { withApiHandler } from '@/lib/api/handler';
-import { generateRandomSecret } from '@/lib/stackInstall/randomSecret';
+import { DEVICE_SAFE_SECRET_LENGTH, generateRandomSecret } from '@/lib/stackInstall/randomSecret';
 import { GenerateSecretRequestSchema } from '@servicebay/api-client';
 
 export const dynamic = 'force-dynamic';
@@ -17,6 +17,12 @@ export const dynamic = 'force-dynamic';
  * server-side as a logic primitive.
  */
 export const POST = withApiHandler({ body: GenerateSecretRequestSchema }, async ({ body }) => {
-  const secret = generateRandomSecret(body.length);
+  // #2577 — the regenerate button on a `deviceSafe` variable must mint the
+  // same shape the install path does, or the operator regenerates their way
+  // back into a value their device truncates. An explicit `length` still
+  // wins; the flag only supplies the default.
+  const secret = generateRandomSecret(
+    body.length ?? (body.deviceSafe ? DEVICE_SAFE_SECRET_LENGTH : undefined),
+  );
   return NextResponse.json({ secret });
 });

--- a/packages/frontend/src/components/StackVariableField.test.tsx
+++ b/packages/frontend/src/components/StackVariableField.test.tsx
@@ -76,3 +76,52 @@ describe('StackVariableField — secret regenerate feedback (#2186)', () => {
     expect(onChange).toHaveBeenCalledWith('manual');
   });
 });
+
+// #2577 — the regenerate button must mint the SAME shape the install path
+// generates for a device-facing variable. Without this the operator can
+// regenerate their way back into a value the device truncates, and the
+// symptom (a device claiming the credentials are wrong) points nowhere near
+// this button. The length policy stays server-side; the browser only forwards
+// the declaration.
+describe('StackVariableField — device-safe regenerate (#2577)', () => {
+  type FetchMock = ReturnType<typeof vi.fn<(url: string, init: RequestInit) => Promise<Response>>>;
+  const stubFetch = (secret: string): FetchMock => {
+    const fetchMock = vi.fn<(url: string, init: RequestInit) => Promise<Response>>(() =>
+      Promise.resolve(new Response(JSON.stringify({ secret }), { status: 200 })),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  };
+  const fetchBody = (fetchMock: FetchMock) =>
+    JSON.parse(String(fetchMock.mock.calls[0][1].body));
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('asks for the device-safe profile when the variable declares it', async () => {
+    const fetchMock = stubFetch('short');
+
+    render(
+      <StackVariableField
+        variable={{ name: 'MQTT_PASSWORD', value: 'old', meta: { type: 'secret', deviceSafe: true } }}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTitle('Regenerate'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/install/generate-secret');
+    expect(fetchBody(fetchMock)).toEqual({ deviceSafe: true });
+  });
+
+  it('leaves an ordinary secret on the default profile', async () => {
+    const fetchMock = stubFetch('long');
+
+    render(<StackVariableField variable={secretVar} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByTitle('Regenerate'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchBody(fetchMock)).toEqual({});
+  });
+});

--- a/packages/frontend/src/components/StackVariableField.tsx
+++ b/packages/frontend/src/components/StackVariableField.tsx
@@ -221,7 +221,14 @@ export default function StackVariableField({
   // regenerate request can drive a pending/disabled/error affordance
   // (hooks can't live behind these early-return branches).
   if (v.meta?.type === 'secret') {
-    return <SecretField value={v.value} onChange={onChange} cls={cls} />;
+    return (
+      <SecretField
+        value={v.value}
+        onChange={onChange}
+        cls={cls}
+        deviceSafe={v.meta.deviceSafe}
+      />
+    );
   }
 
   // Default — plain text. Placeholder prefers `meta.example`, then
@@ -239,11 +246,11 @@ export default function StackVariableField({
   );
 }
 
-const fetchGeneratedSecret = () =>
+const fetchGeneratedSecret = (deviceSafe?: boolean) =>
   typedFetch('/api/install/generate-secret', GenerateSecretResponseSchema, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
+    body: JSON.stringify(deviceSafe ? { deviceSafe: true } : {}),
   });
 
 /**
@@ -252,15 +259,21 @@ const fetchGeneratedSecret = () =>
  * pending: the button disables + spins, and a failed request surfaces a
  * visible inline hint instead of silence (#2186). The field stays typeable
  * throughout — the operator can always enter a value manually.
+ *
+ * `deviceSafe` (#2577) forwards the variable's declaration so a regenerate
+ * mints the same device-safe shape the install path generates; the length
+ * policy itself stays server-side.
  */
 function SecretField({
   value,
   onChange,
   cls,
+  deviceSafe,
 }: {
   value: string;
   onChange: (value: string) => void;
   cls: string;
+  deviceSafe?: boolean;
 }) {
   const [regenerating, setRegenerating] = useState(false);
   const [error, setError] = useState(false);
@@ -273,7 +286,7 @@ function SecretField({
     setRegenerating(true);
     setError(false);
     try {
-      onChange((await fetchGeneratedSecret()).secret);
+      onChange((await fetchGeneratedSecret(deviceSafe)).secret);
     } catch {
       setError(true);
     } finally {

--- a/templates/beets/CHANGELOG.md
+++ b/templates/beets/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Beets — changelog
 
+## v3
+
+**The library health check now measures coverage, not existence (#2584).**
+
+v2's `beets-library-populated` check asserted `"items": [1-9]` on beets'
+`/stats` — "at least one item in the library". That is green after a single
+album and green forever after, which is exactly the state the check was
+introduced to catch: a box with 27,000 audio files and 485 items in its beets
+library reported healthy while ~98 % of the collection had never been tagged.
+
+What v3 changes:
+
+- A second container in the pod (`coverage`) counts the audio files under
+  `/music`, asks beets for its item count, and publishes the **ratio**. It
+  answers HTTP 200 above the floor and 503 below it, so the registered check is
+  a plain status-code assertion again.
+- The floor is a **percentage** — `BEETS_COVERAGE_MIN_PERCENT`, default 90 —
+  not an item count. A percentage still means the same thing after you add
+  another thousand files; a count does not. 100 % is not a realistic target:
+  `beet import -q` deliberately skips what it cannot match confidently.
+- A new host port, `BEETS_COVERAGE_PORT` (default 8338), bound to
+  **127.0.0.1 only**. Its one consumer is ServiceBay's health poller, which
+  runs on the host. Change the variable in the wizard if that port is already
+  taken on your box.
+- The check keeps its id, so the existing row is rewritten in place instead of
+  leaving a stale, permanently-green twin behind. Its name in the UI becomes
+  "Beets library coverage".
+
+**Expect the check to go red after this upgrade** if your library really is
+behind — that is the point of the change. `curl -s http://127.0.0.1:8338/coverage`
+prints the numbers behind the verdict; `podman exec beets-beets beet import -q -i /music`
+is the way to close the gap.
+
+Nothing moves on disk: `migrations/v2-to-v3.py` is an informational notice
+only.
+
 ## v2 (breaking)
 
 **Required action, if `beets` was installed from a local (file-dropped)

--- a/templates/beets/README.md
+++ b/templates/beets/README.md
@@ -48,9 +48,11 @@ unnoticed is worse.
   are and never relocates or renames anything. `web.readonly: yes` keeps the
   browser a browser.
 - **A health check that tells the truth.** Alongside the normal "is it up"
-  probe, the install registers a second check that goes **red when the beets
-  library is empty**. A service that is running but has never been given
-  anything to do no longer looks green.
+  probe, the install registers a second check that compares what is in the
+  beets library against the audio files actually sitting under `/music`, and
+  goes **red when the library covers less than `BEETS_COVERAGE_MIN_PERCENT`
+  of them** (default 90 %). See below for why it is a ratio and not "the
+  library has something in it".
 - **An import you can run in one line**, below.
 
 ## Running an import
@@ -86,6 +88,43 @@ them interactively.
 > or `copy: yes` under `import:`, an import **will relocate and rename** every
 > file it touches, whichever command above you use. Set them to `no` first
 > unless that is genuinely what you want.
+
+## The coverage check, and why it is a ratio
+
+The first version of this check asserted that beets' `/stats` endpoint reported
+at least one item. It went green after the first album and never went back —
+so a box with 27,000 audio files and 485 items in the library reported healthy
+while nearly all of the music was still untagged. A media server then scans
+that untagged remainder over and over, which is how "beets looks fine" turns
+into a machine under load.
+
+The number that was missing is the **denominator**: how many audio files are on
+disk. It is not in beets' answer, and ServiceBay's HTTP check is status code +
+body regex, so no pattern over `{"albums": M, "items": N}` can express it.
+Baking a file count into the check instead would only move the lie — it would
+be wrong again the next time you add an album.
+
+So a second container in the pod answers the question where both numbers exist:
+
+```bash
+curl -s http://127.0.0.1:8338/coverage
+{"music_dir": "/music", "files": 27268, "items": 485, "percent": 1.8,
+ "min_percent": 90.0, "status": "behind", "detail": "…"}
+```
+
+It walks `/music` once an hour (dot-directories such as Syncthing's
+`.stversions` are skipped so copies don't inflate the count), asks beets for
+its item count over the pod's own loopback, and answers `200` at or above the
+floor and `503` below it. That endpoint is bound to `127.0.0.1` on the host —
+its only consumer is ServiceBay's health poller.
+
+Two consequences worth knowing:
+
+- **100 % is not the target.** `beet import -q` skips albums it can't match
+  confidently, and a folder can hold audio beets has no business tagging. 90 %
+  is the default floor; `BEETS_COVERAGE_MIN_PERCENT` moves it.
+- **A red check here means "there is tagging work to do"**, not "the service is
+  broken". The liveness check is separate and stays green.
 
 ## Why it is LAN-only, with no subdomain and no SSO
 

--- a/templates/beets/migrations/v2-to-v3.py
+++ b/templates/beets/migrations/v2-to-v3.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""beets v2 → v3 (#2584): informational only — nothing on disk moves.
+
+v3 adds a second container to the pod (`coverage`) and publishes it on a
+new host port, bound to 127.0.0.1. No data path changes, no ownership
+changes, no config rewrite: the library database, /config and the music
+tree are all exactly where v2 left them.
+
+This script exists because the migration chain has to be unbroken — the
+install runner refuses a deploy when a hop between the installed schema
+version and the template's has no script (`selectMigrationChain`,
+`lib/stackInstall/migrations.ts`). So the hop is spelled out here rather
+than aborting an operator's redeploy over a change that needs no
+migration at all.
+
+Idempotent by construction: it only prints.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def log(msg: str) -> None:
+    print(msg)
+    sys.stdout.flush()
+
+
+def main() -> int:
+    port = os.environ.get("BEETS_COVERAGE_PORT", "8338")
+    log("beets v2 → v3: nothing to migrate — no data moves, no permissions change.")
+    log("  What changes: the 'Beets library populated' health check used to go")
+    log("  green as soon as ONE item was in the library, so a 99%-untagged")
+    log("  collection reported healthy. It now compares the library against the")
+    log("  audio files under /music and is RED below a percentage floor")
+    log("  (BEETS_COVERAGE_MIN_PERCENT, default 90%).")
+    log(f"  A new container answers that question on 127.0.0.1:{port} — loopback")
+    log("  only, not reachable from the LAN. If something else on this box already")
+    log("  owns that port, set BEETS_COVERAGE_PORT in the wizard before deploying.")
+    log("  Expect the check to go RED after this upgrade if your library really is")
+    log("  behind. That is the fix working, not a new fault.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/beets/post-deploy.py
+++ b/templates/beets/post-deploy.py
@@ -12,10 +12,13 @@ informed one:
      `seed-config` initContainer owns the "no config yet" case) and warn
      loudly if it is configured to move or copy files, because then an
      import relocates and renames the collection.
-  2. Register a health check that goes RED while the beets library is
-     empty, so "running but has never been given anything to do" stops
-     looking green — the #2581 complaint that a service waiting for a
-     command nobody gives should not count as healthy.
+  2. Register a health check that goes RED while the beets library
+     covers less of the music on disk than the configured floor, so
+     "running but has never been given anything to do" stops looking
+     green — the #2581 complaint that a service waiting for a command
+     nobody gives should not count as healthy, with the #2584 fix that
+     the same must hold for a library holding one album out of two
+     thousand.
   3. Print the commands that actually trigger an import.
 
 Exit 0 unconditionally: everything here is advisory, and post-deploy
@@ -32,6 +35,7 @@ import urllib.request
 
 CONTAINER = "beets-beets"
 DEFAULT_PORT = "8337"
+DEFAULT_COVERAGE_PORT = "8338"
 
 
 def log(msg: str) -> None:
@@ -113,27 +117,41 @@ def warn_about_existing_config() -> None:
     log("")
 
 
-def register_empty_library_check(sb_api: str, port: str) -> None:
-    """Health check: red while the beets library holds zero items.
+def register_coverage_check(sb_api: str, coverage_port: str) -> None:
+    """Health check: red while beets covers less of /music than the floor.
 
-    `beet web`'s /stats answers `{"items": N, "albums": M}`. A body match on a
-    non-zero item count turns "beets is up but has never imported anything"
-    into a visible red check instead of a green pod. Registered here rather
-    than as the template's `servicebay.healthcheck` annotation on purpose:
-    that annotation gates install settleWait, and a fresh install legitimately
-    has an empty library — it must not block the deploy.
+    This check used to point at `beet web`'s /stats with a body regex of
+    `"items"\\s*:\\s*[1-9]` — "at least one item". That is green after a
+    single album and stays green forever, which is precisely the state it
+    existed to catch (#2584): a 27k-file collection with 485 items in the
+    library reported healthy.
+
+    A ratio cannot be expressed in an HTTP status + body-regex check, and
+    extending that check type would not help — the denominator (how many
+    audio files are on disk) is not in the response at all, and baking a
+    count into the pattern is a threshold that ages into a lie. So the pod
+    computes it instead: the `coverage` sidecar mounts /music, asks beets
+    for its item count, and answers 200/503 against a percentage floor.
+    This check is back to a plain status-code assertion.
+
+    The check id is deliberately UNCHANGED. The POST is an upsert by id, so
+    a box that already carries the old regex row has it rewritten in place
+    rather than gaining a second, permanently-green one.
+
+    Registered here rather than as the template's `servicebay.healthcheck`
+    annotation on purpose: that annotation gates install settleWait, and a
+    fresh install legitimately has an empty library — it must not block the
+    deploy.
     """
     payload = {
         "id": "beets-library-populated",
-        "name": "Beets library populated",
+        "name": "Beets library coverage",
         "type": "http",
-        "target": f"http://127.0.0.1:{port}/stats",
+        "target": f"http://127.0.0.1:{coverage_port}/coverage",
         "interval": 300,
         "enabled": True,
         "httpConfig": {
             "expectedStatus": 200,
-            "bodyMatch": r'"items"\s*:\s*[1-9]',
-            "bodyMatchType": "regex",
         },
     }
     body = json.dumps(payload).encode("utf-8")
@@ -147,8 +165,10 @@ def register_empty_library_check(sb_api: str, port: str) -> None:
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             if resp.status == 200:
-                log("✅ Registered health check 'beets-library-populated' — it stays")
-                log("   RED until an import has actually put something in the library.")
+                log("✅ Registered health check 'Beets library coverage' — it is RED")
+                log("   while the library holds less of your music than the configured")
+                log("   floor, not merely while it is empty.")
+                log(f"     curl -s http://127.0.0.1:{coverage_port}/coverage   # the numbers behind it")
                 return
             log(f"⚠️ Health-check registration returned HTTP {resp.status}. "
                 "The auto-created service:beets check still applies.")
@@ -173,8 +193,9 @@ def print_import_instructions(port: str) -> None:
 
 def main() -> int:
     port = env("BEETS_PORT", DEFAULT_PORT)
+    coverage_port = env("BEETS_COVERAGE_PORT", DEFAULT_COVERAGE_PORT)
     warn_about_existing_config()
-    register_empty_library_check(env("SB_API_URL", "http://localhost:3000"), port)
+    register_coverage_check(env("SB_API_URL", "http://localhost:3000"), coverage_port)
     print_import_instructions(port)
     return 0
 

--- a/templates/beets/template.yml
+++ b/templates/beets/template.yml
@@ -11,8 +11,12 @@ metadata:
     # this service before. See CHANGELOG.md — the bump exists so an
     # operator upgrading off that local copy sees the breaking-change
     # acknowledgement, and so migrations/v1-to-v2.py runs.
-    servicebay.schema-version: "2"
-    servicebay.ports: "{{BEETS_PORT}}/tcp"
+    # v3 (#2584): adds the `coverage` sidecar below and its loopback port.
+    servicebay.schema-version: "3"
+    # BEETS_PORT first — it is the consumer-facing one (see
+    # readPrimaryTcpPort in lib/network/service.ts). The coverage port is
+    # bound to the host loopback only; nothing on the LAN talks to it.
+    servicebay.ports: "{{BEETS_PORT}}/tcp,{{BEETS_COVERAGE_PORT}}/tcp"
     # The music/audiobook trees this pod mounts are file-share's data
     # volume, so file-share must be installed and settled first.
     servicebay.dependencies: "file-share"
@@ -21,9 +25,12 @@ metadata:
     # process is up": it proves the web plugin loaded AND the library
     # database opened. A pod that starts but can't read its DB answers
     # 500 here. post-deploy.py registers a SECOND, stricter check
-    # (`beets-library-populated`) against the same URL that also asserts
-    # the item count is non-zero, which is what makes "beets is running
-    # but has never imported anything" visible instead of green (#2581).
+    # (`beets-library-populated`) against the `coverage` sidecar below,
+    # which compares the library against the files on disk — see that
+    # container for why the assertion had to move out of a body regex
+    # (#2584). Keeping the two apart matters: this annotation gates
+    # install settleWait, and a fresh install legitimately has an empty
+    # library.
     servicebay.healthcheck: |
       url: http://localhost:{{BEETS_PORT}}/stats
       interval: 60s
@@ -189,6 +196,223 @@ spec:
         name: music-data
       - mountPath: /audiobooks
         name: audiobooks-data
+  # ── Library-coverage endpoint (#2584) ────────────────────────────────
+  #
+  # The check that is supposed to say "beets isn't doing its job" asked a
+  # question it could not express. ServiceBay's HTTP check is
+  # status-code + body-regex, and `beet web`'s /stats answers only
+  # `{"albums": M, "items": N}` — so the strongest thing a regex over that
+  # body can assert is "N is at least 1". On a 27k-file collection with 485
+  # items in the library that reads GREEN: the exact state the check was
+  # invented to catch (#2581 → #2584).
+  #
+  # Extending the check machinery does not fix it. The missing number is the
+  # DENOMINATOR — how many audio files are on disk — and that lives on the
+  # box's filesystem, not in the response. A body-comparison operator (or a
+  # baked-in item floor) would have to hard-code a count that ages into a lie
+  # the moment the operator adds an album. So the assertion moves to the one
+  # place where both numbers exist at once: inside the pod, which already
+  # mounts /music and can ask beets for its item count over the shared pod
+  # netns. This sidecar publishes the RATIO and answers 200/503 against a
+  # percentage floor; the registered check goes back to being a plain
+  # status-code check, and stays honest at any collection size.
+  #
+  # Loopback-bound on purpose: the only consumer is ServiceBay's health
+  # probe, which runs on the host (same reasoning as radicale's DAV port,
+  # #2357). It walks the music tree, so it has no business on the LAN.
+  - name: coverage
+    # The beets image itself — beets IS a Python app, so the interpreter is
+    # already there and this costs no second image pull. `command` replaces
+    # the linuxserver s6 entrypoint, so no PUID/PGID dance applies here.
+    image: docker.io/linuxserver/beets:latest
+    # Same UID-0 mapping as the beets container: under rootless podman that
+    # is the host user that owns the music tree. UID 1000 could not even
+    # READ it (see the beets container above).
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+    env:
+      - name: TZ
+        value: "{{TZ}}"
+      # The floor the ratio is held to. A PERCENTAGE, deliberately: it keeps
+      # meaning the same thing when the collection doubles, which a fixed
+      # item count does not.
+      - name: SB_COVERAGE_MIN_PERCENT
+        value: "{{BEETS_COVERAGE_MIN_PERCENT}}"
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        cat > /tmp/coverage.py <<'PY'
+        """Library-coverage endpoint for the ServiceBay beets template (#2584).
+
+        GET / (any path) answers JSON:
+
+            {"items": 485, "files": 27268, "percent": 1.8,
+             "min_percent": 90.0, "status": "behind", "detail": "..."}
+
+        HTTP 200 when the library covers at least `min_percent` of the audio
+        files under /music (or while the first scan is still running), 503
+        when it is behind or when beets itself does not answer. The status
+        code IS the assertion — the registered health check needs no regex.
+        """
+        import json
+        import os
+        import threading
+        import time
+        import urllib.request
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+        MUSIC_DIR = "/music"
+        # Containers in one pod share a netns (ADR 0007), so beets' own web
+        # plugin is on loopback here. Asking beets for the item count keeps
+        # this endpoint off the library database's schema.
+        STATS_URL = "http://127.0.0.1:8337/stats"
+        LISTEN_PORT = 8338
+        # A full walk of a large collection is seconds, not minutes, and the
+        # answer moves only when the operator adds files — hourly is plenty,
+        # and it keeps a health poll from ever touching the disk.
+        RESCAN_SECONDS = 3600
+
+        AUDIO_EXTENSIONS = {
+            ".mp3", ".flac", ".m4a", ".m4b", ".aac", ".ogg", ".oga", ".opus",
+            ".wma", ".wv", ".ape", ".alac", ".aiff", ".aif", ".dsf", ".mpc",
+            ".wav",
+        }
+
+        _state = {"files": None, "scanned_at": None, "error": None}
+        _lock = threading.Lock()
+
+
+        def min_percent():
+            raw = os.environ.get("SB_COVERAGE_MIN_PERCENT", "") or "90"
+            try:
+                return max(0.0, min(100.0, float(raw)))
+            except ValueError:
+                return 90.0
+
+
+        def count_audio_files(root):
+            """Audio files under `root`, ignoring dot-files and dot-dirs.
+
+            Syncthing's `.stversions` holds copies of files that are also
+            live in the tree; counting them would inflate the denominator
+            and make a fully-tagged library look behind.
+            """
+            total = 0
+            for _dirpath, dirnames, filenames in os.walk(root):
+                dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+                for name in filenames:
+                    if name.startswith("."):
+                        continue
+                    if os.path.splitext(name)[1].lower() in AUDIO_EXTENSIONS:
+                        total += 1
+            return total
+
+
+        def rescan_forever():
+            while True:
+                try:
+                    total = count_audio_files(MUSIC_DIR)
+                    with _lock:
+                        _state["files"] = total
+                        _state["scanned_at"] = time.time()
+                        _state["error"] = None
+                except OSError as exc:
+                    with _lock:
+                        _state["error"] = str(exc)
+                time.sleep(RESCAN_SECONDS)
+
+
+        def library_items():
+            with urllib.request.urlopen(STATS_URL, timeout=5) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+            return int(payload.get("items", 0))
+
+
+        def coverage_report():
+            """Return (http_status, report)."""
+            with _lock:
+                files = _state["files"]
+                scanned_at = _state["scanned_at"]
+                scan_error = _state["error"]
+            floor = min_percent()
+            report = {
+                "music_dir": MUSIC_DIR,
+                "files": files,
+                "scanned_at": scanned_at,
+                "min_percent": floor,
+            }
+            try:
+                items = library_items()
+            except Exception as exc:
+                report["status"] = "unknown"
+                report["detail"] = "beets /stats did not answer: %s" % (exc,)
+                return 503, report
+            report["items"] = items
+            if files is None:
+                # First scan still running. Bounded and transient, so it is
+                # not a red — but it is never silently "ok" either.
+                report["status"] = "scanning"
+                report["detail"] = scan_error or (
+                    "counting the audio files under %s" % (MUSIC_DIR,)
+                )
+                return 200, report
+            if files == 0:
+                report["status"] = "ok"
+                report["percent"] = 100.0
+                report["detail"] = "no audio files under %s — nothing to cover" % (
+                    MUSIC_DIR,
+                )
+                return 200, report
+            percent = round(100.0 * items / files, 1)
+            report["percent"] = percent
+            covered = percent >= floor
+            report["status"] = "ok" if covered else "behind"
+            report["detail"] = (
+                "%d of %d audio files under %s are in the beets library "
+                "(%.1f%%, floor %.1f%%)" % (items, files, MUSIC_DIR, percent, floor)
+            )
+            return (200 if covered else 503), report
+
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                status, report = coverage_report()
+                body = json.dumps(report).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, fmt, *args):
+                # A line per health poll, every 5 minutes, forever. No.
+                return
+
+
+        def main():
+            threading.Thread(target=rescan_forever, daemon=True).start()
+            ThreadingHTTPServer(("0.0.0.0", LISTEN_PORT), Handler).serve_forever()
+
+
+        if __name__ == "__main__":
+            main()
+        PY
+        exec python3 -u /tmp/coverage.py
+    ports:
+      # Container side FIXED at 8338 (the script's LISTEN_PORT); only the
+      # host-side publication is operator-configurable, exactly as with the
+      # beets UI port above. `hostIP` pins it to the host loopback — unlike
+      # the UI, nothing outside this box has a reason to reach it, and
+      # ServiceBay's health poller runs on the host.
+      - containerPort: 8338
+        hostPort: {{BEETS_COVERAGE_PORT}}
+        hostIP: 127.0.0.1
+    volumeMounts:
+      # Read-only: this container counts files, it never touches them.
+      - mountPath: /music
+        name: music-data
+        readOnly: true
   volumes:
   - name: beets-config
     hostPath:

--- a/templates/beets/variables.json
+++ b/templates/beets/variables.json
@@ -9,6 +9,16 @@
     "description": "Host port for the beets web UI (library browser). LAN-only — beets' web plugin has no login of any kind, so this service deliberately gets no public subdomain and no SSO. Inside the container beets always serves 8337; this is only where it is published on the host.",
     "default": "8337"
   },
+  "BEETS_COVERAGE_PORT": {
+    "type": "text",
+    "description": "Host port for the library-coverage endpoint the health check reads. Bound to the host loopback only (127.0.0.1) — it is not reachable from the LAN and there is nothing on it a browser wants. Change it only if something else on this box already owns the port.",
+    "default": "8338"
+  },
+  "BEETS_COVERAGE_MIN_PERCENT": {
+    "type": "text",
+    "description": "How much of your music must be in the beets library before the 'Beets library coverage' health check counts as healthy, in percent of the audio files under /music. A percentage rather than a file count on purpose: it keeps meaning the same thing as the collection grows. 100 is rarely reachable — beets skips what it cannot match confidently.",
+    "default": "90"
+  },
   "BEETS_MUSIC_PATH": {
     "type": "text",
     "description": "Host path mounted at /music, read-write. Defaults to the file-share music folder, so anything dropped into the Samba/Syncthing share is what beets tags. beets writes tags into these files in place; on a fresh install it never moves or renames them.",

--- a/templates/home-assistant/CHANGELOG.md
+++ b/templates/home-assistant/CHANGELOG.md
@@ -10,6 +10,50 @@ operator's installed schema-version and the current one and surfaces
 them in the re-deploy dialog. Each `(breaking)` section needs an
 explicit acknowledgement before the deploy can proceed.
 
+## v8 — #2573
+
+**The reverse-proxy trust list moved out of `configuration.yaml` and into
+Home Assistant's own HTTP config store.**
+
+No action required — the deploy does it for you. This section exists
+because the change rewrites a file you may have edited.
+
+Home Assistant 2026.8 moved the `http:` integration out of YAML into its
+own store (Settings → System → Network). It imports an existing `http:`
+block once, then **ignores** the YAML and raises a permanent repair issue,
+*"HTTP YAML configuration is ignored after migration"*, for as long as the
+block is still in the file. ServiceBay both rendered that block into
+`configuration.yaml` and re-appended it from a pre-start hook on every
+deploy, so deleting it as the repair issue asked never stuck — it came
+back on the next deploy.
+
+What the deploy does now:
+
+* Sets `use_x_forwarded_for` + the trusted-proxy CIDRs through HA's own
+  `http/config/configure` websocket command, then **promotes** the result.
+  The promote matters: HA applies a new HTTP config as a five-minute trial
+  that reverts itself unless an admin confirms it, so an unattended import
+  would silently lose the trust list.
+* Removes the now-ignored `http:` block from `configuration.yaml` — but
+  only after HA's store is confirmed to carry the trust list, never before.
+  The whole file is backed up once to `configuration.yaml.pre-http-migration.bak`
+  first, in case you had your own settings (SSL paths, CORS, ban policy)
+  under that key. HA already imported those into the store; the backup is
+  there so you can read them back.
+* Leaves your migrated settings alone on every later deploy. If the store
+  already trusts the proxy, nothing is written and HA is not restarted.
+
+A Home Assistant older than 2026.8 has no store to write to. There the
+`http:` block stays in `configuration.yaml` and is still re-added when
+missing — the deploy asks the running HA which era it is on rather than
+guessing.
+
+If the deploy cannot reach HA's config API (no admin token on the box), it
+says so and changes nothing. Set it yourself under **Settings → System →
+Network → HTTP server**: turn on *Trust X-Forwarded-For* and add
+`127.0.0.1/32`, `192.168.0.0/16`, `10.0.0.0/8`, `172.16.0.0/12` to
+*Trusted proxies*.
+
 ## v7 (breaking) — #2416
 
 **Z-Wave and Matter admin/control ports bound to loopback — no longer

--- a/templates/home-assistant/configuration.yaml.mustache
+++ b/templates/home-assistant/configuration.yaml.mustache
@@ -1,12 +1,20 @@
 # Home Assistant base config. ServiceBay writes this once on first
 # install. Edit freely afterwards — re-deploys don't overwrite.
 #
+# Reverse-proxy trust list: deliberately NOT here. Home Assistant
+# 2026.8 moved the `http:` integration out of YAML and into its own
+# store (Settings → System → Network), and raises a permanent repair
+# issue — "HTTP YAML configuration is ignored after migration" — for
+# as long as an `http:` block is still in this file. ServiceBay now
+# sets `use_x_forwarded_for` + `trusted_proxies` through HA's own
+# `http/config/configure` websocket command from post-deploy.py
+# instead, so the setting lands where HA actually reads it and the
+# repair issue stays cleared (#2573).
+#
 # Backup-restore caveat: when you restore a HA backup, the snapshot's
-# own configuration.yaml replaces this file. Re-add an `http:` block
-# with `use_x_forwarded_for: true` and the trusted-proxy CIDRs below,
-# otherwise NPM-proxied requests fail with HTTP 400 "request from
-# reverse proxy but HTTP integration is not set up for reverse
-# proxies".
+# own configuration.yaml replaces this file — but the HTTP settings
+# live in `.storage/http`, not here, so the trust list survives. The
+# `auth_oidc:` block below does not; post-deploy.py re-appends it.
 
 # Loads default set of integrations. Do not remove.
 default_config:
@@ -21,18 +29,6 @@ default_config:
 automation: !include automations.yaml
 script: !include scripts.yaml
 scene: !include scenes.yaml
-
-# Reverse-proxy trust list. NPM (on the same host) forwards
-# X-Forwarded-For for every proxied request. Trusting the private
-# RFC1918 ranges + loopback works regardless of which LAN subnet
-# ServiceBay sits on — no per-install variable injection needed.
-http:
-  use_x_forwarded_for: true
-  trusted_proxies:
-    - 127.0.0.1
-    - 192.168.0.0/16
-    - 10.0.0.0/8
-    - 172.16.0.0/12
 
 # OIDC auth via the `auth_oidc` custom component (installed by
 # post-deploy.py from a pinned tarball — see HA_OIDC_AUTH_VERSION).

--- a/templates/home-assistant/post-deploy.py
+++ b/templates/home-assistant/post-deploy.py
@@ -33,12 +33,19 @@ Responsibilities:
      provider, so this is the bridge. Idempotent via a `.sb_installed_version`
      stamp; only re-downloads + extracts when HA_OIDC_AUTH_VERSION changes.
 
+  4. **Reverse-proxy trust list** — sets `use_x_forwarded_for` +
+     `trusted_proxies` through HA's own `http/config/configure` websocket
+     command, then removes the migrated `http:` block from configuration.yaml
+     (#2573). HA 2026.8 moved that setting into its own store and nags with a
+     permanent repair issue for as long as the YAML block is still around.
+
 Idempotent overall: safe to re-run on every deploy.
 """
 
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import os
 import re
@@ -474,11 +481,13 @@ def _ha_config_dir() -> str:
 # A HA backup-restore replaces ServiceBay's base configuration.yaml with the
 # snapshot's own, which carries the user's content but NOT ServiceBay's
 # `auth_oidc:` SSO block — so the "Sign in with Authelia" button disappears
-# and SSO breaks. The trusted_proxies (`http:`) self-heal lives in TS
-# (serviceLifecycle's runHomeAssistantHook), but auth_oidc needs the rendered
-# HA_OIDC_SECRET / group / domain values, which only exist here in the
-# post-deploy env. We re-append the block when the file has no `auth_oidc:`
-# key — coexisting with the restored user config rather than overwriting it.
+# and SSO breaks. It has to be re-added here rather than from the TS pre-start
+# hook (serviceLifecycle's runHomeAssistantHook) because it needs the rendered
+# HA_OIDC_SECRET / group / domain values, which only exist in the post-deploy
+# env. We re-append the block when the file has no `auth_oidc:` key —
+# coexisting with the restored user config rather than overwriting it.
+# (The reverse-proxy trust list is a separate story since #2573 — see
+# "Reverse-proxy trust list via HA's own HTTP config store" further down.)
 
 
 def _build_auth_oidc_block() -> str | None:
@@ -1145,6 +1154,366 @@ def configure_oscar_ha_onboarding() -> None:
         log(f"✅ HA admin '{username}' created + long-lived token persisted.")
 
 
+# ── Reverse-proxy trust list via HA's own HTTP config store (#2573) ──────────
+#
+# Home Assistant 2026.8 moved the `http:` integration out of configuration.yaml
+# into its own store (`<config>/.storage/http`, surfaced as Settings → System →
+# Network). On the first start after that upgrade HA imports an existing `http:`
+# block; from then on the YAML is IGNORED, and a permanent repair issue —
+# "HTTP YAML configuration is ignored after migration" — tells the operator to
+# delete it. ServiceBay used to render that block from
+# configuration.yaml.mustache AND re-append it from the pre-start hook on every
+# deploy, so the operator could delete it but never make the warning stay gone.
+#
+# Two things make "just stop writing the block" wrong on its own, which is why
+# this section exists rather than a one-line deletion:
+#
+#   1. A FRESH install with no `http:` block gets HA's DEFAULT http config —
+#      `use_x_forwarded_for` off, empty `trusted_proxies` — and HA then rejects
+#      every NPM-proxied request outright. Something has to put the trust list
+#      into the store.
+#   2. HA's own YAML import is not that something. It stages the imported
+#      config in the store's PENDING slot and schedules an auto-revert five
+#      minutes later unless an admin PROMOTES it. Unattended, the trust list
+#      silently reverts. Promotion is the part only an authenticated client
+#      can do — which is exactly what we are.
+#
+# We drive HA's own websocket commands (`http/config`, `http/config/configure`,
+# `http/config/promote`) instead of hand-editing `.storage/http`: HA holds that
+# store in memory and rewrites it on its own schedule, so a file written under
+# a running instance is both raced and version-unaware. Vehicle is the same one
+# the long-lived-token mint above already uses — a tiny `websockets` client run
+# inside HA's container, which ships the library as its own dependency.
+
+# Loopback + the RFC1918 ranges. NPM runs on this same host and forwards
+# X-Forwarded-For for every proxied request; trusting the private ranges works
+# on any LAN subnet, so no per-install variable injection is needed. HA
+# normalises each entry through `ipaddress.ip_network`, which REQUIRES a
+# network address (10.0.0.0/8), never a host address (10.1.2.3/8).
+HA_TRUSTED_PROXIES = [
+    "127.0.0.1/32",
+    "192.168.0.0/16",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+]
+# Bookkeeping HA adds to a stored config. `HTTP_STORAGE_SCHEMA` rejects unknown
+# keys, so these must be stripped before a config read from the store is handed
+# back to `http/config/configure`.
+HA_HTTP_META_KEYS = ("created_at", "error", "error_message")
+
+
+def _persisted_ha_token() -> str:
+    """The long-lived access token `configure_oscar_ha_onboarding` persists,
+    or "" when this box was set up without admin credentials."""
+    path = os.path.join(_ha_config_dir(), HA_LONG_LIVED_TOKEN_PATH.lstrip("/"))
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read().strip()
+    except OSError:
+        return ""
+
+
+def _ha_ws_commands(token: str, commands: list[dict], timeout: int = 30) -> list[dict] | None:
+    """Run `commands` against HA's websocket API from inside HA's own container
+    and return one result envelope per command, or None if the call could not
+    be made at all.
+
+    The close handshake is deliberately swallowed: `http/config/configure`
+    answers and *then* restarts HA, so the socket often dies right after the
+    result we care about has already arrived."""
+    script = (
+        "import asyncio, json, os, sys, websockets\n"
+        "async def run(ws, cmds):\n"
+        "    out = []\n"
+        "    await ws.recv()  # auth_required hello\n"
+        "    await ws.send(json.dumps({'type': 'auth', 'access_token': os.environ['ACCESS']}))\n"
+        "    a = json.loads(await ws.recv())\n"
+        "    if a.get('type') != 'auth_ok':\n"
+        "        raise SystemExit('auth fail: ' + json.dumps(a))\n"
+        "    for i, cmd in enumerate(cmds, start=1):\n"
+        "        await ws.send(json.dumps(dict(cmd, id=i)))\n"
+        "        while True:\n"
+        "            r = json.loads(await ws.recv())\n"
+        "            if r.get('id') == i and r.get('type') == 'result':\n"
+        "                out.append(r)\n"
+        "                break\n"
+        "    return out\n"
+        "async def main():\n"
+        "    cmds = json.loads(os.environ['SB_WS_COMMANDS'])\n"
+        "    ws = await websockets.connect('ws://127.0.0.1:8123/api/websocket')\n"
+        "    try:\n"
+        "        out = await run(ws, cmds)\n"
+        "    finally:\n"
+        "        try:\n"
+        "            await ws.close()\n"
+        "        except Exception:\n"
+        "            pass\n"
+        "    print(json.dumps(out))\n"
+        "asyncio.run(main())\n"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "podman", "exec",
+                "-e", f"ACCESS={token}",
+                "-e", f"SB_WS_COMMANDS={json.dumps(commands)}",
+                HA_CONTAINER_NAME, "python3", "-c", script,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        log(f"   ⚠️ HA websocket exec failed: {e}")
+        return None
+    if result.returncode != 0:
+        log(f"   ⚠️ HA websocket call exited {result.returncode}: {result.stderr.strip()[:400]}")
+        return None
+    try:
+        parsed = json.loads(result.stdout.strip())
+    except ValueError:
+        log(f"   ⚠️ HA websocket call returned unparseable output: {result.stdout.strip()[:200]}")
+        return None
+    return parsed if isinstance(parsed, list) else None
+
+
+def _ha_ws_call(token: str, command: dict, attempts: int = 3) -> dict | None:
+    """One websocket command, retried while HA reports it is still starting.
+
+    `http/config/configure` refuses with `not_running` until HA has finished
+    coming up — which is common right after a deploy, and is transient. A
+    substantive rejection is returned as-is so the caller can report it."""
+    envelope: dict | None = None
+    for attempt in range(attempts):
+        if attempt:
+            time.sleep(HA_READY_INTERVAL)
+        results = _ha_ws_commands(token, [command])
+        if not results:
+            continue
+        envelope = results[0]
+        if envelope.get("success"):
+            return envelope
+        if (envelope.get("error") or {}).get("code") == "not_running":
+            continue
+        return envelope
+    return envelope
+
+
+def _normalise_networks(values: object) -> set[str]:
+    """Canonical `ipaddress` form of each entry, so `127.0.0.1` and
+    `127.0.0.1/32` compare equal — HA stores the latter."""
+    out: set[str] = set()
+    if not isinstance(values, list):
+        return out
+    for value in values:
+        try:
+            out.add(str(ipaddress.ip_network(value, strict=False)))
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
+def _http_config_trusts_proxies(conf: object) -> bool:
+    """True iff `conf` would let HA accept an NPM-proxied request AND read the
+    real client address out of X-Forwarded-For."""
+    if not isinstance(conf, dict) or not conf.get("use_x_forwarded_for"):
+        return False
+    return _normalise_networks(HA_TRUSTED_PROXIES) <= _normalise_networks(conf.get("trusted_proxies"))
+
+
+def _desired_http_config(stable: dict) -> dict:
+    """HA's current stored config plus ServiceBay's trust list. Everything the
+    operator set (port, SSL paths, CORS, ban policy) is carried through
+    untouched, and their own trusted proxies are kept alongside ours — this is
+    an addition to their config, not a replacement of it."""
+    desired = {k: v for k, v in stable.items() if k not in HA_HTTP_META_KEYS}
+    desired["use_x_forwarded_for"] = True
+    desired["trusted_proxies"] = sorted(
+        _normalise_networks(desired.get("trusted_proxies")) | _normalise_networks(HA_TRUSTED_PROXIES)
+    )
+    return desired
+
+
+def ensure_http_trusted_proxies() -> str:
+    """Make HA's *stored* HTTP config trust ServiceBay's reverse proxy.
+
+    Verdicts:
+      "ok"          — the store carries the trust list (already did, or now does)
+      "unsupported" — this HA predates the 2026.8 store; configuration.yaml still rules
+      "skipped"     — no usable admin token; only the operator can set it
+      "failed"      — HA has the store but we could not write it
+    """
+    token = _persisted_ha_token()
+    if not token:
+        log("   No HA long-lived token on disk — cannot reach HA's HTTP config API.")
+        return "skipped"
+
+    probe = _ha_ws_call(token, {"type": "http/config"})
+    if probe is None:
+        return "failed"
+    if not probe.get("success"):
+        error = probe.get("error") or {}
+        if error.get("code") in ("unknown_command", "invalid_format"):
+            log("   This Home Assistant predates the 2026.8 HTTP config store — "
+                "configuration.yaml is still the only place the trust list can live.")
+            return "unsupported"
+        if error.get("code") == "unauthorized":
+            log("   The persisted HA token is not an admin token — cannot set the HTTP config.")
+            return "skipped"
+        log(f"   ⚠️ HA rejected http/config: {error}")
+        return "failed"
+
+    result = probe.get("result") or {}
+    stable = result.get("stable") or {}
+    pending = result.get("pending")
+
+    if _http_config_trusts_proxies(stable):
+        # The steady state on every deploy after the first: already correct AND
+        # already confirmed, so we touch nothing and HA is not restarted.
+        log("✅ HA's stored HTTP config already trusts the reverse proxy — leaving it alone.")
+        return "ok"
+
+    if result.get("active_config_type") == "pending" and _http_config_trusts_proxies(pending):
+        # HA imported the old YAML block into the PENDING slot on this very
+        # start and is counting down to an auto-revert. Confirm what it
+        # imported rather than writing a second config — one restart fewer,
+        # and the operator's own imported values are preserved exactly.
+        promote = _ha_ws_call(token, {"type": "http/config/promote"})
+        if promote and promote.get("success"):
+            log("✅ Confirmed HA's imported HTTP config (it would have auto-reverted in 5 minutes).")
+            return "ok"
+        log(f"   ⚠️ Could not promote HA's pending HTTP config: {promote}")
+        return "failed"
+
+    log("Setting HA's reverse-proxy trust list through its own HTTP config API...")
+    configured = _ha_ws_call(token, {"type": "http/config/configure", "config": _desired_http_config(stable)})
+    if not configured or not configured.get("success"):
+        log(f"   ⚠️ HA rejected the HTTP config: {configured}")
+        return "failed"
+    if (configured.get("result") or {}).get("restart"):
+        # HA applies a new HTTP config by restarting into it, as a five-minute
+        # trial. Wait for it back, then promote — an unpromoted trial reverts.
+        if not _wait_ha_ready():
+            log("   ⚠️ HA did not come back after the HTTP config restart — the new config auto-reverts.")
+            return "failed"
+    promote = _ha_ws_call(token, {"type": "http/config/promote"})
+    if not promote or not promote.get("success"):
+        log(f"   ⚠️ HA took the trust list but promoting it failed — it auto-reverts in 5 minutes: {promote}")
+        return "failed"
+    log("✅ HA now trusts ServiceBay's reverse proxy (stored in HA, not in configuration.yaml).")
+    return "ok"
+
+
+def _find_top_level_block(lines: list[str], key: str) -> tuple[int, int] | None:
+    """Span of a top-level `<key>:` block as (start, end-exclusive) line
+    indices, or None when the key is absent. `start` reaches back over the
+    contiguous comment paragraph directly above the key so the block's own
+    explanation goes with it; trailing blank lines are left in place."""
+    for i, line in enumerate(lines):
+        if not re.match(rf"^{re.escape(key)}:(\s|$)", line):
+            continue
+        end = i + 1
+        while end < len(lines) and (not lines[end].strip() or lines[end][:1] in (" ", "\t")):
+            end += 1
+        while end > i + 1 and not lines[end - 1].strip():
+            end -= 1
+        start = i
+        while start > 0 and lines[start - 1].lstrip().startswith("#"):
+            start -= 1
+        return start, end
+    return None
+
+
+def remove_legacy_http_yaml_block(cfg_path: str) -> bool:
+    """Delete a migrated top-level `http:` block from configuration.yaml.
+
+    This is precisely the step HA's repair issue asks the operator to perform;
+    doing it here is what makes the warning stay gone across deploys. Only ever
+    called once HA's own store is CONFIRMED to carry the trust list, so it can
+    never remove the only copy of the setting — and the whole file is backed up
+    once before the first edit, because an operator may have put their own
+    settings (SSL paths, CORS, ban policy) under that key. HA already imported
+    those into the store; the backup is there in case they want to read them
+    back. Returns True iff the block was just removed."""
+    try:
+        with open(cfg_path, encoding="utf-8") as fh:
+            lines = fh.read().splitlines(keepends=True)
+    except OSError:
+        return False
+    span = _find_top_level_block(lines, "http")
+    if span is None:
+        return False
+    start, end = span
+    backup = cfg_path + ".pre-http-migration.bak"
+    try:
+        if not os.path.exists(backup):
+            shutil.copy2(cfg_path, backup)
+        with open(cfg_path, "w", encoding="utf-8") as fh:
+            fh.writelines(lines[:start] + lines[end:])
+    except OSError as exc:
+        log(f"   ⚠️ Could not remove the migrated http: block from {cfg_path}: {exc}")
+        return False
+    log(f"   Removed the migrated `http:` block from configuration.yaml — HA reads the "
+        f"trust list from its own store now. Backup: {backup}")
+    return True
+
+
+def ensure_legacy_http_yaml_block(cfg_path: str) -> bool:
+    """Re-add the pre-2026.8 `http:` block.
+
+    ONLY for a Home Assistant too old to have the HTTP config store. There,
+    configuration.yaml is still the only place the trust list can live, and a
+    backup-restore that replaced the file would otherwise leave every proxied
+    request rejected. This is the last remaining caller of the old self-heal
+    that used to run unconditionally from the pre-start hook — it lives here
+    now because only a *running* HA can tell us which era it is from."""
+    try:
+        with open(cfg_path, encoding="utf-8") as fh:
+            content = fh.read()
+    except OSError:
+        return False
+    if re.search(r"(?m)^http:", content):
+        return False
+    block = "\n".join([
+        "",
+        "# Re-added by ServiceBay: NPM forwards X-Forwarded-For; this Home",
+        "# Assistant predates the 2026.8 HTTP config store, so the trust list",
+        "# still has to live here. It is removed automatically once HA is new",
+        "# enough to keep it in its own store (#2573).",
+        "http:",
+        "  use_x_forwarded_for: true",
+        "  trusted_proxies:",
+    ] + [f"    - {proxy}" for proxy in HA_TRUSTED_PROXIES])
+    try:
+        with open(cfg_path, "a", encoding="utf-8") as fh:
+            fh.write(block + "\n")
+    except OSError as exc:
+        log(f"   ⚠️ Could not re-add the http: block to {cfg_path}: {exc}")
+        return False
+    log("   Re-added the http: trusted_proxies block (pre-2026.8 Home Assistant).")
+    return True
+
+
+def configure_http_trusted_proxies() -> None:
+    """Put ServiceBay's reverse-proxy trust list wherever this HA reads it
+    from, and leave exactly one copy behind."""
+    cfg_path = os.path.join(_ha_config_dir(), "configuration.yaml")
+    verdict = ensure_http_trusted_proxies()
+    if verdict == "ok":
+        remove_legacy_http_yaml_block(cfg_path)
+        return
+    if verdict == "unsupported":
+        ensure_legacy_http_yaml_block(cfg_path)
+        return
+    # Neither path is safe to act on: we could not read HA's store, so we do
+    # NOT touch configuration.yaml — leaving an existing block in place is the
+    # conservative choice even though it keeps HA's repair warning up.
+    log("⚠️ Could not set HA's reverse-proxy trust list. Proxied access may report the "
+        "proxy's own address, or be rejected outright. Set it under Settings → System → "
+        "Network → HTTP server: turn on 'Trust X-Forwarded-For' and add "
+        f"{', '.join(HA_TRUSTED_PROXIES)} to 'Trusted proxies'.")
+
+
 def _strip_first_component(member_path: str) -> str | None:
     """Tarballs from GitHub release tags are wrapped in a top-level
     directory like `hass-oidc-auth-0.6.0/`. We unwrap that prefix and
@@ -1440,8 +1809,12 @@ def main() -> int:
     report_orphaned_helpers()
     if _wait_ha_ready():
         configure_oscar_ha_onboarding()
+        # Needs a running HA and the token the onboarding above persists, so it
+        # runs last (#2573).
+        configure_http_trusted_proxies()
     else:
-        log("⚠️ HA did not become reachable in time — skipping OSCAR onboarding.")
+        log("⚠️ HA did not become reachable in time — skipping OSCAR onboarding "
+            "and the reverse-proxy trust list.")
 
     # ── Health check ─────────────────────────────────────────────────────────
     # Worked example for docs/TEMPLATE_AUTHORING.md § Health checks.

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -9,7 +9,7 @@ metadata:
     # v7 (#2416): every admin/control port in this pod except Home
     # Assistant's own 8123 is bound to the host loopback. No data move;
     # requires a re-deploy so podman recreates the pod from this manifest.
-    servicebay.schema-version: "7"
+    servicebay.schema-version: "8"
     # Home Assistant is reached at home.<domain> via nginx and
     # authenticates via Authelia.
     servicebay.dependencies: "nginx,auth"

--- a/templates/mosquitto/README.md
+++ b/templates/mosquitto/README.md
@@ -53,7 +53,28 @@ networking, which a hardcoded IP does not.
 
 ## Connecting Home Assistant
 
-Settings → Devices & Services → **Add integration** → MQTT:
+**Nothing to do.** If Home Assistant is installed on this box, deploying
+mosquitto sets its MQTT integration up for you — broker
+`host.containers.internal`, the port above, and the credentials ServiceBay just
+generated. Changing the broker password later and deploying again carries the
+change over to Home Assistant too, so its devices do not quietly stop working.
+
+ServiceBay does this through the same interface the Home Assistant UI uses (its
+config-flow API), so Home Assistant validates the settings and tries the broker
+before it accepts them. It never edits Home Assistant's internal files.
+
+Two cases where it stays out of the way:
+
+- **You already set MQTT up by hand.** Your connection is left exactly as it
+  is — never duplicated, never overwritten. If it is already pointing at this
+  broker and connected, ServiceBay simply notes that and keeps its password in
+  step from then on.
+- **Home Assistant is not installed.** Nothing happens and nothing is said. The
+  broker is worth running on its own; there is no dependency in either
+  direction.
+
+If you do need to enter it manually — Settings → Devices & Services → **Add
+integration** → MQTT:
 
 ```
 Broker  : host.containers.internal

--- a/templates/mosquitto/README.md
+++ b/templates/mosquitto/README.md
@@ -27,6 +27,14 @@ every MQTT device you will ever add.
 Both credentials appear in the **SAVE-THESE-NOW** banner (and the Bitwarden CSV)
 right after install. You need them again for every device you add, so save them.
 
+Both are generated **device-safe**: letters and digits only, 24 characters. The
+strength is in the length (~142 bits — nothing brute-forces that), not in
+punctuation, because these values have to survive being typed into a smart
+lock's app. Device firmware routinely rejects symbols or silently cuts a long
+password short, and then reports your perfectly correct credentials as *wrong
+username or password*. If you replace them with your own, keep to letters and
+digits and stay around this length.
+
 ## Which host do I enter?
 
 This is the question that eats an evening. There are two right answers,
@@ -142,6 +150,7 @@ credentials are what protects the port.
 |---|---|
 | Service won't start, log says credentials are required | The username or password variable is empty. Re-run the wizard; the broker refuses to start without auth rather than come up open. |
 | Home Assistant: "unable to connect" | Wrong host. From a container it is `host.containers.internal`, not `localhost` — `localhost` inside a container is that container. |
+| Device says the username or password is wrong, but Home Assistant connects with the same ones | Believe the broker, not the device: its log shows `disconnected: not authorised` for that client. The credentials are fine — the device is mangling them, usually by cutting an over-long password short. Give it a shorter, letters-and-digits-only password (24 characters is plenty) and re-enter it everywhere. |
 | Device connects, then drops repeatedly | Two clients using the same client ID. Give each device a unique one. |
 | Device connects but nothing appears in Home Assistant | Discovery is off on the device, or Home Assistant's MQTT integration was added with discovery disabled. |
 | State is wrong or "unknown" right after a reboot | Expected only until the device republishes — if it persists, check that `{{DATA_DIR}}/mosquitto/data` is writable. |

--- a/templates/mosquitto/post-deploy.py
+++ b/templates/mosquitto/post-deploy.py
@@ -4,22 +4,32 @@ post-deploy hook for the `mosquitto` MQTT broker.
 
 The broker's username and password are auto-generated `type: "secret"`
 variables, and they are the only way to connect (anonymous access is off).
-So the one job here is surfacing them: the operator has to type them into
-Home Assistant and into every device, and they never appear anywhere else.
+So the first job here is surfacing them: the operator has to type them into
+every device, and they never appear anywhere else.
 
 Also prints the two addresses that actually work, because "which host do I
 enter?" is the question that eats an evening:
   - LAN devices  -> the box's LAN address
   - on-box containers -> host.containers.internal (ADR 0007 Decision 3)
 
+The second job (#2578) is Home Assistant: if HA is installed on this box, the
+MQTT integration is set up here instead of by hand, and a later password
+rotation is carried over to it. See the section comment further down for why
+that goes through HA's config-flow API and never through its .storage files.
+
 See lib/registry.ts:getTemplatePostDeployScript for the script protocol.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 
 
 def env(key: str, default: str = "") -> str:
@@ -35,6 +45,384 @@ def log(msg: str) -> None:
 def emit_credential(**fields: object) -> None:
     sys.stdout.write("__SB_CREDENTIAL__ " + json.dumps(fields) + "\n")
     sys.stdout.flush()
+
+
+# ── Home Assistant: wire the broker up instead of leaving it to the operator ──
+#
+# WHY THE CONFIG-FLOW API AND NOT `.storage` (the ticket asks for this to be
+# justified, #2578):
+#
+#   Home Assistant keeps integration entries in `<config>/.storage/
+#   core.config_entries`. That file is *not* a configuration file — it is the
+#   serialised form of objects a running HA holds in memory and rewrites on its
+#   own schedule. An entry appended underneath a running instance is overwritten
+#   at the next save at best, and a malformed one stops HA from starting at
+#   worst. It is the classic way to break an HA install.
+#
+#   `POST /api/config/config_entries/flow` is the *same* endpoint HA's own
+#   frontend posts to when a human fills in Settings → Devices & Services →
+#   MQTT. HA validates the input against the integration's own schema, opens a
+#   real connection to the broker before accepting it, writes the entry itself,
+#   and reloads the integration. Nothing here knows the file format, so nothing
+#   here can corrupt it — the worst failure is HA answering "no", which we
+#   report and move on.
+#
+#   The flow is filled in from the form HA hands back (`data_schema`), not from
+#   a payload hard-coded to one HA version: the credentials are laid over HA's
+#   own defaults and suggested values. On a reconfigure that means every setting
+#   the operator made (TLS, transport, keepalive, client id) is carried through
+#   untouched, and on an HA whose form has different fields we still send a form
+#   it accepts.
+
+HA_API = "http://127.0.0.1:8123"
+# HA's pod mounts `{{DATA_DIR}}/home-assistant/homeassistant` onto /config —
+# the same path templates/home-assistant/post-deploy.py resolves.
+HA_CONFIG_SUBPATH = ("home-assistant", "homeassistant")
+# The long-lived admin token HA's own post-deploy mints and persists, newest
+# name first. The older names are still on boxes that were onboarded before the
+# renames and have not re-deployed HA since (see HA_LEGACY_LONG_LIVED_TOKEN_PATHS
+# in templates/home-assistant/post-deploy.py).
+HA_TOKEN_FILENAMES = (
+    ".solaris-long-lived-token",
+    ".solilos-long-lived-token",
+    ".oscar-long-lived-token",
+)
+# ADR 0007 Decision 3: on-box containers address each other by this name, never
+# by a LAN IP that a router hands out differently after a reinstall.
+HA_BROKER_HOST = "host.containers.internal"
+HA_REQUEST_TIMEOUT = 20.0
+HA_READY_ATTEMPTS = 10
+HA_READY_INTERVAL = 3.0
+# Fields HA marks required but gives no default or suggestion for. They only
+# apply to a *fresh* entry — on a reconfigure HA suggests the entry's current
+# values and those win, so an operator's TLS setup is never switched off here.
+# Both answers describe this broker exactly: plain TCP, no certificates.
+HA_FLOW_FALLBACKS: dict[str, object] = {"set_ca_cert": "off", "set_client_cert": False}
+# Where we remember which MQTT entry is ours. Deliberately beside the broker's
+# data dir rather than inside it: it is ServiceBay bookkeeping, not broker state.
+HA_LINK_FILENAME = ".home-assistant-link.json"
+
+
+def _data_dir() -> str:
+    return env("DATA_DIR", "/mnt/data")
+
+
+def _ha_config_dir() -> str:
+    return os.path.join(_data_dir(), *HA_CONFIG_SUBPATH)
+
+
+def _ha_token() -> str:
+    """HA's persisted long-lived admin token, or "" when this box has none."""
+    for name in HA_TOKEN_FILENAMES:
+        try:
+            with open(os.path.join(_ha_config_dir(), name), encoding="utf-8") as fh:
+                token = fh.read().strip()
+        except OSError:
+            continue
+        if token:
+            return token
+    return ""
+
+
+def _ha_request(
+    token: str,
+    path: str,
+    payload: object | None = None,
+    method: str | None = None,
+) -> tuple[int, object]:
+    """One call to HA's REST API. Returns (status, parsed body). Status 0 means
+    HA could not be reached at all; the body is then the error text."""
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {"Authorization": f"Bearer {token}"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(HA_API + path, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=HA_REQUEST_TIMEOUT) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as exc:
+        try:
+            return exc.code, json.loads(exc.read())
+        except (ValueError, OSError):
+            return exc.code, {}
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        return 0, str(exc)
+
+
+def _ha_mqtt_entries(token: str) -> tuple[int, list]:
+    """MQTT config entries as HA reports them. Retried while HA is still coming
+    up — installing both services at once puts this script in front of an HA
+    that is not answering yet, which is transient, not a failure."""
+    status: int = 0
+    body: object = ""
+    for attempt in range(HA_READY_ATTEMPTS):
+        if attempt:
+            time.sleep(HA_READY_INTERVAL)
+        status, body = _ha_request(token, "/api/config/config_entries/entry?domain=mqtt")
+        if status == 200 and isinstance(body, list):
+            return status, body
+        if status not in (0, 502, 503):
+            break
+    return status, []
+
+
+def _form_payload(fields: object, overrides: dict[str, object]) -> dict[str, object]:
+    """Fill in the form HA just handed us.
+
+    `fields` is HA's serialised `data_schema`. Each entry carries its own name,
+    whether it is required, its default, and — on a reconfigure — the entry's
+    current value as `description.suggested_value`. Filling the form from that
+    is what keeps this version-agnostic and non-destructive: we answer only the
+    questions HA asked, we answer them with HA's own values, and we override
+    exactly the four that describe this broker."""
+    payload: dict[str, object] = {}
+    for field in fields if isinstance(fields, list) else []:
+        if not isinstance(field, dict):
+            continue
+        name = field.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        if field.get("type") == "expandable":
+            # A collapsed section (HA 2026.8+ puts the advanced broker settings
+            # in one). It is a required key with no default of its own, so it
+            # has to be sent even when everything inside it is optional.
+            nested = _form_payload(field.get("schema"), overrides)
+            if nested or field.get("required"):
+                payload[name] = nested
+            continue
+        if name in overrides:
+            payload[name] = overrides[name]
+            continue
+        suggested = field.get("description")
+        if isinstance(suggested, dict) and suggested.get("suggested_value") is not None:
+            payload[name] = suggested["suggested_value"]
+            continue
+        if "default" in field:
+            payload[name] = field["default"]
+            continue
+        if field.get("required") and name in HA_FLOW_FALLBACKS:
+            payload[name] = HA_FLOW_FALLBACKS[name]
+    return payload
+
+
+def _flow_error(result: object) -> str:
+    """The most specific thing HA said about why it refused the form."""
+    if not isinstance(result, dict):
+        return str(result)[:200]
+    for key in ("errors", "reason", "message"):
+        value = result.get(key)
+        if value:
+            return json.dumps(value) if not isinstance(value, str) else value
+    return json.dumps(result)[:200]
+
+
+def _submit_broker_form(token: str, start: dict, overrides: dict[str, object]) -> tuple[str, object]:
+    """Answer the broker form of an already-started flow.
+
+    Returns (outcome, detail) where outcome is "created" (detail = entry id),
+    "updated", or "failed" (detail = what HA said)."""
+    flow_id = start.get("flow_id")
+    payload = _form_payload(start.get("data_schema"), overrides)
+    status, result = _ha_request(token, f"/api/config/config_entries/flow/{flow_id}", payload)
+    if status != 200 or not isinstance(result, dict):
+        _abort_flow(token, flow_id)
+        return "failed", _flow_error(result)
+    kind = result.get("type")
+    if kind == "create_entry":
+        entry = result.get("result")
+        entry_id = entry.get("entry_id") if isinstance(entry, dict) else None
+        return "created", entry_id
+    if kind == "abort" and result.get("reason") == "reconfigure_successful":
+        return "updated", None
+    # A form back means HA tried the broker and did not like the answer
+    # (`cannot_connect`, `invalid_auth`); anything else is an abort we did not
+    # ask for. Either way the flow stays open in HA's UI unless we close it.
+    _abort_flow(token, flow_id)
+    return "failed", _flow_error(result)
+
+
+def _abort_flow(token: str, flow_id: object) -> None:
+    if isinstance(flow_id, str) and flow_id:
+        _ha_request(token, f"/api/config/config_entries/flow/{flow_id}", method="DELETE")
+
+
+def _entry_points_at_this_broker(token: str, entry_id: str, port: int) -> bool:
+    """True when HA's own diagnostics say this entry is connected to *our*
+    broker: same host, same port, connection live.
+
+    Read-only, and the values are HA's, not a guess from a file we do not own.
+    MQTT's diagnostics redact the username and password, which is the point —
+    we never need them: the broker accepts exactly one account, so an entry that
+    is *connected* to it is by definition using the credentials below.
+
+    That inference holds because of *when* we ask. This deploy replaced the
+    broker pod, which dropped every client; HA reconnects within seconds from
+    its stored credentials, and cannot if they are stale. So "connected" here is
+    evidence about the credentials as they are now, not as they were. If HA has
+    not finished reconnecting yet we simply get False and leave the entry alone
+    — the safe direction, and the next deploy looks again."""
+    status, body = _ha_request(token, f"/api/diagnostics/config_entry/{entry_id}")
+    if status != 200 or not isinstance(body, dict):
+        return False
+    data = body.get("data")
+    if not isinstance(data, dict) or data.get("connected") is not True:
+        return False
+    mqtt_config = data.get("mqtt_config")
+    config = mqtt_config.get("data") if isinstance(mqtt_config, dict) else None
+    if not isinstance(config, dict) or config.get("broker") != HA_BROKER_HOST:
+        return False
+    try:
+        return int(config.get("port")) == port
+    except (TypeError, ValueError):
+        return False
+
+
+def _link_path() -> str:
+    return os.path.join(_data_dir(), "mosquitto", HA_LINK_FILENAME)
+
+
+def _read_link() -> dict:
+    try:
+        with open(_link_path(), encoding="utf-8") as fh:
+            link = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    return link if isinstance(link, dict) else {}
+
+
+def _write_link(entry_id: str, fingerprint: str) -> None:
+    path = _link_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump({"entry_id": entry_id, "fingerprint": fingerprint}, fh)
+    except OSError as exc:
+        log(f"   ⚠️ Could not record the Home Assistant link at {path}: {exc}")
+        log("      MQTT works; a later password change just won't be carried over on its own.")
+
+
+def _fingerprint(broker: str, port: int, username: str, password: str) -> str:
+    """A short digest of the connection settings, used only to notice that they
+    changed since we last pushed them.
+
+    Truncated on purpose: 64 bits is far more than enough to tell two settings
+    apart, and short enough that the stored value is not a usable handle on the
+    password it was derived from."""
+    material = f"servicebay-mqtt-ha-link:v1|{broker}|{port}|{username}|{password}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+def configure_home_assistant(username: str, password: str, port: int) -> str:
+    """Set up (or update) HA's MQTT integration for this broker.
+
+    Verdicts:
+      "absent"    — no Home Assistant on this box; nothing was said or done
+      "skipped"   — HA is here but unreachable / no admin token; operator's job
+      "created"   — HA had no MQTT integration and now has one
+      "updated"   — ours was there and now carries the current credentials
+      "unchanged" — ours was there and already correct
+      "adopted"   — the operator's own connection is to this broker and live;
+                    recorded so a later rotation follows it, nothing written
+      "external"  — an MQTT integration we did not create; left exactly as is
+      "failed"    — HA has an MQTT integration flow but refused what we sent
+    """
+    if not os.path.isdir(_ha_config_dir()):
+        # No Home Assistant here. The ticket is explicit that this case must be
+        # silent: MQTT is worth running on its own and a note about a service
+        # the operator never installed is noise.
+        return "absent"
+
+    token = _ha_token()
+    if not token:
+        # Happens when HA and mosquitto are installed in the same run: HA's own
+        # post-deploy mints this token, and it may not have run yet.
+        log("ℹ️ Home Assistant is here but ServiceBay has no admin token for it yet, so its MQTT")
+        log("   integration was left alone. Deploying mosquitto again once Home Assistant has")
+        log("   finished setting itself up connects it; until then: Settings → Devices & Services")
+        log(f"   → MQTT, broker {HA_BROKER_HOST}, port {port}, with the credentials above.")
+        return "skipped"
+
+    status, entries = _ha_mqtt_entries(token)
+    if status != 200:
+        reason = ("its token is not accepted" if status in (401, 403)
+                  else f"it did not answer (HTTP {status})")
+        log(f"ℹ️ Home Assistant's MQTT integration was left alone — {reason}.")
+        log("   Deploying mosquitto again wires it in; nothing here is broken.")
+        return "skipped"
+
+    fingerprint = _fingerprint(HA_BROKER_HOST, port, username, password)
+    overrides: dict[str, object] = {
+        "broker": HA_BROKER_HOST,
+        "port": port,
+        "username": username,
+        "password": password,
+    }
+    link = _read_link()
+    entry = entries[0] if entries else None
+
+    if entry is None:
+        start_status, start = _ha_request(
+            token,
+            "/api/config/config_entries/flow",
+            {"handler": "mqtt", "show_advanced_options": True},
+        )
+        if start_status != 200 or not isinstance(start, dict) or start.get("type") != "form":
+            log(f"   ⚠️ Home Assistant would not open the MQTT setup form: {_flow_error(start)}")
+            return "failed"
+        outcome, detail = _submit_broker_form(token, start, overrides)
+        if outcome != "created":
+            log(f"   ⚠️ Home Assistant refused the broker settings: {detail}")
+            log("      Nothing was changed in HA. The credentials above still work by hand.")
+            return "failed"
+        if isinstance(detail, str) and detail:
+            _write_link(detail, fingerprint)
+        log("🏠 Home Assistant is now connected to this broker — no manual step needed.")
+        return "created"
+
+    entry_id = entry.get("entry_id") if isinstance(entry, dict) else None
+    if not isinstance(entry_id, str):
+        return "failed"
+
+    if link.get("entry_id") != entry_id:
+        # Not ours. #2578 is explicit: an existing connection is detected and
+        # left alone, never duplicated and never overwritten. The one thing we
+        # may do is *recognise* it — if HA's diagnostics say it is live against
+        # this very broker, then it already carries these credentials, so
+        # recording it changes nothing today and means the next rotation is
+        # carried over instead of silently breaking it.
+        if _entry_points_at_this_broker(token, entry_id, port):
+            _write_link(entry_id, fingerprint)
+            log("🏠 Home Assistant is already connected to this broker (you set it up yourself).")
+            log("   Left exactly as it is — ServiceBay will keep its password in step from now on.")
+            return "adopted"
+        title = entry.get("title") if isinstance(entry, dict) else None
+        log(f"🏠 Home Assistant already has an MQTT connection ({title or 'unknown broker'}) that")
+        log("   ServiceBay did not create — left exactly as it is. If it should point here, edit it")
+        log("   under Settings → Devices & Services → MQTT with the credentials above.")
+        return "external"
+
+    if link.get("fingerprint") == fingerprint:
+        log("🏠 Home Assistant's MQTT connection is already up to date.")
+        return "unchanged"
+
+    start_status, start = _ha_request(
+        token,
+        "/api/config/config_entries/flow",
+        {"handler": "mqtt", "entry_id": entry_id, "show_advanced_options": True},
+    )
+    if start_status != 200 or not isinstance(start, dict) or start.get("type") != "form":
+        log(f"   ⚠️ Home Assistant would not open the MQTT reconfigure form: {_flow_error(start)}")
+        return "failed"
+    outcome, detail = _submit_broker_form(token, start, overrides)
+    if outcome != "updated":
+        log(f"   ⚠️ Home Assistant refused the new broker settings: {detail}")
+        log("      Its MQTT connection is unchanged and may now be using the old password —")
+        log("      update it under Settings → Devices & Services → MQTT with the credentials above.")
+        return "failed"
+    _write_link(entry_id, fingerprint)
+    log("🏠 Home Assistant's MQTT connection was updated to the current credentials.")
+    return "updated"
 
 
 def main() -> int:
@@ -57,7 +445,7 @@ def main() -> int:
 
     log(f"📡 MQTT broker is up on port {port}. Anonymous access is OFF — every client needs the credentials below.")
     log(f"   Devices on the LAN (locks, plugs, sensors, Zigbee bridges): host {lan}, port {port}")
-    log(f"   Home Assistant and other containers on this box:            host host.containers.internal, port {port}")
+    log(f"   Home Assistant and other containers on this box:            host {HA_BROKER_HOST}, port {port}")
     log("   No TLS: use it on a network you trust, and don't reuse this password elsewhere (see the template README).")
 
     emit_credential(
@@ -67,13 +455,20 @@ def main() -> int:
         password=password,
         importance="critical",
         notes=(
-            "Broker credentials. Enter them in Home Assistant's MQTT integration "
-            f"(host host.containers.internal, port {port}) and in every device that "
-            f"publishes here (host {lan}, port {port}). Anonymous access is off, so "
-            "losing these means re-generating them in the wizard and re-entering them "
-            "on every device."
+            "Broker credentials. Home Assistant is connected to this broker "
+            f"automatically when it is installed here (host {HA_BROKER_HOST}, port "
+            f"{port}); every device that publishes here needs them typed in by hand "
+            f"(host {lan}, port {port}). Anonymous access is off, so losing these "
+            "means re-generating them in the wizard and re-entering them on every "
+            "device."
         ),
     )
+
+    try:
+        configure_home_assistant(username, password, int(port))
+    except Exception as exc:  # noqa: BLE001 — the broker is up; never fail the deploy over the wiring
+        log(f"   ⚠️ Could not set up Home Assistant's MQTT integration: {exc}")
+        log("      The broker itself is fine — add it by hand under Settings → Devices & Services.")
     return 0
 
 

--- a/templates/mosquitto/variables.json
+++ b/templates/mosquitto/variables.json
@@ -6,10 +6,12 @@
   },
   "MQTT_USERNAME": {
     "type": "secret",
+    "deviceSafe": true,
     "description": "Broker username. Every client — Home Assistant and each device — sends this. Anonymous access is off, so nothing connects without it. Auto-generated (no guessable default); overwrite it with something you would rather type into a device's app before deploying."
   },
   "MQTT_PASSWORD": {
     "type": "secret",
-    "description": "Broker password for the username above. Auto-generated and surfaced in the credentials banner after install. Stored on the broker only as a hash (mosquitto_passwd), never in cleartext on disk. Do not reuse a password you use elsewhere — the README explains why it travels the LAN unencrypted."
+    "deviceSafe": true,
+    "description": "Broker password for the username above. Auto-generated at a length device firmware accepts, and surfaced in the credentials banner after install. Stored on the broker only as a hash (mosquitto_passwd), never in cleartext on disk. Do not reuse a password you use elsewhere — the README explains why it travels the LAN unencrypted."
   }
 }

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -515,8 +515,12 @@ describe('Home Assistant base configuration.yaml ships the include wiring', () =
     expect(cfg).toMatch(/^script: !include scripts\.yaml$/m);
     expect(cfg).toMatch(/^scene: !include scenes\.yaml$/m);
     // ServiceBay's required wiring is still present on a fresh install.
-    expect(cfg).toMatch(/^http:/m);
     expect(cfg).toMatch(/^auth_oidc:/m);
+    // …but NOT an `http:` block (#2573). HA 2026.8 keeps that setting in its
+    // own store and raises a permanent repair issue while the YAML block
+    // survives, so post-deploy.py sets it via HA's `http/config/configure`
+    // websocket command instead of this file re-seeding it every deploy.
+    expect(cfg).not.toMatch(/^http:/m);
   });
 
   it('every !include target file is shipped so the include never dangles', () => {
@@ -969,8 +973,13 @@ describe('Home Assistant template: Z-Wave and Matter ports are loopback-bound (#
     expect(ha.yamlContent).toMatch(/servicebay\.ports:\s*"8123\/tcp,8091\/tcp,3001\/tcp,5580\/tcp"/);
   });
 
-  it('schema-version is bumped to 7 with a CHANGELOG section and a v6-to-v7 migration', () => {
-    expect(ha.yamlContent).toMatch(/servicebay\.schema-version:\s*"7"/);
+  it('the v6-to-v7 hop stays in place with its CHANGELOG section and migration', () => {
+    // Pinned as "at least 7", not "exactly 7": later hops (v8 = #2573) must be
+    // free to land without re-opening this #2416 guard, but the template can
+    // never fall back below the hop that moved these binds to loopback.
+    const declared = ha.yamlContent.match(/servicebay\.schema-version:\s*"(\d+)"/);
+    expect(declared, 'home-assistant must declare a schema-version').toBeTruthy();
+    expect(Number(declared![1])).toBeGreaterThanOrEqual(7);
     const changelog = fs.readFileSync(
       path.join(TEMPLATES_DIR, 'home-assistant', 'CHANGELOG.md'), 'utf-8',
     );

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -1678,8 +1678,8 @@ describe('Beets template: reachable UI, in-place imports, no unattended rewrite 
     expect(byName['audiobooks-data']).toBe('/mnt/data/stacks/file-share/data/audiobooks');
   });
 
-  it('ships schema-version 2 with a breaking CHANGELOG entry and the v1→v2 migration', () => {
-    expect(beets.yamlContent).toMatch(/servicebay\.schema-version:\s*"2"/);
+  it('ships schema-version 3 with a breaking v2 CHANGELOG entry and the v1→v2 migration', () => {
+    expect(beets.yamlContent).toMatch(/servicebay\.schema-version:\s*"3"/);
     const changelog = fs.readFileSync(path.join(TEMPLATES_DIR, 'beets', 'CHANGELOG.md'), 'utf-8');
     // Breaking, so the wizard gates the deploy on an acknowledgement — the
     // right place for "this will touch your music" to reach a human.
@@ -1696,12 +1696,96 @@ describe('Beets template: reachable UI, in-place imports, no unattended rewrite 
   it('declares a healthcheck that proves the library opened, not just the process', () => {
     const hc = String(pod().metadata.annotations['servicebay.healthcheck']);
     expect(hc).toMatch(/\/stats/);
-    // The stricter "library is not empty" probe is registered from
-    // post-deploy.py, NOT here: this annotation gates install settleWait and
-    // a fresh install legitimately has an empty library.
+    // The stricter coverage probe is registered from post-deploy.py, NOT
+    // here: this annotation gates install settleWait and a fresh install
+    // legitimately has an empty library.
     const postDeploy = fs.readFileSync(path.join(TEMPLATES_DIR, 'beets', 'post-deploy.py'), 'utf-8');
     expect(postDeploy).toMatch(/beets-library-populated/);
-    expect(postDeploy).toMatch(/"bodyMatchType": "regex"/);
+  });
+
+  // ── #2584: the coverage sidecar ──────────────────────────────────────
+  //
+  // The "library populated" check asserted `"items":[1-9]` on beets' /stats
+  // and was therefore green on a 27k-file collection holding 485 items — the
+  // exact state it was introduced to catch. A ratio needs a denominator that
+  // is nowhere in that response, so the assertion moved into the pod. These
+  // tests pin the parts of that arrangement that are invisible when it is
+  // wrong: a green check.
+  describe('library-coverage endpoint (#2584)', () => {
+    const coverage = () =>
+      pod().spec.containers.find((c: { name: string }) => c.name === 'coverage');
+    const postDeploy = () =>
+      fs.readFileSync(path.join(TEMPLATES_DIR, 'beets', 'post-deploy.py'), 'utf-8');
+
+    it('the registered check is a status-code assertion against the sidecar, not a body regex', () => {
+      const script = postDeploy();
+      // The defect, spelled out: any regex over `{"albums":M,"items":N}` can
+      // only assert "N ≥ something", and any constant put there ages into a
+      // lie the moment the operator adds an album.
+      expect(script).not.toMatch(/bodyMatch/);
+      expect(script).toMatch(/BEETS_COVERAGE_PORT/);
+      expect(script).toMatch(/\/coverage/);
+      // The id is unchanged on purpose: the POST upserts by id, so an
+      // already-installed box has its stale green row rewritten rather than
+      // keeping it alongside a new one.
+      expect(script).toMatch(/"id": "beets-library-populated"/);
+    });
+
+    it('runs in the beets pod, reads /music read-only, and counts what beets should have tagged', () => {
+      const c = coverage();
+      expect(c, 'the coverage container must exist').toBeTruthy();
+      // Same image as beets — beets IS a Python app, so no second pull.
+      expect(c.image).toBe(pod().spec.containers[0].image);
+      const music = c.volumeMounts.find((v: { mountPath: string }) => v.mountPath === '/music');
+      expect(music.name).toBe('music-data');
+      expect(music.readOnly, 'the counter must never be able to write').toBe(true);
+      // UID 0 for the same reason as the beets container: under rootless
+      // podman anything else cannot even read the music tree.
+      expect(c.securityContext).toEqual({ runAsUser: 0, runAsGroup: 0 });
+    });
+
+    it('is loopback-bound — the health poller is its only consumer', () => {
+      const c = coverage();
+      expect(c.ports).toHaveLength(1);
+      expect(c.ports[0].containerPort).toBe(8338);
+      expect(c.ports[0].hostPort).toBe(8338);
+      // Unlike the UI port, this one is pinned to the host loopback: nothing
+      // on the LAN has a reason to reach an endpoint that walks the music
+      // tree (same reasoning as radicale's DAV port, #2357).
+      expect(c.ports[0].hostIP).toBe('127.0.0.1');
+      // …and it is declared, with the consumer-facing UI port still first
+      // (readPrimaryTcpPort takes the head of this list).
+      const ports = String(pod().metadata.annotations['servicebay.ports']);
+      expect(ports).toBe('8337/tcp,8338/tcp');
+    });
+
+    it('holds the library to a PERCENTAGE floor, never a fixed item count', () => {
+      // A count would have to be re-tuned every time the collection grows,
+      // which is the failure mode #2584 is about. The behaviour of the
+      // embedded script is exercised in tests/templates/test_post_deploy.py
+      // (BeetsCoverageEndpoint); this asserts the knob is a ratio.
+      const meta = beets.variables['BEETS_COVERAGE_MIN_PERCENT'] as { default?: string };
+      expect(meta, 'the floor must be an operator-visible variable').toBeTruthy();
+      expect(meta.default).toBe('90');
+      const script = String(coverage().args[0]);
+      expect(script).toMatch(/SB_COVERAGE_MIN_PERCENT/);
+      expect(script).toMatch(/100\.0 \* items \/ files/);
+    });
+
+    it('the v2→v3 hop is informational — no data moves for a health-check change', () => {
+      const mig = fs.readFileSync(
+        path.join(TEMPLATES_DIR, 'beets', 'migrations', 'v2-to-v3.py'), 'utf-8',
+      );
+      // It exists only because the install runner refuses a deploy with a
+      // gap in the migration chain (selectMigrationChain) — so it must not
+      // touch anything.
+      expect(mig).not.toMatch(/shutil\.(move|rmtree|copy)|os\.remove|\.unlink\(|\.rename\(|chown/);
+      const changelog = fs.readFileSync(path.join(TEMPLATES_DIR, 'beets', 'CHANGELOG.md'), 'utf-8');
+      expect(changelog).toMatch(/^## v3$/m);
+      // The operator must be told the check will go red on an untagged
+      // library — that is the fix landing, not a new fault.
+      expect(changelog).toMatch(/red after this upgrade/i);
+    });
   });
 
   it('is offered by a stack, unchecked — it rewrites files, so it is opt-in', () => {

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -1448,6 +1448,20 @@ describe('Mosquitto template: mandatory credentials, LAN reach, persistence (#25
     expect(mosquitto.yamlContent).toMatch(/value: "\{\{MQTT_PASSWORD\}\}"/);
   });
 
+  it('generates both credentials device-safe — they are typed INTO devices (#2577)', () => {
+    // Proven at a real device 2026-08-16: a Nuki lock was rejected
+    // (`disconnected: not authorised`) with the generated 32-char value —
+    // pasted, so complete — while Home Assistant took the same credentials;
+    // a 24-char alphanumeric value connected on the first try. This template
+    // exists so DEVICES can connect, so a credential a device cannot carry
+    // defeats its entire purpose. The flag is what makes the assembler use
+    // the shorter profile (manifestAssembler.ts); pinned here so a later
+    // variables.json edit cannot quietly drop it.
+    for (const name of ['MQTT_USERNAME', 'MQTT_PASSWORD']) {
+      expect(mosquitto.variables[name]?.deviceSafe, `${name} must be deviceSafe`).toBe(true);
+    }
+  });
+
   it('keeps retained messages across a restart: persistence on, store on a host path', () => {
     // Retained messages ARE the device-state store. Without persistence every
     // reboot blanks them and Home Assistant shows `unknown` until each device

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -2455,6 +2455,351 @@ class HomeAssistantScript(unittest.TestCase):
             self.assertFalse(m._yaml_is_effectively_empty(body), body)
 
 
+class HomeAssistantHttpTrustedProxies(unittest.TestCase):
+    """#2573 — Home Assistant 2026.8 moved the `http:` integration out of
+    configuration.yaml into its own store, and raises a permanent repair issue
+    ("HTTP YAML configuration is ignored after migration") for as long as an
+    `http:` block is left in the YAML. ServiceBay used to re-render that block
+    on every deploy, so the operator could never make the warning stay gone.
+
+    The replacement has to hold two things at once: a FRESH install still ends
+    up with a working trust list (HA's defaults reject proxied requests
+    outright), and an ALREADY-MIGRATED install keeps whatever it migrated."""
+
+    TOKEN = "long-lived-tok"
+
+    def _cfg_dir(self, tmp, token=TOKEN):
+        cfg = os.path.join(tmp, "home-assistant", "homeassistant")
+        os.makedirs(cfg, exist_ok=True)
+        if token is not None:
+            with open(os.path.join(cfg, ".solaris-long-lived-token"), "w") as fh:
+                fh.write(token + "\n")
+        return cfg
+
+    @staticmethod
+    def _store(stable, pending=None, active="stable"):
+        """One `http/config` result envelope, shaped like HA's."""
+        return {
+            "success": True,
+            "result": {"stable": stable, "pending": pending, "active_config_type": active},
+        }
+
+    @staticmethod
+    def _default_stable():
+        """What HA stores for an install that never configured HTTP: proxied
+        requests are rejected, because `use_x_forwarded_for` is off and the
+        trust list is empty."""
+        return {
+            "server_port": 8123,
+            "cors_allowed_origins": [],
+            "login_attempts_threshold": -1,
+            "ip_ban_enabled": True,
+            "ssl_profile": "modern",
+            "use_x_frame_options": True,
+            "created_at": "2026-08-17T10:00:00+00:00",
+            "error": None,
+            "error_message": None,
+        }
+
+    def _fake_ws(self, calls, responses):
+        """Record every websocket command and answer from `responses`, keyed by
+        command type. An unstubbed type is a test bug, not a silent pass."""
+        def fake(_token, commands, timeout=30):
+            kind = commands[0]["type"]
+            calls.append(commands[0])
+            if kind not in responses:
+                raise AssertionError(f"unexpected websocket command {kind}")
+            return [responses[kind]]
+        return fake
+
+    # ── criterion 1: the block is gone from what we render ────────────────
+    def test_rendered_configuration_yaml_carries_no_http_block(self):
+        """The seed template must not reintroduce the block on a fresh install
+        — that is what re-armed HA's repair issue every deploy."""
+        body = (TEMPLATES_DIR / "home-assistant" / "configuration.yaml.mustache").read_text()
+        # Comments may (and do) explain where the setting went; only what HA
+        # actually parses counts.
+        yaml_lines = [ln for ln in body.splitlines() if not ln.lstrip().startswith("#")]
+        for line in yaml_lines:
+            self.assertFalse(
+                line.startswith("http:"),
+                f"configuration.yaml.mustache still renders a top-level http: block: {line!r}",
+            )
+        self.assertNotIn("trusted_proxies", "\n".join(yaml_lines))
+        self.assertNotIn("use_x_forwarded_for", "\n".join(yaml_lines))
+        # …and it says where the setting went, so the next reader isn't puzzled.
+        self.assertIn("http/config/configure", body)
+
+    # ── criterion 2: a fresh install still ends up trusted ────────────────
+    def test_fresh_install_writes_the_trust_list_into_has_own_store(self):
+        import tempfile
+        m = load_script("home-assistant")
+        calls = []
+        responses = {
+            "http/config": self._store(self._default_stable()),
+            "http/config/configure": {"success": True, "result": {"restart": True}},
+            "http/config/promote": {"success": True, "result": None},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cfg_dir(tmp)
+            with run_with_env({"DATA_DIR": tmp}), \
+                    mock.patch.object(m, "_ha_ws_commands", self._fake_ws(calls, responses)), \
+                    mock.patch.object(m, "_wait_ha_ready", lambda *_a, **_kw: True):
+                verdict = m.ensure_http_trusted_proxies()
+
+        self.assertEqual(verdict, "ok")
+        configure = next(c for c in calls if c["type"] == "http/config/configure")
+        sent = configure["config"]
+        self.assertIs(sent["use_x_forwarded_for"], True)
+        # Loopback + every RFC1918 range, in the network form HA requires.
+        self.assertEqual(
+            set(sent["trusted_proxies"]),
+            {"127.0.0.1/32", "192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"},
+        )
+        # HA applies a new HTTP config as a 5-minute trial that reverts itself
+        # unless it is promoted — so the promote is not optional.
+        self.assertIn("http/config/promote", [c["type"] for c in calls])
+
+    def test_a_config_that_is_never_promoted_is_reported_as_failed(self):
+        """An unpromoted trial silently auto-reverts. Reporting "ok" there
+        would hand back a box whose trust list disappears five minutes later."""
+        import tempfile
+        m = load_script("home-assistant")
+        calls = []
+        responses = {
+            "http/config": self._store(self._default_stable()),
+            "http/config/configure": {"success": True, "result": {"restart": True}},
+            "http/config/promote": {"success": False, "error": {"code": "not_allowed"}},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cfg_dir(tmp)
+            with run_with_env({"DATA_DIR": tmp}), \
+                    mock.patch.object(m, "_ha_ws_commands", self._fake_ws(calls, responses)), \
+                    mock.patch.object(m, "_wait_ha_ready", lambda *_a, **_kw: True):
+                verdict = m.ensure_http_trusted_proxies()
+        self.assertEqual(verdict, "failed")
+
+    # ── criterion 3 + 5: an already-migrated install is left alone ────────
+    def test_already_trusted_store_is_left_untouched_on_every_later_deploy(self):
+        """The steady state. No configure, no promote, no HA restart — which is
+        what makes the fix survive the next deploy instead of fighting it."""
+        import tempfile
+        m = load_script("home-assistant")
+        calls = []
+        stable = dict(
+            self._default_stable(),
+            use_x_forwarded_for=True,
+            # HA stores what the operator typed in canonical network form.
+            trusted_proxies=["127.0.0.1/32", "192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"],
+        )
+        responses = {"http/config": self._store(stable)}
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cfg_dir(tmp)
+            with run_with_env({"DATA_DIR": tmp}), \
+                    mock.patch.object(m, "_ha_ws_commands", self._fake_ws(calls, responses)):
+                verdict = m.ensure_http_trusted_proxies()
+        self.assertEqual(verdict, "ok")
+        self.assertEqual([c["type"] for c in calls], ["http/config"])
+
+    def test_ha_s_own_yaml_import_is_promoted_rather_than_overwritten(self):
+        """The real box: HA imported the old `http:` block into the PENDING
+        slot on this very start and is counting down to an auto-revert.
+        Confirming what it imported preserves the operator's migrated values
+        exactly, and costs one restart fewer than writing a second config."""
+        import tempfile
+        m = load_script("home-assistant")
+        calls = []
+        imported = dict(
+            self._default_stable(),
+            use_x_forwarded_for=True,
+            trusted_proxies=["127.0.0.1/32", "192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"],
+        )
+        responses = {
+            "http/config": self._store(self._default_stable(), pending=imported, active="pending"),
+            "http/config/promote": {"success": True, "result": None},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            self._cfg_dir(tmp)
+            with run_with_env({"DATA_DIR": tmp}), \
+                    mock.patch.object(m, "_ha_ws_commands", self._fake_ws(calls, responses)):
+                verdict = m.ensure_http_trusted_proxies()
+        self.assertEqual(verdict, "ok")
+        self.assertEqual([c["type"] for c in calls], ["http/config", "http/config/promote"])
+
+    def test_operator_settings_survive_and_their_own_proxies_are_kept(self):
+        """We add to the operator's stored config, never replace it: their port,
+        SSL paths and extra proxy stay, and HA's own bookkeeping keys are
+        stripped (HTTP_STORAGE_SCHEMA rejects unknown keys)."""
+        m = load_script("home-assistant")
+        stable = dict(
+            self._default_stable(),
+            server_port=8124,
+            ssl_certificate="/ssl/fullchain.pem",
+            cors_allowed_origins=["https://example.com"],
+            trusted_proxies=["172.30.0.0/16"],
+        )
+        desired = m._desired_http_config(stable)
+        self.assertEqual(desired["server_port"], 8124)
+        self.assertEqual(desired["ssl_certificate"], "/ssl/fullchain.pem")
+        self.assertEqual(desired["cors_allowed_origins"], ["https://example.com"])
+        self.assertIn("172.30.0.0/16", desired["trusted_proxies"])
+        self.assertIn("10.0.0.0/8", desired["trusted_proxies"])
+        for meta in ("created_at", "error", "error_message"):
+            self.assertNotIn(meta, desired)
+
+    def test_host_and_network_proxy_forms_compare_equal(self):
+        """`127.0.0.1` and `127.0.0.1/32` are the same trust entry; HA stores
+        the second. Without normalising, every deploy would rewrite the config
+        and restart HA in a loop."""
+        m = load_script("home-assistant")
+        self.assertTrue(m._http_config_trusts_proxies({
+            "use_x_forwarded_for": True,
+            "trusted_proxies": ["127.0.0.1", "192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"],
+        }))
+        # Trusting the proxy range but not reading the header is still broken:
+        # HA would report the proxy's own address as the client.
+        self.assertFalse(m._http_config_trusts_proxies({
+            "use_x_forwarded_for": False,
+            "trusted_proxies": ["127.0.0.1/32", "192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12"],
+        }))
+        self.assertFalse(m._http_config_trusts_proxies({
+            "use_x_forwarded_for": True,
+            "trusted_proxies": ["192.168.0.0/16"],
+        }))
+
+    # ── criterion 1 + 4: what happens to the YAML block on disk ───────────
+    def test_block_is_removed_only_once_the_store_is_confirmed(self):
+        """Ordering is the safety property: strip the YAML only after HA's own
+        store is known to carry the trust list, never before."""
+        import tempfile
+        m = load_script("home-assistant")
+        legacy = (
+            "default_config:\n"
+            "\n"
+            "# Reverse-proxy trust list. NPM forwards X-Forwarded-For.\n"
+            "http:\n"
+            "  use_x_forwarded_for: true\n"
+            "  trusted_proxies:\n"
+            "    - 127.0.0.1\n"
+            "\n"
+            "auth_oidc:\n"
+            "  client_id: homeassistant\n"
+        )
+        for verdict, expect_removed in (("ok", True), ("failed", False), ("skipped", False)):
+            with tempfile.TemporaryDirectory() as tmp:
+                cfg = self._cfg_dir(tmp)
+                cfg_file = os.path.join(cfg, "configuration.yaml")
+                with open(cfg_file, "w") as fh:
+                    fh.write(legacy)
+                with run_with_env({"DATA_DIR": tmp}), \
+                        mock.patch.object(m, "ensure_http_trusted_proxies", lambda: verdict):
+                    m.configure_http_trusted_proxies()
+                with open(cfg_file) as fh:
+                    content = fh.read()
+                if expect_removed:
+                    self.assertNotIn("http:", content, verdict)
+                    self.assertNotIn("trusted_proxies", content, verdict)
+                else:
+                    self.assertIn("http:", content, verdict)
+
+    def test_removing_the_block_keeps_the_rest_of_the_file_and_backs_it_up(self):
+        import tempfile
+        m = load_script("home-assistant")
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_file = os.path.join(tmp, "configuration.yaml")
+            original = (
+                "default_config:\n"
+                "\n"
+                "automation: !include automations.yaml\n"
+                "\n"
+                "# Reverse-proxy trust list, explained over\n"
+                "# two comment lines.\n"
+                "http:\n"
+                "  use_x_forwarded_for: true\n"
+                "  trusted_proxies:\n"
+                "    - 127.0.0.1\n"
+                "    - 10.0.0.0/8\n"
+                "\n"
+                "auth_oidc:\n"
+                "  client_id: homeassistant\n"
+            )
+            with open(cfg_file, "w") as fh:
+                fh.write(original)
+
+            self.assertTrue(m.remove_legacy_http_yaml_block(cfg_file))
+            with open(cfg_file) as fh:
+                    content = fh.read()
+            self.assertNotIn("http:", content)
+            self.assertNotIn("trusted_proxies", content)
+            self.assertNotIn("two comment lines", content)   # the block's own comment went with it
+            self.assertIn("default_config:", content)
+            self.assertIn("automation: !include automations.yaml", content)
+            self.assertIn("auth_oidc:", content)
+            self.assertIn("  client_id: homeassistant", content)
+            # The operator may have had their own settings under that key.
+            with open(cfg_file + ".pre-http-migration.bak") as fh:
+                self.assertEqual(fh.read(), original)
+
+            # Idempotent: nothing left to remove, and the backup is not
+            # overwritten with the already-stripped file.
+            self.assertFalse(m.remove_legacy_http_yaml_block(cfg_file))
+            with open(cfg_file + ".pre-http-migration.bak") as fh:
+                self.assertEqual(fh.read(), original)
+
+    def test_a_key_that_merely_starts_with_http_is_not_touched(self):
+        import tempfile
+        m = load_script("home-assistant")
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_file = os.path.join(tmp, "configuration.yaml")
+            body = "http_response_sensor:\n  resource: http://x\nhttpx:\n  a: b\n"
+            with open(cfg_file, "w") as fh:
+                fh.write(body)
+            self.assertFalse(m.remove_legacy_http_yaml_block(cfg_file))
+            with open(cfg_file) as fh:
+                self.assertEqual(fh.read(), body)
+
+    def test_pre_2026_8_home_assistant_keeps_its_yaml_block(self):
+        """An older HA has no store to write to — there the YAML block is still
+        the only place the trust list can live, so it is re-added, not
+        removed. Only a running HA can tell us which era the box is on, which
+        is why this moved out of the pre-start hook."""
+        import tempfile
+        m = load_script("home-assistant")
+        calls = []
+        responses = {"http/config": {"success": False, "error": {"code": "unknown_command"}}}
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = self._cfg_dir(tmp)
+            cfg_file = os.path.join(cfg, "configuration.yaml")
+            with open(cfg_file, "w") as fh:
+                fh.write("default_config:\n")
+            with run_with_env({"DATA_DIR": tmp}), \
+                    mock.patch.object(m, "_ha_ws_commands", self._fake_ws(calls, responses)):
+                m.configure_http_trusted_proxies()
+            with open(cfg_file) as fh:
+                    content = fh.read()
+        self.assertIn("http:", content)
+        self.assertIn("use_x_forwarded_for: true", content)
+        self.assertIn("- 10.0.0.0/8", content)
+
+    def test_no_admin_token_explains_the_manual_step_instead_of_failing_silently(self):
+        import tempfile
+        m = load_script("home-assistant")
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = self._cfg_dir(tmp, token=None)
+            cfg_file = os.path.join(cfg, "configuration.yaml")
+            with open(cfg_file, "w") as fh:
+                fh.write("default_config:\n\nhttp:\n  use_x_forwarded_for: true\n")
+            buf = io.StringIO()
+            with run_with_env({"DATA_DIR": tmp}), contextlib.redirect_stdout(buf):
+                m.configure_http_trusted_proxies()
+            out = buf.getvalue()
+            # The existing block is the only working copy — leave it alone.
+            with open(cfg_file) as fh:
+                self.assertIn("http:", fh.read())
+        self.assertIn("Settings", out)
+        self.assertIn("Trust X-Forwarded-For", out)
+
+
 class HomeAssistantAuthOidcTarball(unittest.TestCase):
     """#2453: the auth_oidc release tarball is fetched over the network and
     unpacked as root. Extraction must not be able to write outside the staging

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -3532,6 +3532,7 @@ class BeetsScript(unittest.TestCase):
             env = {
                 "DATA_DIR": tmp,
                 "BEETS_PORT": "8337",
+                "BEETS_COVERAGE_PORT": "8338",
                 "SB_API_URL": "http://localhost:3000",
                 "SB_API_TOKEN": "t",
             }
@@ -3580,13 +3581,47 @@ class BeetsScript(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("seeds one on start", out)
 
-    def test_registers_the_empty_library_check_and_prints_the_trigger(self):
+    def test_registers_the_coverage_check_and_prints_the_trigger(self):
         rc, out = self._run("import:\n  move: false\n")
         self.assertEqual(rc, 0)
-        self.assertIn("beets-library-populated", out)
+        self.assertIn("Beets library coverage", out)
         # The service must be genuinely operable: the command is in the log.
         self.assertIn("beet import /music", out)
         self.assertIn("beet import -q -i /music", out)
+
+    def test_the_registered_check_asks_about_coverage_not_existence(self):
+        """#2584 — the payload, not just the log line.
+
+        The old check was `"items"\\s*:\\s*[1-9]` against beets' /stats: green
+        at one item, forever. The replacement asserts a status code from the
+        coverage endpoint, and it keeps the same check id so an upgraded box
+        has its stale row rewritten instead of gaining a green twin.
+        """
+        import tempfile
+        import urllib.error
+
+        posted: list[dict[str, Any]] = []
+
+        def capture(req, *_a, **_kw):
+            posted.append(json.loads(req.data.decode("utf-8")))
+            raise urllib.error.URLError("registration response is not the point")
+
+        module = load_script("beets")
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "beets" / "config").mkdir(parents=True)
+            env = {"DATA_DIR": tmp, "BEETS_PORT": "8337", "BEETS_COVERAGE_PORT": "9338"}
+            with run_with_env(env), mock.patch("urllib.request.urlopen", capture):
+                rc, _out = capture_main(module)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(posted), 1)
+        check = posted[0]
+        self.assertEqual(check["id"], "beets-library-populated")
+        self.assertEqual(check["target"], "http://127.0.0.1:9338/coverage")
+        self.assertEqual(check["httpConfig"].get("expectedStatus"), 200)
+        # No body regex at all — a ratio is not expressible as one, and a
+        # baked-in item floor is the threshold that ages into a lie.
+        self.assertNotIn("bodyMatch", check["httpConfig"])
+        self.assertNotIn("bodyMatchType", check["httpConfig"])
 
     def test_health_check_registration_failure_is_not_fatal(self):
         module = load_script("beets")
@@ -3604,6 +3639,116 @@ class BeetsScript(unittest.TestCase):
                 rc, out = capture_main(module)
         self.assertEqual(rc, 0)
         self.assertIn("service:beets check still applies", out)
+
+
+class BeetsCoverageEndpoint(unittest.TestCase):
+    """#2584 — the coverage sidecar embedded in templates/beets/template.yml.
+
+    The script lives in a heredoc inside the pod spec (beets ships no
+    `*.mustache` companion — that would clobber the operator's config on every
+    redeploy, see template_consistency.test.ts), so the test extracts it and
+    exercises it directly. What is under test is the property the issue is
+    about: the verdict must depend on the RATIO, so it cannot go green on a
+    library holding one album out of thousands, and it must not need
+    re-tuning when the collection grows.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import re
+        import textwrap
+
+        raw = (TEMPLATES_DIR / "beets" / "template.yml").read_text(encoding="utf-8")
+        match = re.search(r"<<'PY'\n(.*?)\n\s*PY\n", raw, re.DOTALL)
+        assert match, "beets template.yml must embed the coverage script in a PY heredoc"
+        cls.source = textwrap.dedent(match.group(1))
+
+    def _module(self):
+        """A fresh instance of the extracted script (module state is global)."""
+        spec = importlib.util.spec_from_loader("_beets_coverage", loader=None)
+        assert spec is not None
+        module = importlib.util.module_from_spec(spec)
+        exec(compile(self.source, "beets-coverage.py", "exec"), module.__dict__)  # noqa: S102
+        return module
+
+    @contextlib.contextmanager
+    def _library(self, files: int, items: int, floor: str = "90"):
+        """A music tree with `files` audio files and a beets library of `items`."""
+        import tempfile
+
+        module = self._module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "Artist" / "Album"
+            root.mkdir(parents=True)
+            for i in range(files):
+                (root / f"{i:05d}.mp3").write_text("", encoding="utf-8")
+            module.MUSIC_DIR = str(tmp)
+            module.library_items = lambda: items
+            with run_with_env({"SB_COVERAGE_MIN_PERCENT": floor}):
+                module._state["files"] = module.count_audio_files(str(tmp))
+                module._state["scanned_at"] = 1.0
+                yield module
+
+    def test_one_album_out_of_a_full_collection_is_not_healthy(self):
+        # The exact defect: the old regex went green here.
+        with self._library(files=200, items=1) as module:
+            status, report = module.coverage_report()
+        self.assertEqual(status, 503)
+        self.assertEqual(report["status"], "behind")
+        self.assertEqual(report["percent"], 0.5)
+        self.assertIn("1 of 200", report["detail"])
+
+    def test_a_covered_library_is_healthy(self):
+        with self._library(files=200, items=195) as module:
+            status, report = module.coverage_report()
+        self.assertEqual(status, 200)
+        self.assertEqual(report["status"], "ok")
+
+    def test_the_floor_is_a_ratio_so_it_does_not_age(self):
+        # Same proportion, ten times the collection: same verdict. A
+        # hard-coded item floor would flip here, which is what #2584 forbids.
+        verdicts = []
+        for scale in (1, 10):
+            with self._library(files=50 * scale, items=48 * scale) as module:
+                verdicts.append(module.coverage_report()[0])
+            with self._library(files=50 * scale, items=10 * scale) as module:
+                verdicts.append(module.coverage_report()[0])
+        self.assertEqual(verdicts, [200, 503, 200, 503])
+
+    def test_syncthing_version_copies_do_not_inflate_the_denominator(self):
+        with self._library(files=10, items=10) as module:
+            versions = Path(module.MUSIC_DIR) / ".stversions" / "Artist"
+            versions.mkdir(parents=True)
+            for i in range(40):
+                (versions / f"old-{i}.mp3").write_text("", encoding="utf-8")
+            (Path(module.MUSIC_DIR) / "Artist" / "cover.jpg").write_text("", encoding="utf-8")
+            self.assertEqual(module.count_audio_files(module.MUSIC_DIR), 10)
+
+    def test_beets_not_answering_is_red_not_green(self):
+        with self._library(files=10, items=10) as module:
+            def boom():
+                raise OSError("connection refused")
+
+            module.library_items = boom
+            status, report = module.coverage_report()
+        self.assertEqual(status, 503)
+        self.assertEqual(report["status"], "unknown")
+
+    def test_the_first_scan_is_reported_as_scanning_never_as_ok(self):
+        # Transient and bounded (one walk), so it must not flap the check red —
+        # but it must not claim a coverage verdict it does not have either.
+        with self._library(files=10, items=1) as module:
+            module._state["files"] = None
+            status, report = module.coverage_report()
+        self.assertEqual(status, 200)
+        self.assertEqual(report["status"], "scanning")
+        self.assertNotIn("percent", report)
+
+    def test_an_empty_music_folder_is_not_a_failure(self):
+        with self._library(files=0, items=0) as module:
+            status, report = module.coverage_report()
+        self.assertEqual(status, 200)
+        self.assertEqual(report["status"], "ok")
 
 
 class BeetsV1ToV2Migration(unittest.TestCase):

--- a/tests/templates/test_post_deploy.py
+++ b/tests/templates/test_post_deploy.py
@@ -3110,6 +3110,604 @@ class MosquittoScript(unittest.TestCase):
         self.assertIn("MQTT_USERNAME/MQTT_PASSWORD missing", out)
 
 
+class MosquittoHomeAssistantLink(unittest.TestCase):
+    """#2578 — installing mosquitto next to Home Assistant used to leave the
+    operator typing broker/port/user/password into HA by hand, and a later
+    password rotation (#2574) silently broke that hand-entered connection.
+
+    The wiring goes through HA's config-flow REST API — the same endpoints HA's
+    own frontend posts to — and never through `.storage`, which a running HA
+    holds in memory and rewrites on its own schedule.
+
+    The four acceptance criteria pull in different directions, so each has its
+    own tests: wire it up unasked, follow a rotation, stay silent without HA,
+    and never touch a connection the operator made themselves."""
+
+    TOKEN = "ha-admin-token"
+    ENTRY_ID = "01ENTRY0000000000000000000"
+    USERNAME = "mqtt-user"
+    PASSWORD = "s3cret-broker-pass"
+    PWD_SENTINEL = "__**password_not_changed**__"
+
+    def _box(self, tmp, with_ha=True, token=TOKEN):
+        """Lay DATA_DIR out the way a real box has it, and return the env the
+        install runner would hand this script."""
+        os.makedirs(os.path.join(tmp, "mosquitto"), exist_ok=True)
+        if with_ha:
+            cfg = os.path.join(tmp, "home-assistant", "homeassistant")
+            os.makedirs(cfg, exist_ok=True)
+            if token is not None:
+                with open(os.path.join(cfg, ".solaris-long-lived-token"), "w") as fh:
+                    fh.write(token + "\n")
+        return {
+            "DATA_DIR": tmp,
+            "HOST": "box.example",
+            "LAN_IP": "192.168.1.10",
+            "MQTT_PORT": "1883",
+            "MQTT_USERNAME": self.USERNAME,
+            "MQTT_PASSWORD": self.PASSWORD,
+        }
+
+    def _http(self, calls, routes):
+        """Fake urlopen over HA's REST API. `routes` maps "METHOD /path-prefix"
+        to (status, body); the longest matching prefix wins so the flow-resource
+        route beats the flow-index one. An unrouted call is a test bug, not a
+        silent pass — that is how we assert "nothing was written"."""
+        class FakeResponse:
+            def __init__(self, status, body):
+                self.status = status
+                self._body = json.dumps(body if body is not None else {}).encode("utf-8")
+
+            def read(self):
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        ordered = sorted(routes.items(), key=lambda kv: -len(kv[0]))
+
+        def fake(req, *_a, **_kw):
+            method = req.get_method()
+            path = req.full_url.split("127.0.0.1:8123", 1)[1]
+            calls.append({
+                "method": method,
+                "path": path,
+                "body": json.loads(req.data.decode("utf-8")) if req.data else None,
+                "auth": req.headers.get("Authorization"),
+            })
+            for key, response in ordered:
+                route_method, _, prefix = key.partition(" ")
+                if method == route_method and path.startswith(prefix):
+                    if callable(response):
+                        response = response(len(calls))
+                    return FakeResponse(response[0], response[1])
+            raise AssertionError(f"unexpected {method} {path}")
+
+        return fake
+
+    # ── fixtures shaped like the forms HA 2026.8.2 actually returns ────────
+    #
+    # Captured from a live Home Assistant, not invented: `broker` is required
+    # with no default at all, the advanced settings sit in a required section,
+    # and two fields inside it are required with neither default nor suggestion
+    # — which is exactly what a hand-written payload gets wrong.
+
+    def _fresh_form(self, flow_id="flow-new"):
+        return {
+            "type": "form",
+            "flow_id": flow_id,
+            "handler": "mqtt",
+            "step_id": "broker",
+            "data_schema": [
+                {"name": "broker", "required": True, "selector": {"text": {}}},
+                {"name": "port", "type": "integer", "required": True, "default": 1883},
+                {"name": "protocol", "required": True, "default": "5"},
+                {"name": "username", "required": False, "optional": True},
+                {"name": "password", "required": False, "optional": True},
+                {
+                    "type": "expandable",
+                    "name": "other_settings",
+                    "required": True,
+                    "schema": [
+                        {"name": "client_id", "required": False, "optional": True},
+                        {"name": "keepalive", "required": False, "optional": True},
+                        {"name": "set_client_cert", "required": True},
+                        {"name": "set_ca_cert", "required": True},
+                        {"name": "transport", "required": True, "default": "tcp"},
+                    ],
+                },
+            ],
+        }
+
+    def _reconfigure_form(self, flow_id="flow-reconf"):
+        """A reconfigure form carries the entry's current values back as
+        `suggested_value` — including HA's password sentinel, never the real
+        password."""
+        return {
+            "type": "form",
+            "flow_id": flow_id,
+            "handler": "mqtt",
+            "step_id": "broker",
+            "data_schema": [
+                {"name": "broker", "required": True,
+                 "description": {"suggested_value": "host.containers.internal"}},
+                {"name": "port", "type": "integer", "required": True, "default": 1883,
+                 "description": {"suggested_value": 1883}},
+                {"name": "protocol", "required": True, "default": "5",
+                 "description": {"suggested_value": "3.1.1"}},
+                {"name": "username", "required": False, "optional": True,
+                 "description": {"suggested_value": "old-user"}},
+                {"name": "password", "required": False, "optional": True,
+                 "description": {"suggested_value": self.PWD_SENTINEL}},
+                {
+                    "type": "expandable",
+                    "name": "other_settings",
+                    "required": True,
+                    "schema": [
+                        {"name": "keepalive", "required": False, "optional": True,
+                         "description": {"suggested_value": 90}},
+                        {"name": "set_client_cert", "required": True,
+                         "description": {"suggested_value": True}},
+                        {"name": "set_ca_cert", "required": True,
+                         "description": {"suggested_value": "custom"}},
+                        {"name": "transport", "required": True, "default": "tcp",
+                         "description": {"suggested_value": "websockets"}},
+                    ],
+                },
+            ],
+        }
+
+    def _entry(self, entry_id=None, title="host.containers.internal", state="loaded"):
+        return {
+            "entry_id": entry_id or self.ENTRY_ID,
+            "domain": "mqtt",
+            "title": title,
+            "source": "user",
+            "state": state,
+            "supports_reconfigure": True,
+        }
+
+    def _diagnostics(self, broker="host.containers.internal", port=1883, connected=True):
+        """HA's own diagnostics for an MQTT entry. Username and password come
+        back redacted — we never need them, which is the point."""
+        return {
+            "home_assistant": {"version": "2026.8.2"},
+            "data": {
+                "connected": connected,
+                "mqtt_config": {
+                    "data": {
+                        "broker": broker,
+                        "port": port,
+                        "username": "**REDACTED**",
+                        "password": "**REDACTED**",
+                    },
+                    "options": {},
+                },
+            },
+        }
+
+    def _link(self, tmp):
+        with open(os.path.join(tmp, "mosquitto", ".home-assistant-link.json")) as fh:
+            return json.load(fh)
+
+    # ── criterion 1: mosquitto onto a box that already has HA ──────────────
+
+    def test_a_box_with_home_assistant_gets_mqtt_wired_up_with_no_manual_step(self):
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            routes = {
+                "GET /api/config/config_entries/entry": (200, []),
+                "POST /api/config/config_entries/flow": (200, self._fresh_form()),
+                "POST /api/config/config_entries/flow/": (
+                    200, {"type": "create_entry", "result": self._entry()},
+                ),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+
+            submit = [c for c in calls
+                      if c["method"] == "POST" and c["path"].startswith("/api/config/config_entries/flow/")]
+            self.assertEqual(len(submit), 1, "the broker form is answered exactly once")
+            payload = submit[0]["body"]
+            # ADR 0007 Decision 3 — the container-to-container name, never a LAN IP.
+            self.assertEqual(payload["broker"], "host.containers.internal")
+            self.assertEqual(payload["port"], 1883)
+            self.assertEqual(payload["username"], self.USERNAME)
+            self.assertEqual(payload["password"], self.PASSWORD)
+            # …and the parts of HA's form we did not come to change are answered
+            # from HA's own defaults, including the required section that has none.
+            self.assertEqual(payload["protocol"], "5")
+            self.assertEqual(payload["other_settings"]["transport"], "tcp")
+            self.assertEqual(payload["other_settings"]["set_ca_cert"], "off")
+            self.assertIs(payload["other_settings"]["set_client_cert"], False)
+
+            self.assertEqual(self._link(tmp)["entry_id"], self.ENTRY_ID)
+            self.assertIn("Home Assistant is now connected to this broker", out)
+
+    def test_every_call_is_home_assistants_own_api_and_never_its_storage(self):
+        """The ticket's central ask: the way into HA's configuration must be
+        justified as safe. It is safe because nothing here knows the file
+        format — every write is a form post HA validates itself."""
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            routes = {
+                "GET /api/config/config_entries/entry": (200, []),
+                "POST /api/config/config_entries/flow": (200, self._fresh_form()),
+                "POST /api/config/config_entries/flow/": (
+                    200, {"type": "create_entry", "result": self._entry()},
+                ),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                capture_main(m)
+            for call in calls:
+                self.assertTrue(
+                    call["path"].startswith("/api/config/config_entries/")
+                    or call["path"].startswith("/api/diagnostics/"),
+                    f"unexpected endpoint {call['path']}",
+                )
+                self.assertEqual(call["auth"], f"Bearer {self.TOKEN}")
+            # Nothing was written anywhere inside HA's config dir.
+            ha_dir = os.path.join(tmp, "home-assistant", "homeassistant")
+            self.assertEqual(sorted(os.listdir(ha_dir)), [".solaris-long-lived-token"])
+
+    # ── criterion 2: a password rotation is carried over ───────────────────
+
+    def test_rotating_the_broker_password_updates_home_assistants_entry(self):
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            # What the previous deploy left behind: our entry, wired with the
+            # OLD password.
+            with open(os.path.join(tmp, "mosquitto", ".home-assistant-link.json"), "w") as fh:
+                json.dump({
+                    "entry_id": self.ENTRY_ID,
+                    "fingerprint": m._fingerprint("host.containers.internal", 1883, self.USERNAME, "old-pass"),
+                }, fh)
+            routes = {
+                "GET /api/config/config_entries/entry": (200, [self._entry()]),
+                "POST /api/config/config_entries/flow": (200, self._reconfigure_form()),
+                "POST /api/config/config_entries/flow/": (
+                    200, {"type": "abort", "reason": "reconfigure_successful"},
+                ),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+
+            start = [c for c in calls if c["path"] == "/api/config/config_entries/flow"]
+            self.assertEqual(len(start), 1)
+            # A reconfigure, not a second entry: HA is told which entry to edit.
+            self.assertEqual(start[0]["body"]["entry_id"], self.ENTRY_ID)
+
+            payload = [c for c in calls if c["path"].startswith("/api/config/config_entries/flow/")][0]["body"]
+            self.assertEqual(payload["password"], self.PASSWORD)
+            self.assertNotEqual(payload["password"], self.PWD_SENTINEL)
+            self.assertEqual(payload["username"], self.USERNAME)
+            # Everything the operator set on that entry survives the update —
+            # this is a credential change, not a reset to our defaults.
+            self.assertEqual(payload["protocol"], "3.1.1")
+            self.assertEqual(payload["other_settings"]["keepalive"], 90)
+            self.assertEqual(payload["other_settings"]["transport"], "websockets")
+            self.assertEqual(payload["other_settings"]["set_ca_cert"], "custom")
+            self.assertIs(payload["other_settings"]["set_client_cert"], True)
+
+            self.assertEqual(
+                self._link(tmp)["fingerprint"],
+                m._fingerprint("host.containers.internal", 1883, self.USERNAME, self.PASSWORD),
+            )
+            self.assertIn("updated to the current credentials", out)
+
+    def test_a_deploy_that_changes_nothing_touches_home_assistant_not_at_all(self):
+        """The steady state. Reconfiguring on every deploy would reload HA's
+        MQTT integration — and every device with it — for no reason."""
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            with open(os.path.join(tmp, "mosquitto", ".home-assistant-link.json"), "w") as fh:
+                json.dump({
+                    "entry_id": self.ENTRY_ID,
+                    "fingerprint": m._fingerprint(
+                        "host.containers.internal", 1883, self.USERNAME, self.PASSWORD),
+                }, fh)
+            routes = {"GET /api/config/config_entries/entry": (200, [self._entry()])}
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertEqual([c["method"] for c in calls], ["GET"])
+            self.assertIn("already up to date", out)
+
+    # ── criterion 3: a box without Home Assistant, unchanged and unmentioned ──
+
+    def test_a_box_without_home_assistant_says_and_does_nothing(self):
+        """"Ohne Home Assistant läuft die Installation unverändert und ohne
+        Meldung durch" — no HTTP call, and not one line about a service the
+        operator never installed."""
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp, with_ha=False)
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, {})
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertEqual(calls, [])
+            for phrase in ("no admin token", "left alone", "left exactly as it is",
+                           "now connected to this broker", "⚠️"):
+                self.assertNotIn(phrase, out)
+            self.assertEqual(parse_credentials(out)[0]["password"], self.PASSWORD)
+
+    def test_home_assistant_without_a_token_asks_for_the_manual_step_and_exits_clean(self):
+        """Both installed in one wizard run: HA's own post-deploy mints the
+        token and may not have run yet. That is a "later", not a failure."""
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp, token=None)
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, {})
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertEqual(calls, [])
+            self.assertIn("no admin token", out)
+            self.assertIn("Settings → Devices & Services", out)
+            self.assertNotIn("⚠️", out)
+
+    def test_an_unreachable_home_assistant_never_fails_the_deploy(self):
+        import tempfile
+        import urllib.error
+        m = load_script("mosquitto")
+        m.HA_READY_ATTEMPTS = 2
+        m.HA_READY_INTERVAL = 0
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+
+            def refused(*_a, **_kw):
+                raise urllib.error.URLError("connection refused")
+
+            with run_with_env(env), mock.patch.object(m.urllib.request, "urlopen", refused):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("left alone", out)
+            self.assertFalse(os.path.exists(os.path.join(tmp, "mosquitto", ".home-assistant-link.json")))
+
+    # ── criterion 4: an existing hand-made connection is left alone ─────────
+
+    def test_a_hand_made_connection_to_a_different_broker_is_left_untouched(self):
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            routes = {
+                "GET /api/config/config_entries/entry": (
+                    200, [self._entry(entry_id="OTHER", title="192.168.1.55")],
+                ),
+                "GET /api/diagnostics/config_entry/": (
+                    200, self._diagnostics(broker="192.168.1.55"),
+                ),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            # Not one write: no flow started, so nothing duplicated and nothing
+            # overwritten. `single_config_entry` on HA's side would have refused
+            # a second entry anyway — we do not even ask.
+            self.assertEqual([c["method"] for c in calls], ["GET", "GET"])
+            self.assertNotIn("/flow", "".join(c["path"] for c in calls))
+            self.assertIn("left exactly as it is", out)
+            self.assertFalse(os.path.exists(os.path.join(tmp, "mosquitto", ".home-assistant-link.json")))
+
+    def test_a_hand_made_connection_that_is_live_against_this_broker_is_recognised_not_rewritten(self):
+        """The case on a box that was wired by hand before this shipped. HA's
+        diagnostics say the entry is connected to this very broker — and the
+        broker accepts exactly one account, so it is already using these
+        credentials. Recording it writes NOTHING into HA today and means the
+        next rotation follows it instead of silently breaking it."""
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            routes = {
+                "GET /api/config/config_entries/entry": (200, [self._entry()]),
+                "GET /api/diagnostics/config_entry/": (200, self._diagnostics()),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertEqual([c["method"] for c in calls], ["GET", "GET"])
+            self.assertEqual(self._link(tmp), {
+                "entry_id": self.ENTRY_ID,
+                "fingerprint": m._fingerprint(
+                    "host.containers.internal", 1883, self.USERNAME, self.PASSWORD),
+            })
+            self.assertIn("you set it up yourself", out)
+
+    def test_a_hand_made_connection_that_is_not_connected_is_not_claimed(self):
+        """Without a live connection there is no evidence it is this broker's
+        account, so the conservative branch wins: leave it, claim nothing."""
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            routes = {
+                "GET /api/config/config_entries/entry": (
+                    200, [self._entry(state="setup_retry")],
+                ),
+                "GET /api/diagnostics/config_entry/": (200, self._diagnostics(connected=False)),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertNotIn("/flow", "".join(c["path"] for c in calls))
+            self.assertFalse(os.path.exists(os.path.join(tmp, "mosquitto", ".home-assistant-link.json")))
+            self.assertIn("left exactly as it is", out)
+
+    def test_a_connection_on_the_right_host_but_a_different_port_is_not_ours(self):
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            routes = {
+                "GET /api/config/config_entries/entry": (200, [self._entry()]),
+                "GET /api/diagnostics/config_entry/": (200, self._diagnostics(port=1884)),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                rc, _ = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertFalse(os.path.exists(os.path.join(tmp, "mosquitto", ".home-assistant-link.json")))
+
+    # ── failure handling: HA says no ────────────────────────────────────────
+
+    def test_a_refused_broker_form_closes_the_flow_and_leaves_no_link(self):
+        """HA opens a real connection to the broker before accepting the
+        settings. A rejection comes back as the same form with errors — leaving
+        it open would park a half-finished "Configure" prompt in HA's UI."""
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            refused = dict(self._fresh_form(), errors={"base": "cannot_connect"})
+            routes = {
+                "GET /api/config/config_entries/entry": (200, []),
+                "POST /api/config/config_entries/flow": (200, self._fresh_form()),
+                "POST /api/config/config_entries/flow/": (200, refused),
+                "DELETE /api/config/config_entries/flow/": (200, {"message": "Flow aborted"}),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0, "the broker is up; the wiring never fails the deploy")
+            self.assertIn("DELETE", [c["method"] for c in calls])
+            self.assertIn("cannot_connect", out)
+            self.assertFalse(os.path.exists(os.path.join(tmp, "mosquitto", ".home-assistant-link.json")))
+
+    def test_an_unexpected_error_is_reported_without_failing_the_deploy(self):
+        import tempfile
+        m = load_script("mosquitto")
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            with run_with_env(env), mock.patch.object(
+                m, "configure_home_assistant", side_effect=RuntimeError("boom")
+            ):
+                rc, out = capture_main(m)
+            self.assertEqual(rc, 0)
+            self.assertIn("boom", out)
+            self.assertIn("broker itself is fine", out)
+
+    # ── secret hygiene ─────────────────────────────────────────────────────
+
+    def test_the_password_never_reaches_the_log_or_the_link_file(self):
+        """It travels in exactly two places: the __SB_CREDENTIAL__ marker
+        ServiceBay stores encrypted, and the form body HA gets over loopback."""
+        import tempfile
+        m = load_script("mosquitto")
+        calls = []
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._box(tmp)
+            routes = {
+                "GET /api/config/config_entries/entry": (200, []),
+                "POST /api/config/config_entries/flow": (200, self._fresh_form()),
+                "POST /api/config/config_entries/flow/": (
+                    200, {"type": "create_entry", "result": self._entry()},
+                ),
+            }
+            with run_with_env(env), mock.patch.object(
+                m.urllib.request, "urlopen", self._http(calls, routes)
+            ):
+                _, out = capture_main(m)
+            log_only = "\n".join(
+                line for line in out.splitlines() if not line.startswith("__SB_CREDENTIAL__ ")
+            )
+            self.assertNotIn(self.PASSWORD, log_only)
+            with open(os.path.join(tmp, "mosquitto", ".home-assistant-link.json")) as fh:
+                raw_link = fh.read()
+            self.assertNotIn(self.PASSWORD, raw_link)
+            self.assertNotIn(self.USERNAME, raw_link)
+
+    def test_the_fingerprint_changes_with_the_password_and_is_short(self):
+        m = load_script("mosquitto")
+        one = m._fingerprint("host.containers.internal", 1883, "u", "pass-a")
+        two = m._fingerprint("host.containers.internal", 1883, "u", "pass-b")
+        self.assertNotEqual(one, two)
+        self.assertEqual(m._fingerprint("host.containers.internal", 1883, "u", "pass-a"), one)
+        # Truncated on purpose: enough to notice a change, too short to be a
+        # usable handle on the password it came from.
+        self.assertEqual(len(one), 16)
+
+    # ── the form filler, which is where a hand-written payload goes wrong ───
+
+    def test_the_form_is_answered_from_home_assistants_own_schema(self):
+        m = load_script("mosquitto")
+        payload = m._form_payload(
+            self._fresh_form()["data_schema"],
+            {"broker": "b", "port": 1883, "username": "u", "password": "p"},
+        )
+        # The required section is sent even though everything we know about it
+        # comes from defaults — HA rejects the form outright when it is missing.
+        self.assertIn("other_settings", payload)
+        self.assertEqual(payload["other_settings"]["set_ca_cert"], "off")
+        # Optional fields HA did not suggest a value for are left out rather
+        # than sent as null: `PREVENT_EXTRA`/None would fail validation.
+        self.assertNotIn("client_id", payload["other_settings"])
+        self.assertNotIn("keepalive", payload["other_settings"])
+
+    def test_an_unknown_future_field_is_answered_from_its_own_default(self):
+        """The payload is not pinned to one HA version: a field this script has
+        never heard of is answered with what HA itself proposes."""
+        m = load_script("mosquitto")
+        schema = [
+            {"name": "broker", "required": True},
+            {"name": "some_new_thing", "required": True, "default": "sane"},
+            {"name": "another_new_thing", "required": True,
+             "description": {"suggested_value": "current"}},
+        ]
+        payload = m._form_payload(schema, {"broker": "host.containers.internal"})
+        self.assertEqual(payload, {
+            "broker": "host.containers.internal",
+            "some_new_thing": "sane",
+            "another_new_thing": "current",
+        })
+
+
 class ImmichScript(unittest.TestCase):
     """#1556: on a wipe-configs reinstall Authelia regenerates the OIDC
     client secret (CONFIG) but Immich keeps its copy in its DB (survived
@@ -3422,7 +4020,7 @@ class VerbatimScriptBodies(unittest.TestCase):
     quietly start depending on a render pass that no longer happens.
     """
 
-    # The eight `{{…}}` sites across templates/*/post-deploy.py, and the
+    # The nine `{{…}}` sites across templates/*/post-deploy.py, and the
     # env var that actually carries the value (None = prose only).
     SITES = [
         ("auth", "DATA_DIR"),            # authelia_db_path() docstring
@@ -3432,6 +4030,7 @@ class VerbatimScriptBodies(unittest.TestCase):
         ("file-share", "DATA_DIR"),      # _notes_dir() docstring
         ("home-assistant", "DATA_DIR"),  # _ha_config_dir() docstring
         ("home-assistant", "ZWAVE_DEVICE"),  # udev/zwave.port docstring
+        ("mosquitto", "DATA_DIR"),       # _ha_config_dir() comment (#2578)
         ("immich", None),                # comment: podman --format '{{.State}}'
     ]
 
@@ -3458,6 +4057,7 @@ class VerbatimScriptBodies(unittest.TestCase):
             ("nginx", "npm_db_path", ("nginx-proxy-manager", "data", "database.sqlite")),
             ("file-share", "_notes_dir", ("file-share", "data", "notes")),
             ("home-assistant", "_ha_config_dir", ("home-assistant", "homeassistant")),
+            ("mosquitto", "_ha_config_dir", ("home-assistant", "homeassistant")),
         ]
         for template, fn_name, tail in cases:
             with self.subTest(template=template):


### PR DESCRIPTION
Fünf Issues in einem Batch, alle mit Belegen von der laufenden Box statt aus Annahmen.

- **#2577 — erzeugte Geräte-Passwörter.** Die Prämisse des Tickets war falsch: es gibt keinen Generator, der Sonderzeichen liefert — alle Pfade ziehen seit #19 aus demselben 62-Zeichen-Alphabet. Der Nuki scheiterte an der **Länge** (32 Zeichen werden von der Firmware still abgeschnitten). Zeichenvorrat wird jetzt ein global geprüfter Vertrag, die Länge bleibt pro Variable hinter einem neuen `deviceSafe`-Schalter.
- **#2573 — HA ignoriert den `http:`-Block.** Der Block kam aus *zwei* Quellen; nur die Vorlage zu ändern hätte die Warnung wiederkehren lassen. Außerdem gefunden: HAs YAML-Import landet in einem `pending`-Slot und verfällt nach 5 Minuten ohne Bestätigung — auf der Referenzbox ist das ein aktiver Defekt. post-deploy fährt jetzt HAs eigene Websocket-Kommandos und entfernt den YAML-Block erst, nachdem der Speicher die Liste nachweislich trägt.
- **#2579 — Sonde meldet einen Fehler, den es nicht gibt.** Gemessen, nicht geraten: AdGuard drosselt bei 20 Anfragen/s pro Client und verwirft den Rest still. Die Sonde fragte alle 21 Domains gleichzeitig, das Ende der eigenen Salve lief in den Timeout — und der wurde mit NXDOMAIN in denselben `null` zusammengefaltet. Stille ist jetzt `warn` mit Hinweis, nur eine echte Negativantwort ist `fail`.
- **#2584 — beets-Health-Check.** Der Check war mit `"items": [1-9]` zufrieden, also ab einem einzigen Titel grün. Auf der Box: 485 von 27.228 Dateien = 1,8 %, und trotzdem grün. Die Aussage zieht jetzt aus einem Beiwagen im Pod, der den Nenner kennt, und prüft einen Prozentsatz statt einer Zahl, die zur Lüge altert.
- **#2578 — HA automatisch mit dem Broker verbinden.** Über HAs eigene Config-Flow-API, nie über `.storage`; eine von Hand angelegte Verbindung wird nicht überschrieben, höchstens erkannt.

Box-Verify: die beets-Auslieferung aus dem Vorgänger-Batch ist grün bestätigt.
