### PR TITLE
fix: back up the identity store, stop overwriting operator configs, stop offering impossible cert renewals

### DIFF
--- a/docs/TEMPLATE_AUTHORING.md
+++ b/docs/TEMPLATE_AUTHORING.md
@@ -37,6 +37,7 @@ the wizard substitutes at deploy time. Use these annotations under
 | `servicebay.label` | yes | Friendly UI label shown in the wizard's configure step (e.g. `"Vaultwarden (Passwords)"`). Without it the section header falls back to the raw template name. |
 | `servicebay.ports` | optional | Comma-separated `port/proto` list (e.g. `"8080/tcp,8443/tcp"`). Drives gateway probes + the network graph. |
 | `servicebay.config-mount` | required if any `*.mustache` files | Container mountPath that companion `*.mustache` files should land in. Avoids the `/config`-suffix heuristic picking the wrong volume in multi-container pods. |
+| `servicebay.seed-only-configs` | optional (default `[]`) | Comma-separated companion config filenames (e.g. `"automations.yaml,scenes.yaml,scripts.yaml"`) that ServiceBay writes **only when they are absent** on the box. Use it for any `*.mustache` file whose real owner after first install is the application or the operator — an app that rewrites the file from its own UI, or a file the operator edits by hand. Without the annotation a deploy re-renders the file every time, which overwrites that content (#2590). Each name must match a `*.mustache` file the template ships, minus the suffix. |
 | `servicebay.schema-version` | optional (default `1`) | Bump when the pod structure or variable shape changes in a way operators need to be aware of (containers extracted, variables renamed, data paths moved). Plain image-tag bumps don't need this — Quadlet's `AutoUpdate=registry` handles those silently. Each bump should ship a `CHANGELOG.md` section + (if data needs to move) a `migrations/v{N-1}-to-v{N}.py` script. See #352. |
 | `servicebay.tier` | optional (default `"feature"`) | `"infrastructure"` for platform templates that the wizard auto-includes (DNS / proxy / SSO) and pins checked; everything else defaults to `"feature"` and starts unchecked. Stacks don't carry this annotation. |
 | `servicebay.dependencies` | optional (default `[]`) | Comma-separated list of template names that must install before this one. Drives three things in the wizard: (1) the red **`requires X`** badge under the template name; (2) auto-checking those templates when the operator checks this one; (3) the uncheck-guard that prompts before removing a template another selected template needs. The install loop then topo-sorts the deploy order so deps land first. Example: `servicebay.dependencies: "nginx,auth"`. |
@@ -283,6 +284,18 @@ container's `servicebay.config-mount`.
 Use these for service config files that need substituted values
 on first start (AdGuard's `AdGuardHome.yaml`, Authelia's
 `configuration.yml`).
+
+**Every deploy re-renders and rewrites them** — that is the right default
+for a file ServiceBay owns end to end, and the wrong one for a file the
+application or the operator takes over after first install. If the running
+service rewrites the file itself (Home Assistant's automation editor owns
+`automations.yaml`), or you tell operators they may edit it, list it in
+[`servicebay.seed-only-configs`](#templateyml): ServiceBay then writes
+it only when it is **absent**, and a redeploy leaves the on-disk content
+byte-for-byte alone (#2590, [ADR 0004](adr/0004-installs-are-non-destructive.md)).
+A seed-only file must therefore be self-sufficient after seeding — anything
+that has to stay in sync with a changed variable belongs in `post-deploy.py`,
+which runs against the live service, not in a file nobody rewrites.
 
 ### `post-deploy.py`
 

--- a/packages/backend/src/lib/backupWorker/service.test.ts
+++ b/packages/backend/src/lib/backupWorker/service.test.ts
@@ -96,6 +96,31 @@ describe('runBackupForInstalled', () => {
     expect(arg.services).toEqual(expect.arrayContaining(['adguard', 'home-assistant', 'home-assistant-zwave']));
   });
 
+  it('selects the apps of a multi-app template — auth ⇒ authelia+lldap, media ⇒ jellyfin (#2595)', async () => {
+    // The box's real shape: installedTemplates carries TEMPLATE names. Before
+    // the gate fix, these three manifest entries waited on `authelia`/`lldap`/
+    // `jellyfin` keys that no box has, so they silently dropped out of the
+    // nightly run — which then reported "8/8 services backed up" against a
+    // denominator that had lost the SSO server and the whole identity store.
+    mockCfg.getConfig.mockResolvedValue({
+      installedTemplates: { nginx: {}, auth: {}, adguard: {}, media: {}, 'home-assistant': {} },
+      templateSettings: { DATA_DIR: '/mnt/data/stacks' },
+    });
+    mockLauncher.readBackupStatus.mockResolvedValue(doneStatus([{ service: 'authelia', ok: true }]));
+
+    await runBackupForInstalled();
+    const { services } = mockLauncher.launchBackupWorker.mock.calls[0][0];
+    expect(services).toEqual(expect.arrayContaining(['authelia', 'lldap', 'jellyfin']));
+    // Nothing gates on a name no template has any more, so nothing is dropped:
+    // every entry whose gate is installed is selected.
+    expect(services).toEqual(
+      expect.arrayContaining(['nginx', 'adguard', 'home-assistant', 'home-assistant-zwave']),
+    );
+    // …and an entry for a template this box does NOT have stays correctly out.
+    expect(services).not.toContain('vaultwarden');
+    expect(services).not.toContain('radicale');
+  });
+
   it('returns null (no launch) when nothing with a manifest is installed', async () => {
     mockCfg.getConfig.mockResolvedValue({ installedTemplates: { 'unmanaged-thing': {} } });
     expect(await runBackupForInstalled()).toBeNull();

--- a/packages/backend/src/lib/capabilities/adguard.test.ts
+++ b/packages/backend/src/lib/capabilities/adguard.test.ts
@@ -27,7 +27,7 @@ import type { TemplateManifest } from '@/lib/template/contract';
 import type { StackVariable } from '@/lib/stackInstall/types';
 
 const MANIFEST: TemplateManifest = {
-  label: 'X', tier: 'feature', schemaVersion: 1, dependencies: [],
+  label: 'X', tier: 'feature', schemaVersion: 1, dependencies: [], seedOnlyConfigs: [],
 };
 
 function subdomainVar(

--- a/packages/backend/src/lib/capabilities/authelia.test.ts
+++ b/packages/backend/src/lib/capabilities/authelia.test.ts
@@ -23,7 +23,7 @@ import type { StackVariable } from '@/lib/stackInstall/types';
 const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
 const MANIFEST: TemplateManifest = {
-  label: 'Test', tier: 'feature', schemaVersion: 1, dependencies: [],
+  label: 'Test', tier: 'feature', schemaVersion: 1, dependencies: [], seedOnlyConfigs: [],
 };
 
 const VARS_PUBLIC: StackVariable[] = [

--- a/packages/backend/src/lib/capabilities/bus.test.ts
+++ b/packages/backend/src/lib/capabilities/bus.test.ts
@@ -25,6 +25,7 @@ const MANIFEST: TemplateManifest = {
   tier: 'feature',
   schemaVersion: 1,
   dependencies: [],
+  seedOnlyConfigs: [],
 };
 const VARS: StackVariable[] = [];
 

--- a/packages/backend/src/lib/capabilities/credentials.test.ts
+++ b/packages/backend/src/lib/capabilities/credentials.test.ts
@@ -23,7 +23,7 @@ import type { TemplateManifest } from '@/lib/template/contract';
 import type { StackVariable } from '@/lib/stackInstall/types';
 
 const MANIFEST: TemplateManifest = {
-  label: 'X', tier: 'feature', schemaVersion: 1, dependencies: [],
+  label: 'X', tier: 'feature', schemaVersion: 1, dependencies: [], seedOnlyConfigs: [],
 };
 
 function oidcSubdomainVar(template: string, subVarName: string, clientId: string, secretVar: string): StackVariable {

--- a/packages/backend/src/lib/capabilities/hostFirewall.test.ts
+++ b/packages/backend/src/lib/capabilities/hostFirewall.test.ts
@@ -41,7 +41,7 @@ import {
 } from './hostFirewall';
 import type { TemplateManifest } from '@/lib/template/contract';
 
-const MANIFEST: TemplateManifest = { label: 'Sign-In Gate', tier: 'infrastructure', schemaVersion: 3, dependencies: [] };
+const MANIFEST: TemplateManifest = { label: 'Sign-In Gate', tier: 'infrastructure', schemaVersion: 3, dependencies: [], seedOnlyConfigs: [] };
 
 const AUTH_VARS = {
   LLDAP_LDAP_PORT: { blockLanAccess: true, default: '3890' },

--- a/packages/backend/src/lib/capabilities/nginx.test.ts
+++ b/packages/backend/src/lib/capabilities/nginx.test.ts
@@ -14,7 +14,7 @@ import type { StackVariable } from '@/lib/stackInstall/types';
 const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
 const MANIFEST: TemplateManifest = {
-  label: 'Test', tier: 'feature', schemaVersion: 1, dependencies: [],
+  label: 'Test', tier: 'feature', schemaVersion: 1, dependencies: [], seedOnlyConfigs: [],
 };
 
 /** Subdomain variable belonging to `template`. The `service` field in

--- a/packages/backend/src/lib/capabilities/serviceLifecycleEvents.ts
+++ b/packages/backend/src/lib/capabilities/serviceLifecycleEvents.ts
@@ -158,7 +158,7 @@ async function loadManifest(template: string): Promise<TemplateManifest> {
     if (parsed.ok) return parsed.manifest;
     logger.warn(LOG_SCOPE, `template.yml for ${template} did not parse (${parsed.errors.join('; ')}); using a minimal manifest`);
   }
-  return { label: template, tier: 'feature', schemaVersion: 1, dependencies: [] };
+  return { label: template, tier: 'feature', schemaVersion: 1, dependencies: [], seedOnlyConfigs: [] };
 }
 
 /**

--- a/packages/backend/src/lib/diagnose/actions.ts
+++ b/packages/backend/src/lib/diagnose/actions.ts
@@ -165,21 +165,34 @@ export interface ResolvedProbeItem {
 /**
  * Resolve a probe's items[] action-ids to the full ProbeAction
  * objects from the registry, so the UI doesn't need a second lookup.
- * Items whose actionIds reference unknown actions silently drop those
- * ids — better to render fewer buttons than crash the diagnose page.
+ * Items whose actionIds reference unknown actions still drop those ids
+ * — better to render fewer buttons than crash the diagnose page — but
+ * they no longer do it silently: an unresolvable id means a probe is
+ * offering a fix that cannot be dispatched, which renders as a row with
+ * no button and no explanation. That is a wiring bug in this repo, so
+ * it gets logged at error level rather than swallowed.
  */
 export function resolveItemActions(probeId: string, items: ProbeItem[]): ResolvedProbeItem[] {
   const actions = actionsForProbe(probeId);
   const byId = new Map(actions.map(a => [a.id, a]));
-  return items.map(item => ({
-    id: item.id,
-    label: item.label,
-    detail: item.detail,
-    status: item.status,
-    actions: item.actionIds
-      .map(id => byId.get(id))
-      .filter((a): a is ProbeAction => a !== undefined),
-  }));
+  return items.map(item => {
+    const unknown = item.actionIds.filter(id => !byId.has(id));
+    if (unknown.length > 0) {
+      logger.error(
+        'diagnose:actions',
+        `Probe ${probeId} item ${item.id} offers unregistered action${unknown.length === 1 ? '' : 's'} ${unknown.join(', ')} — no handler is registered, so the row renders without that button. Register it in lib/diagnose/probes/register.ts.`,
+      );
+    }
+    return {
+      id: item.id,
+      label: item.label,
+      detail: item.detail,
+      status: item.status,
+      actions: item.actionIds
+        .map(id => byId.get(id))
+        .filter((a): a is ProbeAction => a !== undefined),
+    };
+  });
 }
 
 interface RegistryEntry {

--- a/packages/backend/src/lib/diagnose/probes/certExpiry.test.ts
+++ b/packages/backend/src/lib/diagnose/probes/certExpiry.test.ts
@@ -27,11 +27,57 @@ vi.mock('@/lib/health/store', () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-import { dispatchProbeAction } from '../actions';
+import { dispatchProbeAction, actionsForProbe } from '../actions';
 import { checkCertExpiry } from './certExpiry';
 import './certExpiry';
+import { CERT_EXPIRY_ACTION_IDS } from '@/lib/health/probes/certExpiry';
 
 const ACTIVE_NGINX = [{ name: 'nginx', active: true, ports: [{ host: '8081', container: '81' }] }];
+
+const BOUND_HOST = [{ id: 1, certificate_id: 7, domain_names: ['vault.example.com'] }];
+
+/** Answer NPM by URL instead of by call order — both cert actions now
+ *  re-read the cert + the proxy-host table before they act, so a fixed
+ *  `mockResolvedValueOnce` chain would encode call order as if it were
+ *  behaviour. */
+function npm(opts: {
+  token?: boolean;
+  cert?: { id: number; domain_names?: string[] } | 'missing' | 'error';
+  hosts?: unknown[] | 'error';
+  renew?: { ok: boolean; status?: number; body?: string };
+  del?: { ok: boolean; status?: number; body?: string };
+} = {}) {
+  mockFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+    const u = String(url);
+    if (u.endsWith('/api/tokens')) {
+      return opts.token === false
+        ? { ok: false, status: 401, json: async () => ({}) }
+        : { ok: true, json: async () => ({ token: 'tok' }) };
+    }
+    if (u.includes('/renew')) {
+      return { ok: opts.renew?.ok ?? true, status: opts.renew?.status ?? 200, text: async () => opts.renew?.body ?? '' };
+    }
+    if (u.includes('/api/nginx/proxy-hosts')) {
+      return opts.hosts === 'error'
+        ? { ok: false, status: 500 }
+        : { ok: true, json: async () => opts.hosts ?? BOUND_HOST };
+    }
+    if (u.includes('/api/nginx/certificates/')) {
+      if (init?.method === 'DELETE') {
+        return { ok: opts.del?.ok ?? true, status: opts.del?.status ?? 200, text: async () => opts.del?.body ?? '' };
+      }
+      if (opts.cert === 'missing') return { ok: false, status: 404 };
+      if (opts.cert === 'error') return { ok: false, status: 502 };
+      return { ok: true, json: async () => opts.cert ?? { id: 7, domain_names: ['vault.example.com'] } };
+    }
+    throw new Error(`unexpected fetch ${u}`);
+  });
+}
+
+const called = (fragment: string, method?: string) =>
+  mockFetch.mock.calls.some(
+    ([url, init]) => String(url).includes(fragment) && (!method || (init as { method?: string })?.method === method),
+  );
 
 beforeEach(() => {
   state.config = { reverseProxy: { npm: { email: 'a@b.c', password: 'pw' } } };
@@ -135,9 +181,7 @@ describe('cert_expiry.renew_cert', () => {
   });
 
   it('triggers NPM renew on success', async () => {
-    mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'tok' }) })
-      .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve('') });
+    npm();
     const result = await dispatchProbeAction({
       probeId: 'cert_expiry',
       actionId: 'renew_cert',
@@ -146,14 +190,11 @@ describe('cert_expiry.renew_cert', () => {
     });
     expect(result.ok).toBe(true);
     expect(result.message).toMatch(/Renewal triggered for cert 7/);
-    expect(mockFetch.mock.calls[1][0]).toMatch(/\/api\/nginx\/certificates\/7\/renew/);
-    expect(mockFetch.mock.calls[1][1].method).toBe('POST');
+    expect(called('/api/nginx/certificates/7/renew', 'POST')).toBe(true);
   });
 
   it('surfaces NPM HTTP error on renewal failure', async () => {
-    mockFetch
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'tok' }) })
-      .mockResolvedValueOnce({ ok: false, status: 500, text: () => Promise.resolve('challenge failed') });
+    npm({ renew: { ok: false, status: 500, body: 'challenge failed' } });
     const result = await dispatchProbeAction({
       probeId: 'cert_expiry',
       actionId: 'renew_cert',
@@ -165,10 +206,7 @@ describe('cert_expiry.renew_cert', () => {
   });
 
   it('reports auth failure when NPM rejects every credential candidate', async () => {
-    // Both /api/tokens calls return 401 → token resolution fails
-    mockFetch
-      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
-      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) });
+    npm({ token: false });
     const result = await dispatchProbeAction({
       probeId: 'cert_expiry',
       actionId: 'renew_cert',
@@ -177,5 +215,117 @@ describe('cert_expiry.renew_cert', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/authenticate/);
+  });
+
+  it('refuses to renew a cert no proxy host uses, without firing the ACME attempt (#2594)', async () => {
+    npm({ cert: { id: 11, domain_names: ['books.example.com'] }, hosts: [] });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_expiry',
+      actionId: 'renew_cert',
+      itemId: '11',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/books\.example\.com/);
+    expect(result.message).toMatch(/Delete certificate/);
+    // The point of refusing up front: no failed renewal to resurface
+    // under cert_request_failure, no wasted Let's Encrypt attempt.
+    expect(called('/renew')).toBe(false);
+  });
+
+  it('renews as before when the binding state cannot be read', async () => {
+    npm({ hosts: 'error' });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_expiry',
+      actionId: 'renew_cert',
+      itemId: '7',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(called('/api/nginx/certificates/7/renew', 'POST')).toBe(true);
+  });
+});
+
+describe('cert_expiry.delete_orphaned_cert (#2594)', () => {
+  it('deletes a cert that no proxy host binds', async () => {
+    npm({ cert: { id: 11, domain_names: ['books.example.com'] }, hosts: [] });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_expiry',
+      actionId: 'delete_orphaned_cert',
+      itemId: '11',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/books\.example\.com/);
+    expect(called('/api/nginx/certificates/11', 'DELETE')).toBe(true);
+  });
+
+  it('refuses when a proxy host has meanwhile started using the cert', async () => {
+    // The row the operator clicked can be up to an hour old.
+    npm({ cert: { id: 7, domain_names: ['vault.example.com'] }, hosts: BOUND_HOST });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_expiry',
+      actionId: 'delete_orphaned_cert',
+      itemId: '7',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/still uses this certificate/);
+    expect(called('/api/nginx/certificates/7', 'DELETE')).toBe(false);
+  });
+
+  it('refuses when the binding state cannot be established at all', async () => {
+    npm({ cert: { id: 11, domain_names: ['books.example.com'] }, hosts: 'error' });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_expiry',
+      actionId: 'delete_orphaned_cert',
+      itemId: '11',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/Not deleting/);
+    expect(called('/api/nginx/certificates/11', 'DELETE')).toBe(false);
+  });
+
+  it('refuses a non-numeric id before touching NPM', async () => {
+    npm();
+    const result = await dispatchProbeAction({
+      probeId: 'cert_expiry',
+      actionId: 'delete_orphaned_cert',
+      itemId: '../7',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an NPM HTTP error from the delete', async () => {
+    npm({ cert: { id: 11, domain_names: ['books.example.com'] }, hosts: [], del: { ok: false, status: 500 } });
+    const result = await dispatchProbeAction({
+      probeId: 'cert_expiry',
+      actionId: 'delete_orphaned_cert',
+      itemId: '11',
+      node: 'Local',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/HTTP 500/);
+  });
+});
+
+describe('cert_expiry action wiring', () => {
+  it('registers a handler for every action id the health probe can emit', () => {
+    // The emitting side (health probe) and the handling side (here) are
+    // two files. An id emitted with no handler behind it is dropped by
+    // resolveItemActions, i.e. the row renders a fix with no button.
+    const registered = actionsForProbe('cert_expiry').map(a => a.id);
+    for (const id of Object.values(CERT_EXPIRY_ACTION_IDS)) {
+      expect(registered).toContain(id);
+    }
+  });
+
+  it('marks the delete action destructive so the UI confirms first', () => {
+    const del = actionsForProbe('cert_expiry').find(a => a.id === CERT_EXPIRY_ACTION_IDS.deleteOrphaned)!;
+    expect(del.destructive).toBe(true);
+    expect(del.label).toBe('Delete certificate');
   });
 });

--- a/packages/backend/src/lib/diagnose/probes/certExpiry.ts
+++ b/packages/backend/src/lib/diagnose/probes/certExpiry.ts
@@ -14,7 +14,14 @@
  *
  * The `renew_cert` action handler stays here because it mutates NPM
  * state at click-time (re-runs the ACME challenge for one cert id) —
- * only the detection moved into the health subsystem.
+ * only the detection moved into the health subsystem. `delete_orphaned_cert`
+ * (#2594) is its counterpart for a certificate no proxy host uses any
+ * more, where renewing is the wrong direction entirely.
+ *
+ * Both handlers re-derive the binding state from NPM before they act.
+ * The item list they were clicked from is up to an hour old, and the two
+ * actions point opposite ways — so neither is allowed to run on the
+ * strength of a stale row.
  */
 
 import { getConfig } from '@/lib/config';
@@ -22,6 +29,8 @@ import { ServiceManager } from '@/lib/services/ServiceManager';
 import { logger } from '@/lib/logger';
 import { registerProbeAction, type ProbeActionResult, type ProbeItem } from '../actions';
 import { HealthStore } from '@/lib/health/store';
+import { CERT_EXPIRY_ACTION_IDS } from '@/lib/health/probes/certExpiry';
+import { classifyCertBinding } from '@/lib/health/probes/npmAdmin';
 import { registerRefreshNow } from './refreshHealthCheck';
 
 const PROBE_ID = 'cert_expiry';
@@ -121,6 +130,39 @@ async function getNpmToken(adminUrl: string): Promise<string | null> {
   return null;
 }
 
+/** Shared preamble for both cert actions: validate the id, locate NPM,
+ *  authenticate. Returns either the refusal to hand straight back to the
+ *  UI or the session both handlers need. */
+async function openNpmSession(
+  node: string,
+  itemId: string | undefined,
+): Promise<{ ok: false; result: ProbeActionResult } | { ok: true; adminUrl: string; token: string }> {
+  if (!itemId) return { ok: false, result: { ok: false, message: 'No certificate id supplied.', refresh: false } };
+  // NPM cert IDs come from the API and are numeric — guard for safety
+  // even though the dispatcher already validates the request body.
+  if (!/^\d+$/.test(itemId)) {
+    return { ok: false, result: { ok: false, message: `Certificate id "${itemId}" doesn't look numeric.`, refresh: false } };
+  }
+  const adminUrl = await findNpmAdminUrl(node);
+  if (!adminUrl) {
+    return { ok: false, result: { ok: false, message: 'Nginx Proxy Manager is not deployed on this node.', refresh: false } };
+  }
+  const token = await getNpmToken(adminUrl);
+  if (!token) {
+    return {
+      ok: false,
+      result: {
+        ok: false,
+        message: 'Could not authenticate with NPM — fix the npm_data_stale probe first.',
+        refresh: false,
+      },
+    };
+  }
+  return { ok: true, adminUrl, token };
+}
+
+const describeDomains = (domains: string[], itemId: string) => domains.join(', ') || `certificate ${itemId}`;
+
 async function renewCert({
   node,
   itemId,
@@ -128,22 +170,28 @@ async function renewCert({
   node: string;
   itemId?: string;
 }): Promise<ProbeActionResult> {
-  if (!itemId) return { ok: false, message: 'No certificate id supplied.', refresh: false };
-  // NPM cert IDs come from the API and are numeric — guard for safety
-  // even though the dispatcher already validates the request body.
-  if (!/^\d+$/.test(itemId)) {
-    return { ok: false, message: `Certificate id "${itemId}" doesn't look numeric.`, refresh: false };
-  }
-  const adminUrl = await findNpmAdminUrl(node);
-  if (!adminUrl) return { ok: false, message: 'Nginx Proxy Manager is not deployed on this node.', refresh: false };
-  const token = await getNpmToken(adminUrl);
-  if (!token) {
+  const session = await openNpmSession(node, itemId);
+  if (!session.ok) return session.result;
+  const { adminUrl, token } = session;
+  const id = itemId as string;
+  // Refuse up front rather than burn an ACME attempt that cannot
+  // succeed: without a proxy host the challenge has nowhere to land,
+  // the failure resurfaces under cert_request_failure as if it were a
+  // new problem, and repeated tries count against Let's Encrypt's
+  // rate limit. `unknown` (NPM unreadable) still renews — same-as-before
+  // behaviour, and a pointless renewal is only noise.
+  const binding = await classifyCertBinding(adminUrl, token, id);
+  if (binding.kind === 'orphaned') {
     return {
       ok: false,
-      message: 'Could not authenticate with NPM — fix the npm_data_stale probe first.',
-      refresh: false,
+      message: `Nothing is served from ${describeDomains(binding.domains, id)} any more — no NPM proxy host uses this certificate, so a renewal has no route to prove ownership over and would fail. "Delete certificate" is the action that resolves this row.`,
+      refresh: true,
     };
   }
+  return performRenew(adminUrl, token, id);
+}
+
+async function performRenew(adminUrl: string, token: string, itemId: string): Promise<ProbeActionResult> {
   try {
     const res = await fetch(`${adminUrl}/api/nginx/certificates/${itemId}/renew`, {
       method: 'POST',
@@ -178,10 +226,87 @@ async function renewCert({
   }
 }
 
+/** Delete a certificate that no proxy host uses any more (#2594).
+ *  Never acts on the row alone: NPM is asked again, and anything other
+ *  than a confirmed "orphaned" refuses. `unknown` refuses too — a
+ *  wrongly-skipped delete leaves a warning, a wrongly-performed one
+ *  takes TLS off a live site. */
+async function deleteOrphanedCert({
+  node,
+  itemId,
+}: {
+  node: string;
+  itemId?: string;
+}): Promise<ProbeActionResult> {
+  const session = await openNpmSession(node, itemId);
+  if (!session.ok) return session.result;
+  const { adminUrl, token } = session;
+  const id = itemId as string;
+  const binding = await classifyCertBinding(adminUrl, token, id);
+  if (binding.kind === 'unknown') {
+    return { ok: false, message: `Not deleting: ${binding.reason} Nothing was changed — re-run the check and try again.`, refresh: true };
+  }
+  if (binding.kind === 'in-use') {
+    return {
+      ok: false,
+      message: `Not deleting: an NPM proxy host still uses this certificate (${describeDomains(binding.domains, id)}). Deleting it would drop TLS for that route. Renew it instead.`,
+      refresh: true,
+    };
+  }
+  return performCertDelete(adminUrl, token, id, binding.domains);
+}
+
+async function performCertDelete(
+  adminUrl: string,
+  token: string,
+  itemId: string,
+  domains: string[],
+): Promise<ProbeActionResult> {
+  try {
+    const res = await fetch(`${adminUrl}/api/nginx/certificates/${itemId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      logger.warn('diagnose:cert_expiry', `DELETE cert id=${itemId} returned HTTP ${res.status}: ${body.slice(0, 200)}`);
+      return {
+        ok: false,
+        message: `NPM returned HTTP ${res.status} when deleting certificate ${itemId}.`,
+        refresh: false,
+      };
+    }
+    return {
+      ok: true,
+      message: `Certificate for ${describeDomains(domains, itemId)} deleted. It served no route, so nothing goes offline; adding the domain back later requests a fresh certificate.`,
+      refresh: true,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      message: `Could not reach NPM: ${e instanceof Error ? e.message : String(e)}`,
+      refresh: false,
+    };
+  }
+}
+
 registerProbeAction(
   PROBE_ID,
   {
-    id: 'renew_cert',
+    id: CERT_EXPIRY_ACTION_IDS.deleteOrphaned,
+    label: 'Delete certificate',
+    description:
+      'Removes this certificate from Nginx Proxy Manager. It is offered only for a certificate no proxy host uses any more, and the check is repeated against NPM before anything is deleted — if a route has been created for it in the meantime, the deletion is refused. Nothing goes offline; re-adding the domain later requests a fresh certificate.',
+    destructive: true,
+  },
+  deleteOrphanedCert,
+);
+
+registerProbeAction(
+  PROBE_ID,
+  {
+    id: CERT_EXPIRY_ACTION_IDS.renew,
     label: 'Renew now',
     description:
       'Triggers NPM\'s ACME renewal endpoint for this certificate. Usually completes in 30-60 s; the underlying ACME challenge runs against Let\'s Encrypt and re-fetches a fresh cert.',

--- a/packages/backend/src/lib/externalBackup/restore.test.ts
+++ b/packages/backend/src/lib/externalBackup/restore.test.ts
@@ -327,6 +327,105 @@ describe('wipeServiceForReinstall (#1585)', () => {
   });
 });
 
+describe('#2595 — the multi-app template stores round-trip through wipe + auto-restore', () => {
+  /**
+   * The backup half of #2595 (adding `gateOn`) only matters if the RESTORE half
+   * lands the bytes back where the app reads them. These three paths had never
+   * been backed up, so they had never been restored either — the install
+   * runner's `[item.name, ...getSiblingBackupServices(item.name)]` list was
+   * empty for `auth` and `media`. Assert the whole per-service path end to end:
+   * data-dir resolution (via `dataSubdir`), the wipe's CONFIG/DATA split, and
+   * the auto-restore that re-seeds over it.
+   */
+  const APP_STORES = [
+    { service: 'authelia', dir: ['auth', 'authelia-data'], config: 'db.sqlite3', payload: 'TOTP-WEBAUTHN-SECRETS' },
+    { service: 'lldap', dir: ['auth', 'lldap'], config: 'users.db', payload: 'FAMILY-IDENTITY-BYTES' },
+    { service: 'jellyfin', dir: ['media', 'jellyfin-config'], config: 'data/jellyfin.db', payload: 'JELLYFIN-USERS-DB' },
+  ] as const;
+
+  /** Serve `<service>.tar` off the NAS with the given file contents. */
+  async function serveServiceTar(service: string, files: Record<string, string>) {
+    const tar = await buildServiceTar(files);
+    mockNas.nasList.mockResolvedValue([{ name: `${service}.tar`, size: tar.length }]);
+    mockNas.nasDownload.mockImplementation(async (p: string) => {
+      if (p === `${NAS_BACKUP_DIR}/${service}.tar`) return tar;
+      throw new Error('not found'); // no meta sidecar
+    });
+  }
+
+  it.each(APP_STORES)(
+    '$service: restores into <DATA_DIR>/$dir.0/$dir.1 — the dir the template actually mounts',
+    async ({ service, dir, config, payload }) => {
+      const target = path.join(tmpRoot, ...dir);
+      await serveServiceTar(service, { [config]: payload });
+      const logs: string[] = [];
+      await autoRestoreServiceOnReinstall(
+        service,
+        { wipeMode: 'install', node: 'Local', local: true },
+        async l => { logs.push(l); },
+      );
+      expect(await fs.readFile(path.join(target, config), 'utf8')).toBe(payload);
+      expect(logs.some(l => l.includes('restored') && l.includes(service))).toBe(true);
+    },
+  );
+
+  it('lldap: wipe-config clears the identity store, then the restore puts it back', async () => {
+    const target = path.join(tmpRoot, 'auth', 'lldap');
+    await fs.mkdir(target, { recursive: true });
+    await fs.writeFile(path.join(target, 'users.db'), 'STALE-IDENTITIES');
+    await fs.writeFile(path.join(target, 'lldap_config.toml'), 'NOT-CONFIG-CLASS');
+
+    const logs: string[] = [];
+    await wipeServiceForReinstall('lldap', { wipeMode: 'wipe-config', node: 'Local', local: true }, async l => { logs.push(l); });
+    // The manifest's CONFIG path went; anything unclassified stayed.
+    await expect(fs.access(path.join(target, 'users.db'))).rejects.toThrow();
+    expect(await fs.readFile(path.join(target, 'lldap_config.toml'), 'utf8')).toBe('NOT-CONFIG-CLASS');
+    // Pre-fix this logged "no backup manifest" for the template name `auth`,
+    // because `lldap` was never in the deploy's service list at all.
+    expect(logs.some(l => l.includes('wipe-config') && l.includes('lldap'))).toBe(true);
+
+    await serveServiceTar('lldap', { 'users.db': 'RESTORED-IDENTITIES' });
+    await autoRestoreServiceOnReinstall('lldap', { wipeMode: 'wipe-config', node: 'Local', local: true }, async l => { logs.push(l); });
+    expect(await fs.readFile(path.join(target, 'users.db'), 'utf8')).toBe('RESTORED-IDENTITIES');
+    // The force-restore did not disturb the kept, unclassified file.
+    expect(await fs.readFile(path.join(target, 'lldap_config.toml'), 'utf8')).toBe('NOT-CONFIG-CLASS');
+  });
+
+  it('jellyfin: wipe-config clears CONFIG, KEEPS the re-scannable metadata DATA', async () => {
+    const target = path.join(tmpRoot, 'media', 'jellyfin-config');
+    await fs.mkdir(path.join(target, 'config'), { recursive: true });
+    await fs.mkdir(path.join(target, 'data'), { recursive: true });
+    await fs.mkdir(path.join(target, 'metadata'), { recursive: true });
+    await fs.writeFile(path.join(target, 'config/system.xml'), '<ServerConfiguration/>');
+    await fs.writeFile(path.join(target, 'data/jellyfin.db'), 'USERS-AND-LIBRARIES');
+    await fs.writeFile(path.join(target, 'metadata/poster.jpg'), 'BULK-ARTWORK');
+
+    await wipeServiceForReinstall('jellyfin', { wipeMode: 'wipe-config', node: 'Local', local: true }, async () => {});
+    await expect(fs.access(path.join(target, 'config/system.xml'))).rejects.toThrow();
+    await expect(fs.access(path.join(target, 'data/jellyfin.db'))).rejects.toThrow();
+    // metadata is DATA — heavy and re-scannable, kept on the RAID.
+    expect(await fs.readFile(path.join(target, 'metadata/poster.jpg'), 'utf8')).toBe('BULK-ARTWORK');
+
+    await serveServiceTar('jellyfin', { 'data/jellyfin.db': 'RESTORED-USERS' });
+    await autoRestoreServiceOnReinstall('jellyfin', { wipeMode: 'wipe-config', node: 'Local', local: true }, async () => {});
+    expect(await fs.readFile(path.join(target, 'data/jellyfin.db'), 'utf8')).toBe('RESTORED-USERS');
+    expect(await fs.readFile(path.join(target, 'metadata/poster.jpg'), 'utf8')).toBe('BULK-ARTWORK');
+  });
+
+  it('authelia: an install into a live data dir still refuses to clobber (#1584 guard holds)', async () => {
+    const target = path.join(tmpRoot, 'auth', 'authelia-data');
+    await fs.mkdir(target, { recursive: true });
+    await fs.writeFile(path.join(target, 'db.sqlite3'), 'LIVE-SECRETS');
+    await serveServiceTar('authelia', { 'db.sqlite3': 'BACKUP-SECRETS' });
+
+    const logs: string[] = [];
+    await autoRestoreServiceOnReinstall('authelia', { wipeMode: 'install', node: 'Local', local: true }, async l => { logs.push(l); });
+    // Newly-gated entries inherit the existing safety rule, not a new one.
+    expect(await fs.readFile(path.join(target, 'db.sqlite3'), 'utf8')).toBe('LIVE-SECRETS');
+    expect(logs.some(l => l.includes('not empty') && l.includes('skipping restore'))).toBe(true);
+  });
+});
+
 describe('NPM credential reconcile after restore (#1529)', () => {
   /** Serve an nginx.tar (restored into tmpRoot/nginx-proxy-manager). The bare
    *  slot is a valid undated snapshot the latest-resolver finds (#1865). */

--- a/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.test.ts
@@ -18,11 +18,16 @@ describe('service backup manifests', () => {
     const names = SERVICE_BACKUP_MANIFESTS.map(m => m.service);
     expect(names).toEqual(
       expect.arrayContaining([
-        'home-assistant', 'authelia', 'adguard', 'syncthing', 'hermes',
+        'home-assistant', 'authelia', 'adguard', 'nginx',
         // #2153 — previously unprotected services now covered.
         'lldap', 'vaultwarden', 'radicale', 'jellyfin', 'file-share',
       ]),
     );
+    // #2595 — `syncthing` (config lives in a podman PVC, not under DATA_DIR) and
+    // `hermes` (retired Solaris name, no template) could never activate and were
+    // removed rather than left as entries that promise a backup and stage nothing.
+    expect(names).not.toContain('syncthing');
+    expect(names).not.toContain('hermes');
   });
 
   it('backs up LLDAP users.db — the family identity store (#2153)', () => {
@@ -102,10 +107,35 @@ describe('service backup manifests', () => {
     expect(getBackupGate(getServiceManifest('adguard')!)).toBe('adguard');
   });
 
+  it('the apps of a multi-app template gate on the TEMPLATE name (#2595)', () => {
+    // installedTemplates carries template names — `auth` and `media` — never the
+    // app names. Defaulting the gate to the app name (the pre-fix state) left
+    // these three permanently dormant: the SSO server, the whole identity store,
+    // and the media server's config, none of them ever backed up.
+    expect(getBackupGate(getServiceManifest('authelia')!)).toBe('auth');
+    expect(getBackupGate(getServiceManifest('lldap')!)).toBe('auth');
+    expect(getBackupGate(getServiceManifest('jellyfin')!)).toBe('media');
+    // Their data dirs are the ones the template declares — the gate change does
+    // not move them.
+    expect(getServiceManifest('authelia')!.dataSubdir).toBe('auth/authelia-data');
+    expect(getServiceManifest('lldap')!.dataSubdir).toBe('auth/lldap');
+    expect(getServiceManifest('jellyfin')!.dataSubdir).toBe('media/jellyfin-config');
+  });
+
   it('getSiblingBackupServices lists the stores that ride a template deploy (#1594)', () => {
     expect(getSiblingBackupServices('home-assistant')).toEqual(['home-assistant-zwave']);
     // A template with no sibling stores gets an empty list.
     expect(getSiblingBackupServices('adguard')).toEqual([]);
+  });
+
+  it('the auth/media deploys now carry their app stores through wipe+restore (#2595)', () => {
+    // This is the RESTORE direction: install/runner.ts's deployItem builds
+    // `[item.name, ...getSiblingBackupServices(item.name)]` and runs
+    // wipeServiceForReinstall + autoRestoreServiceOnReinstall over each. Before
+    // the gate fix these lists were empty, so a reinstall of `auth` or `media`
+    // restored nothing for the apps inside them — there was never a tar either.
+    expect(getSiblingBackupServices('auth')).toEqual(['authelia', 'lldap']);
+    expect(getSiblingBackupServices('media')).toEqual(['jellyfin']);
   });
 
   it('excludes the recorder DB from home-assistant', () => {
@@ -200,13 +230,27 @@ describe('config/data classification (#1585)', () => {
 });
 
 describe('applyStripRules', () => {
+  // No shipped manifest declares a strip rule today (#2595 retired the last one
+  // with the `hermes` entry), so the rule engine is exercised against an
+  // explicit manifest — it stays live for the next service that needs it.
+  const withStrip = {
+    service: 'probe',
+    include: ['config.yaml'],
+    exclude: [],
+    strip: [{ file: 'config.yaml', dropYamlKeys: ['api_key'] }],
+  };
+
   it('strips a targeted file and passes other files through untouched', () => {
-    // hermes strips LLM api keys from config.yaml; other files pass through.
-    const hermes = getServiceManifest('hermes')!;
-    const stripped = applyStripRules(hermes, 'config.yaml', 'api_key: SEKRIT\nmodel: gemma\n');
+    const stripped = applyStripRules(withStrip, 'config.yaml', 'api_key: SEKRIT\nmodel: gemma\n');
     expect(stripped).not.toContain('SEKRIT');
-    const passthrough = applyStripRules(hermes, 'some-other-file.yml', 'api_key: keep\n');
+    expect(stripped).toContain('gemma');
+    const passthrough = applyStripRules(withStrip, 'some-other-file.yml', 'api_key: keep\n');
     expect(passthrough).toBe('api_key: keep\n');
+  });
+
+  it('passes everything through for a manifest with no strip rules', () => {
+    const lldap = getServiceManifest('lldap')!;
+    expect(applyStripRules(lldap, 'users.db', 'IDENTITY-BYTES')).toBe('IDENTITY-BYTES');
   });
 });
 

--- a/packages/backend/src/lib/externalBackup/serviceManifest.ts
+++ b/packages/backend/src/lib/externalBackup/serviceManifest.ts
@@ -93,15 +93,22 @@ export interface ServiceBackupManifest {
   dataSubdir?: string;
   /**
    * A SIBLING-store manifest (#1594): this entry has no `installedTemplates`
-   * key of its own — it backs up a store that lives in a sibling dir of a real
-   * template (e.g. the zwave-js store at `home-assistant/zwave-js/`, beside
-   * HA's own `home-assistant/homeassistant/` config). `gateOn` names the
-   * template whose presence activates this backup, and whose deploy carries
-   * this entry through the per-service wipe/restore. Crucially this is a plain
-   * `dataSubdir` under DATA_DIR — NOT a `../` traversal off the parent's dir —
-   * so it never trips safeTarExtract's `..` refusal or wipeServiceForReinstall's
-   * dataDir-prefix guard (those security ratchets stay intact). Omitted for a
-   * normal service that gates on its own `service` name.
+   * key of its own — it backs up a store that belongs to a template installed
+   * under a DIFFERENT name. Two shapes, same mechanism:
+   *   - a sibling dir of a template's own config (the zwave-js store at
+   *     `home-assistant/zwave-js/`, beside HA's `home-assistant/homeassistant/`);
+   *   - one app inside a MULTI-APP template (#2595 — `authelia` and `lldap` are
+   *     both apps of the `auth` template; `jellyfin` is an app of `media`).
+   * `gateOn` names the template whose presence activates this backup, and whose
+   * deploy carries this entry through the per-service wipe/restore. Crucially
+   * this is a plain `dataSubdir` under DATA_DIR — NOT a `../` traversal off the
+   * parent's dir — so it never trips safeTarExtract's `..` refusal or
+   * wipeServiceForReinstall's dataDir-prefix guard (those security ratchets stay
+   * intact). Omitted for a normal service that gates on its own `service` name.
+   *
+   * A gate — `gateOn ?? service` — that names no shipped template is ALWAYS a
+   * defect, not a config choice: the entry can never activate on any box.
+   * `scripts/check-backup-coverage.ts` fails the build on one (#2595).
    */
   gateOn?: string;
   /**
@@ -152,6 +159,24 @@ export interface ServiceBackupManifest {
  * persistent `{{DATA_DIR}}/…` volume must either appear here (a manifest entry)
  * or be listed in `EXCLUDED_BULK_VOLUMES` below — enforced by
  * `scripts/check-backup-coverage.ts` so a new template can't silently opt out.
+ *
+ * The same gate also enforces the REVERSE direction (#2595): every entry's
+ * `gateOn ?? service` must name a template this repo ships. Two entries were
+ * removed when that gate went in, because neither could ever activate:
+ *   - `syncthing` — Syncthing is an app of the `file-share` template, so the
+ *     gate name was wrong; but re-gating it would not have helped. Its config
+ *     (`config.xml`, the device identity) lives in the podman-managed PVC
+ *     `file-share-syncthing-config`, deliberately NOT a `{{DATA_DIR}}` hostPath
+ *     (see templates/file-share/template.yml: a bind mount there fails
+ *     Syncthing's startup `chmod` under rootless podman). The producer/worker
+ *     only ever read DATA_DIR-relative paths, so there is nothing here for a
+ *     manifest to point at. Backing a named volume up needs machinery this
+ *     file-copy path does not have — tracked in #2596, not faked with an entry
+ *     that silently stages nothing.
+ *   - `hermes` — the retired Solaris name (CLAUDE.md: legacy `hermes` path
+ *     references are deprecated; the stack now ships from `mdopp/solaris` as
+ *     `solaris-*`). No `templates/hermes` exists and none will; the leftover
+ *     `/mnt/data/stacks/hermes` dir on an old box is not a ServiceBay template.
  */
 export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
   {
@@ -244,8 +269,13 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     // preserved nothing useful while the actual secrets were lost on reinstall.
     // `configuration.yml` is NOT backed up: ServiceBay re-renders it from
     // `configuration.yml.mustache` on every deploy (it's regenerable, not state).
+    // Authelia is an APP of the `auth` template (which also ships LLDAP), so
+    // there is no `authelia` key in installedTemplates to gate on (#2595 — the
+    // missing `gateOn` here silently kept the SSO server's secret store out of
+    // every nightly backup since #2153 shipped).
     service: 'authelia',
     dataSubdir: 'auth/authelia-data',
+    gateOn: 'auth',
     // db.sqlite3 is WAL-mode (post-deploy.py flips journal_mode=WAL, #1679). We
     // stage the main DB plus its `-wal`/`-shm` sidecars byte-for-byte so a live
     // copy stays whole on restore (the same reason NPM ships a snapshot). The DB
@@ -260,27 +290,8 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     include: ['conf/AdGuardHome.yaml'],
     exclude: ['data/querylog.json', 'data/stats.db', 'data/sessions.db', 'data/filters'],
   },
-  {
-    service: 'syncthing',
-    // device list + folder-share definitions; the synced data re-syncs from peers.
-    include: ['config.xml'],
-    exclude: ['index-v0.14.0.db', 'index'],
-    // The synced-folder index re-syncs from peers, but it's a heavy on-RAID
-    // artifact worth keeping through a wipe-config rather than re-indexing.
-    data: ['index-v0.14.0.db', 'index'],
-  },
-  {
-    service: 'hermes',
-    // model selection, prompts, household persona, MCP endpoint list,
-    // installed-skills git URLs, household-member personalization.
-    include: ['config.yaml'],
-    exclude: ['vectordb', 'embeddings', 'conversations', 'history'],
-    // The vector store + embeddings are large and rebuildable, but kept on the
-    // RAID through a wipe-config (re-embedding is expensive).
-    data: ['vectordb', 'embeddings'],
-    // LLM API keys are re-entered after a restore.
-    strip: [{ file: 'config.yaml', dropYamlKeys: ['api_key', 'apiKey', 'llm_api_key'] }],
-  },
+  // (`syncthing` and `hermes` used to sit here — removed in #2595, see the
+  // block comment above this array for why neither could ever activate.)
   {
     // Nginx Proxy Manager (#1528). Template name is `nginx`; data lives under
     // `nginx-proxy-manager/` (`data/` ← /data, `letsencrypt/` ← /etc/letsencrypt).
@@ -321,8 +332,12 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     // container's /data → `auth/lldap/`. Kept verbatim (identities can't be
     // regenerated; trusted-NAS class). The `-wal`/`-shm` sidecars ride along so
     // a live copy restores whole.
+    // LLDAP is the other app of the `auth` template — same gate as authelia
+    // (#2595). Without it the family identity store was never backed up, so a
+    // reinstall would have left nobody able to sign in to anything.
     service: 'lldap',
     dataSubdir: 'auth/lldap',
+    gateOn: 'auth',
     include: ['users.db', 'users.db-wal', 'users.db-shm'],
     exclude: [],
   },
@@ -360,8 +375,11 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     // the regenerable bulk: transcode/artwork caches, logs, and re-scannable
     // metadata. The media files themselves live on a separate volume
     // (`JELLYFIN_MEDIA_PATH`) that is never backed up (EXCLUDED_BULK_VOLUMES).
+    // Jellyfin is an app of the `media` template, so it gates on `media`, not on
+    // its own name (#2595).
     service: 'jellyfin',
     dataSubdir: 'media/jellyfin-config',
+    gateOn: 'media',
     include: [
       'config',
       'data/jellyfin.db', 'data/jellyfin.db-wal', 'data/jellyfin.db-shm',

--- a/packages/backend/src/lib/health/probes/certExpiry.test.ts
+++ b/packages/backend/src/lib/health/probes/certExpiry.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Detection half of `cert_expiry` (#2594): which rows get `renew_cert`
+ * and which get `delete_orphaned_cert`.
+ *
+ * Only NPM discovery + auth are mocked. The certificate→proxy-host link
+ * under test (`npmAdmin.isCertOrphaned`) stays real, so these cases
+ * exercise the actual rule, not a restatement of it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./npmAdmin', async importOriginal => ({
+  ...(await importOriginal<typeof import('./npmAdmin')>()),
+  findNpmAdminUrl: vi.fn(async () => ({ kind: 'url' as const, url: 'http://localhost:81' })),
+  getNpmToken: vi.fn(async () => 'tok'),
+}));
+
+import './certExpiry';
+import { CERT_EXPIRY_ACTION_IDS } from './certExpiry';
+import { getProbe } from './registry';
+import type { CheckConfig } from '../types';
+
+const DAY = 24 * 60 * 60 * 1000;
+const inDays = (n: number) => new Date(Date.now() + n * DAY + 60_000).toISOString();
+
+const check = (): CheckConfig => ({
+  id: 'cert_expiry',
+  name: 'TLS certificate expiry',
+  type: 'cert_expiry',
+  target: 'Local',
+  interval: 3600,
+  enabled: true,
+  created_at: new Date().toISOString(),
+  nodeName: 'Local',
+});
+
+interface Payload {
+  status: string;
+  detail: string;
+  hint?: string;
+  items?: { id: string; label: string; detail: string; status: string; actionIds: string[] }[];
+}
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+/** Wire NPM's two tables. `hosts: null` simulates an unreadable
+ *  proxy-host list (HTTP 500). */
+function npmReturns(certs: unknown[], hosts: unknown[] | null) {
+  mockFetch.mockImplementation(async (url: string) => {
+    if (String(url).includes('/api/nginx/certificates')) {
+      return { ok: true, json: async () => certs } as unknown as Response;
+    }
+    if (String(url).includes('/api/nginx/proxy-hosts')) {
+      return hosts === null
+        ? ({ ok: false, status: 500 } as unknown as Response)
+        : ({ ok: true, json: async () => hosts } as unknown as Response);
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  });
+}
+
+const cert = (id: number, domain: string, days: number) => ({
+  id,
+  provider: 'letsencrypt',
+  domain_names: [domain],
+  expires_on: inDays(days),
+});
+
+const run = async (): Promise<Payload> => {
+  const probe = getProbe('cert_expiry')!;
+  const res = (await probe.run(check(), { executor: {} as never })) as { status: string; payload: Payload };
+  return res.payload;
+};
+
+const runRaw = async () => {
+  const probe = getProbe('cert_expiry')!;
+  return (await probe.run(check(), { executor: {} as never })) as { status: string; payload: Payload };
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('cert_expiry orphan vs renewable (#2594)', () => {
+  it('keeps renew_cert for a cert a proxy host binds by certificate_id — unchanged behaviour', async () => {
+    npmReturns(
+      [cert(7, 'vault.example.com', 6)],
+      [{ id: 1, certificate_id: 7, domain_names: ['vault.example.com'] }],
+    );
+    const p = await run();
+    expect(p.items).toHaveLength(1);
+    expect(p.items![0]).toMatchObject({
+      id: '7',
+      label: 'vault.example.com',
+      status: 'warn',
+      actionIds: [CERT_EXPIRY_ACTION_IDS.renew],
+    });
+    expect(p.detail).toBe("1 of 1 Let's Encrypt cert expiring within 14 days.");
+    expect(p.hint).not.toMatch(/no proxy host/);
+  });
+
+  it('keeps renew_cert when the domain is served, even if the binding host picked a different cert row', async () => {
+    // Duplicate cert for a live domain: still not "belongs to nothing".
+    npmReturns(
+      [cert(9, 'vault.example.com', 3)],
+      [{ id: 1, certificate_id: 42, domain_names: ['vault.example.com'] }],
+    );
+    const p = await run();
+    expect(p.items![0].actionIds).toEqual([CERT_EXPIRY_ACTION_IDS.renew]);
+  });
+
+  it('keeps renew_cert for a wildcard cert while any host under it is served', async () => {
+    npmReturns(
+      [cert(11, '*.example.com', 5)],
+      [{ id: 1, certificate_id: 42, domain_names: ['vault.example.com'] }],
+    );
+    const p = await run();
+    expect(p.items![0].actionIds).toEqual([CERT_EXPIRY_ACTION_IDS.renew]);
+  });
+
+  it('offers delete_orphaned_cert instead of renew_cert for a near-expiry cert no host uses', async () => {
+    // The live bug: books.dopp.cloud has no proxy host left.
+    npmReturns(
+      [cert(11, 'books.example.com', 2), cert(7, 'vault.example.com', 6)],
+      [{ id: 1, certificate_id: 7, domain_names: ['vault.example.com'] }],
+    );
+    const p = await run();
+    const orphan = p.items!.find(i => i.id === '11')!;
+    expect(orphan.actionIds).toEqual([CERT_EXPIRY_ACTION_IDS.deleteOrphaned]);
+    expect(orphan.label).toContain('no proxy host');
+    expect(orphan.detail).toMatch(/renewing it would serve nothing/);
+    // The still-bound neighbour is untouched.
+    expect(p.items!.find(i => i.id === '7')!.actionIds).toEqual([CERT_EXPIRY_ACTION_IDS.renew]);
+    expect(p.detail).toMatch(/1 of them belong to no proxy host any more/);
+    expect(p.hint).toMatch(/Delete those instead/);
+  });
+
+  it('still offers delete_orphaned_cert once the orphan is already expired', async () => {
+    npmReturns([cert(11, 'books.example.com', -3)], []);
+    const res = await runRaw();
+    const item = res.payload.items![0];
+    expect(item.actionIds).toEqual([CERT_EXPIRY_ACTION_IDS.deleteOrphaned]);
+    // Warn/fail policy deliberately unchanged (#2594 leaves the
+    // thresholds alone): expired is still a red item and a red check.
+    expect(item.status).toBe('fail');
+    expect(res.status).toBe('fail');
+    expect(res.payload.status).toBe('fail');
+  });
+
+  it('offers NO action at all for an unbound cert that is not near expiry — the pre-provisioned case', async () => {
+    // 60 days left: freshly issued ahead of its route. Not listed, so
+    // neither renew nor delete is suggested.
+    npmReturns([cert(11, 'not-yet.example.com', 60)], []);
+    const res = await runRaw();
+    expect(res.payload.items).toBeUndefined();
+    expect(res.payload.status).toBe('ok');
+    expect(res.payload.detail).toMatch(/none expiring in 14 days/);
+  });
+
+  it('falls back to renew_cert for every row when the proxy-host list cannot be read', async () => {
+    // Fail-closed: "we do not know what is bound" must never read as
+    // "nothing is bound" — that would offer to delete live certs.
+    npmReturns([cert(11, 'books.example.com', 2)], null);
+    const p = await run();
+    expect(p.items![0].actionIds).toEqual([CERT_EXPIRY_ACTION_IDS.renew]);
+    expect(p.detail).not.toMatch(/no proxy host/);
+  });
+
+  it('treats a disabled proxy host as a binding — the route is off, not given up', async () => {
+    npmReturns(
+      [cert(7, 'vault.example.com', 4)],
+      [{ id: 1, enabled: false, certificate_id: 7, domain_names: ['vault.example.com'] }],
+    );
+    const p = await run();
+    expect(p.items![0].actionIds).toEqual([CERT_EXPIRY_ACTION_IDS.renew]);
+  });
+});

--- a/packages/backend/src/lib/health/probes/certExpiry.ts
+++ b/packages/backend/src/lib/health/probes/certExpiry.ts
@@ -1,13 +1,50 @@
 /**
  * `cert_expiry` probe — lists NPM-managed Let's Encrypt certs and
  * flags those expiring within 14 days (warn) or already expired (fail).
+ *
+ * Each flagged cert is also asked one further question (#2594): does any
+ * NPM proxy host still use it? NPM keeps certificates and proxy hosts in
+ * two independent tables, so removing a route leaves its certificate
+ * behind. Such a cert cannot be usefully renewed — a fresh certificate
+ * for a domain nothing serves — and the failed ACME run then resurfaces
+ * in `cert_request_failure` looking like a new problem. Those rows get
+ * `delete_orphaned_cert` instead of `renew_cert`.
+ *
+ * Why "unbound" alone is NOT the orphan test: a certificate can also be
+ * provisioned deliberately *before* its route exists, and offering to
+ * delete that one would be worse than the noise this fixes. The test is
+ * therefore "unbound AND already inside the expiry window" — and the
+ * window is the pre-existing one, unchanged. A Let's Encrypt cert is
+ * valid 90 days, so a cert with ≤14 days left has been unused for ~76
+ * days; that is an abandoned cert, not one waiting for its route.
+ * Outside the window nothing changed at all: an unbound cert is not
+ * listed and gets no action offered, exactly as before.
+ *
+ * The warn/fail thresholds themselves are deliberately untouched here —
+ * "expiring soon" stays `ok` at the check level and only an actually
+ * expired cert goes red (`encode` below).
  */
 
 import { registerProbe } from './registry';
-import { findNpmAdminUrl, getNpmToken } from './npmAdmin';
+import { findNpmAdminUrl, getNpmToken, fetchProxyHostBindings, isCertOrphaned, type ProxyHostBindings } from './npmAdmin';
+
+/**
+ * The action ids a `cert_expiry` item may carry. Single source of truth:
+ * the diagnose twin registers its handlers against these constants, and
+ * `certExpiry.test.ts` asserts every id here has one. An id emitted with
+ * no handler behind it would otherwise render as a row with no button —
+ * `resolveItemActions` drops unknown ids — i.e. an offer that silently
+ * cannot be taken.
+ */
+export const CERT_EXPIRY_ACTION_IDS = {
+  renew: 'renew_cert',
+  deleteOrphaned: 'delete_orphaned_cert',
+} as const;
+
+export type CertExpiryActionId = (typeof CERT_EXPIRY_ACTION_IDS)[keyof typeof CERT_EXPIRY_ACTION_IDS];
 
 interface NpmCert { id: number; provider?: string; domain_names?: string[]; expires_on?: string; }
-interface CertItem { id: string; label: string; detail: string; status: 'warn' | 'fail'; actionIds: string[]; }
+interface CertItem { id: string; label: string; detail: string; status: 'warn' | 'fail'; actionIds: CertExpiryActionId[]; }
 
 type Payload = { status: 'ok' | 'warn' | 'fail' | 'info'; detail: string; hint?: string; items?: CertItem[] };
 
@@ -18,26 +55,51 @@ const encode = (payload: Payload) => ({
 
 const WARN_DAYS = 14;
 
-function buildCertItems(leCerts: NpmCert[]): { items: CertItem[]; expired: number; expiringSoon: number } {
+const ORPHAN_HINT =
+  ' Certificates marked "no proxy host" belong to no route any more: renewing them would re-issue a certificate nothing serves, and the failed challenge would show up under cert_request_failure. Delete those instead.';
+
+/** Per-row wording. An orphaned row says why renewing is not the move. */
+function describeCert(daysLeft: number, orphaned: boolean): string {
+  const age = daysLeft < 0
+    ? `EXPIRED ${-daysLeft} day${daysLeft === -1 ? '' : 's'} ago`
+    : `Expires in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`;
+  if (orphaned) {
+    return `${age} — no proxy host uses this certificate any more, so renewing it would serve nothing. Deleting it is what ends the warning.`;
+  }
+  return daysLeft < 0
+    ? `${age} — services served via this cert show browser warnings.`
+    : `${age}.`;
+}
+
+function buildCertItems(
+  leCerts: NpmCert[],
+  bindings: ProxyHostBindings | null,
+): { items: CertItem[]; expired: number; expiringSoon: number; orphaned: number } {
   const now = Date.now();
   const items: CertItem[] = [];
   let expiringSoon = 0;
   let expired = 0;
+  let orphaned = 0;
   for (const c of leCerts) {
     if (!c.expires_on) continue;
     const exp = Date.parse(c.expires_on);
     if (!Number.isFinite(exp)) continue;
     const daysLeft = Math.floor((exp - now) / (1000 * 60 * 60 * 24));
+    if (daysLeft > WARN_DAYS) continue;
     const domains = (c.domain_names ?? []).join(', ') || `cert ${c.id}`;
-    if (daysLeft < 0) {
-      expired += 1;
-      items.push({ id: String(c.id), label: domains, detail: `EXPIRED ${-daysLeft} day${daysLeft === -1 ? '' : 's'} ago — services served via this cert show browser warnings.`, status: 'fail', actionIds: ['renew_cert'] });
-    } else if (daysLeft <= WARN_DAYS) {
-      expiringSoon += 1;
-      items.push({ id: String(c.id), label: domains, detail: `Expires in ${daysLeft} day${daysLeft === 1 ? '' : 's'}.`, status: 'warn', actionIds: ['renew_cert'] });
-    }
+    const isOrphan = isCertOrphaned(c, bindings);
+    if (isOrphan) orphaned += 1;
+    if (daysLeft < 0) expired += 1;
+    else expiringSoon += 1;
+    items.push({
+      id: String(c.id),
+      label: isOrphan ? `${domains} — no proxy host` : domains,
+      detail: describeCert(daysLeft, isOrphan),
+      status: daysLeft < 0 ? 'fail' : 'warn',
+      actionIds: [isOrphan ? CERT_EXPIRY_ACTION_IDS.deleteOrphaned : CERT_EXPIRY_ACTION_IDS.renew],
+    });
   }
-  return { items, expired, expiringSoon };
+  return { items, expired, expiringSoon, orphaned };
 }
 
 registerProbe({
@@ -67,17 +129,25 @@ registerProbe({
       const leCerts = (certs ?? []).filter(c => c.provider === 'letsencrypt');
       if (leCerts.length === 0) return encode({ status: 'info', detail: "No Let's Encrypt certificates managed by NPM." });
 
-      const { items, expired, expiringSoon } = buildCertItems(leCerts);
+      // null (host list unreadable) → nothing is classified as orphaned
+      // and every row keeps `renew_cert`, i.e. the pre-#2594 behaviour.
+      const bindings = await fetchProxyHostBindings(adminUrl, token);
+
+      const { items, expired, expiringSoon, orphaned } = buildCertItems(leCerts, bindings);
       if (items.length === 0) {
         return encode({ status: 'ok', detail: `${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'} managed; none expiring in ${WARN_DAYS} days.` });
       }
       const status: 'warn' | 'fail' = expired > 0 ? 'fail' : 'warn';
+      const base = expired > 0
+        ? `${expired} expired + ${expiringSoon} expiring soon out of ${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'}.`
+        : `${expiringSoon} of ${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'} expiring within ${WARN_DAYS} days.`;
       return encode({
         status,
-        detail: expired > 0
-          ? `${expired} expired + ${expiringSoon} expiring soon out of ${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'}.`
-          : `${expiringSoon} of ${leCerts.length} Let's Encrypt cert${leCerts.length === 1 ? '' : 's'} expiring within ${WARN_DAYS} days.`,
-        hint: 'NPM auto-renews on a schedule; click "Renew now" if you want to force a refresh ahead of expiry. Failed renewals usually mean DNS or port-80 challenge changed since issuance.',
+        detail: orphaned > 0
+          ? `${base} ${orphaned} of them belong to no proxy host any more.`
+          : base,
+        hint: 'NPM auto-renews on a schedule; click "Renew now" if you want to force a refresh ahead of expiry. Failed renewals usually mean DNS or port-80 challenge changed since issuance.'
+          + (orphaned > 0 ? ORPHAN_HINT : ''),
         items,
       });
     } catch (e) {

--- a/packages/backend/src/lib/health/probes/npmAdmin.test.ts
+++ b/packages/backend/src/lib/health/probes/npmAdmin.test.ts
@@ -15,7 +15,7 @@ vi.mock('../../services/ServiceManager', () => ({
   },
 }));
 
-import { findNpmAdminUrl } from './npmAdmin';
+import { findNpmAdminUrl, indexProxyHostBindings, isCertOrphaned } from './npmAdmin';
 
 beforeEach(() => {
   for (const k of Object.keys(twinNodes)) delete twinNodes[k];
@@ -92,5 +92,44 @@ describe('findNpmAdminUrl', () => {
     );
     const r = await findNpmAdminUrl('Local');
     expect(r).toEqual({ kind: 'url', url: 'http://localhost:8181' });
+  });
+});
+
+describe('cert → proxy-host binding (#2594)', () => {
+  const hosts = [
+    { id: 1, certificate_id: 7, domain_names: ['vault.example.com'] },
+    { id: 2, certificate_id: 0, domain_names: ['plain.example.com'] },
+  ];
+  const bindings = indexProxyHostBindings(hosts);
+
+  it('indexes both the selected cert ids and the served domains', () => {
+    expect([...bindings.certIds]).toEqual([7]); // certificate_id 0 = "no cert"
+    expect([...bindings.domains].sort()).toEqual(['plain.example.com', 'vault.example.com']);
+  });
+
+  it('survives a non-array / malformed body without throwing', () => {
+    expect(indexProxyHostBindings(undefined).certIds.size).toBe(0);
+    expect(indexProxyHostBindings([{ domain_names: 'nope' }]).domains.size).toBe(0);
+  });
+
+  it('is orphaned only when neither the id nor any domain is referenced', () => {
+    expect(isCertOrphaned({ id: 7, domain_names: ['vault.example.com'] }, bindings)).toBe(false);
+    expect(isCertOrphaned({ id: 99, domain_names: ['vault.example.com'] }, bindings)).toBe(false);
+    expect(isCertOrphaned({ id: 7, domain_names: ['gone.example.com'] }, bindings)).toBe(false);
+    expect(isCertOrphaned({ id: 99, domain_names: ['gone.example.com'] }, bindings)).toBe(true);
+  });
+
+  it('matches case-insensitively and ignores surrounding whitespace', () => {
+    expect(isCertOrphaned({ id: 99, domain_names: ['  VAULT.example.com '] }, bindings)).toBe(false);
+  });
+
+  it('treats a wildcard cert as in use while any host under it is served', () => {
+    expect(isCertOrphaned({ id: 99, domain_names: ['*.example.com'] }, bindings)).toBe(false);
+    expect(isCertOrphaned({ id: 99, domain_names: ['*.other.com'] }, bindings)).toBe(true);
+  });
+
+  it('never reports orphaned when the host table is unknown, or the cert has no domains', () => {
+    expect(isCertOrphaned({ id: 99, domain_names: ['gone.example.com'] }, null)).toBe(false);
+    expect(isCertOrphaned({ id: 99, domain_names: [] }, bindings)).toBe(false);
   });
 });

--- a/packages/backend/src/lib/health/probes/npmAdmin.ts
+++ b/packages/backend/src/lib/health/probes/npmAdmin.ts
@@ -15,6 +15,11 @@
  *   - `getNpmToken(adminUrl)` — tries stored creds first, then the
  *     wizard's default (`admin@example.com`/`changeme`); returns null
  *     if all candidates 401.
+ *   - `fetchProxyHostBindings` / `isCertOrphaned` / `classifyCertBinding`
+ *     — the certificate→host link (#2594). NPM keeps certificates and
+ *     proxy hosts in two independent tables; deleting a host leaves its
+ *     certificate behind with nothing pointing at it. Everything that
+ *     wants to know "is this cert still serving anything?" asks here.
  */
 import { getConfig } from '../../config';
 import { ServiceManager } from '../../services/ServiceManager';
@@ -97,4 +102,127 @@ export async function getNpmToken(adminUrl: string): Promise<string | null> {
     } catch { /* try next */ }
   }
   return null;
+}
+
+// ─── Certificate → proxy-host binding (#2594) ───────────────────────────
+
+/** The bit of an NPM certificate row the binding check needs. */
+export interface NpmCertRef {
+  id: number;
+  domain_names?: string[];
+}
+
+/** Everything NPM's proxy-host table currently points at, indexed both
+ *  ways: by the certificate id a host selected, and by the domain a host
+ *  serves. Two keys, not one, on purpose — a duplicate certificate for a
+ *  domain that IS served (by some other cert row) must not read as
+ *  unused. See `isCertOrphaned`. */
+export interface ProxyHostBindings {
+  /** `certificate_id` values referenced by at least one proxy host. */
+  certIds: Set<number>;
+  /** Every domain served by a proxy host, lower-cased. */
+  domains: Set<string>;
+}
+
+/** Pure indexer over a `GET /api/nginx/proxy-hosts` response body.
+ *  Disabled hosts count as bindings: the operator switched the route
+ *  off, they did not give the domain up, and re-enabling it must not
+ *  find the certificate deleted underneath. */
+export function indexProxyHostBindings(hosts: unknown): ProxyHostBindings {
+  const certIds = new Set<number>();
+  const domains = new Set<string>();
+  for (const raw of Array.isArray(hosts) ? hosts : []) {
+    const host = raw as { certificate_id?: unknown; domain_names?: unknown };
+    const certId = Number(host.certificate_id);
+    if (Number.isFinite(certId) && certId > 0) certIds.add(certId);
+    for (const d of Array.isArray(host.domain_names) ? host.domain_names : []) {
+      if (typeof d === 'string' && d.trim()) domains.add(d.trim().toLowerCase());
+    }
+  }
+  return { certIds, domains };
+}
+
+/** Read NPM's proxy-host table and index it. Returns `null` — not an
+ *  empty index — when the table could not be read, so callers can tell
+ *  "nothing is bound" from "we don't know what is bound". Every caller
+ *  must treat `null` as "assume in use" (see `isCertOrphaned`): the two
+ *  mistakes are not symmetric, offering a renewal for a dead cert is
+ *  noise, offering a delete for a live one takes a site down. */
+export async function fetchProxyHostBindings(
+  adminUrl: string,
+  token: string,
+): Promise<ProxyHostBindings | null> {
+  try {
+    const res = await fetch(`${adminUrl}/api/nginx/proxy-hosts`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(6000),
+    });
+    if (!res.ok) return null;
+    return indexProxyHostBindings(await res.json());
+  } catch {
+    return null;
+  }
+}
+
+/** True when nothing in NPM's proxy-host table uses this certificate:
+ *  no host selected it by id, and no host serves any domain it covers.
+ *
+ *  Deliberately conservative in three places:
+ *   - `bindings === null` (host table unreadable) → not orphaned.
+ *   - a cert with no domain names → not orphaned (nothing to compare).
+ *   - a wildcard cert matches any host domain under it, so `*.x.tld`
+ *     counts as in use while `a.x.tld` is served, even by another cert.
+ *
+ *  Note what this does NOT decide on its own: a certificate provisioned
+ *  *ahead* of its route is unbound too. The caller adds the second half
+ *  of the test — see `certExpiry.ts`, which only ever acts on an unbound
+ *  cert once it is inside the expiry window. */
+export function isCertOrphaned(cert: NpmCertRef, bindings: ProxyHostBindings | null): boolean {
+  if (!bindings) return false;
+  if (bindings.certIds.has(cert.id)) return false;
+  const domains = (cert.domain_names ?? [])
+    .filter((d): d is string => typeof d === 'string' && d.trim().length > 0)
+    .map(d => d.trim().toLowerCase());
+  if (domains.length === 0) return false;
+  return !domains.some(d => (d.startsWith('*.')
+    ? [...bindings.domains].some(h => h === d.slice(2) || h.endsWith(d.slice(1)))
+    : bindings.domains.has(d)));
+}
+
+/** Verdict for one certificate id, resolved live against NPM. */
+export type CertBindingVerdict =
+  | { kind: 'in-use'; domains: string[] }
+  | { kind: 'orphaned'; domains: string[] }
+  | { kind: 'unknown'; reason: string };
+
+/** Re-derive a single certificate's binding state at click time.
+ *  The `cert_expiry` item list is up to an hour old, so an action that
+ *  depends on "this cert belongs to nothing" must confirm it against
+ *  NPM before it does anything — a route may have been created in the
+ *  meantime. Anything it cannot read comes back `unknown`, never a
+ *  guess. */
+export async function classifyCertBinding(
+  adminUrl: string,
+  token: string,
+  certId: string,
+): Promise<CertBindingVerdict> {
+  let cert: NpmCertRef;
+  try {
+    const res = await fetch(`${adminUrl}/api/nginx/certificates/${certId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(6000),
+    });
+    if (res.status === 404) return { kind: 'unknown', reason: `NPM has no certificate ${certId} any more.` };
+    if (!res.ok) return { kind: 'unknown', reason: `NPM certificate lookup returned HTTP ${res.status}.` };
+    cert = (await res.json()) as NpmCertRef;
+  } catch (e) {
+    return { kind: 'unknown', reason: `Could not read certificate ${certId} from NPM: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  const bindings = await fetchProxyHostBindings(adminUrl, token);
+  if (!bindings) return { kind: 'unknown', reason: 'Could not read the NPM proxy-host list.' };
+  const domains = (cert.domain_names ?? []).filter((d): d is string => typeof d === 'string');
+  const id = Number.isFinite(Number(cert.id)) ? Number(cert.id) : Number(certId);
+  return isCertOrphaned({ id, domain_names: domains }, bindings)
+    ? { kind: 'orphaned', domains }
+    : { kind: 'in-use', domains };
 }

--- a/packages/backend/src/lib/services/extraConfigFiles.test.ts
+++ b/packages/backend/src/lib/services/extraConfigFiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { writeExtraConfigFiles } from './serviceLifecycle';
+import { writeExtraConfigFiles } from './extraConfigFiles';
 
 vi.mock('../logger', () => ({
     logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
@@ -119,6 +119,111 @@ describe('writeExtraConfigFiles', () => {
         const writes = agent.calls.filter(c => c.action === 'write_file');
         expect(writes).toHaveLength(2);
         expect(writes[1].params?.sudo).toBe(true);
+    });
+
+    // ── #2590: seed-only companion files ────────────────────────────────
+    //
+    // The incident: a routine convergence pass re-rendered Home Assistant's
+    // `automations.yaml` seed over 6729 B of the operator's real automations,
+    // unconditionally and silently. A file the template declares seed-only is
+    // written ONLY when the node says it is absent.
+    describe('seed-only config files (#2590)', () => {
+        const HA_DIR = '/mnt/data/stacks/home-assistant/homeassistant';
+        const automations = { path: `${HA_DIR}/automations.yaml`, content: '# seed\n[]\n' };
+        const authelia = { path: `${HA_DIR}/configuration.yml`, content: 'rendered: true\n' };
+        const seedOnly = new Set(['automations.yaml']);
+
+        /** Agent whose `test -e` probe answers with `present`/`absent`. */
+        function makeProbeAgent(exists: boolean) {
+            return makeAgent((action, params) => {
+                if (action === 'exec' && /test -e/.test(params?.command ?? '')) {
+                    return { code: 0, stdout: exists ? 'sb-present\n' : 'sb-absent\n' };
+                }
+                if (action === 'exec') return { code: 0 };
+                return 'ok';
+            });
+        }
+
+        it('does not write a declared file that already exists on the node', async () => {
+            const agent = makeProbeAgent(true);
+            await writeExtraConfigFiles(agent, 'home-assistant', [automations], seedOnly);
+
+            expect(agent.calls.filter(c => c.action === 'write_file')).toHaveLength(0);
+            // Nothing about the deploy touches the target — not even the mkdir.
+            expect(agent.calls.filter(c => /mkdir/.test(c.params?.command ?? ''))).toHaveLength(0);
+        });
+
+        it('seeds a declared file when it is absent (first install unchanged)', async () => {
+            const agent = makeProbeAgent(false);
+            await writeExtraConfigFiles(agent, 'home-assistant', [automations], seedOnly);
+
+            const writes = agent.calls.filter(c => c.action === 'write_file');
+            expect(writes).toHaveLength(1);
+            expect(writes[0].params?.path).toBe(automations.path);
+            expect(writes[0].params?.content).toBe(automations.content);
+        });
+
+        it('leaves undeclared files on the unconditional-write path', async () => {
+            // The default must not change for every other config file: an
+            // Authelia `configuration.yml` MUST be re-rendered every deploy.
+            const agent = makeProbeAgent(true);
+            await writeExtraConfigFiles(agent, 'home-assistant', [automations, authelia], seedOnly);
+
+            const writes = agent.calls.filter(c => c.action === 'write_file');
+            expect(writes).toHaveLength(1);
+            expect(writes[0].params?.path).toBe(authelia.path);
+            // And no existence probe was run for it.
+            const probes = agent.calls.filter(c => /test -e/.test(c.params?.command ?? ''));
+            expect(probes).toHaveLength(1);
+            expect(probes[0].params?.command).toContain(automations.path);
+        });
+
+        it('matches on the file name, not on a path substring', async () => {
+            // A same-named file under a different service must still resolve
+            // by basename; a differently-named neighbour must not be caught.
+            const other = { path: `${HA_DIR}/scenes.yaml`, content: '[]\n' };
+            const agent = makeProbeAgent(true);
+            await writeExtraConfigFiles(agent, 'home-assistant', [other], seedOnly);
+
+            expect(agent.calls.filter(c => c.action === 'write_file')).toHaveLength(1);
+        });
+
+        it('does NOT write when the existence probe throws (fail closed)', async () => {
+            // An unreachable/erroring probe must never be read as "absent" —
+            // that is exactly the write that destroyed the automations.
+            const agent = makeAgent((action, params) => {
+                if (action === 'exec' && /test -e/.test(params?.command ?? '')) {
+                    throw new Error('agent transport closed');
+                }
+                if (action === 'exec') return { code: 0 };
+                return 'ok';
+            });
+            await expect(writeExtraConfigFiles(agent, 'home-assistant', [automations], seedOnly))
+                .resolves.toBeUndefined();
+
+            expect(agent.calls.filter(c => c.action === 'write_file')).toHaveLength(0);
+        });
+
+        it('does NOT write when the existence probe answers with something unexpected', async () => {
+            const agent = makeAgent((action, params) => {
+                if (action === 'exec' && /test -e/.test(params?.command ?? '')) {
+                    return { code: 0, stdout: 'bash: test: command not found' };
+                }
+                if (action === 'exec') return { code: 0 };
+                return 'ok';
+            });
+            await writeExtraConfigFiles(agent, 'home-assistant', [automations], seedOnly);
+
+            expect(agent.calls.filter(c => c.action === 'write_file')).toHaveLength(0);
+        });
+
+        it('probes nothing at all when the template declares no seed-only files', async () => {
+            const agent = makeProbeAgent(true);
+            await writeExtraConfigFiles(agent, 'home-assistant', [automations]);
+
+            expect(agent.calls.filter(c => /test -e/.test(c.params?.command ?? ''))).toHaveLength(0);
+            expect(agent.calls.filter(c => c.action === 'write_file')).toHaveLength(1);
+        });
     });
 
     it('still retries with sudo on a defensive non-ok return value (no throw)', async () => {

--- a/packages/backend/src/lib/services/extraConfigFiles.ts
+++ b/packages/backend/src/lib/services/extraConfigFiles.ts
@@ -1,0 +1,198 @@
+/**
+ * Shipping a template's rendered companion config + asset files to a node.
+ *
+ * Extracted from `serviceLifecycle.ts` (#2590) — that module was at its
+ * size ceiling and this is a self-contained concern: one agent-facing
+ * write loop plus the rules about WHICH files a deploy may write.
+ *
+ * The central rule, and the reason this file exists as its own unit: a
+ * deploy re-renders and rewrites every companion config file, which is
+ * correct for a file ServiceBay owns and destructive for a file the
+ * running application owns (ADR 0004 — installs are non-destructive).
+ * Templates mark the latter with `servicebay.seed-only-configs`; those
+ * are written only when the node reports them absent.
+ */
+
+import { logger } from '../logger';
+
+/** Minimal agent shape needed to ship files to a node. */
+interface FileWritingAgent {
+    sendCommand(action: string, params?: unknown): Promise<unknown>;
+}
+
+/**
+ * #1298 — realign a sudo-written (root-owned) file to its parent dir's owner so
+ * a later rootless `kube play --replace` relabel of the dir can still lsetxattr
+ * it. Best-effort; logged but never fatal (the file is already written, and an
+ * ownership mismatch only bites a later relabel).
+ */
+async function alignOwnershipToDir(agent: FileWritingAgent, path: string, dir: string): Promise<void> {
+    try {
+        const res = await agent.sendCommand('exec', { command: `sudo chown --reference=${dir} ${path}` });
+        if (res && typeof res === 'object' && 'code' in res && (res as { code: unknown }).code !== 0) {
+            logger.warn('ServiceManager', `chown to match ${dir} owner failed for ${path}: ${JSON.stringify(res)}`);
+        }
+    } catch (err) {
+        logger.warn('ServiceManager', `chown to match ${dir} owner failed for ${path}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
+/** Best-effort stdout of an agent `exec` reply, whatever shape it arrives in. */
+function extractStdout(res: unknown): string | null {
+    if (typeof res === 'string') return res;
+    if (res && typeof res === 'object' && 'stdout' in res) {
+        const out = (res as { stdout: unknown }).stdout;
+        if (typeof out === 'string') return out;
+    }
+    return null;
+}
+
+/**
+ * #2590 — does a seed-only target already exist on the node?
+ *
+ * FAIL-CLOSED: an unreadable / unexpected / throwing probe answers "yes, it
+ * exists", so the deploy skips the write. The two outcomes are not symmetric.
+ * Wrongly skipping a seed leaves a companion file absent — recoverable, and
+ * for the Home Assistant includes the pre-start hook (`runHomeAssistantHook`)
+ * seeds it a moment later anyway. Wrongly writing destroys operator content
+ * that may exist nowhere else, silently, which is the incident this guard
+ * exists to prevent. Only a probe that positively reports "absent" earns a
+ * write.
+ */
+async function seedTargetExists(agent: FileWritingAgent, path: string): Promise<boolean> {
+    let raw: string | null;
+    try {
+        // `&& … || …` so the command exits 0 either way — a non-zero exit
+        // would be indistinguishable from a transport failure here.
+        raw = extractStdout(await agent.sendCommand('exec', {
+            command: `test -e ${path} && echo sb-present || echo sb-absent`,
+        }));
+    } catch (err) {
+        logger.warn('ServiceManager', `Seed-only existence probe for ${path} failed (${err instanceof Error ? err.message : String(err)}); treating the file as present and NOT writing it.`);
+        return true;
+    }
+    const answer = raw?.trim();
+    if (answer === 'sb-absent') return false;
+    if (answer === 'sb-present') return true;
+    logger.warn('ServiceManager', `Seed-only existence probe for ${path} returned an unexpected reply (${JSON.stringify(raw)}); treating the file as present and NOT writing it.`);
+    return true;
+}
+
+/**
+ * #2590 — is `path` a seed-only target that must be left as it is? True means
+ * "declared seed-only AND already on the node", i.e. the deploy skips it
+ * entirely. False means either the template never declared it, or it is
+ * genuinely absent and this deploy gets to seed it once.
+ */
+async function skipAsSeedOnly(
+    agent: FileWritingAgent,
+    path: string,
+    seedOnlyFilenames: ReadonlySet<string>,
+): Promise<boolean> {
+    if (seedOnlyFilenames.size === 0) return false;
+    if (!seedOnlyFilenames.has(path.substring(path.lastIndexOf('/') + 1))) return false;
+    if (await seedTargetExists(agent, path)) {
+        logger.info('ServiceManager', `Seed-only config ${path} already exists — leaving it untouched (its content belongs to the service/operator, not to the template).`);
+        return true;
+    }
+    logger.info('ServiceManager', `Seed-only config ${path} is absent — seeding it once.`);
+    return false;
+}
+
+/**
+ * Write a template's rendered config + asset files to the node, creating
+ * parent dirs first.
+ *
+ * Failures are FATAL — the previous behaviour was to log a warning and
+ * continue, which produced the radicale crash-loop class of bug: the
+ * service starts, finds its config file missing, dies, and the operator
+ * has no breadcrumb back to the silent write_file failure during deploy.
+ * Throwing surfaces the problem at deploy time with a useful path.
+ *
+ * #1171 — a write target can sit under a hostPath pre-provisioned by a
+ * consumer container (owned by its uid, not the agent's `core`/uid-1000),
+ * e.g. the asset-transport `skills/` dir on a volume the hermes/syncthing
+ * pod created. The plain write EACCESes there, so a failed write is
+ * retried once via the agent's #1000 privileged path (`core` has
+ * passwordless sudo on FCoS) before being recorded as a failure.
+ *
+ * #1258 — the agent rejects (the promise throws) when a command replies
+ * with an error, e.g. the EACCES above. The retry therefore has to catch
+ * the thrown error, not inspect a returned value — the original `res !==
+ * 'ok'` check never fired because the await threw first, so the raw
+ * `[Errno 13]` propagated straight to the deploy loop and the sudo retry
+ * was dead code.
+ *
+ * #1298 — a sudo write lands the new file owned by root (uid 0). But the
+ * only reason the unprivileged write failed is that the asset dir is owned
+ * by the consuming rootless pod's subuid; a root-owned file inside it
+ * breaks the next `podman kube play --replace` of that pod — rootless
+ * podman can't `lsetxattr` (relabel) a path it doesn't own, so the volume
+ * relabel fails and the pod won't restart. After a sudo write we therefore
+ * realign the file's ownership to its parent directory (i.e. the subuid the
+ * siblings already use) so the relabel stays possible. Best-effort: the file
+ * is already written, and an ownership mismatch only bites a later relabel,
+ * so a chown failure is logged but does not fail the deploy.
+ *
+ * @param seedOnlyFilenames Basenames the template declared via
+ *   `servicebay.seed-only-configs` (#2590). Such a file is written ONLY when
+ *   it is absent on the node: its content belongs to the application or the
+ *   operator from first install onward, so re-rendering the template's seed
+ *   over it is data loss (ADR 0004). Everything not in this set keeps the
+ *   unconditional-write behaviour every other config file relies on.
+ */
+export async function writeExtraConfigFiles(
+    agent: FileWritingAgent,
+    serviceName: string,
+    extraFiles: { path: string; content: string }[],
+    seedOnlyFilenames: ReadonlySet<string> = new Set<string>(),
+): Promise<void> {
+    const failures: string[] = [];
+    // Returns 'ok' on success, otherwise the failure reason as a string —
+    // covering both the rejection (agent error reply) and the defensive
+    // non-'ok' return value cases.
+    const attemptWrite = async (target: { path: string; content: string }, sudo: boolean): Promise<string> => {
+        try {
+            const res = await agent.sendCommand('write_file', { path: target.path, content: target.content, ...(sudo ? { sudo: true } : {}) });
+            return res === 'ok' ? 'ok' : JSON.stringify(res);
+        } catch (err) {
+            return err instanceof Error ? err.message : String(err);
+        }
+    };
+    for (const f of extraFiles) {
+        // Ensure parent directory exists.
+        const dir = f.path.substring(0, f.path.lastIndexOf('/'));
+
+        // #2590 — the check happens BEFORE the mkdir/write so nothing about
+        // the deploy reaches an existing seed-only target.
+        if (await skipAsSeedOnly(agent, f.path, seedOnlyFilenames)) continue;
+        if (dir) {
+            await agent.sendCommand('exec', { command: `mkdir -p ${dir}` });
+        }
+        let outcome = await attemptWrite(f, false);
+        let usedSudo = false;
+        if (outcome !== 'ok') {
+            logger.warn('ServiceManager', `write_file for ${f.path} failed (${outcome}); retrying with sudo.`);
+            outcome = await attemptWrite(f, true);
+            usedSudo = true;
+        }
+        if (outcome !== 'ok') {
+            failures.push(f.path);
+            logger.error('ServiceManager', `Failed to write extra file ${f.path}: ${outcome}`);
+        } else {
+            // The plain (core-owned) write lands in a core-owned dir — fine.
+            // Only the sudo path leaves a root-owned file in a subuid-owned
+            // asset dir, which is what #1298 has to repair.
+            if (usedSudo && dir) {
+                await alignOwnershipToDir(agent, f.path, dir);
+            }
+            logger.info('ServiceManager', `Wrote extra config file: ${f.path}`);
+        }
+    }
+    if (failures.length > 0) {
+        throw new Error(
+            `Failed to write ${failures.length} required config file(s) for service "${serviceName}":\n  ${failures.join('\n  ')}\n\n` +
+            `The service was not started. Re-run the deploy or check the agent's write permissions on the target paths.`,
+        );
+    }
+}

--- a/packages/backend/src/lib/services/serviceLifecycle.homeAssistantHook.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.homeAssistantHook.test.ts
@@ -1,4 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// runPreStartHooks resolves the agent itself; the rest of this file passes a
+// fake agent in directly and is unaffected by the mock.
+const ensureAgentMock = vi.fn();
+vi.mock('../agent/manager', () => ({
+    agentManager: { ensureAgent: (...args: unknown[]) => ensureAgentMock(...args) },
+}));
+
 import { ServiceLifecycle } from './serviceLifecycle';
 
 vi.mock('../logger', () => ({
@@ -212,5 +220,69 @@ describe('runHomeAssistantHook (#1687 config-survival self-heal)', () => {
         await expect(
             ServiceLifecycle.runHomeAssistantHook(agent as never, CFG),
         ).resolves.toBeUndefined();
+    });
+});
+
+/**
+ * #2590 — `runPreStartHooks` wraps every hook in a catch-all that logs at
+ * `debug` and lets the deploy continue. That is right for an incidental hook
+ * failure and WRONG for the #1864 integrity guard, whose only job is to refuse
+ * the deploy: on the owner's box the guard's condition was live for eight
+ * consecutive diagnose runs while deploys kept sailing through.
+ */
+describe('runPreStartHooks — a refusing guard must abort the deploy (#2590)', () => {
+    const HA_POD = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: home-assistant
+spec:
+  containers:
+    - name: homeassistant
+      image: ghcr.io/home-assistant/home-assistant:stable
+      volumeMounts:
+        - mountPath: /config
+          name: ha-config
+  volumes:
+    - name: ha-config
+      hostPath:
+        path: ${DIR}
+`;
+
+    const REGISTRY = `${DIR}/.storage/core.entity_registry`;
+
+    /** `runPreStartHooks` is private; production reaches it through deploy. */
+    const runPreStartHooks = (yamlContent: string) =>
+        (ServiceLifecycle as unknown as {
+            runPreStartHooks(node: string, name: string, yaml: string): Promise<void>;
+        }).runPreStartHooks('Local', 'home-assistant', yamlContent);
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        ensureAgentMock.mockReset();
+    });
+
+    it('propagates the integrity refusal instead of swallowing it', async () => {
+        const agent = makeHaAgent({
+            [CFG]: 'default_config:\nautomation: !include automations.yaml\nscript: !include scripts.yaml\nscene: !include scenes.yaml\n',
+            [REGISTRY]: JSON.stringify({
+                data: { entities: [{ platform: 'automation', entity_id: 'automation.morning' }] },
+            }),
+            [`${DIR}/automations.yaml`]: '[]',
+            [`${DIR}/scripts.yaml`]: '{}',
+            [`${DIR}/scenes.yaml`]: '[]',
+        });
+        ensureAgentMock.mockResolvedValue(agent);
+
+        await expect(runPreStartHooks(HA_POD)).rejects.toThrow(/integrity check FAILED/i);
+    });
+
+    it('still swallows an ordinary hook failure (unchanged behaviour)', async () => {
+        ensureAgentMock.mockRejectedValue(new Error('agent unreachable'));
+        await expect(runPreStartHooks(HA_POD)).resolves.toBeUndefined();
+    });
+
+    it('still swallows unparseable pod yaml (unchanged behaviour)', async () => {
+        await expect(runPreStartHooks('::: not yaml :::')).resolves.toBeUndefined();
     });
 });

--- a/packages/backend/src/lib/services/serviceLifecycle.seedOnlyConfigs.test.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.seedOnlyConfigs.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * #2590 — the deploy path must honour `servicebay.seed-only-configs`.
+ *
+ * The unit-level guard lives in `serviceLifecycle.writeExtraConfigFiles.test.ts`.
+ * THIS file covers the seam that actually failed on the owner's box: the guard
+ * exists but nothing tells the deploy which files it protects. It drives
+ * `deployKubeService` with the REAL `templates/home-assistant/template.yml`, so
+ * a fix that lands only in the write helper — or a template that stops
+ * declaring the annotation — fails here.
+ */
+
+const mockSendCommand = vi.fn();
+vi.mock('../agent/manager', () => ({
+    agentManager: {
+        ensureAgent: async () => ({ sendCommand: mockSendCommand }),
+    },
+}));
+// The deploy path snapshots history and reads config; neither is under test.
+vi.mock('../history', () => ({ saveSnapshot: vi.fn() }));
+
+import { ServiceLifecycle } from './serviceLifecycle';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
+const HA_TEMPLATE = path.join(REPO_ROOT, 'templates', 'home-assistant', 'template.yml');
+
+/** The shipped manifest with `{{VAR}}` placeholders substituted, i.e. what a
+ *  real deploy hands to `deployKubeService`. */
+function renderedHomeAssistantYaml(): string {
+    return fs.readFileSync(HA_TEMPLATE, 'utf-8').replace(/\{\{[^}]*\}\}/g, 'x');
+}
+
+const HA_CONFIG_DIR = '/mnt/data/stacks/home-assistant/homeassistant';
+
+/** Every companion file the HA template ships, as the runner assembles them. */
+const EXTRA_FILES = [
+    { path: `${HA_CONFIG_DIR}/configuration.yaml`, content: '# rendered base config\n' },
+    { path: `${HA_CONFIG_DIR}/automations.yaml`, content: '# seed\n[]\n' },
+    { path: `${HA_CONFIG_DIR}/scenes.yaml`, content: '# seed\n[]\n' },
+    { path: `${HA_CONFIG_DIR}/scripts.yaml`, content: '# seed\n{}\n' },
+];
+
+/**
+ * Agent stub. `filesOnBox` decides what `test -e` reports; everything else
+ * answers the generic success shape the deploy path expects.
+ */
+function stubAgent(filesOnBox: Set<string>) {
+    mockSendCommand.mockImplementation(async (action: string, params?: { command?: string; path?: string }) => {
+        if (action === 'write_file') return 'ok';
+        if (action === 'read_file') return { content: '' };
+        const command = params?.command ?? '';
+        const probe = /^test -e (\S+) &&/.exec(command);
+        if (probe) {
+            return { code: 0, stdout: filesOnBox.has(probe[1]) ? 'sb-present\n' : 'sb-absent\n', stderr: '' };
+        }
+        return { code: 0, stdout: '', stderr: '' };
+    });
+}
+
+/** Paths the deploy asked the agent to write. */
+function writtenPaths(): string[] {
+    return mockSendCommand.mock.calls
+        .filter(([action]) => action === 'write_file')
+        .map(([, params]) => (params as { path: string }).path);
+}
+
+async function deployHomeAssistant() {
+    await ServiceLifecycle.deployKubeService(
+        'Local',
+        'home-assistant',
+        '[Kube]\nYaml=home-assistant.yml\n',
+        renderedHomeAssistantYaml(),
+        'home-assistant.yml',
+        EXTRA_FILES,
+    );
+}
+
+describe('deployKubeService honours servicebay.seed-only-configs (#2590)', () => {
+    beforeEach(() => {
+        mockSendCommand.mockReset();
+    });
+
+    it('leaves a populated automations.yaml alone on a redeploy/convergence pass', async () => {
+        // The incident: the operator's 11 automations (6729 B) were replaced by
+        // the 324 B seed by a routine convergence pass, silently.
+        stubAgent(new Set(EXTRA_FILES.map(f => f.path)));
+
+        await deployHomeAssistant();
+
+        const written = writtenPaths();
+        expect(written).not.toContain(`${HA_CONFIG_DIR}/automations.yaml`);
+        expect(written).not.toContain(`${HA_CONFIG_DIR}/scenes.yaml`);
+        expect(written).not.toContain(`${HA_CONFIG_DIR}/scripts.yaml`);
+    });
+
+    it('still seeds all three include targets on a first install', async () => {
+        stubAgent(new Set());
+
+        await deployHomeAssistant();
+
+        const written = writtenPaths();
+        expect(written).toContain(`${HA_CONFIG_DIR}/automations.yaml`);
+        expect(written).toContain(`${HA_CONFIG_DIR}/scenes.yaml`);
+        expect(written).toContain(`${HA_CONFIG_DIR}/scripts.yaml`);
+    });
+
+    it('keeps re-rendering the config files the template still owns', async () => {
+        // Only the declared three are protected — configuration.yaml is not in
+        // the annotation, so it keeps the unconditional-write behaviour.
+        stubAgent(new Set(EXTRA_FILES.map(f => f.path)));
+
+        await deployHomeAssistant();
+
+        expect(writtenPaths()).toContain(`${HA_CONFIG_DIR}/configuration.yaml`);
+    });
+
+    it('protects the three include targets the shipped template declares', () => {
+        // Pins template ↔ code: the promise in the mustache headers ("ServiceBay
+        // only seeds it empty on first install") is now carried by an annotation
+        // the deploy path reads, not by prose.
+        const yamlText = fs.readFileSync(HA_TEMPLATE, 'utf-8');
+        expect(yamlText).toMatch(
+            /servicebay\.seed-only-configs:\s*"automations\.yaml,scenes\.yaml,scripts\.yaml"/,
+        );
+    });
+});

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -24,6 +24,8 @@ import { injectServiceDirectives } from './quadletDirectives';
 import { ServiceListing } from './serviceListing';
 import { buildExpectedContainerNames } from './containerNameMatcher';
 import { assertTrashId } from '../api/schemas';
+import { readManifestAnnotations } from '../template/contract';
+import { writeExtraConfigFiles } from './extraConfigFiles';
 import {
     reconstructTemplateVariables,
     emitFeatureUninstalling,
@@ -67,113 +69,26 @@ export interface RestartSettleResult {
  */
 export const RESTART_SETTLE_TUNING = { timeoutMs: 180_000, pollIntervalMs: 2_000 };
 
-/** Minimal agent shape needed to ship files to a node. */
-interface FileWritingAgent {
-    sendCommand(action: string, params?: unknown): Promise<unknown>;
-}
-
 /**
- * Write a template's rendered config + asset files to the node, creating
- * parent dirs first.
+ * A pre-start hook failure that must ABORT the deploy.
  *
- * Failures are FATAL — the previous behaviour was to log a warning and
- * continue, which produced the radicale crash-loop class of bug: the
- * service starts, finds its config file missing, dies, and the operator
- * has no breadcrumb back to the silent write_file failure during deploy.
- * Throwing surfaces the problem at deploy time with a useful path.
- *
- * #1171 — a write target can sit under a hostPath pre-provisioned by a
- * consumer container (owned by its uid, not the agent's `core`/uid-1000),
- * e.g. the asset-transport `skills/` dir on a volume the hermes/syncthing
- * pod created. The plain write EACCESes there, so a failed write is
- * retried once via the agent's #1000 privileged path (`core` has
- * passwordless sudo on FCoS) before being recorded as a failure.
- *
- * #1258 — the agent rejects (the promise throws) when a command replies
- * with an error, e.g. the EACCES above. The retry therefore has to catch
- * the thrown error, not inspect a returned value — the original `res !==
- * 'ok'` check never fired because the await threw first, so the raw
- * `[Errno 13]` propagated straight to the deploy loop and the sudo retry
- * was dead code.
- *
- * #1298 — a sudo write lands the new file owned by root (uid 0). But the
- * only reason the unprivileged write failed is that the asset dir is owned
- * by the consuming rootless pod's subuid; a root-owned file inside it
- * breaks the next `podman kube play --replace` of that pod — rootless
- * podman can't `lsetxattr` (relabel) a path it doesn't own, so the volume
- * relabel fails and the pod won't restart. After a sudo write we therefore
- * realign the file's ownership to its parent directory (i.e. the subuid the
- * siblings already use) so the relabel stays possible. Best-effort: the file
- * is already written, and an ownership mismatch only bites a later relabel,
- * so a chown failure is logged but does not fail the deploy.
+ * `runPreStartHooks` deliberately swallows hook errors — a malformed pod spec
+ * or an unreachable optional path should not fail an otherwise fine deploy.
+ * But that catch-all also swallowed the #1864 HA config-integrity guard, whose
+ * entire job is to refuse the deploy when the config on disk is already
+ * hollowed out (#2590: the guard's condition was live on the owner's box for
+ * eight diagnose runs while deploys kept sailing through). Errors of this type
+ * are re-thrown by the catch-all instead.
  */
-/**
- * #1298 — realign a sudo-written (root-owned) file to its parent dir's owner so
- * a later rootless `kube play --replace` relabel of the dir can still lsetxattr
- * it. Best-effort; logged but never fatal (the file is already written, and an
- * ownership mismatch only bites a later relabel).
- */
-async function alignOwnershipToDir(agent: FileWritingAgent, path: string, dir: string): Promise<void> {
-    try {
-        const res = await agent.sendCommand('exec', { command: `sudo chown --reference=${dir} ${path}` });
-        if (res && typeof res === 'object' && 'code' in res && (res as { code: unknown }).code !== 0) {
-            logger.warn('ServiceManager', `chown to match ${dir} owner failed for ${path}: ${JSON.stringify(res)}`);
-        }
-    } catch (err) {
-        logger.warn('ServiceManager', `chown to match ${dir} owner failed for ${path}: ${err instanceof Error ? err.message : String(err)}`);
+export class FatalPreStartHookError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'FatalPreStartHookError';
     }
 }
 
-export async function writeExtraConfigFiles(
-    agent: FileWritingAgent,
-    serviceName: string,
-    extraFiles: { path: string; content: string }[],
-): Promise<void> {
-    const failures: string[] = [];
-    // Returns 'ok' on success, otherwise the failure reason as a string —
-    // covering both the rejection (agent error reply) and the defensive
-    // non-'ok' return value cases.
-    const attemptWrite = async (target: { path: string; content: string }, sudo: boolean): Promise<string> => {
-        try {
-            const res = await agent.sendCommand('write_file', { path: target.path, content: target.content, ...(sudo ? { sudo: true } : {}) });
-            return res === 'ok' ? 'ok' : JSON.stringify(res);
-        } catch (err) {
-            return err instanceof Error ? err.message : String(err);
-        }
-    };
-    for (const f of extraFiles) {
-        // Ensure parent directory exists.
-        const dir = f.path.substring(0, f.path.lastIndexOf('/'));
-        if (dir) {
-            await agent.sendCommand('exec', { command: `mkdir -p ${dir}` });
-        }
-        let outcome = await attemptWrite(f, false);
-        let usedSudo = false;
-        if (outcome !== 'ok') {
-            logger.warn('ServiceManager', `write_file for ${f.path} failed (${outcome}); retrying with sudo.`);
-            outcome = await attemptWrite(f, true);
-            usedSudo = true;
-        }
-        if (outcome !== 'ok') {
-            failures.push(f.path);
-            logger.error('ServiceManager', `Failed to write extra file ${f.path}: ${outcome}`);
-        } else {
-            // The plain (core-owned) write lands in a core-owned dir — fine.
-            // Only the sudo path leaves a root-owned file in a subuid-owned
-            // asset dir, which is what #1298 has to repair.
-            if (usedSudo && dir) {
-                await alignOwnershipToDir(agent, f.path, dir);
-            }
-            logger.info('ServiceManager', `Wrote extra config file: ${f.path}`);
-        }
-    }
-    if (failures.length > 0) {
-        throw new Error(
-            `Failed to write ${failures.length} required config file(s) for service "${serviceName}":\n  ${failures.join('\n  ')}\n\n` +
-            `The service was not started. Re-run the deploy or check the agent's write permissions on the target paths.`,
-        );
-    }
-}
+// Companion config/asset file delivery lives in its own module (#2590).
+export { writeExtraConfigFiles } from './extraConfigFiles';
 
 /** Extract string content from agent read_file response. */
 function extractFileContent(res: unknown): string {
@@ -1019,9 +934,19 @@ export class ServiceLifecycle {
 
         // Write extra config files (e.g. Authelia configuration.yml) to the
         // node filesystem. Failures are FATAL (see writeExtraConfigFiles).
+        //
+        // #2590 — the manifest itself says which of those files ServiceBay may
+        // only SEED. Read from the rendered pod YAML this deploy is about to
+        // apply, so every entry point (install runner, MCP `deploy_service`,
+        // the HTTP route) is covered by one rule and no caller can forget to
+        // pass the flag. `readManifestAnnotations` (permissive) rather than
+        // `parseTemplateManifest` on purpose: a manifest missing some
+        // UNRELATED required annotation must not silently drop this
+        // protection.
         if (extraFiles?.length) {
             const agent = await agentManager.ensureAgent(nodeName);
-            await writeExtraConfigFiles(agent, name, extraFiles);
+            const seedOnly = new Set(readManifestAnnotations(yamlContent).seedOnlyConfigs ?? []);
+            await writeExtraConfigFiles(agent, name, extraFiles, seedOnly);
         }
 
         // Ensure unprivileged port binding if any port < 1024 is used
@@ -1644,7 +1569,7 @@ export class ServiceLifecycle {
                 `This is the fingerprint of the automations/scripts/scenes data-loss incident: the entity registry still references these entities but their config file is empty, so starting HA would let it overwrite the only remaining copy. ` +
                 `ServiceBay has NOT modified or deleted anything. Restore ${includeDir} from a backup (or confirm the data really was removed) before redeploying.`;
             logger.error('ServiceManager', message);
-            throw new Error(message);
+            throw new FatalPreStartHookError(message);
         }
     }
 
@@ -1703,6 +1628,10 @@ export class ServiceLifecycle {
                 }
             }
         } catch (e) {
+            // A guard that refuses the deploy on purpose must survive this
+            // catch-all — otherwise "refuse and shout" degrades to "log at
+            // debug and carry on" (#2590).
+            if (e instanceof FatalPreStartHookError) throw e;
             logger.debug('ServiceManager', 'Pre-start hooks skipped:', e);
         }
     }

--- a/packages/backend/src/lib/services/serviceLifecycle.ts
+++ b/packages/backend/src/lib/services/serviceLifecycle.ts
@@ -87,8 +87,9 @@ export class FatalPreStartHookError extends Error {
     }
 }
 
-// Companion config/asset file delivery lives in its own module (#2590).
-export { writeExtraConfigFiles } from './extraConfigFiles';
+// Companion config/asset file delivery lives in its own module (#2590):
+// `./extraConfigFiles`. Import it from there — this file deliberately keeps no
+// re-export, so there is exactly one path to it and knip can see the truth.
 
 /** Extract string content from agent read_file response. */
 function extractFileContent(res: unknown): string {

--- a/packages/backend/src/lib/systemBackup.ts
+++ b/packages/backend/src/lib/systemBackup.ts
@@ -1015,7 +1015,7 @@ export async function createSystemBackup(kind: 'auto' | 'manual' = 'manual', pro
 
         // Stage per-service CONFIG (not bulk data) from every installed service
         // that has a backup manifest — HA `.storage`/automations/zwave keys,
-        // adguard, authelia, syncthing, hermes, and nginx (just another atom).
+        // adguard, authelia, lldap, jellyfin, and nginx (just another atom).
         // This reuses the per-service producer (`stageServiceBackup` via the
         // host-agent backend, #1597) so the Snapshot's service-config section is
         // byte-identical to the NAS atom (epic invariant #1607/#1608). It
@@ -1180,7 +1180,7 @@ export async function previewSystemBackup(archivePath: string): Promise<BackupPr
         }
 
         // Preview per-service config (HA `.storage`/automations/zwave keys,
-        // adguard, authelia, syncthing, hermes, nginx). Falls back to the legacy
+        // adguard, authelia, lldap, jellyfin, nginx). Falls back to the legacy
         // `service-data/` dir name so a v2 backup still previews.
         let serviceConfigDir = path.join(stagingDir, 'service-config');
         if (!(await pathExists(serviceConfigDir))) {

--- a/packages/backend/src/lib/template/contract.ts
+++ b/packages/backend/src/lib/template/contract.ts
@@ -58,6 +58,19 @@ export interface TemplateManifest {
    */
   configMount?: string;
   /**
+   * `metadata.annotations['servicebay.seed-only-configs']` — companion config
+   * filenames ServiceBay may write ONLY when they do not already exist on the
+   * box (#2590). Empty array when the annotation is missing, i.e. the default
+   * stays "re-render this file on every deploy".
+   *
+   * This is the declaration side of ADR 0004 ("installs are non-destructive")
+   * for companion config files: a file the *application* owns after first
+   * install — Home Assistant's `automations.yaml` is rewritten by HA's own
+   * editor — must never be re-seeded over. See `writeExtraConfigFiles` in
+   * `services/serviceLifecycle.ts` for the enforcement side.
+   */
+  seedOnlyConfigs: string[];
+  /**
    * `metadata.annotations['servicebay.ports']` — comma-separated `port/proto`
    * list (e.g. `"8080/tcp,8443/tcp"`). Recommended; no validation beyond
    * "is a string" today.
@@ -94,6 +107,12 @@ export interface ParseContext {
    *  the annotation the resolver falls back to a `/config`-suffix heuristic
    *  that silently picks the wrong mount in multi-volume pods. */
   hasMustacheConfigs?: boolean;
+  /** Deployed filenames of the `*.mustache` companion configs the template
+   *  directory ships (i.e. with the `.mustache` suffix stripped). When
+   *  provided, every entry of `servicebay.seed-only-configs` must name one of
+   *  them — a typo'd or stale entry would otherwise silently protect nothing,
+   *  which is the failure mode the annotation exists to prevent. */
+  mustacheConfigFilenames?: string[];
 }
 
 export type ParseResult =
@@ -145,6 +164,19 @@ export const TEMPLATE_FIELDS: readonly TemplateFieldSpec[] = [
     description:
       'Container mountPath that companion `*.mustache` files should land in. ' +
       'Avoids the `/config`-suffix heuristic picking the wrong volume in multi-container pods.',
+  },
+  {
+    annotation: 'servicebay.seed-only-configs',
+    field: 'seedOnlyConfigs',
+    required: false,
+    default: [],
+    description:
+      'Comma-separated companion config filenames (e.g. `"automations.yaml,scenes.yaml,scripts.yaml"`) that ' +
+      'ServiceBay writes **only when they are absent** on the box. Use it for any `*.mustache` file whose ' +
+      'real owner after first install is the application or the operator — an app that rewrites the file from ' +
+      'its own UI, or a file the operator edits by hand. Without the annotation a deploy re-renders the file ' +
+      'every time, which overwrites that content (#2590). Each name must match a `*.mustache` file the ' +
+      'template ships, minus the suffix.',
   },
   {
     annotation: 'servicebay.schema-version',
@@ -276,6 +308,7 @@ function validateTemplateMetadata(
   label: string | undefined;
   ports: string | undefined;
   configMount: string | undefined;
+  seedOnlyConfigs: string[];
   schemaVersion: number;
   tier: TemplateTier;
   dependencies: string[];
@@ -302,6 +335,36 @@ function validateTemplateMetadata(
       'wrong mount in multi-volume pods. Add `servicebay.config-mount: "<container mountPath>"` ' +
       'pointing at the volume the configs should land in.',
     );
+  }
+
+  // #2590 — the files a deploy is only allowed to SEED, never to overwrite.
+  // Two rules, both errors rather than warnings: an entry that names nothing
+  // the template ships protects nothing, and an entry with a path separator
+  // would be compared against a basename and therefore also never match. Both
+  // shapes fail silently at runtime (the file is simply re-rendered over the
+  // operator's content), so they have to fail loudly here instead.
+  const seedOnlyConfigs: string[] = [];
+  const seedOnlyRaw = readAnnotation(yamlText, 'servicebay.seed-only-configs');
+  if (seedOnlyRaw !== undefined) {
+    const shipped = ctx.mustacheConfigFilenames;
+    for (const entry of seedOnlyRaw.split(',').map(s => s.trim()).filter(Boolean)) {
+      if (entry.includes('/') || entry === '.' || entry === '..') {
+        errors.push(
+          `Annotation \`servicebay.seed-only-configs\` entry "${entry}" must be a bare filename ` +
+          `(no path separators) — it is matched against the config file's own name.`,
+        );
+        continue;
+      }
+      if (shipped && !shipped.includes(entry)) {
+        errors.push(
+          `Annotation \`servicebay.seed-only-configs\` names "${entry}", but the template ships no ` +
+          `\`${entry}.mustache\` config file${shipped.length > 0 ? ` (it ships: ${shipped.join(', ')})` : ''}. ` +
+          `An entry that matches nothing protects nothing — fix the name or drop it.`,
+        );
+        continue;
+      }
+      seedOnlyConfigs.push(entry);
+    }
   }
 
   let schemaVersion = 1;
@@ -356,6 +419,7 @@ function validateTemplateMetadata(
     label,
     ports,
     configMount,
+    seedOnlyConfigs,
     schemaVersion,
     tier,
     dependencies,
@@ -404,6 +468,7 @@ export function parseTemplateManifest(
       schemaVersion: meta.schemaVersion,
       dependencies: meta.dependencies,
       configMount: meta.configMount,
+      seedOnlyConfigs: meta.seedOnlyConfigs,
       ports: meta.ports,
       requiresApi: meta.requiresApi,
       healthcheckRaw,
@@ -456,6 +521,17 @@ function resolveAnnotationDefaults(yamlText: string): Partial<TemplateManifest> 
   const depsRaw = readAnnotation(yamlText, 'servicebay.dependencies');
   if (depsRaw !== undefined) {
     out.dependencies = depsRaw.split(',').map(s => s.trim()).filter(Boolean);
+  }
+
+  // #2590 — permissive read of the seed-only list. Entries carrying a path
+  // separator are dropped rather than kept: they can never match a basename,
+  // and the runtime consumer must not be handed something path-shaped.
+  const seedOnlyRaw = readAnnotation(yamlText, 'servicebay.seed-only-configs');
+  if (seedOnlyRaw !== undefined) {
+    out.seedOnlyConfigs = seedOnlyRaw
+      .split(',')
+      .map(s => s.trim())
+      .filter(s => s !== '' && !s.includes('/') && s !== '.' && s !== '..');
   }
 
   let requiresApi: TemplateApiVersions | undefined;

--- a/packages/backup-worker/src/engine/serviceManifest.ts
+++ b/packages/backup-worker/src/engine/serviceManifest.ts
@@ -55,7 +55,10 @@ export interface ServiceBackupManifest {
   /** On-disk data subdir under the stacks root, when it differs from `service`. */
   dataSubdir?: string;
   /** Sibling-store manifest (#1594): gates on the named template, not its own
-   *  service name. */
+   *  service name — a sibling dir (`home-assistant/zwave-js`) or one app of a
+   *  multi-app template (#2595: `authelia`/`lldap` under `auth`, `jellyfin`
+   *  under `media`). A gate naming no shipped template can never activate and is
+   *  a build-breaking defect (scripts/check-backup-coverage.ts). */
   gateOn?: string;
   /** CONFIG paths/dirs worth preserving across a reinstall (the tar contents). */
   include: string[];
@@ -76,8 +79,14 @@ export interface ServiceBackupManifest {
 /** Per-service config scope, transcribed from the table in #1190 and extended
  *  in #2153 (lldap/vaultwarden/radicale/jellyfin/file-share + authelia
  *  db.sqlite3). Kept in sync with the backend copy; the coverage contract that
- *  gates new template volumes lives on the backend side
- *  (scripts/check-backup-coverage.ts + EXCLUDED_BULK_VOLUMES). */
+ *  gates new template volumes — and, since #2595, the reverse check that every
+ *  `gateOn ?? service` names a shipped template — lives on the backend side
+ *  (scripts/check-backup-coverage.ts + EXCLUDED_BULK_VOLUMES).
+ *
+ *  #2595 also removed the `syncthing` and `hermes` entries: syncthing's config
+ *  lives in the podman PVC `file-share-syncthing-config` (no DATA_DIR path for
+ *  this file-copy path to read — #2596), and `hermes` is the retired Solaris
+ *  name with no template. See the backend copy for the full reasoning. */
 export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
   {
     service: 'home-assistant',
@@ -118,8 +127,10 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     // configuration.yml is re-rendered per deploy (regenerable), so it's excluded.
     // WAL-mode → stage the -wal/-shm sidecars so a live copy restores whole.
     // Encrypted at rest, kept verbatim (trusted-NAS class) — no strip.
+    // An APP of the `auth` template — gates on `auth`, not on its own name (#2595).
     service: 'authelia',
     dataSubdir: 'auth/authelia-data',
+    gateOn: 'auth',
     include: ['db.sqlite3', 'db.sqlite3-wal', 'db.sqlite3-shm'],
     exclude: [],
   },
@@ -128,19 +139,7 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
     include: ['conf/AdGuardHome.yaml'],
     exclude: ['data/querylog.json', 'data/stats.db', 'data/sessions.db', 'data/filters'],
   },
-  {
-    service: 'syncthing',
-    include: ['config.xml'],
-    exclude: ['index-v0.14.0.db', 'index'],
-    data: ['index-v0.14.0.db', 'index'],
-  },
-  {
-    service: 'hermes',
-    include: ['config.yaml'],
-    exclude: ['vectordb', 'embeddings', 'conversations', 'history'],
-    data: ['vectordb', 'embeddings'],
-    strip: [{ file: 'config.yaml', dropYamlKeys: ['api_key', 'apiKey', 'llm_api_key'] }],
-  },
+  // (`syncthing` and `hermes` used to sit here — removed in #2595.)
   {
     service: 'nginx',
     dataSubdir: 'nginx-proxy-manager',
@@ -150,9 +149,11 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
   },
   {
     // LLDAP (#2153): users.db is the family identity store (LLDAP 0.6.x SQLite
-    // under /data → auth/lldap/). Kept verbatim; sidecars ride along.
+    // under /data → auth/lldap/). Kept verbatim; sidecars ride along. The other
+    // app of the `auth` template — same gate as authelia (#2595).
     service: 'lldap',
     dataSubdir: 'auth/lldap',
+    gateOn: 'auth',
     include: ['users.db', 'users.db-wal', 'users.db-shm'],
     exclude: [],
   },
@@ -178,9 +179,11 @@ export const SERVICE_BACKUP_MANIFESTS: readonly ServiceBackupManifest[] = [
   {
     // Jellyfin (#2153): server config + users/libraries DB + plugins; caches,
     // logs, transcodes and re-scannable metadata excluded. The media library is
-    // a separate volume, never backed up.
+    // a separate volume, never backed up. An app of the `media` template — gates
+    // on `media`, not on its own name (#2595).
     service: 'jellyfin',
     dataSubdir: 'media/jellyfin-config',
+    gateOn: 'media',
     include: [
       'config',
       'data/jellyfin.db', 'data/jellyfin.db-wal', 'data/jellyfin.db-shm',

--- a/packages/backup-worker/src/engine/staging.test.ts
+++ b/packages/backup-worker/src/engine/staging.test.ts
@@ -24,6 +24,18 @@ async function write(base: string, rel: string, content: string): Promise<void> 
   await fs.writeFile(full, content);
 }
 
+/**
+ * A manifest with a strip rule. No SHIPPED manifest declares one since #2595
+ * retired the `hermes` entry, so the strip step is exercised against an explicit
+ * manifest — the machinery stays covered for the next service that needs it.
+ */
+const STRIPS_API_KEYS: ServiceBackupManifest = {
+  service: 'strip-probe',
+  include: ['config.yaml'],
+  exclude: [],
+  strip: [{ file: 'config.yaml', dropYamlKeys: ['api_key', 'apiKey', 'llm_api_key'] }],
+};
+
 beforeEach(() => { tmpDirs = []; });
 afterEach(async () => {
   await Promise.all(tmpDirs.map(d => fs.rm(d, { recursive: true, force: true })));
@@ -58,12 +70,11 @@ describe('stageServiceBackup', () => {
   });
 
   it('applies strip rules (secrets never enter the tar)', async () => {
-    // hermes strips LLM api keys from config.yaml before it enters the tarball.
     const src = await mkTmp();
     await write(src, 'config.yaml', 'api_key: SEKRIT\nmodel: gemma-e4b\n');
     const staging = await mkTmp();
 
-    await stageServiceBackup(src, getServiceManifest('hermes')!, staging);
+    await stageServiceBackup(src, STRIPS_API_KEYS, staging);
 
     const out = await fs.readFile(path.join(staging, 'config.yaml'), 'utf8');
     expect(out).not.toContain('SEKRIT');
@@ -119,7 +130,7 @@ describe('stageServiceBackup', () => {
       await fs.symlink(path.join(victim, 'config.yaml'), path.join(src, 'config.yaml'));
       const staging = await mkTmp();
 
-      const staged = await stageServiceBackup(src, getServiceManifest('hermes')!, staging);
+      const staged = await stageServiceBackup(src, STRIPS_API_KEYS, staging);
 
       expect(staged).toEqual([]);
       await expect(fs.access(path.join(staging, 'config.yaml'))).rejects.toThrow();

--- a/packages/backup-worker/src/engine/staging.test.ts
+++ b/packages/backup-worker/src/engine/staging.test.ts
@@ -28,8 +28,16 @@ async function write(base: string, rel: string, content: string): Promise<void> 
  * A manifest with a strip rule. No SHIPPED manifest declares one since #2595
  * retired the `hermes` entry, so the strip step is exercised against an explicit
  * manifest — the machinery stays covered for the next service that needs it.
+ *
+ * The name matters: this held no secret when it was called `STRIPS_API_KEYS`
+ * either — `dropYamlKeys` lists the field NAMES to remove, and `service` is
+ * `strip-probe` — but CodeQL's `js/clear-text-logging` treats every property
+ * read off a variable whose name matches its secret heuristic as tainted, and
+ * flagged the `#2454` symlink-escape `console.warn` (which logs a service name
+ * and a relative path) as a high-severity leak. Renaming removes the false
+ * positive without a suppression comment and without weakening that log.
  */
-const STRIPS_API_KEYS: ServiceBackupManifest = {
+const MANIFEST_WITH_STRIP_RULE: ServiceBackupManifest = {
   service: 'strip-probe',
   include: ['config.yaml'],
   exclude: [],
@@ -74,7 +82,7 @@ describe('stageServiceBackup', () => {
     await write(src, 'config.yaml', 'api_key: SEKRIT\nmodel: gemma-e4b\n');
     const staging = await mkTmp();
 
-    await stageServiceBackup(src, STRIPS_API_KEYS, staging);
+    await stageServiceBackup(src, MANIFEST_WITH_STRIP_RULE, staging);
 
     const out = await fs.readFile(path.join(staging, 'config.yaml'), 'utf8');
     expect(out).not.toContain('SEKRIT');
@@ -130,7 +138,7 @@ describe('stageServiceBackup', () => {
       await fs.symlink(path.join(victim, 'config.yaml'), path.join(src, 'config.yaml'));
       const staging = await mkTmp();
 
-      const staged = await stageServiceBackup(src, STRIPS_API_KEYS, staging);
+      const staged = await stageServiceBackup(src, MANIFEST_WITH_STRIP_RULE, staging);
 
       expect(staged).toEqual([]);
       await expect(fs.access(path.join(staging, 'config.yaml'))).rejects.toThrow();

--- a/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
+++ b/packages/frontend/src/app/(dashboard)/settings/_lib/sections/McpSection.tsx
@@ -293,7 +293,6 @@ export default function McpSection() {
     // Read window.location after mount to avoid SSR/hydration mismatch.
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async settings fetch, guarded by a cancelled flag
     setMcpUrl(`${window.location.origin}/mcp`);
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- same post-mount window read as above
     setOnBoxUrl(`http://${ON_BOX_HOST}:${DEFAULT_APP_PORT}/mcp`);
   }, []);
 

--- a/scripts/check-backup-coverage.ts
+++ b/scripts/check-backup-coverage.ts
@@ -17,13 +17,19 @@
  * `adguard/work` + `adguard/conf` volumes are both under the `adguard` manifest,
  * and `file-share/samba-private` is under the `file-share` manifest.
  *
- * Exits 0 (all covered) or 1 (one or more uncovered volumes).
+ * The REVERSE direction (#2595) is checked too: every manifest entry must gate
+ * on a template this repo ships. See {@link unknownGateManifests}.
+ *
+ * Exits 0 (all covered) or 1 (an uncovered volume, or a gate that names no
+ * template).
  */
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import {
   SERVICE_BACKUP_MANIFESTS,
   EXCLUDED_BULK_VOLUMES,
+  getBackupGate,
+  type ServiceBackupManifest,
 } from '../packages/backend/src/lib/externalBackup/serviceManifest.js';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -126,20 +132,89 @@ function uncoveredVolumes(vols: readonly TemplateVolume[]): TemplateVolume[] {
   return vols.filter(v => !isUnder(v.key, manifestRoots) && !isUnder(v.key, excludedRoots));
 }
 
-function main(): void {
-  const templates = readdirSync(TEMPLATES_DIR, { withFileTypes: true })
+/** A manifest entry whose activation key names no shipped template. */
+interface UnknownGate {
+  service: string;
+  gate: string;
+  /** True when the gate came from `gateOn` rather than defaulting to `service`. */
+  explicit: boolean;
+}
+
+/**
+ * The reverse of the volume check (#2595). A manifest entry activates when
+ * `getBackupGate(m)` — `gateOn ?? service` — is a key in `installedTemplates`,
+ * i.e. a template NAME. Two situations look identical at runtime and are not:
+ *
+ *   - the gate names a real template that this box has not installed → the entry
+ *     is correctly dormant. Normal, expected, nothing to report.
+ *   - the gate names something no template is ever called → the entry is
+ *     PERMANENTLY dormant on every box, and the backup it promises silently does
+ *     not exist. That is always a defect.
+ *
+ * Only a repo-level check can tell the two apart, because only here is the full
+ * set of template names known; at runtime the backup selector just sees a key
+ * that is absent and moves on — which is exactly how `authelia`, `lldap` and
+ * `jellyfin` sat un-backed-up while the nightly run reported "8/8 services
+ * backed up" against a denominator that had quietly shrunk.
+ *
+ * Pure over its inputs so the gate's own decision is testable without the
+ * filesystem (tests/scripts/gate-config-truth.test.ts).
+ */
+function unknownGateManifests(
+  manifests: readonly ServiceBackupManifest[],
+  templateNames: readonly string[],
+): UnknownGate[] {
+  const known = new Set(templateNames);
+  return manifests
+    .filter(m => !known.has(getBackupGate(m)))
+    .map(m => ({ service: m.service, gate: getBackupGate(m), explicit: m.gateOn !== undefined }));
+}
+
+/** The names of the templates this repo ships (a dir with a `template.yml`). */
+function shippedTemplateNames(): string[] {
+  return readdirSync(TEMPLATES_DIR, { withFileTypes: true })
     .filter(e => e.isDirectory())
-    .map(e => e.name);
+    .map(e => e.name)
+    .filter(name => existsSync(path.join(TEMPLATES_DIR, name, 'template.yml')));
+}
+
+function main(): void {
+  const templates = shippedTemplateNames();
 
   const all: TemplateVolume[] = [];
   for (const template of templates) {
-    const tmplPath = path.join(TEMPLATES_DIR, template, 'template.yml');
-    if (!existsSync(tmplPath)) continue;
-    all.push(...extractHostPathVolumes(template, readFileSync(tmplPath, 'utf8')));
+    all.push(
+      ...extractHostPathVolumes(
+        template,
+        readFileSync(path.join(TEMPLATES_DIR, template, 'template.yml'), 'utf8'),
+      ),
+    );
   }
 
   const checked = all.length;
   const uncovered = uncoveredVolumes(all);
+
+  // Fail closed: an empty template list would make BOTH checks vacuously green.
+  if (templates.length === 0) {
+    console.error('✗ backup-coverage: no templates found under templates/ — the gate would scan nothing.');
+    process.exit(1);
+  }
+
+  const unknownGates = unknownGateManifests(SERVICE_BACKUP_MANIFESTS, templates);
+  if (unknownGates.length > 0) {
+    console.error('✗ backup-coverage contract (#2595): manifest entr(ies) gating on a name no template has — permanently inactive, so the backup they promise never runs:\n');
+    for (const g of unknownGates) {
+      const source = g.explicit ? `gateOn: '${g.gate}'` : `service: '${g.gate}' (no gateOn)`;
+      console.error(`  ${g.service}: ${source} — no templates/${g.gate}/template.yml`);
+    }
+    console.error('\nThis is NOT the same as "the template is not installed on this box" — that is fine and expected.');
+    console.error('A gate that matches no template can never activate anywhere. Fix it by setting `gateOn` to the');
+    console.error('template that owns the data dir (an app of a multi-app template gates on the template, e.g.');
+    console.error("jellyfin → 'media', authelia/lldap → 'auth'), or by deleting the entry if the service is retired.");
+    console.error('Both copies must change: packages/backend/src/lib/externalBackup/serviceManifest.ts and the');
+    console.error('packages/backup-worker/src/engine/serviceManifest.ts mirror.');
+    process.exit(1);
+  }
 
   if (uncovered.length > 0) {
     console.error('✗ backup-coverage contract (#2153): persistent volume(s) with no manifest entry and no EXCLUDED_BULK_VOLUMES marker:\n');
@@ -154,14 +229,22 @@ function main(): void {
   }
 
   console.log(`✓ backup-coverage: ${checked} persistent template volume(s) all covered (manifest or explicit bulk-exclude).`);
+  console.log(`✓ backup-gates: ${SERVICE_BACKUP_MANIFESTS.length} manifest entr(ies) all gate on a shipped template.`);
 }
 
 // Run only when invoked as the CLI — `toCoverageKey` / `extractHostPathVolumes`
-// / `uncoveredVolumes` are imported by tests/scripts/gate-config-truth.test.ts,
-// which must not trigger a full run (and a `process.exit`) just by importing.
+// / `uncoveredVolumes` / `unknownGateManifests` are imported by
+// tests/scripts/gate-config-truth.test.ts, which must not trigger a full run
+// (and a `process.exit`) just by importing.
 if (/check-backup-coverage\.ts$/.test(process.argv[1] ?? '')) {
   main();
 }
 
-export { toCoverageKey, extractHostPathVolumes, uncoveredVolumes };
-export type { TemplateVolume };
+export {
+  toCoverageKey,
+  extractHostPathVolumes,
+  uncoveredVolumes,
+  unknownGateManifests,
+  shippedTemplateNames,
+};
+export type { TemplateVolume, UnknownGate };

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -28,6 +28,9 @@ metadata:
     servicebay.ports: "8080/tcp"
     servicebay.schema-version: "1"     # bump on every breaking change
     # servicebay.config-mount: "/config"   # required iff *.mustache files exist
+    # servicebay.seed-only-configs: "automations.yaml"  # *.mustache files the app
+    #   or the operator owns after first install — written ONLY when absent, so a
+    #   redeploy never overwrites what they put there (#2590)
     # servicebay.tier: "infrastructure"    # auto-include + lock checked
     # servicebay.dependencies: "nginx,auth" # comma-separated install-time deps
     # servicebay.healthcheck: |             # continuous health probe (#626/#628)

--- a/templates/home-assistant/template.yml
+++ b/templates/home-assistant/template.yml
@@ -14,6 +14,13 @@ metadata:
     # authenticates via Authelia.
     servicebay.dependencies: "nginx,auth"
     servicebay.config-mount: "/config"
+    # The three UI-editable include targets are Home Assistant's to own after
+    # the first install: HA's own automation/script/scene editors rewrite them,
+    # and the operator edits them by hand. ServiceBay seeds each one empty when
+    # it is missing and never writes it again (#2590 — before this annotation
+    # every convergence pass re-rendered the empty seed over the operator's
+    # real automations, silently).
+    servicebay.seed-only-configs: "automations.yaml,scenes.yaml,scripts.yaml"
     # 8123 = Home Assistant (own login + OIDC, public via home.<domain>).
     # 8091 = Z-Wave JS UI, 3001 = the raw Z-Wave JS control websocket,
     # 5580 = python-matter-server's control websocket. Those three carry no

--- a/tests/backend/backup_roundtrip.test.ts
+++ b/tests/backend/backup_roundtrip.test.ts
@@ -26,7 +26,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { buildServiceBackupTar } from '../../packages/backup-worker/src/engine/staging';
-import { getServiceManifest } from '../../packages/backup-worker/src/engine/serviceManifest';
+import {
+  getServiceManifest,
+  type ServiceBackupManifest,
+} from '../../packages/backup-worker/src/engine/serviceManifest';
 import { safeTarExtract } from '@/lib/systemBackup';
 
 function tarPresent(): boolean {
@@ -68,8 +71,10 @@ afterEach(async () => {
 async function roundTrip(
   service: string,
   seed: (src: string) => Promise<void>,
+  /** Explicit manifest, for a shape no shipped service declares (strip rules). */
+  manifestOverride?: ServiceBackupManifest,
 ): Promise<string> {
-  const manifest = getServiceManifest(service)!;
+  const manifest = manifestOverride ?? getServiceManifest(service)!;
   expect(manifest, `manifest for ${service} must exist`).toBeDefined();
   const src = await mkTmp(`${service}-src`);
   await seed(src);
@@ -162,10 +167,22 @@ describe('backup round-trip (#2154) — content survives backup→wipe→restore
     await expect(fs.access(path.join(restored, 'users_database.yml'))).rejects.toThrow();
   });
 
-  maybeIt('hermes: strip removes LLM api keys before the tar (secret never lands)', async () => {
-    const restored = await roundTrip('hermes', async src => {
-      await write(src, 'config.yaml', 'api_key: SUPER-SECRET-KEY\nmodel: gemma-e4b\n');
-    });
+  maybeIt('strip removes api keys before the tar (secret never lands on the NAS)', async () => {
+    // #2595 retired the last shipped strip rule with the `hermes` entry, so the
+    // staging path's strip step is exercised against an explicit manifest — the
+    // machinery stays covered for the next service that needs it.
+    const restored = await roundTrip(
+      'strip-probe',
+      async src => {
+        await write(src, 'config.yaml', 'api_key: SUPER-SECRET-KEY\nmodel: gemma-e4b\n');
+      },
+      {
+        service: 'strip-probe',
+        include: ['config.yaml'],
+        exclude: [],
+        strip: [{ file: 'config.yaml', dropYamlKeys: ['api_key', 'apiKey', 'llm_api_key'] }],
+      },
+    );
     const cfg = await read(restored, 'config.yaml');
     // The strip rule removed the secret but kept the rest of the config.
     expect(cfg).not.toContain('SUPER-SECRET-KEY');

--- a/tests/backend/template_consistency.test.ts
+++ b/tests/backend/template_consistency.test.ts
@@ -100,6 +100,13 @@ function extractMustacheVars(text: string): Set<string> {
   return out;
 }
 
+/** Deployed names of a template's companion configs — `automations.yaml`
+ *  for `automations.yaml.mustache`. This is the name a deploy writes and the
+ *  name `servicebay.seed-only-configs` has to match (#2590). */
+function mustacheTargetNames(t: TemplateInfo): string[] {
+  return Object.keys(t.configs).map(f => f.replace(/\.mustache$/, ''));
+}
+
 const templates = listTemplates();
 const templateNames = new Set(templates.map(t => t.name));
 const globalVars = new Set(readSettingsGlobals());
@@ -219,6 +226,10 @@ describe('Template ↔ source-name consistency', () => {
     for (const t of templates) {
       const result = parseTemplateManifest(t.yamlContent, {
         hasMustacheConfigs: Object.keys(t.configs).length > 0,
+        // #2590 — the shipped file list turns `servicebay.seed-only-configs`
+        // into a checkable claim: an entry naming a file the template does
+        // not ship would protect nothing and is a build error here.
+        mustacheConfigFilenames: mustacheTargetNames(t),
       });
       if (!result.ok) {
         for (const err of result.errors) {
@@ -2281,6 +2292,7 @@ describe('Healthcheck contract', () => {
     for (const t of templates) {
       manifests.set(t.name, parseTemplateManifest(t.yamlContent, {
         hasMustacheConfigs: Object.keys(t.configs).length > 0,
+        mustacheConfigFilenames: mustacheTargetNames(t),
       }));
     }
     const dependedOn = new Set<string>();

--- a/tests/backend/template_contract.test.ts
+++ b/tests/backend/template_contract.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseTemplateManifest, tryParseTemplateManifest } from '@/lib/template/contract';
+import { parseTemplateManifest, tryParseTemplateManifest, readManifestAnnotations } from '@/lib/template/contract';
 
 function fixture(annotations: Record<string, string | number>, opts: { quotes?: 'double' | 'single' | 'bare' } = {}) {
   const quotes = opts.quotes ?? 'double';
@@ -64,6 +64,9 @@ describe('parseTemplateManifest — happy path', () => {
       schemaVersion: 1,
       dependencies: [],
       configMount: undefined,
+      // #2590 — no declaration means "ServiceBay owns every config file",
+      // i.e. the pre-existing re-render-on-every-deploy behaviour.
+      seedOnlyConfigs: [],
       ports: undefined,
     });
   });
@@ -157,6 +160,76 @@ describe('parseTemplateManifest — invalid values', () => {
     if (r.ok) return;
     // label missing + tier invalid + schema-version invalid
     expect(r.errors.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('parseTemplateManifest — seed-only configs (#2590)', () => {
+  const shipped = { mustacheConfigFilenames: ['automations.yaml', 'scenes.yaml', 'scripts.yaml'] };
+
+  it('defaults to an empty list — every config file is re-rendered unless declared', () => {
+    const r = parseTemplateManifest(fixture({ 'servicebay.label': 'X' }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.manifest.seedOnlyConfigs).toEqual([]);
+  });
+
+  it('parses the comma-separated list', () => {
+    const r = parseTemplateManifest(
+      fixture({ 'servicebay.label': 'X', 'servicebay.seed-only-configs': 'automations.yaml, scenes.yaml' }),
+      shipped,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.manifest.seedOnlyConfigs).toEqual(['automations.yaml', 'scenes.yaml']);
+  });
+
+  it('rejects an entry the template ships no mustache file for', () => {
+    // The whole failure mode this annotation guards against is a protection
+    // that silently matches nothing — so a typo has to be a build error, not
+    // a quietly re-enabled overwrite.
+    const r = parseTemplateManifest(
+      fixture({ 'servicebay.label': 'X', 'servicebay.seed-only-configs': 'automation.yaml' }),
+      shipped,
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => e.includes('automation.yaml') && e.includes('protects nothing'))).toBe(true);
+  });
+
+  it('rejects a path-shaped entry', () => {
+    const r = parseTemplateManifest(
+      fixture({ 'servicebay.label': 'X', 'servicebay.seed-only-configs': 'sub/automations.yaml' }),
+      shipped,
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors.some(e => e.includes('bare filename'))).toBe(true);
+  });
+
+  it('accepts any name when the caller cannot supply the shipped file list', () => {
+    // Runtime parses have no template directory to check against.
+    const r = parseTemplateManifest(
+      fixture({ 'servicebay.label': 'X', 'servicebay.seed-only-configs': 'whatever.yaml' }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.manifest.seedOnlyConfigs).toEqual(['whatever.yaml']);
+  });
+});
+
+describe('readManifestAnnotations — seed-only configs (#2590)', () => {
+  // The deploy path uses the permissive reader so an unrelated missing
+  // annotation can never disable the data-loss guard.
+  it('reads the list off a manifest that would fail strict validation', () => {
+    const m = readManifestAnnotations(
+      fixture({ 'servicebay.seed-only-configs': 'automations.yaml,scenes.yaml' }),
+    );
+    expect(tryParseTemplateManifest(fixture({ 'servicebay.seed-only-configs': 'automations.yaml' }))).toBeNull();
+    expect(m.seedOnlyConfigs).toEqual(['automations.yaml', 'scenes.yaml']);
+  });
+
+  it('drops path-shaped entries rather than passing them on', () => {
+    const m = readManifestAnnotations(
+      fixture({ 'servicebay.label': 'X', 'servicebay.seed-only-configs': '../../etc/passwd, ok.yaml' }),
+    );
+    expect(m.seedOnlyConfigs).toEqual(['ok.yaml']);
   });
 });
 

--- a/tests/scripts/gate-config-truth.test.ts
+++ b/tests/scripts/gate-config-truth.test.ts
@@ -13,7 +13,14 @@ import {
   toCoverageKey,
   extractHostPathVolumes,
   uncoveredVolumes,
+  unknownGateManifests,
+  shippedTemplateNames,
 } from '../../scripts/check-backup-coverage';
+import {
+  SERVICE_BACKUP_MANIFESTS,
+  getBackupGate,
+} from '../../packages/backend/src/lib/externalBackup/serviceManifest';
+import { SERVICE_BACKUP_MANIFESTS as WORKER_MANIFESTS } from '../../packages/backup-worker/src/engine/serviceManifest';
 
 /**
  * #2428 / #2429 / #2427 — the two ways a quality gate lies, and the doc that
@@ -304,6 +311,85 @@ describe('#2465 — backup-coverage fails closed on volume variables of any name
       });
     expect(vols.length).toBeGreaterThan(10);
     expect(uncoveredVolumes(vols)).toEqual([]);
+  });
+});
+
+describe('#2595 — a backup manifest gating on a name no template has is build-breaking', () => {
+  /**
+   * The third way a gate lies, alongside "scans nothing" and "runs nowhere":
+   * it scans and runs, but the thing it protects opted itself out. A manifest
+   * entry activates on an `installedTemplates` KEY, so an entry whose
+   * `gateOn ?? service` matches no template name is dormant on every box
+   * forever — and looked exactly like a template that merely wasn't installed.
+   * That is how authelia / lldap / jellyfin went un-backed-up while the nightly
+   * run logged "8/8 services backed up" against a shrunken denominator.
+   */
+  const templateNames = shippedTemplateNames();
+
+  it('finds the shipped templates at all (the gate is not vacuous)', () => {
+    expect(templateNames.length).toBeGreaterThan(5);
+    expect(templateNames).toEqual(expect.arrayContaining(['auth', 'media', 'file-share']));
+  });
+
+  it('every manifest entry at HEAD gates on a template this repo ships', () => {
+    expect(unknownGateManifests(SERVICE_BACKUP_MANIFESTS, templateNames)).toEqual([]);
+  });
+
+  it('the worker mirror gates identically — a divergence is the same defect', () => {
+    // The worker's copy is what actually SELECTS services for the nightly run
+    // (backupWorker/service.ts imports it, not the backend copy), so a gate that
+    // is right here and wrong there still loses the backup.
+    expect(WORKER_MANIFESTS.map(m => [m.service, m.gateOn ?? m.service]))
+      .toEqual(SERVICE_BACKUP_MANIFESTS.map(m => [m.service, m.gateOn ?? m.service]));
+  });
+
+  it('the three #2595 entries resolve to the templates that own their data dirs', () => {
+    const gateOf = (service: string) =>
+      getBackupGate(SERVICE_BACKUP_MANIFESTS.find(m => m.service === service)!);
+    // Multi-app templates: `auth` ships authelia + lldap, `media` ships jellyfin.
+    expect(gateOf('authelia')).toBe('auth');
+    expect(gateOf('lldap')).toBe('auth');
+    expect(gateOf('jellyfin')).toBe('media');
+    // The sibling-store precedent that was always right stays right.
+    expect(gateOf('home-assistant-zwave')).toBe('home-assistant');
+    // A single-app template still gates on its own name.
+    expect(gateOf('adguard')).toBe('adguard');
+  });
+
+  it('flags a permanently-inactive entry but NOT a merely-uninstalled one', () => {
+    // The distinction the runtime cannot make. `radicale` here is a real
+    // template that a given box may simply not have installed — not a defect.
+    const manifests = [
+      { service: 'radicale', include: ['collections'], exclude: [] },
+      { service: 'jellyfin', dataSubdir: 'media/jellyfin-config', include: ['config'], exclude: [] },
+      { service: 'ghost', gateOn: 'nowhere', include: ['x'], exclude: [] },
+    ];
+    expect(unknownGateManifests(manifests, ['auth', 'media', 'radicale'])).toEqual([
+      // jellyfin defaulted its gate to its own name — the exact pre-fix bug.
+      { service: 'jellyfin', gate: 'jellyfin', explicit: false },
+      // an explicit gateOn pointing nowhere is the same class of defect.
+      { service: 'ghost', gate: 'nowhere', explicit: true },
+    ]);
+  });
+
+  it('would have failed on the pre-fix manifests (the bug is actually caught)', () => {
+    const preFix = SERVICE_BACKUP_MANIFESTS.map(m =>
+      ['authelia', 'lldap', 'jellyfin'].includes(m.service) ? { ...m, gateOn: undefined } : m,
+    );
+    expect(unknownGateManifests(preFix, templateNames).map(g => g.service))
+      .toEqual(['authelia', 'lldap', 'jellyfin']);
+  });
+
+  it('the two retired entries are gone, not re-added under a dead gate', () => {
+    // syncthing's config lives in the podman PVC `file-share-syncthing-config`
+    // (no DATA_DIR path for the file-copy producer to read); `hermes` is the
+    // retired Solaris name with no template. Re-adding either would fail the
+    // gate above — this pins the decision so it isn't quietly reversed.
+    const names = SERVICE_BACKUP_MANIFESTS.map(m => m.service);
+    expect(names).not.toContain('syncthing');
+    expect(names).not.toContain('hermes');
+    expect(existsSync(path.join(REPO_ROOT, 'templates', 'syncthing'))).toBe(false);
+    expect(existsSync(path.join(REPO_ROOT, 'templates', 'hermes'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Drei Fehler, die alle dieselbe Form haben: **etwas meldete Erfolg, während es nichts tat.** Deshalb ist bei jedem der drei die dauerhafte Hälfte des Fixes nicht die Reparatur selbst, sondern den unmöglichen Zustand laut zu machen.

- **#2595 — die NAS-Sicherung übersprang Authelia, LLDAP und Jellyfin.** Das Protokoll meldete `8/8 services backed up` — vollständig gegenüber einem zu kleinen Nenner. `getBackupGate()` liefert `gateOn ?? service`; drei Sibling-Einträge trugen kein `gateOn` und warteten damit auf Template-Namen (`authelia`, `lldap`, `jellyfin`), die es nicht gibt — die Box hat `auth` und `media`. Der Nachbareintrag `home-assistant-zwave` macht dieselbe Bauform richtig. Ungesichert waren dadurch der SSO-Server und der **komplette Identitätsspeicher**.

  Ein Gate, das auf einen Namen zeigt, den kein Template haben kann, bricht jetzt den Build (`unknownGateManifests()`), im Unterschied zu einem Gate auf ein bloß nicht installiertes Template. Ein Test weist nach, dass die Prüfung die drei kaputten Einträge **vor** der Reparatur gefunden hätte. `syncthing` und `hermes` wurden bewusst entfernt statt mit einer Alibi-Zeile bedacht — syncthings Konfiguration liegt in einem Podman-Volume, das der dateibasierte Produzent gar nicht sieht, was als **#2596** eigenständig aufgenommen ist.

- **#2590 — eine gefüllte `automations.yaml` wurde beim Deploy durch den leeren Seed ersetzt.** Drei Konfigurationsdateien versprechen im eigenen Kopf „nur bei der Erstinstallation". Durchgesetzt hat das nichts: `writeExtraConfigFiles` schrieb unbedingt, und die `test -f … || seed`-Wächter laufen **vier Sekunden danach** — sie fanden die Datei immer vor. Die Zusage war nie wirksam, nicht kaputtgegangen.

  Nach ADR 0004 erklärt das Manifest jetzt, welche Begleitdateien nur gesät werden dürfen, und die eine Schreibstelle hält sich daran — gelesen aus dem deployten Pod-YAML, sodass Install-Runner, MCP und HTTP-Route derselben Regel folgen und kein Aufrufer ein Flag vergessen kann. Die Existenzprüfung ist fehlerschließend: unklare Antwort zählt als „vorhanden", denn ein ausgelassener Seed ist nachholbar, ein Überschreiben nicht. Ein Eintrag, der eine Datei nennt, die das Template gar nicht mitbringt, ist ebenfalls ein Build-Fehler.

  **Zusätzlich gefunden:** der Integritätswächter aus #1864 wurde von einem Sammel-`catch` verschluckt (`logger.debug`, Deploy läuft weiter). Auf der Referenzbox war seine Bedingung acht Diagnoseläufe hintereinander erfüllt. Er bricht jetzt ab.

- **#2594 — der Zertifikatscheck bot „erneuern" für Zertifikate an, deren Host es nicht mehr gibt.** Diese Erneuerung *kann* nicht gelingen; sie verbrennt einen ACME-Versuch gegen Let's Encrypts Kontingent und taucht danach in `cert_request_failure` wie ein neues Problem auf.

  Die offene Entwurfsfrage ist entschieden, nicht geraten: „verwaist" heißt **von keinem NPM-Host benutzt UND bereits im Ablauffenster**. Der zweite Teil schützt den vorsorglich ausgestellten Fall — ein 90-Tage-Zertifikat erreicht die 14-Tage-Marke erst nach ~76 Tagen, wer dort ungebunden ankommt, wurde aufgegeben. Außerhalb des Fensters ändert sich gar nichts. Überall sonst fehlerschließend: unlesbare Host-Tabelle → alles behält `renew_cert`.

Beide Kopien des Checks sind angefasst (health *und* diagnose) — ein Fix nur in der Sonde hätte eine Aktions-ID ohne Handler ausgeliefert, die `resolveItemActions` still verwirft. Genau diese Lücke ist jetzt ebenfalls laut.

**Für den Box-Verify zu prüfen, nicht durchzuwinken:** eine Neuinstallation von `auth` oder `media` mit „Konfiguration verwerfen" räumt deren Speicher ab jetzt tatsächlich aus und spielt ihn zurück, wo vorher „kein Backup-Manifest" stand und nichts geschah. Das ist die Reparatur — aber bei `auth` hängt daran der Identitätsspeicher.
