### PR TITLE
feat: surface stuck OS-update loops, hand Jellyfin the GPU

### DIFF
--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -122,7 +122,20 @@ shadowing `.kube`/`.yml` on every redeploy so the swap survives
 on CPU with no error — which is why the multi-container shape above is
 refused outright rather than deployed.
 
-Worked reference: `templates/ollama/`.
+**Attaching the device is only half of it.** Whether the workload
+*uses* the card is the application's own setting, and it almost never
+defaults to on: Jellyfin re-encodes in software until its
+`HardwareAccelerationType` says `nvenc`, no matter what `/dev` holds. A
+template that adds `AddDevice=` and stops there ships a service that
+looks fixed and behaves exactly as before. Set the application-side
+option from `post-deploy.py` too, read-modify-write so an existing
+install keeps the rest of its configuration, and gate it on the device
+swap having actually succeeded — pointing an app at an absent
+accelerator turns a slow path into a broken one.
+
+Worked reference: `templates/media/` (`JELLYFIN_GPU_PASSTHROUGH` →
+`install_gpu_quadlet_fallback()` + `jellyfin_enable_nvenc()`, #2580).
+The pattern originates in `ollama`, which now lives outside this repo.
 
 ### `variables.json`
 

--- a/packages/backend/src/lib/diagnose/groupForProbe.test.ts
+++ b/packages/backend/src/lib/diagnose/groupForProbe.test.ts
@@ -30,6 +30,10 @@ describe('groupForProbe (#1534 problem-domain grouping)', () => {
       // panel where an operator would never trip over it.
       raid: 'storage-backups',
       nas_backup_reachable: 'storage-backups',
+      // #2585 — a stuck OS-update loop must land in an EXPANDED card. It is
+      // the answer to "why is the box pegged", so `system-info` (collapsed,
+      // for things that are never a problem) would bury it.
+      os_update: 'other',
     };
     for (const [id, group] of Object.entries(cases)) {
       expect(groupForProbe(id)).toBe(group);

--- a/packages/backend/src/lib/diagnose/probes/osUpdateStuck.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/osUpdateStuck.test.ts
@@ -1,0 +1,269 @@
+/**
+ * `os_update` probe (#2585).
+ *
+ * The fixtures are the real thing, not an invented format. `PAUSED` is a
+ * verbatim capture of `rpm-ostree status` on the reference box taken
+ * 2026-08-17 after the operator paused auto-updates, down to the two-layer
+ * deployment list and the wrapped `LayeredPackages` value; `STUCK` is the same
+ * box with the DriverState line it carried while the akmod build was failing
+ * (`trying to stage 44.20260720.3.1 (failed attempts: 7)`, quoted in #2585).
+ * The Zincati drop-in fixture is the shape `updateWindow.ts` writes plus the
+ * hand-written pause file that was actually on the box.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseRpmOstreeStatus,
+  zincatiUpdatesDisabled,
+  evaluateOsUpdate,
+  OS_UPDATE_CONFIG_MARKER,
+  OS_UPDATE_COMMAND,
+  STUCK_ATTEMPTS_THRESHOLD,
+} from './osUpdateStuck';
+
+/** Verbatim from the box, 2026-08-17, after the operator paused updates. */
+const STATUS_PAUSED = `State: idle
+AutomaticUpdatesDriver: Zincati
+  DriverState: active; initialization complete, auto-updates logic disabled by configuration
+Deployments:
+  ostree-image-signed:docker://quay.io/fedora/fedora-coreos:stable
+                   Digest: sha256:5f6a577c329cecf1a4db6013f6241ef0b3f88f67ac6f30d2d1f637f28055fe13
+                  Version: 44.20260720.3.1 (2026-07-28T16:37:49Z)
+                     Diff: 67 upgraded, 42 added
+          LayeredPackages: akmod-nvidia-open ffmpeg-free nvidia-container-toolkit python3
+                           xorg-x11-drv-nvidia-cuda
+            LocalPackages: rpmfusion-free-release-44-3.noarch
+                           rpmfusion-nonfree-release-44-3.noarch
+
+● ostree-image-signed:docker://quay.io/fedora/fedora-coreos:stable
+                   Digest: sha256:5f6a577c329cecf1a4db6013f6241ef0b3f88f67ac6f30d2d1f637f28055fe13
+                  Version: 44.20260510.3.1 (2026-05-26T16:37:49Z)
+          LayeredPackages: akmod-nvidia-open nvidia-container-toolkit python3
+                           xorg-x11-drv-nvidia-cuda
+            LocalPackages: rpmfusion-free-release-44-3.noarch
+                           rpmfusion-nonfree-release-44-3.noarch
+
+  ostree-image-signed:docker://quay.io/fedora/fedora-coreos:stable
+                   Digest: sha256:a7857f3413747f6186b748346c60e87523d67b3165def2f59890b25364ac3de1
+                  Version: 44.20260419.3.1 (2026-05-10T20:44:27Z)
+          LayeredPackages: akmod-nvidia-open nvidia-container-toolkit python3
+                           xorg-x11-drv-nvidia-cuda
+            LocalPackages: rpmfusion-free-release-44-3.noarch
+                           rpmfusion-nonfree-release-44-3.noarch
+`;
+
+/** Same box while the akmod build was failing over and over (#2585). */
+const STATUS_STUCK = STATUS_PAUSED.replace(
+  '  DriverState: active; initialization complete, auto-updates logic disabled by configuration',
+  '  DriverState: active; trying to stage 44.20260720.3.1 (failed attempts: 7)',
+);
+
+/** One failure, still retrying — the normal, uninteresting case. */
+const STATUS_ONE_FAILURE = STATUS_PAUSED.replace(
+  '  DriverState: active; initialization complete, auto-updates logic disabled by configuration',
+  '  DriverState: active; trying to stage 44.20260720.3.1 (failed attempts: 1)',
+);
+
+/** Nothing wrong: the driver is just polling. */
+const STATUS_HEALTHY = STATUS_PAUSED.replace(
+  '  DriverState: active; initialization complete, auto-updates logic disabled by configuration',
+  '  DriverState: active; periodically polling for updates (last checked Mon 2026-08-17 19:31:02 UTC)',
+);
+
+/** ServiceBay's own auto-update window drop-in — updates stay ENABLED. */
+const CONFIG_WINDOW = `# Managed by ServiceBay — Settings → System → Auto-update window.
+# Edits in this file are overwritten on the next save.
+
+[updates]
+strategy = "periodic"
+
+[[updates.periodic.window]]
+days = [ "Sat", "Sun" ]
+start_time = "03:00"
+length_minutes = 120
+`;
+
+/** The operator's pause file, with the prose comment it really carries. */
+const CONFIG_PAUSED = `${CONFIG_WINDOW}
+# Automatic OS updates paused on 2026-08-17.
+#
+# REASON: akmod-nvidia-open cannot build against the target release's kernel;
+# the driver still includes a header the kernel dropped. Note that a naive
+# substring search would trip over the words "enabled = false" in this very
+# comment, which is why the reader strips comments first.
+[updates]
+enabled = false
+`;
+
+/** Assemble the probe's raw output the way OS_UPDATE_COMMAND does. */
+const raw = (status: string, config: string) => `${status}${OS_UPDATE_CONFIG_MARKER}\n${config}`;
+
+describe('OS_UPDATE_COMMAND', () => {
+  it('reads only the operator-owned drop-ins and never fails on a box without them', () => {
+    expect(OS_UPDATE_COMMAND).toContain('/etc/zincati/config.d/');
+    // The distro defaults would only add precedence rules to reason about.
+    expect(OS_UPDATE_COMMAND).not.toContain('/usr/lib/zincati');
+    // Without this the last command's exit code decides the probe's verdict.
+    expect(OS_UPDATE_COMMAND.trimEnd().endsWith('|| true')).toBe(true);
+  });
+});
+
+describe('parseRpmOstreeStatus', () => {
+  it('reads the driver, its state and the failed-attempt count', () => {
+    const state = parseRpmOstreeStatus(STATUS_STUCK);
+    expect(state.driver).toBe('Zincati');
+    expect(state.stagingRelease).toBe('44.20260720.3.1');
+    expect(state.failedAttempts).toBe(7);
+    expect(state.disabledByConfig).toBe(false);
+    expect(state.unavailable).toBe(false);
+  });
+
+  it('recognises the paused DriverState as disabled-by-configuration', () => {
+    const state = parseRpmOstreeStatus(STATUS_PAUSED);
+    expect(state.disabledByConfig).toBe(true);
+    expect(state.failedAttempts).toBeNull();
+  });
+
+  it('collects layered packages including the wrapped continuation line', () => {
+    // `xorg-x11-drv-nvidia-cuda` only appears on the wrapped second line, and
+    // the akmod name is what makes the CPU explanation truthful.
+    expect(parseRpmOstreeStatus(STATUS_STUCK).layeredPackages).toEqual([
+      'akmod-nvidia-open',
+      'ffmpeg-free',
+      'nvidia-container-toolkit',
+      'python3',
+      'xorg-x11-drv-nvidia-cuda',
+    ]);
+  });
+
+  it('takes the version from the booted deployment, not the staged one', () => {
+    // The pending deployment is printed FIRST; only the `●` block is running.
+    expect(parseRpmOstreeStatus(STATUS_STUCK).bootedVersion).toBe('44.20260510.3.1');
+  });
+
+  it('does not mistake a LocalPackages tail or an ostree ref for a layered package', () => {
+    const layered = parseRpmOstreeStatus(STATUS_STUCK).layeredPackages;
+    expect(layered.some(p => p.includes('rpmfusion'))).toBe(false);
+    expect(layered.some(p => p.includes('ostree-image-signed'))).toBe(false);
+  });
+
+  it('flags output that is not rpm-ostree status at all', () => {
+    expect(parseRpmOstreeStatus('bash: rpm-ostree: command not found').unavailable).toBe(true);
+    expect(parseRpmOstreeStatus('').unavailable).toBe(true);
+  });
+});
+
+describe('zincatiUpdatesDisabled', () => {
+  it('finds `enabled = false` under [updates]', () => {
+    expect(zincatiUpdatesDisabled(CONFIG_PAUSED)).toBe(true);
+  });
+
+  it('does not fire on ServiceBay\'s ordinary auto-update window drop-in', () => {
+    expect(zincatiUpdatesDisabled(CONFIG_WINDOW)).toBe(false);
+  });
+
+  it('ignores the phrase when it only appears in a comment', () => {
+    expect(zincatiUpdatesDisabled('[updates]\n# enabled = false was tried once\nstrategy = "immediate"\n')).toBe(false);
+  });
+
+  it('ignores `enabled = false` belonging to another table', () => {
+    expect(zincatiUpdatesDisabled('[identity]\nenabled = false\n')).toBe(false);
+  });
+
+  it('is silent on an empty drop-in directory', () => {
+    expect(zincatiUpdatesDisabled('')).toBe(false);
+  });
+});
+
+describe('evaluateOsUpdate — the three states (#2585)', () => {
+  it('warns once staging has failed repeatedly, and names the kernel-module build as the CPU source', () => {
+    const result = evaluateOsUpdate(raw(STATUS_STUCK, CONFIG_WINDOW), 0);
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('44.20260720.3.1');
+    expect(result.detail).toContain('7 times in a row');
+    // The whole point of the probe: an operator hunting the load must be told
+    // it is a kernel-module compile, not a vague "updates are failing".
+    expect(result.detail).toContain('akmod-nvidia-open');
+    expect(result.detail).toMatch(/kernel module from source/);
+    expect(result.detail).toMatch(/not any service or container/);
+    // And that it will not clear on its own.
+    expect(result.detail).toMatch(/repeats indefinitely/);
+    expect(result.hint).toBeTruthy();
+  });
+
+  it('stays quiet on a single failed attempt — retrying is how staging recovers', () => {
+    const result = evaluateOsUpdate(raw(STATUS_ONE_FAILURE, CONFIG_WINDOW), 0);
+    expect(result.status).toBe('ok');
+    expect(result.hint).toBeUndefined();
+  });
+
+  it('stays quiet one attempt below the threshold and fires exactly at it', () => {
+    const at = (n: number) =>
+      evaluateOsUpdate(
+        raw(STATUS_STUCK.replace('failed attempts: 7', `failed attempts: ${n}`), CONFIG_WINDOW),
+        0,
+      ).status;
+    expect(at(STUCK_ATTEMPTS_THRESHOLD - 1)).toBe('ok');
+    expect(at(STUCK_ATTEMPTS_THRESHOLD)).toBe('warn');
+  });
+
+  it('reports a healthy, polling updater without noise', () => {
+    const result = evaluateOsUpdate(raw(STATUS_HEALTHY, CONFIG_WINDOW), 0);
+    expect(result.status).toBe('ok');
+    expect(result.detail).toContain('Zincati');
+  });
+
+  it('treats a deliberately paused updater as information, never a warning', () => {
+    const result = evaluateOsUpdate(raw(STATUS_PAUSED, CONFIG_PAUSED), 0);
+    expect(result.status).toBe('info');
+    expect(result.detail).toMatch(/deliberate choice, not a fault/);
+    // It still says what the pause costs, so nobody forgets they paused.
+    expect(result.detail).toMatch(/stays on this release/);
+  });
+
+  it('does NOT warn on a pause even while a high failed-attempt count is still reported', () => {
+    // The window between writing the pause drop-in and zincati restarting:
+    // the config already says off, the daemon still reports the old retry.
+    const result = evaluateOsUpdate(raw(STATUS_STUCK, CONFIG_PAUSED), 0);
+    expect(result.status).toBe('info');
+    expect(result.detail).toMatch(/history, not a fault/);
+    expect(result.detail).toContain('7');
+  });
+
+  it('does NOT warn when only the DriverState reports the pause and no drop-in is readable', () => {
+    // The mirror case: the pause came from somewhere this probe cannot read,
+    // but zincati's own effective state is authoritative.
+    const result = evaluateOsUpdate(raw(STATUS_PAUSED, ''), 0);
+    expect(result.status).toBe('info');
+  });
+});
+
+describe('evaluateOsUpdate — boxes with nothing to report', () => {
+  it('is silent on a system that is not rpm-ostree based', () => {
+    const result = evaluateOsUpdate(raw('bash: rpm-ostree: command not found\n', ''), 0);
+    expect(result.status).toBe('info');
+    expect(result.detail).toMatch(/Not an rpm-ostree system/);
+  });
+
+  it('is silent when rpm-ostree is present but no update driver is configured', () => {
+    const noDriver = STATUS_PAUSED.split('\n')
+      .filter(l => !/AutomaticUpdatesDriver|DriverState/.test(l))
+      .join('\n');
+    const result = evaluateOsUpdate(raw(noDriver, ''), 0);
+    expect(result.status).toBe('info');
+    expect(result.detail).toMatch(/No automatic OS update driver/);
+  });
+
+  it('reports an unreadable state honestly instead of guessing', () => {
+    const result = evaluateOsUpdate('', undefined);
+    expect(result.status).toBe('info');
+    expect(result.detail).toMatch(/unknown/);
+  });
+
+  it('falls back to a generic cost sentence when nothing kernel-shaped is layered', () => {
+    const plain = STATUS_STUCK.replace(/akmod-nvidia-open /g, '');
+    const result = evaluateOsUpdate(raw(plain, CONFIG_WINDOW), 0);
+    expect(result.status).toBe('warn');
+    expect(result.detail).not.toContain('kernel module from source');
+    expect(result.detail).toContain('layered packages');
+  });
+});

--- a/packages/backend/src/lib/diagnose/probes/osUpdateStuck.ts
+++ b/packages/backend/src/lib/diagnose/probes/osUpdateStuck.ts
@@ -1,0 +1,385 @@
+/**
+ * `os_update` probe (#2585) — is the box's automatic OS update retrying a
+ * staging step it can never complete?
+ *
+ * ## Why this needs a probe at all
+ *
+ * On Fedora CoreOS, Zincati stages OS updates on a fixed retry interval. When
+ * the box has **layered packages** (`rpm-ostree status` → `LayeredPackages:`),
+ * every staging attempt re-runs those packages' `%post` scripts inside the new
+ * deployment. An `akmod-*` package's `%post` *builds a kernel module from
+ * source*, which is a multi-minute, near-full-core compile.
+ *
+ * If that build cannot succeed against the target release's kernel — an NVIDIA
+ * driver including a header the kernel dropped, say — the attempt fails, the
+ * retry timer fires, and the compile starts over. Forever. On the reference box
+ * this ran from 2026-08-14 to 2026-08-17: an attempt every ~6 minutes, ~7
+ * minutes of `cc1` at ~75 % CPU each, 457 attempts, no update ever installed.
+ *
+ * The reason it needs *ServiceBay* to say something is the shape of the
+ * symptom. The operator sees "the box is slow", opens ServiceBay, and looks at
+ * the **services** — where there is nothing wrong, because nothing here is a
+ * service. Every other signal points away from the cause: no container is
+ * misbehaving, no unit is failed (the retry is Zincati working as designed),
+ * disk is fine, and the version string still reads like a normal release. So
+ * the probe's job is not "updates are failing" — it is naming the CPU burn and
+ * saying which layer it comes from.
+ *
+ * ## Three states, and why a pause is not a fault
+ *
+ * `rpm-ostree status` reports Zincati's own state machine verbatim, so all
+ * three states are one cheap read:
+ *
+ *   * stuck   — `DriverState: active; trying to stage <release> (failed attempts: N)`
+ *   * paused  — `DriverState: active; …, auto-updates logic disabled by configuration`
+ *   * healthy — `DriverState: active; periodically polling for updates …`
+ *
+ * The paused state matters as much as the stuck one. Pausing auto-updates is a
+ * **supported ServiceBay action** — `updateWindow.ts` writes exactly
+ * `[updates] enabled = false` into `/etc/zincati/config.d/55-servicebay-lock.toml`
+ * when the operator locks updates from Settings → System — and an operator who
+ * pauses updates to stop a broken kernel-module build has *resolved* the
+ * problem this probe exists to report. A probe that then went red would be
+ * punishing the fix. So a paused updater is reported as information, never as a
+ * warning, no matter what attempt count is still lying around in the state
+ * string.
+ *
+ * The pause is detected two ways, deliberately: Zincati's own DriverState text
+ * (authoritative — it reflects the *effective* config), plus a direct read of
+ * the `/etc/zincati/config.d` drop-ins (covers the window where the file is
+ * written but `systemctl restart zincati` has not landed yet, so the daemon is
+ * still reporting the old "trying to stage" string).
+ *
+ * Detection is read-only — one `rpm-ostree status` plus a `cat` of the drop-in
+ * directory. The parse and the verdict are pure functions, so all three states
+ * are unit-testable from fixtures without a host.
+ */
+
+export const PROBE_ID = 'os_update';
+export const PROBE_LABEL = 'OS updates';
+
+/** Separates the `rpm-ostree status` output from the Zincati drop-ins. */
+export const OS_UPDATE_CONFIG_MARKER = '---zincati-config---';
+
+/**
+ * One read: the updater's live state, then the operator-owned Zincati
+ * drop-ins. Only `/etc/zincati/config.d` is read — `/usr/lib/zincati/config.d`
+ * holds the distro defaults, which cannot express an operator's intent and
+ * would only add precedence rules to reason about.
+ */
+export const OS_UPDATE_COMMAND =
+  'rpm-ostree status 2>&1; ' +
+  `echo "${OS_UPDATE_CONFIG_MARKER}"; ` +
+  // `|| true` so a box with no drop-in directory (the glob then expands to
+  // itself and `cat` exits 1) still reports exit 0. Whether this is an
+  // rpm-ostree box at all is decided by the parse, not by an exit code the
+  // last command in the pipeline happens to own.
+  'cat /etc/zincati/config.d/*.toml 2>/dev/null || true';
+
+/**
+ * How many consecutive failed staging attempts before this is a warning.
+ *
+ * **One failure is normal and must not fire.** Staging pulls an ostree commit
+ * and re-runs layered `%post` scripts; a network blip, a busy mirror or a
+ * transient rpm-md read all produce a single failure that the next retry
+ * clears, and warning on that would make the probe noise on every healthy box.
+ * Two is still plausibly the same transient condition being retried too soon.
+ *
+ * At **three consecutive failures on the same release** the transient
+ * explanation is spent: the same deterministic step has now failed three times
+ * in a row against the same target. Three is also where the cost becomes the
+ * operator's problem rather than a curiosity — on the reference box each
+ * attempt was ~7 minutes of compile at ~75 % CPU, so three attempts is already
+ * ~20 minutes of unexplained near-full load, which is roughly when someone
+ * starts looking for it.
+ *
+ * The ceiling matters too: Zincati's counter resets (a daemon restart, a new
+ * target release), and the live box showed `failed attempts: 7` in DriverState
+ * while the journal held 457 failures over three days. The count is therefore a
+ * *floor*, not a total — a threshold up in the tens would simply never fire.
+ */
+export const STUCK_ATTEMPTS_THRESHOLD = 3;
+
+export type OsUpdateProbeStatus = 'ok' | 'warn' | 'fail' | 'info';
+
+/** What Zincati is doing right now, as parsed from `rpm-ostree status`. */
+export interface OsUpdateState {
+  /** `AutomaticUpdatesDriver: <name>`, or null when no driver is configured. */
+  driver: string | null;
+  /** The raw `DriverState:` text, or null when absent. */
+  driverState: string | null;
+  /** Release the driver is trying to stage, when it says so. */
+  stagingRelease: string | null;
+  /** `failed attempts: N` from the DriverState, or null when not reported. */
+  failedAttempts: number | null;
+  /** Zincati itself reports auto-updates off (the effective state). */
+  disabledByConfig: boolean;
+  /** Every layered package name found in the status output, de-duplicated. */
+  layeredPackages: string[];
+  /** Version of the currently-booted deployment (the `●` block). */
+  bootedVersion: string | null;
+  /** True when the output does not look like `rpm-ostree status` at all. */
+  unavailable: boolean;
+}
+
+/** `DriverState: active; trying to stage 44.20260720.3.1 (failed attempts: 7)` */
+const STAGING_RELEASE = /trying to stage\s+(\S+)/i;
+const FAILED_ATTEMPTS = /failed attempts:\s*(\d+)/i;
+/** Zincati's wording when `[updates] enabled = false` is in effect. */
+const DISABLED_BY_CONFIG = /auto-?updates?\s+logic\s+disabled\s+by\s+configuration/i;
+
+/** A `Key: value` line. Top-level fields (`State`, `AutomaticUpdatesDriver`)
+ *  sit at column 0 while per-deployment fields are indented, so leading
+ *  whitespace is optional. The required space *after* the colon is what keeps
+ *  `ostree-image-signed:docker://…` (a deployment header) from being read as
+ *  a key. */
+const KEY_LINE = /^\s*([A-Za-z][A-Za-z0-9 -]*):[ \t]+(.*)$/;
+/** A wrapped continuation of a package list: bare package tokens only, so a
+ *  line carrying a colon (a key, a URL, an ostree ref) never qualifies. */
+const PACKAGE_CONTINUATION = /^\s+[A-Za-z0-9][A-Za-z0-9._+-]*(\s+[A-Za-z0-9][A-Za-z0-9._+-]*)*\s*$/;
+/** Package-list fields whose value can wrap onto following indented lines.
+ *  Only the layered sets feed the "what does staging rebuild" explanation;
+ *  `LocalPackages` is tracked purely so its wrapped tail isn't mistaken for
+ *  the start of a new deployment block. */
+const WRAPPED_LISTS: Record<string, { layered: boolean }> = {
+  LayeredPackages: { layered: true },
+  RequestedLayeredPackages: { layered: true },
+  LocalPackages: { layered: false },
+  RequestedLocalPackages: { layered: false },
+};
+
+/**
+ * Parse `rpm-ostree status` (the human-readable form — `--json` is not
+ * available on every rpm-ostree the fleet runs, and the driver state we need
+ * is printed here regardless). Tolerant by design: an unrecognised line is
+ * skipped rather than throwing, because the layout varies with rpm-ostree
+ * version and a parse hiccup must never take down the diagnose run.
+ */
+export function parseRpmOstreeStatus(raw: string): OsUpdateState {
+  const lines = (raw ?? '').split('\n');
+  const state: OsUpdateState = {
+    driver: null,
+    driverState: null,
+    stagingRelease: null,
+    failedAttempts: null,
+    disabledByConfig: false,
+    layeredPackages: [],
+    bootedVersion: null,
+    unavailable: true,
+  };
+
+  const layered = new Set<string>();
+  // Non-null while the previous key line opened a package list whose value may
+  // wrap onto the following indented lines; the flag says whether those
+  // wrapped tokens are layered packages we want to collect.
+  let wrappedList: { layered: boolean } | null = null;
+  // True while we're inside the `●`-marked (currently booted) deployment.
+  let inBooted = false;
+
+  for (const line of lines) {
+    if (line.trim() === '') {
+      wrappedList = null;
+      continue;
+    }
+    if (/^\s*●/.test(line)) {
+      // The booted-deployment marker starts a new block.
+      inBooted = true;
+      wrappedList = null;
+      continue;
+    }
+    const key = KEY_LINE.exec(line);
+    if (key) {
+      const name = key[1].trim();
+      const value = key[2].trim();
+      wrappedList = WRAPPED_LISTS[name] ?? null;
+      if (wrappedList?.layered) {
+        for (const pkg of value.split(/\s+/).filter(Boolean)) layered.add(pkg);
+      } else if (name === 'AutomaticUpdatesDriver') {
+        state.driver = value;
+        state.unavailable = false;
+      } else if (name === 'DriverState') {
+        state.driverState = value;
+        state.unavailable = false;
+      } else if (name === 'State') {
+        state.unavailable = false;
+      } else if (name === 'Version') {
+        state.unavailable = false;
+        // `44.20260510.3.1 (2026-05-26T16:37:49Z)` — keep the release id only.
+        if (inBooted && state.bootedVersion === null) state.bootedVersion = value.split(/\s+/)[0] ?? null;
+      }
+      continue;
+    }
+    if (wrappedList && PACKAGE_CONTINUATION.test(line)) {
+      if (wrappedList.layered) {
+        for (const pkg of line.trim().split(/\s+/).filter(Boolean)) layered.add(pkg);
+      }
+      continue;
+    }
+    // Anything else that is neither a key nor a wrapped tail is a deployment
+    // header (`  ostree-image-signed:docker://…`) or the `Deployments:` banner
+    // — either way the previous block, booted or not, has ended.
+    wrappedList = null;
+    inBooted = false;
+  }
+
+  if (state.driverState) {
+    state.stagingRelease = STAGING_RELEASE.exec(state.driverState)?.[1] ?? null;
+    const attempts = FAILED_ATTEMPTS.exec(state.driverState)?.[1];
+    state.failedAttempts = attempts === undefined ? null : Number.parseInt(attempts, 10);
+    state.disabledByConfig = DISABLED_BY_CONFIG.test(state.driverState);
+  }
+  state.layeredPackages = [...layered].sort();
+  return state;
+}
+
+/**
+ * Does any Zincati drop-in turn auto-updates off? A minimal TOML read: track
+ * the current table header and look for `enabled = false` under `[updates]`.
+ * Comments are stripped first — the pause file on the reference box carries a
+ * long prose comment explaining *why*, and a naive substring match on it would
+ * be both wrong and unstable.
+ */
+export function zincatiUpdatesDisabled(configText: string): boolean {
+  let table = '';
+  for (const rawLine of (configText ?? '').split('\n')) {
+    const line = rawLine.replace(/#.*$/, '').trim();
+    if (line === '') continue;
+    const header = /^\[+\s*([^\]]+?)\s*\]+$/.exec(line);
+    if (header) {
+      table = header[1];
+      continue;
+    }
+    if (table !== 'updates') continue;
+    if (/^enabled\s*=\s*false\b/i.test(line)) return true;
+  }
+  return false;
+}
+
+export interface OsUpdateProbeResult {
+  status: OsUpdateProbeStatus;
+  detail: string;
+  hint?: string;
+}
+
+/** Layered packages whose `%post` compiles a kernel module — the reason a
+ *  failing staging retry costs a full core for minutes instead of seconds. */
+function kernelModulePackages(layered: string[]): string[] {
+  return layered.filter(p => /^(akmod|kmod)-/.test(p));
+}
+
+/** The cost sentence — what the retry loop is actually spending, named
+ *  concretely enough that an operator hunting "why is the CPU pegged"
+ *  recognises it. */
+function costExplanation(layered: string[]): string {
+  const kmods = kernelModulePackages(layered);
+  if (kmods.length > 0) {
+    return (
+      `Each attempt re-runs the layered packages' install scripts, and ${kmods.join(', ')} ` +
+      'builds a kernel module from source — a multi-minute compile that saturates a CPU core. ' +
+      'That compile, not any service or container, is what the load is.'
+    );
+  }
+  if (layered.length > 0) {
+    return (
+      `Each attempt re-runs the install scripts of the layered packages (${layered.join(', ')}) ` +
+      'against the new deployment, so the work is repeated in full every time.'
+    );
+  }
+  return 'Each attempt repeats the whole staging step from the start.';
+}
+
+const STUCK_HINT =
+  'Find out what is failing with `sudo journalctl -u zincati -b | grep -i "failed to stage"` and, for the ' +
+  'underlying error, `sudo rpm-ostree upgrade --preview` or the last `rpm-ostree` transaction in ' +
+  '`journalctl -u rpm-ostreed`. A layered kernel-module package that cannot build against the target ' +
+  "release's kernel is the usual cause, and it will not fix itself — the retry repeats the same build. " +
+  'Two ways out, both operator decisions ServiceBay does not take for you: remove or replace the layered ' +
+  'package (`sudo rpm-ostree uninstall <package>`) so staging can finish, or stop the retries until the ' +
+  'package catches up — Settings → System → Auto-update window can lock auto-updates, which writes ' +
+  '`[updates] enabled = false` for Zincati. Pausing stops the CPU burn but leaves the box on its current ' +
+  'OS release, so it is a hold, not a fix.';
+
+/**
+ * Pure verdict over the probe's raw output. `execCode` is the exit code of
+ * the read itself, so an unreadable box is reported honestly instead of being
+ * mistaken for "no updater configured".
+ */
+export function evaluateOsUpdate(raw: string, execCode: number | undefined): OsUpdateProbeResult {
+  if (execCode !== 0) {
+    return {
+      status: 'info',
+      detail: 'Could not read the OS update state (`rpm-ostree status` did not run), so it is unknown.',
+    };
+  }
+
+  const markerAt = (raw ?? '').indexOf(OS_UPDATE_CONFIG_MARKER);
+  const statusText = markerAt === -1 ? (raw ?? '') : raw.slice(0, markerAt);
+  const configText = markerAt === -1 ? '' : raw.slice(markerAt + OS_UPDATE_CONFIG_MARKER.length);
+
+  const state = parseRpmOstreeStatus(statusText);
+  if (state.unavailable) {
+    // Not an rpm-ostree box (a package-based distro, a container dev box).
+    // Silence, not a warning — there is no staging loop to be stuck in.
+    return {
+      status: 'info',
+      detail: 'Not an rpm-ostree system — no automatic OS update staging to watch.',
+    };
+  }
+
+  const on = state.bootedVersion ? ` The box is running ${state.bootedVersion}.` : '';
+  const attempts = state.failedAttempts;
+
+  // Paused FIRST, before any attempt count is considered. A deliberate pause
+  // is a normal, ServiceBay-supported condition — see the module header.
+  if (state.disabledByConfig || zincatiUpdatesDisabled(configText)) {
+    const leftover =
+      attempts !== null && attempts > 0
+        ? ` The last staging run had failed ${attempts} time(s) before the pause; that is history, not a fault.`
+        : '';
+    return {
+      status: 'info',
+      detail:
+        'Automatic OS updates are switched off by configuration — a deliberate choice, not a fault.' +
+        `${on}${leftover} The box stays on this release until updates are switched back on.`,
+      hint:
+        'Re-enable them in Settings → System → Auto-update window, or by removing the ' +
+        '`[updates] enabled = false` drop-in under /etc/zincati/config.d and restarting zincati.',
+    };
+  }
+
+  if (!state.driver) {
+    return {
+      status: 'info',
+      detail: `No automatic OS update driver is configured on this box.${on}`,
+    };
+  }
+
+  if (attempts !== null && attempts >= STUCK_ATTEMPTS_THRESHOLD) {
+    const target = state.stagingRelease ? ` ${state.stagingRelease}` : ' the next OS release';
+    return {
+      status: 'warn',
+      detail:
+        `Automatic OS updates are stuck: staging${target} has failed ${attempts} times in a row and is ` +
+        `still being retried.${on} ${costExplanation(state.layeredPackages)} ` +
+        'The retry runs on a timer and the failure is deterministic, so this repeats indefinitely — the ' +
+        'box neither updates nor stops trying.',
+      hint: STUCK_HINT,
+    };
+  }
+
+  if (attempts !== null && attempts > 0) {
+    // Below the threshold: a retry in progress is how staging is supposed to
+    // recover from a blip. Report it, don't warn about it.
+    return {
+      status: 'ok',
+      detail:
+        `Automatic OS updates are staging${state.stagingRelease ? ` ${state.stagingRelease}` : ''} after ` +
+        `${attempts} failed attempt(s) — still within the normal retry range.${on}`,
+    };
+  }
+
+  return {
+    status: 'ok',
+    detail: `Automatic OS updates are active via ${state.driver}: ${state.driverState ?? 'running'}.${on}`,
+  };
+}

--- a/packages/backend/src/lib/diagnose/runDiagnose.ts
+++ b/packages/backend/src/lib/diagnose/runDiagnose.ts
@@ -43,6 +43,12 @@ import {
   PROBE_ID as DISK_PROBE_ID,
   PROBE_LABEL as DISK_PROBE_LABEL,
 } from '@/lib/diagnose/probes/diskFill';
+import {
+  OS_UPDATE_COMMAND,
+  evaluateOsUpdate,
+  PROBE_ID as OS_UPDATE_PROBE_ID,
+  PROBE_LABEL as OS_UPDATE_PROBE_LABEL,
+} from '@/lib/diagnose/probes/osUpdateStuck';
 import { wasInstallActiveWithin } from '@/lib/install/jobStore';
 import { persistDiagnoseResults, buildProbeHistory, type ProbeHistory } from '@/lib/diagnose/persistDiagnoseResults';
 import '@/lib/diagnose/probes/register';
@@ -111,6 +117,12 @@ const PROBE_GROUP: Record<string, ProbeGroup> = {
   disk: 'storage-backups',
   raid: 'storage-backups',
   nas_backup_reachable: 'storage-backups',
+  // Host/OS state (#2585). Deliberately NOT `system-info`: that card is
+  // collapsed because it holds things that are never a problem, and a
+  // permanently-failing update loop is exactly the problem an operator is
+  // hunting when the box is pegged. `other` renders as a normal, expanded
+  // card, which is what this row needs.
+  os_update: 'other',
   // System info (collapsed — not a problem)
   serial: 'system-info',
   ports: 'system-info',
@@ -402,6 +414,7 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     serial,
     disk,
     mdstat,
+    osUpdate,
     firstBoot,
     uptimeRes,
     psStatus,
@@ -420,6 +433,12 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     // proves the filesystem mounts — it says nothing about whether the
     // RAID1 underneath it still has both members.
     exec('cat /proc/mdstat', 3000),
+    // Zincati's own state machine (#2585). `rpm-ostree status` prints it
+    // verbatim, including the consecutive-failure count of a staging retry,
+    // so a permanently-failing update loop is a single read away. The
+    // Zincati drop-ins ride along so a deliberate pause is never mistaken
+    // for a fault.
+    exec(OS_UPDATE_COMMAND, 5000),
     exec(
       'systemctl --no-pager status setup-raid install-python install-nginx 2>&1 | grep -E "(●|Active:)" | head -20',
       5000,
@@ -607,6 +626,23 @@ export async function runDiagnose(nodeName: string = 'Local', opts: RunDiagnoseO
     detail: raid.detail,
     hint: raid.hint,
     _items: raid.items,
+  });
+
+  // 7c) Automatic OS updates (#2585). Separate from every service probe on
+  //     purpose: when a layered kernel-module package can no longer build,
+  //     Zincati re-attempts the same staging step on a timer and each attempt
+  //     burns minutes of CPU compiling it. Nothing else on the box reports
+  //     that — no unit is failed, no container misbehaves — so an operator
+  //     chasing the load searches the services and finds nothing. This row is
+  //     where the answer lives. A deliberately paused updater is information,
+  //     not a warning: see probes/osUpdateStuck.ts.
+  const osUpdateResult = evaluateOsUpdate(osUpdate.stdout ?? '', osUpdate.code);
+  probes.push({
+    id: OS_UPDATE_PROBE_ID,
+    label: OS_UPDATE_PROBE_LABEL,
+    status: osUpdateResult.status,
+    detail: osUpdateResult.detail,
+    hint: osUpdateResult.hint,
   });
 
   // 8) First-boot oneshot units (FCOS only)

--- a/templates/media/CHANGELOG.md
+++ b/templates/media/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Media (Jellyfin) — template changelog
 
+## v8 — #2580
+
+**Jellyfin uses the graphics card to re-encode video, if the box has
+one.** Nothing for you to do: redeploy `media` and the next film that
+needs converting runs on the card instead of the processor. On a box
+with no NVIDIA card nothing changes at all.
+
+### Why
+
+Jellyfin was converting video in software. On the reference box a
+single stream took roughly three of six processor cores — enough to
+slow down everything else on the machine — while an idle graphics card
+sat next to it. That was never a misconfiguration: the template simply
+had no way to hand the card over.
+
+### What changed
+
+- New variable `JELLYFIN_GPU_PASSTHROUGH`, on by default. Blank it if
+  you want software conversion even on a machine that has a card.
+- `template.yml` renders the CDI request when the variable is set, and
+  `post-deploy.py` swaps the service to a `.container` unit carrying
+  `AddDevice=nvidia.com/gpu=all` — the only form that actually attaches
+  a card under rootless podman (#1026/#2517); expressed in the pod
+  spec it is silently dropped and everything keeps running on the CPU.
+- `post-deploy.py` also sets Jellyfin's own transcoding option to
+  **NVENC**. Handing over the device is not enough on its own —
+  Jellyfin re-encodes in software until its configuration says
+  otherwise. Your existing playback settings are read, amended and
+  written back, so nothing else moves; if you had already picked a
+  different accelerator by hand, yours is kept.
+- No VRAM budget and no cap on simultaneous conversions. The card is
+  shared with the local AI stack, and the operator decided on
+  2026-08-17 — with the free/used figures in hand — that the headroom
+  makes a limit unnecessary. The residual case (a much larger language
+  model plus several 4K streams at once) is documented in #2580.
+
+### Required action for existing installs
+
+None. Your Jellyfin database, cache and library stay exactly where they
+are — the new unit binds the same three directories the pod did.
+
 ## v7 (breaking) — #2561
 
 **`books.<domain>` goes away — use `media.<domain>` instead.** If you

--- a/templates/media/README.md
+++ b/templates/media/README.md
@@ -24,6 +24,19 @@ Jellyfin's post-deploy auto-adds two libraries: `/media/music` ("Music") and `/m
 
 Override `JELLYFIN_MEDIA_PATH` in the wizard's Configure step if your media lives elsewhere.
 
+## Hardware transcoding (NVIDIA)
+
+`JELLYFIN_GPU_PASSTHROUGH` is **on by default**. Two things have to happen for it to mean anything, and post-deploy does both:
+
+1. **The card is attached.** The pod-spec form (`resources.limits.nvidia.com/gpu`) is silently dropped by `podman kube play` on rootless podman — the pod comes up healthy and still transcodes on the CPU, with nothing in the logs (#1026, class #2517). So post-deploy swaps the service to a `.container` Quadlet carrying `AddDevice=nvidia.com/gpu=all` + `SecurityLabelDisable=true` (the second line is required, not cosmetic: without it NVML can't initialise under SELinux). ServiceBay retires the shadowing `.kube`/`.yml` on every later redeploy (#2174).
+2. **Jellyfin is told to use it.** Jellyfin re-encodes in software until its own `HardwareAccelerationType` says `nvenc`, device or no device. Post-deploy read-modify-writes `/System/Configuration/encoding`, so the rest of your playback settings survive — and if you already picked a different accelerator by hand, yours is kept.
+
+**No card, no problem.** The swap is gated on `/etc/cdi/nvidia.yaml`; a host with no CDI-registered GPU stays a plain pod and keeps transcoding in software. Set the variable to blank to force software transcoding on a machine that does have a card.
+
+There is deliberately **no VRAM budget and no cap on concurrent transcodes** — the card is shared with the local inference stack and the operator decided against a limit on 2026-08-17 with the free/used figures in hand. See #2580 before adding one.
+
+Check it worked: `nvidia-smi` should list `ffmpeg` as a process while something is actually transcoding (start a playback that forces a re-encode, e.g. by picking a lower bitrate in the client's quality menu).
+
 ## Authentication
 
 * **Jellyfin web UI + mobile** — LDAP → LLDAP (#1718). ServiceBay installs the LDAP-Authentication plugin and writes its config (host-side, every deploy → idempotent + self-healing) so family members sign in with their Authelia/LLDAP credentials. The local `admin` account (auto-seeded from `JELLYFIN_ADMIN_PASSWORD`) stays a working break-glass login.

--- a/templates/media/post-deploy.py
+++ b/templates/media/post-deploy.py
@@ -98,8 +98,20 @@ JELLYFIN_WIZARD_PROBE_TIMEOUT = 60
 
 # Pod-container names. Podman names a Pod's containers `<pod>-<container>`;
 # this pod is `media`, the container is `jellyfin` (see template.yml).
-# Used by the Jellyfin LDAP plugin restart (#1718).
+# Used by the Jellyfin LDAP plugin restart (#1718) and kept as the
+# `ContainerName=` of the GPU `.container` Quadlet so every other caller
+# (LDAP restart, ServiceBay's discovery, the operator's `podman logs`)
+# keeps finding the same name after the swap.
 JELLYFIN_CONTAINER = "media-jellyfin"
+
+# Systemd user Quadlet directory — where `media.kube` / `media.yml` land
+# and where the GPU `.container` unit is written (#2580).
+SYSTEMD_USER_DIR = "~/.config/containers/systemd"
+
+# Presence of this file is how the host advertises a CDI-registered
+# NVIDIA GPU (`nvidia-ctk cdi generate`). No file → no card ServiceBay
+# can hand over → leave the pod alone and keep transcoding on the CPU.
+CDI_NVIDIA_SPEC = "/etc/cdi/nvidia.yaml"
 
 
 def request_json(
@@ -134,6 +146,172 @@ def request_json(
             return e.code, None
     except (urllib.error.URLError, TimeoutError, OSError):
         return 0, None
+
+
+# ── GPU passthrough: swap the .kube pod for a .container Quadlet ─────
+
+
+def gpu_requested() -> bool:
+    """Whether the operator wants NVIDIA hardware transcoding.
+
+    Blank means "force software transcoding"; anything else (the default
+    `yes`) means "use the card if this host has one". The *if* is
+    resolved in `install_gpu_quadlet_fallback`, not here — a GPU-less
+    box must install unchanged, so the toggle alone is never enough to
+    change the deploy shape."""
+    return env("JELLYFIN_GPU_PASSTHROUGH", "").strip() != ""
+
+
+def build_jellyfin_container_unit() -> str:
+    """Render the `.container` Quadlet that replaces the `media` pod when
+    the GPU is passed through (#2580).
+
+    It mirrors `template.yml`'s single jellyfin container one directive
+    at a time — image, published port, env, the three bind mounts, and
+    the `auth.<domain>` host alias — and adds the two lines that are the
+    entire point:
+
+      * `AddDevice=nvidia.com/gpu=all` — the CDI handle. Expressed as
+        `resources.limits.nvidia.com/gpu` in a Pod spec it is silently
+        dropped by `podman kube play` on rootless 5.x (#1026/#2517), so
+        the pod deploys healthy and transcodes on the CPU with nothing
+        in the logs to say why.
+      * `SecurityLabelDisable=true` — required, not cosmetic: without it
+        the container gets the device nodes but NVML fails to
+        initialise under SELinux ("Insufficient Permissions").
+
+    `SecurityLabelDisable=true` also subsumes the pod's
+    `io.podman.annotations.label/jellyfin: "disable"` annotation, which
+    exists for the same reason the mounts below carry no `:z`/`:Z`: the
+    /media tree is the SHARED multi-writer file-share volume, and a
+    recursive relabel of it crash-loops the service on a single
+    root-owned stray (#1731). Do not add relabel flags here.
+
+    Values come from the environment (every wizard variable is exported
+    into this script), so this stays in step with what the pod was
+    rendered from."""
+    port = env("JELLYFIN_PORT", "8096")
+    data_dir = env("DATA_DIR", "/mnt/data/stacks")
+    media_path = env("JELLYFIN_MEDIA_PATH", f"{data_dir}/file-share/data")
+    tz = env("TZ", "Europe/Berlin")
+    public_domain = env("PUBLIC_DOMAIN", "")
+    media_subdomain = env("MEDIA_SUBDOMAIN", "media")
+    gateway_ip = env("HOST_GATEWAY_IP", "169.254.1.2")
+
+    lines = [
+        "[Unit]",
+        "Description=Jellyfin (Movies & TV, NVIDIA passthrough #2580)",
+        "Wants=network-online.target",
+        "After=network-online.target",
+        "",
+        "[Container]",
+        "Image=docker.io/jellyfin/jellyfin:latest",
+        f"ContainerName={JELLYFIN_CONTAINER}",
+        f"PublishPort={port}:{port}",
+        f"Environment=TZ={tz}",
+    ]
+    if public_domain:
+        lines.append(
+            f"Environment=JELLYFIN_PublishedServerUrl=https://{media_subdomain}.{public_domain}"
+        )
+        # Mirrors the pod's hostAliases entry: an isolated container
+        # cannot reach the host's own LAN IP under rootless podman
+        # (#817), so server-side calls to Authelia go through the
+        # host-gateway address instead.
+        lines.append(f"AddHost=auth.{public_domain}:{gateway_ip}")
+    lines += [
+        "# CDI device — the only form that actually attaches the card on",
+        "# rootless podman 5.x. See #1026 / #2517 for the dead ends.",
+        "AddDevice=nvidia.com/gpu=all",
+        "# Required for NVML init under SELinux, and it is also what keeps",
+        "# the shared /media tree from being relabelled (#1731).",
+        "SecurityLabelDisable=true",
+        f"Volume={data_dir}/media/jellyfin-config:/config",
+        f"Volume={data_dir}/media/jellyfin-cache:/cache",
+        f"Volume={media_path}:/media:ro",
+        "AutoUpdate=registry",
+        "",
+        "[Service]",
+        "Restart=on-failure",
+        "RestartSec=5",
+        "",
+        "[Install]",
+        "WantedBy=default.target",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def install_gpu_quadlet_fallback() -> bool:
+    """Swap the just-deployed `media.kube` unit for a `.container` Quadlet
+    that carries the CDI device (#2580, mechanism from #1026).
+
+    Returns True when the service is (or has just become) GPU-backed,
+    False when it stays a plain CPU pod — the caller uses that to decide
+    whether to switch Jellyfin's own transcoding setting to NVENC.
+    Pointing Jellyfin at NVENC without the device would turn every
+    transcode into an error, so the two must move together.
+
+    Idempotent in both directions:
+      * no `/etc/cdi/nvidia.yaml` → no card → returns False, touches
+        nothing. This is what makes the default-on toggle safe on a box
+        with no GPU.
+      * `media.container` already present → the swap happened on an
+        earlier deploy; ServiceBay's `reconcileContainerQuadletShadow`
+        retires the freshly re-written `.kube`/`.yml` after this script
+        returns (#2174), so there is nothing to do here.
+
+    Data is untouched: the `.container` unit binds the same three host
+    paths the pod did, so an existing install keeps its Jellyfin
+    database, cache and library exactly where they were."""
+    if not os.path.exists(CDI_NVIDIA_SPEC):
+        log(f"ℹ️ No CDI NVIDIA spec at {CDI_NVIDIA_SPEC} — this host has no GPU to hand over. "
+            "Jellyfin stays on the plain pod and transcodes in software.")
+        return False
+
+    systemd_dir = os.path.expanduser(SYSTEMD_USER_DIR)
+    kube_path = os.path.join(systemd_dir, "media.kube")
+    container_path = os.path.join(systemd_dir, "media.container")
+
+    if os.path.exists(container_path):
+        log("ℹ️ media.container already in place — GPU passthrough is already wired; "
+            "ServiceBay retires the shadowing media.kube after this script (#2174).")
+        return True
+
+    # Stop the .kube-backed unit first. Both unit files generate
+    # `media.service`, so leaving the .kube in place would let systemd's
+    # generator pick either one at reload time.
+    subprocess.run(["systemctl", "--user", "stop", "media.service"], check=False, capture_output=True)
+    if os.path.exists(kube_path):
+        try:
+            os.unlink(kube_path)
+        except OSError as e:
+            log(f"⚠️ Could not remove {kube_path} ({e}) — Quadlet may generate two units for media.service. "
+                "Remove it by hand and run `systemctl --user daemon-reload`.")
+
+    try:
+        with open(container_path, "w") as f:
+            f.write(build_jellyfin_container_unit())
+        os.chmod(container_path, 0o644)
+    except OSError as e:
+        log(f"⚠️ Could not write {container_path} ({e}) — GPU passthrough not applied; "
+            "Jellyfin keeps transcoding in software.")
+        return False
+
+    # The old pod container holds the name; the generated unit runs
+    # `podman run --replace`, but clear it explicitly so a failure to
+    # replace can't leave the CPU container in place.
+    subprocess.run(["podman", "rm", "-f", JELLYFIN_CONTAINER], check=False, capture_output=True)
+    subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, capture_output=True)
+    started = subprocess.run(
+        ["systemctl", "--user", "start", "media.service"], capture_output=True, text=True,
+    )
+    if started.returncode != 0:
+        log(f"⚠️ media.service did not start from the .container Quadlet: {started.stderr.strip()[:400]}")
+        return False
+
+    log("✅ Jellyfin swapped to a .container Quadlet with AddDevice=nvidia.com/gpu=all — the card is attached.")
+    return True
 
 
 # ── Jellyfin first-run + Quick Connect + Music library ───────────────
@@ -850,6 +1028,77 @@ def ensure_jellyfin_dlna_server(base_url: str, token: str) -> bool:
     return False
 
 
+# Codecs to hand NVDEC when we are the ones switching hardware
+# acceleration on. Jellyfin's stock list is `h264, vc1` — fine while
+# acceleration is off, but it leaves HEVC (i.e. most 4K) decoding in
+# software on a box that has just been given a card. Jellyfin falls back
+# to software for any codec the hardware can't do, so an over-broad list
+# costs nothing.
+JELLYFIN_NVDEC_CODECS = ["h264", "hevc", "mpeg2video", "mpeg4", "vc1", "vp8", "vp9", "av1"]
+
+
+def jellyfin_enable_nvenc(base_url: str, token: str) -> bool:
+    """Point Jellyfin's own transcoding configuration at NVENC (#2580).
+
+    **Seeing the device is not using it.** Handing the container the card
+    changes nothing on its own: Jellyfin picks its encoder from
+    `HardwareAccelerationType` in its encoding configuration, which
+    defaults to `none`, so a deploy that stops at `AddDevice=` still
+    burns CPU cores on every re-encode. This is the other half.
+
+    Read-modify-write on the `encoding` named configuration — the same
+    shape `ensure_jellyfin_dlna_server` uses — so nothing else in the
+    operator's transcoding setup is disturbed. That is what makes it
+    safe on an EXISTING install: the settings survive, only the
+    acceleration keys move.
+
+    Non-destructive in the other direction too: an operator who
+    deliberately chose a different accelerator (vaapi, qsv, …) keeps it.
+    Only `none`/unset is taken over. Re-asserted on every deploy, so a
+    reinstall never silently drops back to software."""
+    auth = {"X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{token}"'}
+
+    code, options = request_json(
+        "GET", f"{base_url}/System/Configuration/encoding", None, extra_headers=auth,
+    )
+    if code not in (200, 204) or not isinstance(options, dict):
+        log(f"   (note) Could not read Jellyfin's transcoding configuration ({render_http_code(code)}); "
+            "set Dashboard → Playback → Hardware acceleration to 'Nvidia NVENC' by hand.")
+        return False
+
+    current = str(options.get("HardwareAccelerationType") or "").strip()
+    if current.lower() not in ("", "none", "nvenc"):
+        log(f"   (note) Jellyfin's hardware acceleration is already set to '{current}' — leaving it alone. "
+            "Switch it to 'Nvidia NVENC' in Dashboard → Playback if you want the card used.")
+        return False
+
+    turning_on = current.lower() in ("", "none")
+    options["HardwareAccelerationType"] = "nvenc"
+    options["EnableHardwareEncoding"] = True
+    if turning_on:
+        # We are switching acceleration on, so the decode side is ours to
+        # set: the list Jellyfin carries while acceleration is off is a
+        # default, not a decision. Once it IS on, leave the list alone —
+        # a narrower list from then on is the operator's choice.
+        options["HardwareDecodingCodecs"] = list(JELLYFIN_NVDEC_CODECS)
+        # Only touch keys this Jellyfin actually has — the encoding
+        # options object gains and loses fields across releases, and
+        # posting one it doesn't know is a needless 400 risk.
+        for key in ("EnableEnhancedNvdecDecoder", "EnableDecodingColorDepth10Hevc", "EnableDecodingColorDepth10Vp9"):
+            if key in options:
+                options[key] = True
+
+    code, _ = request_json(
+        "POST", f"{base_url}/System/Configuration/encoding", options, extra_headers=auth,
+    )
+    if code in (200, 204):
+        log("   ✅ Jellyfin transcoding set to NVENC (hardware encode + NVDEC decode).")
+        return True
+    log(f"   (note) Could not write Jellyfin's transcoding configuration ({render_http_code(code)}); "
+        "set Dashboard → Playback → Hardware acceleration to 'Nvidia NVENC' by hand.")
+    return False
+
+
 def main() -> int:
     host = env("HOST", "<server-ip>")
 
@@ -867,6 +1116,18 @@ def main() -> int:
             importance="critical",
             notes="Web UI admin. Mobile apps pair via Quick Connect (Dashboard → Quick Connect → enable on web; in-app shows 6-digit code).",
         )
+
+    # ── GPU passthrough (#2580) ──────────────────────────────────────
+    # Runs FIRST: the swap restarts the container, and everything below
+    # talks to the Jellyfin API — better to point it at the unit that
+    # will still be running when this script exits. `gpu_engaged` also
+    # gates the NVENC setting further down: telling Jellyfin to use a
+    # card it hasn't got turns every transcode into an error.
+    gpu_engaged = install_gpu_quadlet_fallback() if gpu_requested() else False
+    if not gpu_engaged and gpu_requested():
+        log("ℹ️ Jellyfin will transcode in software on this box. That costs several CPU cores per "
+            "stream — if this host does have an NVIDIA card, register it with `nvidia-ctk cdi generate` "
+            "and redeploy `media`.")
 
     # ── Jellyfin first-run + Quick Connect + Music library ───────────
     # `jellyfin_run_first_setup` waits for the UserManager's async init
@@ -914,6 +1175,11 @@ def main() -> int:
                 # Enable the built-in DLNA server by default so LAN TVs /
                 # DLNA clients can browse Jellyfin with no manual step (#2369).
                 ensure_jellyfin_dlna_server(jellyfin_base, jf_token)
+                # The card is attached — now make Jellyfin actually use it
+                # (#2580). Without this the device is present and every
+                # transcode still runs on the CPU.
+                if gpu_engaged:
+                    jellyfin_enable_nvenc(jellyfin_base, jf_token)
 
         # ── Jellyfin → LLDAP SSO (#1718) ──────────────────────────────
         # Wire the LDAP-Auth plugin against LLDAP so the family signs in

--- a/templates/media/template.yml
+++ b/templates/media/template.yml
@@ -7,7 +7,7 @@ metadata:
     servicebay.role: media
   annotations:
     servicebay.label: "Movies & TV"
-    servicebay.schema-version: "7"
+    servicebay.schema-version: "8"
     # Jellyfin's public URL routes through nginx, and its LDAP-Auth
     # plugin binds LLDAP from the `auth` stack — both prerequisites.
     # (#1725: Audiobookshelf retired for fresh installs; audiobooks are
@@ -93,6 +93,34 @@ spec:
     ports:
       - containerPort: {{JELLYFIN_PORT}}
         hostPort: {{JELLYFIN_PORT}}
+    # GPU passthrough (CDI) — #2580. Jellyfin transcodes in SOFTWARE
+    # unless it gets the card, which cost ~3 of 6 cores for a single
+    # stream on the reference box while an idle RTX sat next to it.
+    #
+    # This block is inert on its own and kept for documentation + as the
+    # signal post-deploy.py reads: `podman kube play` on rootless 5.x
+    # silently drops every `resources.limits` key outside cpu/memory, so
+    # a `.kube` deploy comes up healthy and still runs on CPU (#1026,
+    # class documented as #2517). The passthrough that actually works is
+    # post-deploy.py's `install_gpu_quadlet_fallback()`, which swaps this
+    # service to a `.container` Quadlet carrying
+    # `AddDevice=nvidia.com/gpu=all` + `SecurityLabelDisable=true` — the
+    # second line is required, not cosmetic: without it the container
+    # sees the devices but NVML fails to init under SELinux.
+    #
+    # Hosts with no CDI-registered NVIDIA GPU are unaffected: the swap is
+    # gated on `/etc/cdi/nvidia.yaml`, so the service stays a plain
+    # `.kube` pod and Jellyfin keeps transcoding on the CPU.
+    #
+    # Deliberately NO VRAM budget and NO cap on concurrent transcodes —
+    # the operator was shown the numbers (16380 MiB total, ~5900 MiB held
+    # by the Solaris inference stack, ~10 GiB free) and chose the plain
+    # form on 2026-08-17. Don't add a limit here without reopening #2580.
+    {{#JELLYFIN_GPU_PASSTHROUGH}}
+    resources:
+      limits:
+        nvidia.com/gpu: "1"
+    {{/JELLYFIN_GPU_PASSTHROUGH}}
     volumeMounts:
       - mountPath: /config
         name: jellyfin-config

--- a/templates/media/variables.json
+++ b/templates/media/variables.json
@@ -23,6 +23,11 @@
     "description": "Host path mounted at /media (read-only). Defaults to the file-share volume so Music/, Movies/, TV/ etc. dropped into the Samba share appear in Jellyfin's library scan.",
     "default": "/mnt/data/stacks/file-share/data"
   },
+  "JELLYFIN_GPU_PASSTHROUGH": {
+    "type": "text",
+    "description": "NVIDIA hardware transcoding (NVENC/NVDEC). Non-blank (the default, 'yes') hands Jellyfin the host's CDI-registered NVIDIA GPU and switches Jellyfin's own transcoding setting to NVENC — without both, one film re-encode eats several CPU cores while the card idles (#2580). Safe to leave on: a host with no CDI GPU (`/etc/cdi/nvidia.yaml` absent) is detected at deploy time and keeps the plain pod + software transcoding. Set to blank to force software transcoding even on a GPU box. No VRAM budget and no cap on concurrent transcodes — a deliberate operator decision, see #2580.",
+    "default": "yes"
+  },
   "LLDAP_LDAP_PORT": {
     "type": "text",
     "description": "LLDAP LDAP-protocol port — Jellyfin's LDAP-Auth plugin binds LLDAP here for SSO (#1718). Inherited from the auth template.",

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -1215,9 +1215,15 @@ describe('Media template: Audiobookshelf retired for fresh installs (#1725)', ()
     expect(JSON.stringify(hosts)).not.toMatch(/books/);
   });
 
-  it('schema-version is bumped to 7 with a matching CHANGELOG section', () => {
-    expect(media.yamlContent).toMatch(/servicebay\.schema-version:\s*"7"/);
+  it('schema-version is bumped to 8 with a matching CHANGELOG section', () => {
+    expect(media.yamlContent).toMatch(/servicebay\.schema-version:\s*"8"/);
     const changelog = fs.readFileSync(path.join(TEMPLATES_DIR, 'media', 'CHANGELOG.md'), 'utf-8');
+    // v8 (#2580) is additive — no operator action, so it must NOT be
+    // marked breaking or the wizard would gate a deploy on an ack for a
+    // change that asks nothing of the operator.
+    expect(changelog).toMatch(/##\s*v8\b/);
+    const v8 = changelog.slice(changelog.indexOf('## v8'), changelog.indexOf('## v7'));
+    expect(v8).not.toMatch(/\(breaking\)/);
     expect(changelog).toMatch(/##\s*v7\b.*\(breaking\)/);
     // The operator's required action leads the section: they lose an address
     // and need to be told its replacement in the first sentence, not the last
@@ -1252,6 +1258,117 @@ describe('Media template: Audiobookshelf retired for fresh installs (#1725)', ()
     expect(mig).not.toMatch(/shutil\.(move|rmtree)|os\.remove|\.unlink\(|\.rename\(/);
     // Best-effort like v5-to-v6: a leftover route must never abort a deploy.
     expect(mig).not.toMatch(/return 1|sys\.exit\(1\)/);
+  });
+});
+
+// ─── 3c2. Media: Jellyfin gets the card, and actually uses it (#2580) ───────
+// Two halves, and a change that ships only the first one closes nothing:
+//   1. the DEVICE — `AddDevice=nvidia.com/gpu=all` on a `.container`
+//      Quadlet, because `podman kube play` silently drops the pod-spec
+//      form (#1026/#2517) and leaves everything running on the CPU;
+//   2. the SETTING — Jellyfin re-encodes in software until its own
+//      `HardwareAccelerationType` says `nvenc`, device or no device.
+describe('Media template: Jellyfin GPU transcoding (#2580)', () => {
+  const media = templates.find(t => t.name === 'media')!;
+  const mediaPostDeploy = fs.readFileSync(
+    path.join(TEMPLATES_DIR, 'media', 'post-deploy.py'), 'utf-8',
+  );
+
+  const baseView: Record<string, string> = {};
+  for (const v of catalogVars) baseView[v] = `stub-${v.toLowerCase()}`;
+  for (const [name, meta] of Object.entries(media.variables)) {
+    if (meta && typeof meta === 'object' && 'default' in meta && typeof meta.default === 'string') {
+      baseView[name] = meta.default;
+    }
+  }
+  baseView.JELLYFIN_PORT = '8096';
+  baseView.DATA_DIR = '/mnt/data/stacks';
+  baseView.HOST_GATEWAY_IP = '10.88.0.1';
+  baseView.PUBLIC_DOMAIN = 'dopp.cloud';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function renderPod(gpu?: string): any {
+    const view = { ...baseView };
+    if (gpu !== undefined) view.JELLYFIN_GPU_PASSTHROUGH = gpu;
+    // HTML escaping OFF, exactly like the production renderer
+    // (`lib/template/render.ts`). With it on, Mustache turns every `/`
+    // in a hostPath into `&#x2F;` and YAML then reads the leading `&`
+    // as an anchor — every volume path parses as null and the mount
+    // assertion below silently compares nothing.
+    const savedEscape = Mustache.escape;
+    Mustache.escape = (text: string) => text;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return yaml.loadAll(Mustache.render(media.yamlContent, view)).find((d: any) => d?.kind === 'Pod') as any;
+    } finally {
+      Mustache.escape = savedEscape;
+    }
+  }
+
+  it('requests the GPU at template defaults, on a pod the .container escape hatch can serve', () => {
+    const pod = renderPod();
+    expect(pod.spec.containers).toHaveLength(1);
+    expect(pod.spec.containers[0].resources?.limits?.['nvidia.com/gpu']).toBe('1');
+  });
+
+  it('renders an unchanged, GPU-free pod when the operator blanks the toggle', () => {
+    const pod = renderPod('');
+    expect(pod.spec.containers[0].resources).toBeUndefined();
+    expect(JSON.stringify(pod)).not.toMatch(/nvidia/i);
+  });
+
+  it('post-deploy attaches the card via the ONLY form that works on rootless podman', () => {
+    // Both lines are load-bearing: the device alone leaves NVML at
+    // "Insufficient Permissions" under SELinux (#1026).
+    expect(mediaPostDeploy).toMatch(/AddDevice=nvidia\.com\/gpu=all/);
+    expect(mediaPostDeploy).toMatch(/SecurityLabelDisable=true/);
+    // Gated on the host actually having a CDI-registered card, so a box
+    // without one installs unchanged and keeps transcoding in software.
+    expect(mediaPostDeploy).toMatch(/\/etc\/cdi\/nvidia\.yaml/);
+  });
+
+  it('the .container unit binds exactly the pod\'s host paths — a redeploy loses no data', () => {
+    // The swap replaces the deploy artifact, so if these drift the
+    // service comes back pointing at empty directories: new Jellyfin
+    // database, no library, no cache. Pin them to the pod spec.
+    const pod = renderPod();
+    const hostPathByName = new Map<string, string>(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (pod.spec.volumes ?? []).map((v: any) => [v.name, v.hostPath?.path]),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fromPod = (pod.spec.containers[0].volumeMounts ?? []).map((m: any) =>
+      `${hostPathByName.get(m.name)}:${m.mountPath}${m.readOnly ? ':ro' : ''}`,
+    );
+
+    const mediaPath = String(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (media.variables as any).JELLYFIN_MEDIA_PATH?.default ?? '',
+    );
+    const fromUnit = [...mediaPostDeploy.matchAll(/f"Volume=([^"]+)"/g)].map(m =>
+      m[1].replace('{data_dir}', baseView.DATA_DIR).replace('{media_path}', mediaPath),
+    );
+
+    expect(fromUnit).toEqual(fromPod);
+  });
+
+  it('switches Jellyfin\'s own transcoding setting to NVENC — the device alone changes nothing', () => {
+    expect(mediaPostDeploy).toMatch(/System\/Configuration\/encoding/);
+    expect(mediaPostDeploy).toMatch(/"HardwareAccelerationType"\]\s*=\s*"nvenc"/);
+    expect(mediaPostDeploy).toMatch(/"EnableHardwareEncoding"\]\s*=\s*True/);
+    // Read-modify-write, not a blind overwrite: an existing install keeps
+    // the rest of its playback configuration.
+    expect(mediaPostDeploy).toMatch(/"GET",\s*f"\{base_url\}\/System\/Configuration\/encoding"/);
+  });
+
+  it('ships no VRAM budget and no cap on concurrent transcodes', () => {
+    // Explicit operator decision on 2026-08-17 (#2580), taken with the
+    // free/used VRAM figures in hand. A future "just to be safe" limit
+    // reopens that decision — it does not belong in a template edit.
+    for (const src of [media.yamlContent, mediaPostDeploy]) {
+      expect(src).not.toMatch(/NVIDIA_VISIBLE_DEVICES|nvidia\.com\/gpu=\d/);
+      expect(src).not.toMatch(/MaxConcurrent|TranscodingThrottl|VRAM_(BUDGET|LIMIT)/i);
+    }
   });
 });
 


### PR DESCRIPTION
Zwei Issues, beide aus einem realen Vorfall auf der Referenzbox heraus gebaut.

- **#2585 — eine OS-Update-Schleife, die niemand sah.** Zincati hat seit dem 14.08. alle ~6 Minuten dasselbe Release zu stagen versucht; jeder Versuch baute `akmod-nvidia-open` neu (`cc1`, ~7 Minuten, ~75 % CPU) und scheiterte reproduzierbar an `nv-linux.h:1729: fatal error: linux/of_gpio.h: No such file or directory` — der Header wurde upstream entfernt, der Bau kann nicht gelingen. **457 Fehlversuche**, rund 53 von 84 Stunden reine Kompilierzeit, kein einziges installiertes Update. In der Oberfläche: nichts. Der Bediener sieht „der Server ist langsam" und sucht bei den Diensten, wo nichts zu finden ist.

  Neue `os_update`-Sonde. Warnt ab **drei** aufeinanderfolgenden Fehlversuchen (einer ist normal und transient), benennt den Kernelmodul-Bau als Lastquelle statt nur „Updates schlagen fehl", und behandelt einen **bewusst pausierten** Updater als Information, nicht als Fehler — erkannt über zwei unabhängige Signale, damit das Schreib-und-Neustart-Fenster keinen Fehlalarm auslöst. Alle drei Zustände gegen die echte `rpm-ostree status`-Ausgabe geprüft, nicht nur gegen Fixtures.

- **#2580 — Jellyfin bekommt die Karte.** Zwei Hälften, weil die erste allein nichts schließt: das Gerät wird durchgereicht (`AddDevice=nvidia.com/gpu=all`, Mechanismus aus der *laufenden* `ollama.container` abgelesen statt angenommen), **und** Jellyfins `HardwareAccelerationType` wird auf `nvenc` gestellt. Auf der Box steht es aktuell auf `none` bei bereits gesetztem `EnableHardwareEncoding` — also genau so, wie eine reine Geräte-Änderung aussieht, wenn man glaubt, sie hätte gewirkt.

  Kein VRAM-Budget, keine Begrenzung paralleler Transcodes — das war die ausdrückliche Entscheidung des Betreibers, getroffen mit den Zahlen vor Augen (16380 MiB gesamt, 5878 belegt von ollama und der Sprachpipeline, 10072 frei). Ein Test schlägt fehl, falls jemand später doch eine Begrenzung einbaut.

  Auf GPU-losen Boxen ändert sich nichts: die Umschaltung ist zur Deploy-Zeit an `/etc/cdi/nvidia.yaml` gebunden.

Offen und ehrlich benannt: das Akzeptanzkriterium „ein Transcode taucht in `nvidia-smi` als Prozess auf" braucht tatsächlich laufende Wiedergabe und ist an Box-Verify abgetreten — der genaue Nachweisbefehl steht in den Notizen der Einheit.
