### PR TITLE
docs: an on-box MCP client uses the app port, not the reverse proxy

### DIFF
--- a/assists/footgun-mcp-from-a-container-on-the-box.md
+++ b/assists/footgun-mcp-from-a-container-on-the-box.md
@@ -1,0 +1,93 @@
+---
+title: Reaching ServiceBay's API/MCP from a container running on the box itself
+whenToUse: You are an agent or script running in a container ON the ServiceBay host and cannot reach its API or /mcp endpoint — TLS handshakes are rejected, you get a bare 404, or a 301 to the public URL. Read this before concluding you need an /etc/hosts entry, --add-host, or a restored LAN route.
+kind: footgun
+tags: [mcp, api, networking, adr-0007, container, host-containers-internal, reverse-proxy, agent, troubleshooting]
+---
+
+# The MCP endpoint is on the app port, not behind the proxy
+
+**Answer first:**
+
+```
+http://host.containers.internal:5888/mcp
+```
+
+with the usual `Authorization: Bearer sb_<id>_<secret>`. No DNS, no TLS, no
+`Host` header, no `/etc/hosts` entry, no container rebuild. If `PORT` is set on
+the ServiceBay service, use that instead of `5888`.
+
+## Why the obvious route fails
+
+Ports **80/443 are nginx-proxy-manager**. A reverse proxy has to route by
+**vhost name**, and ServiceBay's own admin host is one of six permanently
+LAN-only NPM hosts whose access list ends in `deny all`. So from inside the box
+the proxy is not a path to `/mcp` at all — no header or address gets you
+through it, because the denial is deliberate and happens before the app sees
+the request.
+
+ServiceBay's backend listens on its **app port** as well. That port has no
+vhost logic, so none of the proxy's prerequisites apply to it.
+
+## Why this eats a whole session
+
+Each failed attempt looks like a *different*, solvable problem:
+
+| Attempt | Result | What it looks like |
+|---|---|---|
+| `https://host.containers.internal/mcp` | TLS handshake rejected | a certificate problem |
+| `https://<host-ip>/mcp` | TLS handshake rejected | a certificate problem |
+| `http://<host-ip>/mcp` | `404` | the endpoint moved |
+| `http://<host-ip>/mcp` + `Host: admin.<domain>` | `301` to the public URL | "just map the name to a reachable address" |
+| **`http://host.containers.internal:5888/mcp`** | **`200`** | — |
+
+The fourth row is the trap. It hands you a specific, plausible instruction —
+add `169.254.1.2 admin.<domain>` to `/etc/hosts`, or `--add-host` at container
+creation — and that **actually works**. It is still wrong: it re-creates the
+dependency on the proxy and on the container's LAN route, needs root inside a
+container that usually has no `sudo`, and disappears the next time the
+container is rebuilt. You end up asking a human to run a privileged command on
+the host to restore something you never needed.
+
+**Diagnostic that settles it in one call** — if this returns 200, stop
+theorising about DNS and certificates:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+  http://host.containers.internal:5888/mcp \
+  -H "Authorization: Bearer $SB_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
+```
+
+## Things worth knowing before you use it
+
+- **Plain HTTP is not a downgrade here.** The traffic is host-local
+  link-local and never reaches a network interface.
+- **Authentication is unchanged.** You are bypassing the proxy's *routing*,
+  never its *authorization* — the app port enforces the same Bearer/session
+  check.
+- **Responses are SSE-framed.** Lines arrive as `data: {...}`; strip the prefix
+  before parsing. Call `initialize` first, then `tools/list` / `tools/call`.
+  There is no session header to carry between calls.
+- **`container_exec` / `exec_command` are capped at ~30 s** by the agent. For
+  anything longer, start it detached inside the target container
+  (`nohup … &`) and poll a log file.
+- **Output is secret-redacted.** A line matching `apikey:`/`password:` comes
+  back `<redacted>` even through `container_exec`. Never rewrite a config file
+  wholesale from what you read — edit it in place, or you will destroy the
+  credential you couldn't see.
+- **`exec_command` carries an advisory tripwire** matching `rm -rf /etc`-shaped
+  strings *anywhere* in the command, including inside heredoc **comment** text.
+  Reword the comment; do not encode around the guard.
+- **Prefer the read tools** (`diagnose`, `get_logs`, `list_containers`,
+  `get_system_info`, `read_file`, `list_dir`) — `exec_command` and
+  `container_exec` trip a destructive-op alert and an auto-snapshot.
+
+## Where the rule lives
+
+- `docs/adr/0007-container-network-isolation-and-carveouts.md` — amendment
+  2026-08-17 states the rule and why the proxy is the wrong layer.
+- `docs/MCP.md` — "Client running on the box (agent in a container)".
+- Settings → MCP in the UI shows the on-box URL next to the browser one.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -131,6 +131,50 @@ Claude Code. Refreshing the JWT becomes a one-line `export`, no JSON edit.
   Then point Claude Code at `http://localhost:5888/mcp`. Many browsers and
   clients treat `localhost` as trustworthy, sidestepping cookie/CORS quirks.
 
+## Client running **on the box** (agent in a container)
+
+If the MCP client is itself a container on the ServiceBay host — an agent
+sandbox, a CI runner, `templates/claude-dev` — use the **app port directly**:
+
+```bash
+claude mcp add --transport http servicebay \
+  http://host.containers.internal:5888/mcp \
+  --header "Authorization: Bearer sb_<id>_<secret>"
+```
+
+**Do not use the public hostname from inside the box.** Ports 80/443 are
+nginx-proxy-manager, which routes by vhost name, and ServiceBay's admin host is
+permanently LAN-only with a `deny all` access list. The app port has no vhost
+logic at all, so none of that applies to it.
+
+What this buys you — every one of these is a prerequisite you *don't* have:
+
+| | on the app port |
+|---|---|
+| DNS resolution | not needed (link-local address) |
+| TLS / SNI | not needed (traffic never leaves the machine) |
+| `Host` header | not needed (no vhost matching) |
+| `/etc/hosts` entry or `--add-host` | **not needed** |
+| container rebuild | **not needed** |
+
+Authentication is unchanged: the app port enforces the same Bearer-token or
+session-cookie check. You are bypassing *routing*, not *authorization*.
+
+`169.254.1.2` is podman's fixed address for the host and works identically, but
+`host.containers.internal` survives a reconfiguration — prefer the name. If
+`PORT` is set on the ServiceBay service, use that instead of `5888`.
+
+> **The plausible wrong turn.** Trying the proxy first produces a trail of
+> answers that each look like the whole problem: a rejected TLS handshake (looks
+> like a certificate issue), a `404` without a `Host` header (looks like a moved
+> endpoint), and — with the right `Host` — a `301` to the public URL, which
+> looks like an instruction to map that name onto a reachable address with
+> `/etc/hosts` or `--add-host`. That last one even works. It is still the wrong
+> layer: it re-creates the dependency on the proxy and on the container's LAN
+> route, and it evaporates the next time the container is rebuilt. See
+> [ADR 0007](adr/0007-container-network-isolation-and-carveouts.md), amendment
+> 2026-08-17.
+
 ## What can the LLM actually do?
 
 A non-exhaustive list — call `claude mcp get servicebay` (or `/mcp` inside
@@ -331,6 +375,13 @@ Typical autonomous-verify workflow:
   401. Workaround: `headersHelper` script (Option B above).
 - **`405 Method not allowed`** — only `POST /mcp` is implemented. If you see
   this, your client is using GET or another verb.
+- **Client is on the box and nothing connects** — rejected TLS handshakes, a
+  bare `404`, or a `301` to the public URL all mean the same thing: you are
+  talking to nginx-proxy-manager on 80/443, not to ServiceBay. Switch to
+  `http://host.containers.internal:5888/mcp` — see
+  [Client running on the box](#client-running-on-the-box-agent-in-a-container).
+  Do **not** "fix" it with an `/etc/hosts` entry; that treats the symptom and
+  breaks on the next container rebuild.
 
 ## API tokens (recommended)
 

--- a/docs/adr/0007-container-network-isolation-and-carveouts.md
+++ b/docs/adr/0007-container-network-isolation-and-carveouts.md
@@ -81,6 +81,56 @@ grandfathered entries whose stated precondition is now met should be re-examined
 against Decision 3, and `templates/claude-dev` runs `hostNetwork: true` without
 appearing on the list at all — see #2522.
 
+## Amendment 2026-08-17 — an on-box client reaches ServiceBay on the app port, not through the proxy
+
+Decision 1 tells a container how to reach *another service*. It says nothing
+about reaching **ServiceBay itself** — its REST API and its `/mcp` endpoint —
+from a container on the same box. That gap cost a working session, so the rule
+is written down here:
+
+> **From inside the box, address ServiceBay as
+> `http://host.containers.internal:${PORT:-5888}` — the app port, directly.
+> Never the public hostname, and never port 80/443.**
+
+The reasoning is the same shape as Decision 1, one layer up. Ports 80/443 are
+**nginx-proxy-manager**, and a reverse proxy necessarily routes by **vhost
+name**. ServiceBay's own admin host is one of the six permanently LAN-only NPM
+hosts whose access list ends in `deny all` (see
+`packages/backend/src/lib/reverseProxy/lanDeniedPage.ts`), so every attempt to
+reach `/mcp` through the proxy from a container fails, and each failure looks
+like a *different* problem:
+
+| Attempt from a container | What happens | Why it misleads |
+|---|---|---|
+| `https://host.containers.internal/mcp` | TLS handshake rejected | reads as a certificate problem |
+| `https://169.254.1.2/mcp` | TLS handshake rejected | reads as a certificate problem |
+| `http://169.254.1.2/mcp` | `404` | reads as "the endpoint moved" |
+| `http://169.254.1.2/mcp` + `Host: admin.<domain>` | `301` to the public URL | reads as "just add the hosts entry" |
+| **`http://169.254.1.2:5888/mcp`** | **`200`** | — |
+
+The trap is that the last row is never reached by elimination: the `301` in row
+four points at a real, correct-looking answer (map the name to a reachable
+address via `/etc/hosts` or `--add-host`), and that answer *works*. It is simply
+the wrong layer — it re-creates the proxy dependency instead of dropping it, and
+it dies on the next container rebuild.
+
+Consequences of stating it this way:
+
+- **No DNS, no TLS, no `Host` header, no `/etc/hosts` entry, no container
+  rebuild.** The traffic is host-local link-local and never touches a network
+  interface, so plain HTTP is not a downgrade here.
+- **Authentication is unchanged.** The app port enforces the same session-cookie
+  or `Authorization: Bearer sb_…` check; bypassing the proxy bypasses only
+  *routing*, never authorization. Several route handlers already reason
+  explicitly about a "direct `:5888` call bypassing NPM" — this amendment names
+  the path they were already defending.
+- **`host.containers.internal` is the spelling**, per Decision 1. `169.254.1.2`
+  is podman's fixed host address and works, but the name survives a
+  reconfiguration; prefer it.
+- Losing the container's LAN route does **not** break this path, which is the
+  point — the public hostname resolves to the box's LAN address and is therefore
+  the fragile way in.
+
 ## Consequences
 
 - post-deploy scripts run in the **host** netns, so their `127.0.0.1` probes

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.test.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.test.tsx
@@ -39,6 +39,40 @@ describe('McpSection (#2100 settings migration)', () => {
     expect(html).not.toMatch(/dark:bg-gray-(800|900)/);
   });
 
+  // ADR 0007 amendment 2026-08-17. A client running on the box cannot use the
+  // browser's origin — that is nginx-proxy-manager on :443, routing by vhost,
+  // and this admin host is LAN-only with `deny all`. The card therefore shows a
+  // second, app-port URL. This pins the distinction the whole amendment exists
+  // for: the two fields must NOT be the same value, and the on-box one must
+  // carry the host alias and an explicit port.
+  it('shows a separate on-box endpoint on the app port, distinct from the browser origin', async () => {
+    mockFetch(true);
+    render(<McpSection />);
+    await waitFor(() => expect(screen.getByText('MCP endpoint')).toBeDefined());
+    expect(screen.getByText('From a container on this box')).toBeDefined();
+
+    const browserUrl = (screen.getByDisplayValue(/^https?:\/\/localhost/) as HTMLInputElement).value;
+    const onBox = screen.getByDisplayValue(/host\.containers\.internal/) as HTMLInputElement;
+
+    expect(onBox.value).toBe('http://host.containers.internal:5888/mcp');
+    expect(onBox.value).not.toBe(browserUrl);
+    // Plain HTTP is deliberate here (host-local link-local traffic), so a future
+    // "https everywhere" sweep does not silently break this path.
+    expect(onBox.value.startsWith('http://')).toBe(true);
+  });
+
+  it('copies the on-box endpoint, not the browser one', async () => {
+    mockFetch(true);
+    const { copyToClipboard } = await import('../clipboard');
+    render(<McpSection />);
+    await waitFor(() => expect(screen.getByText('From a container on this box')).toBeDefined());
+
+    fireEvent.click(screen.getByTitle('Copy on-box URL'));
+    await waitFor(() =>
+      expect(copyToClipboard).toHaveBeenCalledWith('http://host.containers.internal:5888/mcp'),
+    );
+  });
+
   it('toggling mutations still POSTs to /api/settings (behaviour preserved)', async () => {
     mockFetch(true);
     render(<McpSection />);

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Check, Copy, ShieldAlert, History, RefreshCw, ShieldCheck } from 'lucide-react';
 import SectionHelp from '@/components/SectionHelp';
-import { Button } from '@/components/ui';
+import { Button, Input } from '@/components/ui';
 import { copyToClipboard } from '../clipboard';
 
 interface AuditEntry {
@@ -217,9 +217,32 @@ function McpAuditFeed({ entries, loading, onRefresh }: { entries: AuditEntry[] |
   );
 }
 
+/**
+ * Endpoint an MCP client that runs **on this box** must use (ADR 0007,
+ * amendment 2026-08-17). The card's main field shows `window.location.origin`,
+ * which is the browser's view — a public hostname served by nginx-proxy-manager
+ * on :443. A container on the box cannot use that: the proxy routes by vhost and
+ * this admin host carries a `deny all` LAN-only access list, so the attempt
+ * fails as a TLS/404/301 trail that reads like three unrelated problems. The app
+ * port has no vhost logic, so it needs no DNS, TLS or `Host` header.
+ *
+ * The port is the documented default, deliberately NOT derived from
+ * `window.location.port`: that reads the port the *browser* reached, which
+ * behind a reverse proxy on a non-standard port (`https://box:8443`) is the
+ * proxy's port, not the app's — the field would then confidently show an
+ * address nothing listens on. `PORT` is a backend env var no client can see, and
+ * exposing it would mean a new API surface for one string. So the value is the
+ * stock default and the copy says so, which is true for every default install
+ * and honest about the one case where it isn't.
+ */
+const ON_BOX_HOST = 'host.containers.internal';
+const DEFAULT_APP_PORT = '5888';
+
 export default function McpSection() {
   const [mcpUrl, setMcpUrl] = useState('');
+  const [onBoxUrl, setOnBoxUrl] = useState('');
   const [copied, setCopied] = useState(false);
+  const [copiedOnBox, setCopiedOnBox] = useState(false);
   const [allowMutations, setAllowMutations] = useState<boolean | null>(null);
   const [allowDangerousExec, setAllowDangerousExec] = useState<boolean | null>(null);
   const [saving, setSaving] = useState(false);
@@ -270,6 +293,8 @@ export default function McpSection() {
     // Read window.location after mount to avoid SSR/hydration mismatch.
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async settings fetch, guarded by a cancelled flag
     setMcpUrl(`${window.location.origin}/mcp`);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- same post-mount window read as above
+    setOnBoxUrl(`http://${ON_BOX_HOST}:${DEFAULT_APP_PORT}/mcp`);
   }, []);
 
   // Poll for pending destructive-tool approvals (#1766). In-memory + short TTL,
@@ -319,6 +344,14 @@ export default function McpSection() {
     }
   };
 
+  const handleCopyOnBox = async () => {
+    if (!onBoxUrl) return;
+    if (await copyToClipboard(onBoxUrl)) {
+      setCopiedOnBox(true);
+      setTimeout(() => setCopiedOnBox(false), 1500);
+    }
+  };
+
   return (
     <>
       <div className="flex justify-end">
@@ -353,6 +386,40 @@ export default function McpSection() {
         </div>
         <p className="text-xs text-text-muted mt-2">
           Authenticate with a scoped <span className="font-medium">API token</span> (see the API tokens section) or the same session cookie as this UI. Click <span className="font-medium">How to connect</span> for the full setup walk-through.
+        </p>
+      </div>
+
+      {/* ADR 0007 amendment 2026-08-17: a client running on this box cannot use
+          the endpoint above — that URL is served by nginx-proxy-manager, which
+          routes by vhost, and this admin host is deliberately LAN-only. Showing
+          the app-port URL here (rather than only in the help modal) is
+          deliberate: the failure mode is a TLS/404/301 trail that reads like
+          three unrelated problems, and the usual "fix" — an /etc/hosts entry —
+          works just long enough to be believed. */}
+      <div>
+        <label className="block text-xs font-semibold uppercase tracking-wider text-text-muted mb-1">
+          From a container on this box
+        </label>
+        <div className="flex items-stretch gap-2">
+          <Input
+            type="text"
+            readOnly
+            value={onBoxUrl}
+            onFocus={(e) => e.currentTarget.select()}
+            className="flex-1 font-mono text-sm px-3 py-2 rounded-card border border-border bg-surface-2 text-text-muted"
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleCopyOnBox}
+            title="Copy on-box URL"
+          >
+            {copiedOnBox ? <Check size={16} className="text-status-ok" /> : <Copy size={16} />}
+            {copiedOnBox ? 'Copied' : 'Copy'}
+          </Button>
+        </div>
+        <p className="text-xs text-text-muted mt-2">
+          For an assistant or CI runner that runs <span className="font-medium">on this machine</span>. It talks to the app port directly, so it needs no DNS, no TLS and no <span className="font-mono">/etc/hosts</span> entry — the endpoint above goes through the reverse proxy, which a container here cannot reach. Authentication is identical. Shows the default app port; if you set <span className="font-mono">PORT</span> on the ServiceBay service, use that instead.
         </p>
       </div>
 

--- a/packages/frontend/src/content/help/mcp.md
+++ b/packages/frontend/src/content/help/mcp.md
@@ -64,6 +64,29 @@ For Claude Desktop or `~/.claude.json` / `.mcp.json` direct edits:
 }
 ```
 
+## Client running on the box itself
+
+If the assistant runs **in a container on this machine** (an agent sandbox, a CI
+runner, `claude-dev`), don't use the URL above — use the app port directly:
+
+```bash
+claude mcp add --transport http servicebay \
+  http://host.containers.internal:5888/mcp \
+  --header "Authorization: Bearer sb_xxxxxxxx_YOUR_TOKEN_HERE"
+```
+
+Ports 80/443 are the reverse proxy, which routes by hostname, and this admin
+host is deliberately LAN-only. The app port has no hostname logic, so it needs
+no DNS, no TLS, no `Host` header — and **no `/etc/hosts` entry**.
+
+Same authentication either way: you're skipping the proxy's *routing*, not its
+*authorization*.
+
+> Going through the proxy from inside the box produces misleading errors — a
+> rejected TLS handshake, a bare `404`, or a redirect to the public URL that
+> looks like it's asking you to add a hosts entry. Adding one does work, and is
+> still the wrong fix: it breaks the next time the container is rebuilt.
+
 ## Heads-ups
 
 - **The session JWT expires after 24h.** When it does, the MCP server returns


### PR DESCRIPTION
## Was fehlte

ADR 0007 sagt einem Container, wie er **andere Dienste** erreicht. Es sagte nie, wie er **ServiceBay selbst** erreicht — dessen REST-API und `/mcp` —, wenn er auf derselben Box läuft. Diese Lücke hat eine ganze Arbeitssitzung gekostet.

Ports 80/443 sind nginx-proxy-manager, und ein Reverse Proxy muss zwangsläufig nach **vhost-Namen** routen. ServiceBays Admin-Host ist einer der sechs dauerhaft LAN-only-NPM-Hosts mit `deny all`. Von innen ist `/mcp` über den Proxy also gar nicht erreichbar — während `http://host.containers.internal:5888/mcp` mit 200 antwortet, ohne DNS, ohne TLS, ohne `Host`-Header, ohne hosts-Eintrag.

## Warum das teuer ist

Jeder Fehlversuch sieht nach einem **anderen**, lösbaren Problem aus:

| Versuch | Ergebnis | Wonach es aussieht |
|---|---|---|
| `https://host.containers.internal/mcp` | TLS abgelehnt | Zertifikatsproblem |
| `http://<ip>/mcp` | `404` | Endpunkt verschoben |
| `http://<ip>/mcp` + `Host:` | `301` auf die öffentliche URL | „trag den Namen in /etc/hosts ein" |
| **`http://<ip>:5888/mcp`** | **`200`** | — |

Die vierte Zeile ist die Falle: sie liefert eine konkrete, plausible Anweisung — und die **funktioniert sogar**. Sie ist trotzdem die falsche Ebene. Sie stellt die Abhängigkeit vom Proxy und von der LAN-Route wieder her, braucht root in einem Container ohne `sudo`, und verschwindet beim nächsten Neubau.

## Vier Stellen, weil jede einen anderen Leser erwischt

- **ADR 0007**, Amendment 2026-08-17 — die Regel und warum der Proxy die falsche Ebene ist, samt Tabelle des irreführenden Pfades.
- **docs/MCP.md** — Abschnitt „client running on the box" plus ein Troubleshooting-Eintrag, der nach **Symptomen** sucht, nicht nach der Ursache. Wer die Ursache kennt, sucht nicht mehr.
- **Settings → MCP** — ein zweites, beschriftetes Feld neben dem Browser-Endpunkt. Auf der Karte, nicht nur im Hilfe-Dialog: der Fehlermodus besteht ja gerade darin, nicht zu wissen, dass es diese Adresse gibt.
- **`assists/footgun-…`** — für Agenten, die Doku über `get_assist` finden und nicht über das Repository. Enthält die eine curl-Probe, die es entscheidet, plus die umliegenden Fallen (30-s-Deckel auf `exec_command`, geschwärzte Ausgaben, die `rm -rf`-Sperre, die auch in Heredoc-**Kommentaren** greift).

## Eine bewusste Entscheidung in der UI

Der Port ist der dokumentierte Standardwert, **nicht** aus `window.location.port` abgeleitet. Der liest den Port, den der **Browser** benutzt hat — hinter einem Proxy auf ungewöhnlichem Port also dessen Port, nicht den der Anwendung. Das Feld würde dann selbstbewusst eine Adresse anzeigen, auf der nichts lauscht. `PORT` ist eine Backend-Variable, die kein Client sehen kann; dafür eine neue API-Fläche anzulegen wäre für eine Zeichenkette unverhältnismäßig. Der Text benennt darum den Standard, statt zu raten.

Aufgefallen ist das erst durch den neuen Test — die erste Fassung leitete tatsächlich ab.

## Tests

Zwei neue, die das Wesentliche festnageln: die beiden Endpunkt-Felder dürfen **nicht** denselben Wert haben, und der On-Box-Endpunkt bleibt **`http://`** — das ist hier host-lokaler Link-Local-Verkehr, kein Rückschritt, und ein späterer „https überall"-Durchlauf soll den Pfad nicht stillschweigend zerstören.

Lint-Ratchet hält die Grundlinie (89/89) — das neue Feld nutzt das `Input`-Primitiv, nicht ein rohes `<input>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8EtCZVyAd3UacSB1dmeJv